### PR TITLE
fix(ahci): integrate controller with PCI driver model

### DIFF
--- a/kernel/src/arch/riscv64/mm/mod.rs
+++ b/kernel/src/arch/riscv64/mm/mod.rs
@@ -447,6 +447,18 @@ impl FrameAllocator for LockedFrameAllocator {
         }
     }
 
+    unsafe fn allocate_below(
+        &mut self,
+        count: PageFrameCount,
+        max_phys_addr: PhysAddr,
+    ) -> Option<(PhysAddr, PageFrameCount)> {
+        if let Some(ref mut allocator) = *INNER_ALLOCATOR.lock_irqsave() {
+            allocator.buddy_alloc_below(count.next_power_of_two(), max_phys_addr)
+        } else {
+            None
+        }
+    }
+
     unsafe fn free(&mut self, address: crate::mm::PhysAddr, count: PageFrameCount) {
         assert!(count.data().is_power_of_two());
         if let Some(ref mut allocator) = *INNER_ALLOCATOR.lock_irqsave() {

--- a/kernel/src/arch/x86_64/mm/mod.rs
+++ b/kernel/src/arch/x86_64/mm/mod.rs
@@ -797,6 +797,19 @@ impl FrameAllocator for LockedFrameAllocator {
         retry_oom_victim_page_frame_alloc(|| unsafe { Self::allocate_inner(count) })
     }
 
+    unsafe fn allocate_below(
+        &mut self,
+        mut count: PageFrameCount,
+        max_phys_addr: PhysAddr,
+    ) -> Option<(PhysAddr, PageFrameCount)> {
+        count = count.next_power_of_two();
+        if let Some(ref mut allocator) = *INNER_ALLOCATOR.lock_irqsave() {
+            allocator.buddy_alloc_below(count, max_phys_addr)
+        } else {
+            None
+        }
+    }
+
     unsafe fn free(&mut self, address: crate::mm::PhysAddr, count: PageFrameCount) {
         assert!(count.data().is_power_of_two());
         if let Some(ref mut allocator) = *INNER_ALLOCATOR.lock_irqsave() {

--- a/kernel/src/debug/mm.rs
+++ b/kernel/src/debug/mm.rs
@@ -1,0 +1,76 @@
+use alloc::{string::String, string::ToString};
+
+use system_error::SystemError;
+
+use crate::{
+    debug::sysfs::debugfs_kobj,
+    driver::base::kobject::KObject,
+    filesystem::{
+        kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData},
+        vfs::{InodeMode, PollStatus},
+    },
+};
+
+#[derive(Debug)]
+struct DmaAllocatorSelftestCallback;
+
+impl KernFSCallback for DmaAllocatorSelftestCallback {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(
+                crate::mm::dma::dma_allocator_selftest_report(),
+            ));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        let report: &String = match data.file_private_data() {
+            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+            _ => return Err(SystemError::EINVAL),
+        };
+        let bytes = report.as_bytes();
+        if offset >= bytes.len() {
+            return Ok(0);
+        }
+        let len = buf.len().min(bytes.len() - offset);
+        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+        Ok(len)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        _buf: &[u8],
+        _offset: usize,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EPERM)
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ)
+    }
+}
+
+pub fn init_debugfs_mm() -> Result<(), SystemError> {
+    let debugfs = debugfs_kobj();
+    let root = debugfs.inode().ok_or(SystemError::ENOENT)?;
+    let mm = root.add_dir(
+        "mm".to_string(),
+        InodeMode::from_bits_truncate(0o500),
+        None,
+        None,
+    )?;
+    mm.add_file(
+        "dma_allocator_selftest".to_string(),
+        InodeMode::S_IRUSR,
+        Some(4096),
+        None,
+        Some(&DmaAllocatorSelftestCallback),
+    )?;
+    Ok(())
+}

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -6,6 +6,7 @@ pub mod jump_label;
 pub mod klog;
 pub mod kprobe;
 pub mod kthread;
+pub mod mm;
 pub mod page_cache;
 pub mod panic;
 pub mod rcu;

--- a/kernel/src/debug/mod.rs
+++ b/kernel/src/debug/mod.rs
@@ -6,6 +6,7 @@ pub mod jump_label;
 pub mod klog;
 pub mod kprobe;
 pub mod kthread;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 pub mod mm;
 pub mod page_cache;
 pub mod panic;

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -27,6 +27,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::ext4::init_debugfs_ext4()?;
     super::fuse::init_debugfs_fuse()?;
     super::kthread::init_debugfs_kthread()?;
+    super::mm::init_debugfs_mm()?;
     super::page_cache::init_debugfs_page_cache()?;
     super::timekeeping::init_debugfs_timekeeping()?;
     return Ok(());

--- a/kernel/src/debug/sysfs/mod.rs
+++ b/kernel/src/debug/sysfs/mod.rs
@@ -27,6 +27,7 @@ fn debugfs_init() -> Result<(), SystemError> {
     super::ext4::init_debugfs_ext4()?;
     super::fuse::init_debugfs_fuse()?;
     super::kthread::init_debugfs_kthread()?;
+    #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
     super::mm::init_debugfs_mm()?;
     super::page_cache::init_debugfs_page_cache()?;
     super::timekeeping::init_debugfs_timekeeping()?;

--- a/kernel/src/driver/base/block/disk_info.rs
+++ b/kernel/src/driver/base/block/disk_info.rs
@@ -56,10 +56,13 @@ impl TryInto<GeneralBlockRange> for Partition {
     type Error = SystemError;
 
     fn try_into(self) -> Result<GeneralBlockRange, Self::Error> {
-        if let Some(range) = GeneralBlockRange::new(
-            self.lba_start as usize,
-            (self.lba_start + self.sectors_num) as usize,
-        ) {
+        let start = usize::try_from(self.lba_start).map_err(|_| SystemError::EINVAL)?;
+        let end = self
+            .lba_start
+            .checked_add(self.sectors_num)
+            .and_then(|end| usize::try_from(end).ok())
+            .ok_or(SystemError::EINVAL)?;
+        if let Some(range) = GeneralBlockRange::new(start, end) {
             return Ok(range);
         } else {
             return Err(SystemError::EINVAL);

--- a/kernel/src/driver/base/block/gendisk/mod.rs
+++ b/kernel/src/driver/base/block/gendisk/mod.rs
@@ -2,7 +2,6 @@ use core::{
     convert::TryFrom,
     fmt::{Debug, Formatter},
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicU32, Ordering},
 };
 
 use alloc::{
@@ -401,30 +400,23 @@ impl DeviceINode for GenDisk {
 #[derive(Default)]
 pub struct GenDiskMap {
     data: HashMap<u32, Arc<GenDisk>>,
-    max_idx: AtomicU32,
 }
 
 impl GenDiskMap {
     pub fn new() -> Self {
         GenDiskMap {
             data: HashMap::new(),
-            max_idx: AtomicU32::new(1),
         }
     }
 
-    #[inline]
-    #[allow(dead_code)]
-    pub fn max_idx(&self) -> u32 {
-        self.max_idx.load(Ordering::SeqCst)
-    }
-
-    #[inline]
-    pub fn alloc_idx(&self) -> u32 {
-        self.max_idx.fetch_add(1, Ordering::SeqCst)
-    }
-
-    pub fn intersects(&self, range: &GeneralBlockRange) -> bool {
-        for (_, v) in self.iter() {
+    /// Check overlap between partitions.  The whole-disk entry intentionally
+    /// covers every partition and therefore does not participate in this
+    /// validation.
+    pub fn intersects_partition(&self, range: &GeneralBlockRange) -> bool {
+        for (idx, v) in self.iter() {
+            if *idx == GenDisk::ENTIRE_DISK_IDX {
+                continue;
+            }
             if range.intersects_with(&v.range()).is_some() {
                 return true;
             }

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -311,6 +311,49 @@ impl BlockDevManager {
         Ok(())
     }
 
+    /// Unpublish a block device after its hardware has irreversibly gone.
+    ///
+    /// Unlike [`Self::unregister`], this operation cannot be rolled back. It
+    /// removes every devfs node on a best-effort basis, then always drops the
+    /// manager's strong reference and metadata so stale open nodes can only
+    /// observe a dead weak device rather than keeping a controller alive.
+    pub fn unregister_detached(&self, dev: &Arc<dyn BlockDevice>) {
+        let gendisks = dev
+            .blkdev_meta()
+            .inner()
+            .gendisks
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
+
+        for gendisk in &gendisks {
+            match gendisk.dname() {
+                Ok(dname) => {
+                    if let Err(err) = devfs_unregister(dname.as_ref(), gendisk.clone()) {
+                        log::warn!(
+                            "Failed to remove detached block node {}: {:?}",
+                            dname.as_ref(),
+                            err
+                        );
+                    }
+                }
+                Err(err) => log::warn!(
+                    "Failed to resolve a detached block node for {}: {:?}",
+                    dev.dev_name().name(),
+                    err
+                ),
+            }
+        }
+
+        self.inner().disks.remove(dev.dev_name());
+        for gendisk in &gendisks {
+            if let Ok(dname) = gendisk.dname() {
+                self.emit_gendisk_uevent(dev, dname.as_ref(), "remove");
+            }
+        }
+        dev.blkdev_meta().inner().gendisks.clear();
+    }
+
     fn emit_gendisk_uevent(&self, dev: &Arc<dyn BlockDevice>, devname: &str, action: &str) {
         let kobj = dev.device() as Arc<dyn KObject>;
         let Ok(parent_devpath) = <dyn KObject>::devpath(&kobj) else {

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -100,14 +100,31 @@ impl BlockDevManager {
         &self,
         dev: &Arc<dyn BlockDevice>,
     ) -> Result<Vec<Arc<GenDisk>>, SystemError> {
-        if let Ok(gendisks) = self.prepare_gendisks_by_mbr(dev) {
-            if !gendisks.is_empty() {
-                return Ok(gendisks);
-            }
+        let disk_range = dev.disk_range();
+        // Linux publishes part0 (the whole-disk node) before scanning the
+        // partition table.  Keep that invariant here: a missing/malformed
+        // table or a media read error must not make the disk itself disappear.
+        let mut gendisks =
+            vec![self.create_gendisk_with_range(dev, disk_range, GenDisk::ENTIRE_DISK_IDX)];
+
+        // A zero-capacity device has no sector 0 to probe.  This is a normal
+        // state for an unbound loop device, so let the device reject I/O until
+        // media is attached.
+        if disk_range.len() == 0 {
+            return Ok(gendisks);
         }
 
-        let gendisks =
-            vec![self.create_gendisk_with_range(dev, dev.disk_range(), GenDisk::ENTIRE_DISK_IDX)];
+        match self.prepare_gendisks_by_mbr(dev) {
+            Ok(partitions) => gendisks.extend(partitions),
+            Err(SystemError::EINVAL | SystemError::EEXIST) => {}
+            Err(err) => {
+                log::warn!(
+                    "Failed to scan partitions on block device {}: {:?}",
+                    dev.dev_name().name(),
+                    err
+                );
+            }
+        }
         Ok(gendisks)
     }
 
@@ -118,8 +135,17 @@ impl BlockDevManager {
         let mbr = MbrDiskPartionTable::from_disk(dev.clone())?;
         let mut gendisks = Vec::new();
         for p in mbr.partitions_raw() {
-            let idx = dev.blkdev_meta().inner().gendisks.alloc_idx();
-            let range = p.try_into()?;
+            // MBR slots are numbered 1..=4.  Empty slots must not renumber
+            // later partitions (slot 2 is /dev/sda2, not /dev/sda1).
+            let idx = u32::from(p.partno) + 1;
+            let mut range: GeneralBlockRange = p.try_into()?;
+            let disk_range = dev.disk_range();
+            if range.lba_start >= disk_range.lba_end {
+                continue;
+            }
+            // Match Linux partition scanning: keep an in-range prefix rather
+            // than publishing I/O addresses beyond the end of the device.
+            range.lba_end = range.lba_end.min(disk_range.lba_end);
             if gendisks
                 .iter()
                 .any(|gendisk: &Arc<GenDisk>| gendisk.range().intersects_with(&range).is_some())
@@ -157,18 +183,24 @@ impl BlockDevManager {
         dev: &Arc<dyn BlockDevice>,
         gendisks: &[Arc<GenDisk>],
     ) -> Result<(), SystemError> {
-        let mut registered: Vec<Arc<GenDisk>> = Vec::new();
-        for gendisk in gendisks {
-            if let Err(e) = self.publish_gendisk(dev, gendisk.clone()) {
-                for rg in registered.into_iter() {
-                    if let Ok(name) = rg.dname() {
-                        let _ = devfs_unregister(name.as_ref(), rg.clone());
-                    }
-                    dev.blkdev_meta().inner().gendisks.remove(&rg.idx());
-                }
-                return Err(e);
+        let Some((whole_disk, partitions)) = gendisks.split_first() else {
+            return Err(SystemError::EINVAL);
+        };
+        debug_assert_eq!(whole_disk.idx(), GenDisk::ENTIRE_DISK_IDX);
+        self.publish_gendisk(dev, whole_disk.clone())?;
+
+        // Linux keeps part0 registered even if an individual partition cannot
+        // be added.  Partition nodes are therefore best-effort additions and
+        // must not roll back the usable whole-disk node.
+        for partition in partitions {
+            if let Err(err) = self.publish_gendisk(dev, partition.clone()) {
+                log::warn!(
+                    "Failed to publish partition {} on block device {}: {:?}",
+                    partition.idx(),
+                    dev.dev_name().name(),
+                    err
+                );
             }
-            registered.push(gendisk.clone());
         }
         Ok(())
     }
@@ -182,8 +214,10 @@ impl BlockDevManager {
         let idx = gendisk.idx();
         {
             let mut meta_inner = blk_meta.inner();
-            // 检查是否重复
-            if meta_inner.gendisks.intersects(&gendisk.range()) {
+            if meta_inner.gendisks.contains_key(&idx)
+                || (idx != GenDisk::ENTIRE_DISK_IDX
+                    && meta_inner.gendisks.intersects_partition(&gendisk.range()))
+            {
                 return Err(SystemError::EEXIST);
             }
 

--- a/kernel/src/driver/base/block/manager.rs
+++ b/kernel/src/driver/base/block/manager.rs
@@ -314,19 +314,15 @@ impl BlockDevManager {
     /// Unpublish a block device after its hardware has irreversibly gone.
     ///
     /// Unlike [`Self::unregister`], this operation cannot be rolled back. It
-    /// removes every devfs node on a best-effort basis, then always drops the
-    /// manager's strong reference and metadata so stale open nodes can only
-    /// observe a dead weak device rather than keeping a controller alive.
+    /// first detaches all gendisk metadata, removes every devfs node on a
+    /// best-effort basis, and then drops the manager's strong reference so
+    /// stale open nodes can only observe a dead weak device rather than keeping
+    /// a controller alive. The caller serializes this operation against block
+    /// publication and recoverable unregistration for the same device.
     pub fn unregister_detached(&self, dev: &Arc<dyn BlockDevice>) {
-        let gendisks = dev
-            .blkdev_meta()
-            .inner()
-            .gendisks
-            .values()
-            .cloned()
-            .collect::<Vec<_>>();
+        let gendisks = core::mem::take(&mut dev.blkdev_meta().inner().gendisks);
 
-        for gendisk in &gendisks {
+        for gendisk in gendisks.values() {
             match gendisk.dname() {
                 Ok(dname) => {
                     if let Err(err) = devfs_unregister(dname.as_ref(), gendisk.clone()) {
@@ -346,12 +342,11 @@ impl BlockDevManager {
         }
 
         self.inner().disks.remove(dev.dev_name());
-        for gendisk in &gendisks {
+        for gendisk in gendisks.values() {
             if let Ok(dname) = gendisk.dname() {
                 self.emit_gendisk_uevent(dev, dname.as_ref(), "remove");
             }
         }
-        dev.blkdev_meta().inner().gendisks.clear();
     }
 
     fn emit_gendisk_uevent(&self, dev: &Arc<dyn BlockDevice>, devname: &str, action: &str) {

--- a/kernel/src/driver/base/device/bus.rs
+++ b/kernel/src/driver/base/device/bus.rs
@@ -765,7 +765,7 @@ impl Attribute for DriverAttrUnbind {
         let dev = bus.find_device_by_name(s).ok_or(SystemError::ENODEV)?;
         let p = dev.driver().ok_or(SystemError::ENODEV)?;
         if Arc::ptr_eq(&p, &driver) {
-            device_manager().device_driver_detach(&dev)?;
+            device_manager().device_driver_detach(&dev, &driver)?;
             return Ok(buf.len());
         }
         return Err(SystemError::ENODEV);

--- a/kernel/src/driver/base/device/dd.rs
+++ b/kernel/src/driver/base/device/dd.rs
@@ -83,7 +83,6 @@ impl DeviceManager {
             if self.device_bind_driver(dev).is_ok() {
                 return Ok(true);
             } else {
-                dev.set_driver(None);
                 return Ok(false);
             }
         } else {
@@ -205,6 +204,34 @@ impl DeviceManager {
     ///
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/dd.c#496
     pub fn device_bind_driver(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
+        let expected_driver = dev.driver().ok_or(SystemError::ENODEV)?;
+        let lifecycle = self.lifecycle_lock(dev);
+        let _lifecycle_guard = lifecycle.lock();
+
+        let binding_is_current = dev
+            .driver()
+            .is_some_and(|driver| Arc::ptr_eq(&driver, &expected_driver));
+        if dev.is_dead()
+            || self.is_device_removing(dev)
+            || !dev.is_registered()
+            || !binding_is_current
+            || self.device_is_bound(dev)
+        {
+            return Err(SystemError::ENODEV);
+        }
+
+        let result = self.device_bind_driver_locked(dev);
+        if result.is_err()
+            && dev
+                .driver()
+                .is_some_and(|driver| Arc::ptr_eq(&driver, &expected_driver))
+        {
+            dev.set_driver(None);
+        }
+        result
+    }
+
+    fn device_bind_driver_locked(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
         let r = driver_manager().driver_sysfs_add(dev);
         if r.is_ok() {
             self.device_links_force_bind(dev);
@@ -349,7 +376,14 @@ impl DriverManager {
         driver: &Arc<dyn Driver>,
         device: &Arc<dyn Device>,
     ) -> Result<(), SystemError> {
-        let r = self.do_probe_device(driver, device);
+        let lifecycle = device_manager().lifecycle_lock(device);
+        let r = {
+            let _lifecycle_guard = lifecycle.lock();
+            // All eligibility checks in do_probe_device() deliberately happen after taking this
+            // lock.  A concurrent unbind or device removal therefore either runs wholly before
+            // probe starts or waits until really_probe() has committed/rolled back completely.
+            self.do_probe_device(driver, device)
+        };
         PROBE_WAIT_QUEUE.wakeup_all(None);
         return r;
     }
@@ -429,6 +463,35 @@ impl DriverManager {
             bind_failed();
             e
         })?;
+
+        // Driver callbacks may publish private resources.  Before publishing the core binding,
+        // verify the device/driver relationship once more at the commit point.  Concurrent core
+        // removal cannot change these fields while the lifecycle lock is held, but this check also
+        // turns an invalid callback-side mutation into a complete rollback instead of allowing a
+        // later driver_bound() unwrap or a ghost binding.
+        let binding_is_current = device
+            .driver()
+            .is_some_and(|bound| Arc::ptr_eq(&bound, driver));
+        if device.is_dead()
+            || device_manager().is_device_removing(device)
+            || !device.is_registered()
+            || !binding_is_current
+        {
+            warn!(
+                "really_probe: device '{}' changed state before binding commit",
+                device.name()
+            );
+
+            // Bus remove resolves the callback through device.driver().  Restore the driver which
+            // performed this probe before invoking rollback so the correct remove callback owns
+            // cleanup even if a broken probe callback altered the field.
+            device.set_driver(Some(Arc::downgrade(driver)));
+            remove_probed_driver();
+            remove_driver_sysfs();
+            sysfs_failed();
+            bind_failed();
+            return Err(SystemError::ENODEV);
+        }
 
         device_manager()
             .add_groups(device, driver.dev_groups())

--- a/kernel/src/driver/base/device/dd.rs
+++ b/kernel/src/driver/base/device/dd.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         vfs::InodeMode,
     },
-    libs::wait_queue::WaitQueue,
+    libs::{spinlock::SpinLock, wait_queue::WaitQueue},
 };
 use system_error::SystemError;
 
@@ -23,7 +23,65 @@ use super::{
     Device, DeviceManager,
 };
 
-static PROBE_WAIT_QUEUE: WaitQueue = WaitQueue::default();
+static BINDING_WAIT_QUEUE: WaitQueue = WaitQueue::default();
+static BINDING_GATE: SpinLock<BindingGateState> = SpinLock::new(BindingGateState {
+    blocked: false,
+    active: 0,
+});
+
+#[derive(Debug)]
+struct BindingGateState {
+    blocked: bool,
+    active: usize,
+}
+
+/// Admission ticket for operations which can publish a driver binding.
+///
+/// The gate is global because one probe can register child devices.  Shutdown
+/// must drain all admitted binding operations before it snapshots the reverse
+/// registration order from the devices kset.
+struct BindingTicket;
+
+impl BindingTicket {
+    fn acquire() -> Result<Self, SystemError> {
+        let mut gate = BINDING_GATE.lock();
+        if gate.blocked {
+            return Err(SystemError::ENODEV);
+        }
+        gate.active = gate
+            .active
+            .checked_add(1)
+            .expect("active driver binding count overflow");
+        Ok(Self)
+    }
+}
+
+impl Drop for BindingTicket {
+    fn drop(&mut self) {
+        let wake_waiters = {
+            let mut gate = BINDING_GATE.lock();
+            gate.active = gate
+                .active
+                .checked_sub(1)
+                .expect("active driver binding count underflow");
+            gate.active == 0
+        };
+        if wake_waiters {
+            BINDING_WAIT_QUEUE.wakeup_all(None);
+        }
+    }
+}
+
+/// Permanently reject new bindings and wait for every admitted operation to
+/// finish.  Shutdown is a terminal transition, so no unblock operation is
+/// exposed until DragonOS has suspend/resume probing semantics which need one.
+pub(super) fn block_device_bindings_and_wait() {
+    BINDING_GATE.lock().blocked = true;
+    BINDING_WAIT_QUEUE.wait_until(|| {
+        let gate = BINDING_GATE.lock();
+        (gate.active == 0).then_some(())
+    });
+}
 
 impl DeviceManager {
     /// 尝试把一个设备与一个驱动匹配
@@ -208,20 +266,23 @@ impl DeviceManager {
         let lifecycle = self.lifecycle_lock(dev);
         let _lifecycle_guard = lifecycle.lock();
 
-        let binding_is_current = dev
-            .driver()
-            .is_some_and(|driver| Arc::ptr_eq(&driver, &expected_driver));
-        if dev.is_dead()
-            || self.is_device_removing(dev)
-            || !dev.is_registered()
-            || !binding_is_current
-            || self.device_is_bound(dev)
-        {
-            return Err(SystemError::ENODEV);
-        }
+        let result = BindingTicket::acquire().and_then(|_binding_ticket| {
+            let binding_is_current = dev
+                .driver()
+                .is_some_and(|driver| Arc::ptr_eq(&driver, &expected_driver));
+            if dev.is_dead()
+                || self.is_device_removing(dev)
+                || !dev.is_registered()
+                || !binding_is_current
+                || self.device_is_bound(dev)
+            {
+                return Err(SystemError::ENODEV);
+            }
 
-        let result = self.device_bind_driver_locked(dev);
+            self.device_bind_driver_locked(dev)
+        });
         if result.is_err()
+            && !self.device_is_bound(dev)
             && dev
                 .driver()
                 .is_some_and(|driver| Arc::ptr_eq(&driver, &expected_driver))
@@ -379,12 +440,12 @@ impl DriverManager {
         let lifecycle = device_manager().lifecycle_lock(device);
         let r = {
             let _lifecycle_guard = lifecycle.lock();
+            let _binding_ticket = BindingTicket::acquire()?;
             // All eligibility checks in do_probe_device() deliberately happen after taking this
             // lock.  A concurrent unbind or device removal therefore either runs wholly before
             // probe starts or waits until really_probe() has committed/rolled back completely.
             self.do_probe_device(driver, device)
         };
-        PROBE_WAIT_QUEUE.wakeup_all(None);
         return r;
     }
 
@@ -669,12 +730,13 @@ impl DriverManager {
 
     fn driver_is_bound(&self, device: &Arc<dyn Device>) -> bool {
         if let Some(driver) = device.driver() {
-            if driver.find_device_by_name(&device.name()).is_some() {
-                return true;
-            }
+            return driver
+                .devices()
+                .iter()
+                .any(|bound| Arc::ptr_eq(bound, device));
         }
 
-        return false;
+        false
     }
 }
 

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -35,7 +35,7 @@ use system_error::SystemError;
 
 use self::{
     bus::{bus_add_device, bus_probe_device, Bus, BusNotifyEvent},
-    dd::{DeviceAttrCoredump, DeviceAttrStateSynced},
+    dd::{block_device_bindings_and_wait, DeviceAttrCoredump, DeviceAttrStateSynced},
     device_number::{DeviceNumber, Major},
     driver::Driver,
 };
@@ -1357,6 +1357,11 @@ pub fn device_unregister<T: Device + 'static>(device: Arc<T>) {
 ///
 /// 参考: https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/core.c#4611
 pub fn device_shutdown() {
+    // Stabilize the reverse-registration order before removing the first
+    // device from the kset.  In particular, an admitted controller probe may
+    // still register child disks which must be shut down before their parent.
+    block_device_bindings_and_wait();
+
     let devices_kset = sys_devices_kset();
 
     loop {
@@ -1375,8 +1380,16 @@ pub fn device_shutdown() {
             }
         };
 
-        if let Some(dev_bus) = dev.bus().and_then(|bus| bus.upgrade()) {
-            dev_bus.shutdown(&dev);
+        let lifecycle = device_manager().lifecycle_lock(&dev);
+        let _lifecycle_guard = lifecycle.lock();
+
+        // The driver pointer is assigned before probe runs, while the reverse
+        // driver->device relation is published only after a successful commit.
+        // Never call shutdown on a preset or partially initialized driver.
+        if dev.is_registered() && device_manager().device_is_bound(&dev) {
+            if let Some(dev_bus) = dev.bus().and_then(|bus| bus.upgrade()) {
+                dev_bus.shutdown(&dev);
+            }
         }
     }
 }

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -23,6 +23,7 @@ use crate::{
         vfs::InodeMode,
     },
     libs::{
+        mutex::Mutex,
         rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::{SpinLock, SpinLockGuard},
     },
@@ -73,6 +74,21 @@ lazy_static! {
     pub static ref DEVMAP: Arc<LockedKObjMap> = Arc::new(LockedKObjMap::default());
 
     static ref REMOVING_DEVICES: SpinLock<Vec<Weak<dyn Device>>> = SpinLock::new(Vec::new());
+
+    /// Serializes probe, unbind and removal for each device.
+    ///
+    /// Device implementations currently keep [`DeviceCommonData`] behind their own locks, so the
+    /// driver core cannot borrow a sleeping lock from that data without changing every device
+    /// type.  Keep the lock in the core, keyed by the allocation identity of the device instead.
+    /// The weak reference prevents this table from extending a device's lifetime.
+    static ref DEVICE_LIFECYCLE_LOCKS: Mutex<BTreeMap<usize, DeviceLifecycleLock>> =
+        Mutex::new(BTreeMap::new());
+}
+
+#[derive(Debug)]
+struct DeviceLifecycleLock {
+    device: Weak<dyn Device>,
+    lock: Arc<Mutex<()>>,
 }
 
 /// `/sys/devices` 的 kset 实例
@@ -557,6 +573,43 @@ impl DeviceManager {
         return Self;
     }
 
+    /// Return the sleeping lock which serializes binding lifecycle operations for `dev`.
+    ///
+    /// The erased data pointer is stable for the lifetime of an `Arc`.  We still validate the weak
+    /// reference with `Arc::ptr_eq` so a stale entry can never be reused after allocator address
+    /// reuse.
+    pub(super) fn lifecycle_lock(&self, dev: &Arc<dyn Device>) -> Arc<Mutex<()>> {
+        let identity = Arc::as_ptr(dev) as *const () as usize;
+        let mut locks = DEVICE_LIFECYCLE_LOCKS.lock();
+
+        if let Some(entry) = locks.get(&identity) {
+            if entry
+                .device
+                .upgrade()
+                .is_some_and(|registered| Arc::ptr_eq(&registered, dev))
+            {
+                return entry.lock.clone();
+            }
+        }
+
+        // Keep dead device identities from accumulating forever without making every lookup
+        // linear in the number of devices.  Live entries must stay: callers which already cloned
+        // their lock must continue to rendezvous with later lifecycle operations.
+        if locks.len() >= 64 {
+            locks.retain(|_, entry| entry.device.strong_count() != 0);
+        }
+
+        let lock = Arc::new(Mutex::new(()));
+        locks.insert(
+            identity,
+            DeviceLifecycleLock {
+                device: Arc::downgrade(dev),
+                lock: lock.clone(),
+            },
+        );
+        lock
+    }
+
     pub fn register(&self, device: Arc<dyn Device>) -> Result<(), SystemError> {
         self.device_default_initialize(&device);
         return self.add_device(device);
@@ -782,6 +835,11 @@ impl DeviceManager {
     /// - drivers/base/bus.c:bus_remove_device()
     #[inline(never)]
     pub fn remove(&self, dev: &Arc<dyn Device>) {
+        let lifecycle = self.lifecycle_lock(dev);
+        let _lifecycle_guard = lifecycle.lock();
+
+        // Probe and remove use the same lifecycle lock.  All state must be checked after taking it
+        // because either operation may have completed while this caller was sleeping.
         if !dev.is_registered() {
             return;
         }
@@ -790,8 +848,11 @@ impl DeviceManager {
             return;
         }
 
-        if self.device_is_bound(dev) {
-            if let Err(err) = self.release_driver(dev) {
+        // `device_is_bound()` becomes true only after driver_bound().  Looking only at that list
+        // used to miss the interval where really_probe() had set dev.driver but had not published
+        // the reverse driver->device link yet.
+        if dev.driver().is_some() {
+            if let Err(err) = self.release_driver_locked(dev) {
                 warn!(
                     "skip removing bound device '{}': driver detach failed: {:?}",
                     dev.name(),
@@ -1104,7 +1165,11 @@ impl DeviceManager {
         sysfs_instance().remove_link(&driver_kobj, dev.name());
     }
 
-    fn release_driver(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
+    /// Release a bound driver while the caller holds this device's lifecycle lock.
+    ///
+    /// Keep this separate from the public locking entry point: `remove()` already owns the lock
+    /// and recursively acquiring a sleeping mutex would deadlock.
+    fn release_driver_locked(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
         let driver = dev.driver().ok_or(SystemError::ENODEV)?;
         let bus = dev
             .bus()
@@ -1256,8 +1321,21 @@ impl DeviceManager {
     }
 
     /// 参考 https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/base/dd.c?r=&mo=35401&fi=1313#1313
-    pub fn device_driver_detach(&self, dev: &Arc<dyn Device>) -> Result<(), SystemError> {
-        self.release_driver(dev)
+    pub fn device_driver_detach(
+        &self,
+        dev: &Arc<dyn Device>,
+        expected_driver: &Arc<dyn Driver>,
+    ) -> Result<(), SystemError> {
+        let lifecycle = self.lifecycle_lock(dev);
+        let _lifecycle_guard = lifecycle.lock();
+
+        // The driver observed by the sysfs caller may have changed while it waited for an active
+        // probe.  Never let an unbind request for one driver detach a later binding to another.
+        let current_driver = dev.driver().ok_or(SystemError::ENODEV)?;
+        if !Arc::ptr_eq(&current_driver, expected_driver) {
+            return Err(SystemError::ENODEV);
+        }
+        self.release_driver_locked(dev)
     }
 }
 

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -81,8 +81,42 @@ lazy_static! {
     /// driver core cannot borrow a sleeping lock from that data without changing every device
     /// type.  Keep the lock in the core, keyed by the allocation identity of the device instead.
     /// The weak reference prevents this table from extending a device's lifetime.
-    static ref DEVICE_LIFECYCLE_LOCKS: Mutex<BTreeMap<usize, DeviceLifecycleLock>> =
-        Mutex::new(BTreeMap::new());
+    static ref DEVICE_LIFECYCLE_LOCKS: Mutex<DeviceLifecycleLocks> =
+        Mutex::new(DeviceLifecycleLocks::new());
+}
+
+const LIFECYCLE_LOCK_CLEANUP_MIN_INSERTIONS: usize = 64;
+
+#[derive(Debug)]
+struct DeviceLifecycleLocks {
+    entries: BTreeMap<usize, DeviceLifecycleLock>,
+    insertions_until_cleanup: usize,
+}
+
+impl DeviceLifecycleLocks {
+    fn new() -> Self {
+        Self {
+            entries: BTreeMap::new(),
+            insertions_until_cleanup: LIFECYCLE_LOCK_CLEANUP_MIN_INSERTIONS,
+        }
+    }
+
+    fn insert(&mut self, identity: usize, entry: DeviceLifecycleLock) {
+        self.entries.insert(identity, entry);
+        debug_assert!(self.insertions_until_cleanup > 0);
+        self.insertions_until_cleanup -= 1;
+
+        if self.insertions_until_cleanup == 0 {
+            self.entries
+                .retain(|_, entry| entry.device.strong_count() != 0);
+            // Scan at most once per current table size.  This keeps cleanup work amortized while
+            // still reclaiming dead identities in workloads which repeatedly create devices.
+            self.insertions_until_cleanup = self
+                .entries
+                .len()
+                .max(LIFECYCLE_LOCK_CLEANUP_MIN_INSERTIONS);
+        }
+    }
 }
 
 #[derive(Debug)]
@@ -582,7 +616,7 @@ impl DeviceManager {
         let identity = Arc::as_ptr(dev) as *const () as usize;
         let mut locks = DEVICE_LIFECYCLE_LOCKS.lock();
 
-        if let Some(entry) = locks.get(&identity) {
+        if let Some(entry) = locks.entries.get(&identity) {
             if entry
                 .device
                 .upgrade()
@@ -590,13 +624,6 @@ impl DeviceManager {
             {
                 return entry.lock.clone();
             }
-        }
-
-        // Keep dead device identities from accumulating forever without making every lookup
-        // linear in the number of devices.  Live entries must stay: callers which already cloned
-        // their lock must continue to rendezvous with later lifecycle operations.
-        if locks.len() >= 64 {
-            locks.retain(|_, entry| entry.device.strong_count() != 0);
         }
 
         let lock = Arc::new(Mutex::new(()));

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -1,5 +1,4 @@
-use super::{hba::HbaCmdTable, AhciController, AhciIdentify};
-use crate::arch::MMArch;
+use super::{AhciController, AhciIdentify};
 use crate::driver::base::block::block_device::{BlockDevice, BlockId, GeneralBlockRange};
 use crate::driver::base::block::disk_info::Partition;
 use crate::driver::base::block::manager::BlockDevMeta;
@@ -22,7 +21,7 @@ use crate::driver::disk::ahci::hba::{
 };
 use crate::libs::mutex::{Mutex, MutexGuard};
 use crate::libs::rwsem::{RwSemReadGuard, RwSemWriteGuard};
-use crate::mm::{dma::DmaDirection, MemoryManagementArch, PhysAddr};
+use crate::mm::dma::DmaDirection;
 use log::error;
 use system_error::SystemError;
 
@@ -56,6 +55,7 @@ pub struct LockedAhciDisk {
     capacity_lba: usize,
     flush_command: Option<u8>,
     reliable_flush: bool,
+    identify: AhciIdentify,
 }
 
 impl LockedAhciDisk {
@@ -70,6 +70,14 @@ impl LockedAhciDisk {
     pub(crate) fn teardown_flush_command(&self) -> Option<(usize, u8)> {
         self.flush_command
             .map(|command| (self.port_num as usize, command))
+    }
+
+    pub(crate) fn port_num(&self) -> usize {
+        self.port_num as usize
+    }
+
+    pub(crate) fn matches_identify(&self, identify: AhciIdentify) -> bool {
+        self.identify.has_stable_identity() && self.identify == identify
     }
 }
 
@@ -119,14 +127,12 @@ impl LockedAhciDisk {
             return Err(SystemError::EIO);
         }
 
-        let clb = volatile_read!(port.clb);
-        let cmdheader: &mut HbaCmdHeader = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(
-                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ))
-            .ok_or(SystemError::EFAULT)?
-            .data() as *mut HbaCmdHeader)
-        };
+        let (cmdheader, cmdtbl) = self.controller.command_slot_ptrs(
+            self.port_num as usize,
+            slot,
+            volatile_read!(port.clb),
+        )?;
+        let cmdheader: &mut HbaCmdHeader = unsafe { &mut *cmdheader };
 
         cmdheader.cfl = (size_of::<FisRegH2D>() / size_of::<u32>()) as u8;
         volatile_write!(cmdheader._pm, 0);
@@ -139,12 +145,7 @@ impl LockedAhciDisk {
             .allocate_dma(count * 512, DmaDirection::FromDevice)?;
         let mut buf_paddr = dma.paddr();
 
-        let ctba = volatile_read!(cmdheader.ctba);
-        let cmdtbl = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
-                .ok_or(SystemError::EFAULT)?
-                .data() as *mut HbaCmdTable)
-        };
+        let cmdtbl = unsafe { &mut *cmdtbl };
         let mut tmp_count = count;
 
         unsafe {
@@ -187,8 +188,10 @@ impl LockedAhciDisk {
 
         volatile_write!(cmdfis.device, 1 << 6); // LBA Mode
 
-        AhciController::wait_tfd_ready(port)?;
+        self.controller
+            .wait_tfd_ready_or_recover(self.port_num as usize)?;
 
+        let port = unsafe { &mut *self.controller.port_ptr(self.port_num as usize) };
         compiler_fence(Ordering::Release);
         volatile_set_bit!(port.ci, 1 << slot, true); // Issue command
                                                      // debug!("To wait ahci read complete.");
@@ -245,14 +248,12 @@ impl LockedAhciDisk {
         }
 
         compiler_fence(Ordering::SeqCst);
-        let clb = volatile_read!(port.clb);
-        let cmdheader: &mut HbaCmdHeader = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(
-                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ))
-            .ok_or(SystemError::EFAULT)?
-            .data() as *mut HbaCmdHeader)
-        };
+        let (cmdheader, cmdtbl) = self.controller.command_slot_ptrs(
+            self.port_num as usize,
+            slot,
+            volatile_read!(port.clb),
+        )?;
+        let cmdheader: &mut HbaCmdHeader = unsafe { &mut *cmdheader };
         compiler_fence(Ordering::SeqCst);
 
         // DW0: CFL in bits 0..4, W in bit 6. This is an ATA write, not ATAPI.
@@ -272,12 +273,7 @@ impl LockedAhciDisk {
         dma.as_mut_slice()[..count * 512].copy_from_slice(&buf[..count * 512]);
         let mut buf_paddr = dma.paddr();
 
-        let ctba = volatile_read!(cmdheader.ctba);
-        let cmdtbl = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
-                .ok_or(SystemError::EFAULT)?
-                .data() as *mut HbaCmdTable)
-        };
+        let cmdtbl = unsafe { &mut *cmdtbl };
         let mut tmp_count = count;
         compiler_fence(Ordering::SeqCst);
 
@@ -323,7 +319,9 @@ impl LockedAhciDisk {
 
         volatile_write!(cmdfis.device, 1 << 6); // LBA Mode
 
-        AhciController::wait_tfd_ready(port)?;
+        self.controller
+            .wait_tfd_ready_or_recover(self.port_num as usize)?;
+        let port = unsafe { &mut *self.controller.port_ptr(self.port_num as usize) };
         compiler_fence(Ordering::Release);
         volatile_set_bit!(port.ci, 1 << slot, true); // Issue command
 
@@ -381,6 +379,7 @@ impl LockedAhciDisk {
             capacity_lba: identify.capacity_lba,
             flush_command: identify.flush_command,
             reliable_flush: identify.reliable_flush,
+            identify,
         });
         return Ok(result);
     }

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -67,12 +67,9 @@ impl LockedAhciDisk {
         self.flush_command.is_some()
     }
 
-    pub(crate) fn flush_for_teardown(&self) -> Result<(), SystemError> {
-        let Some(command) = self.flush_command else {
-            return Ok(());
-        };
-        self.controller
-            .flush_port(self.port_num as usize, command, true)
+    pub(crate) fn teardown_flush_command(&self) -> Option<(usize, u8)> {
+        self.flush_command
+            .map(|command| (self.port_num as usize, command))
     }
 }
 
@@ -198,7 +195,7 @@ impl LockedAhciDisk {
                                                      // 等待操作完成
         if let Err(err) = AhciController::wait_slot(port, slot) {
             self.controller
-                .abort_failed_dma(self.port_num as usize, dma);
+                .abort_failed_command(self.port_num as usize, Some(dma));
             return Err(err);
         }
         compiler_fence(Ordering::Acquire);
@@ -333,7 +330,7 @@ impl LockedAhciDisk {
         // 等待操作完成
         if let Err(err) = AhciController::wait_slot(port, slot) {
             self.controller
-                .abort_failed_dma(self.port_num as usize, dma);
+                .abort_failed_command(self.port_num as usize, Some(dma));
             return Err(err);
         }
         compiler_fence(Ordering::Acquire);
@@ -350,8 +347,7 @@ impl LockedAhciDisk {
         let Some(command) = self.flush_command else {
             return Ok(());
         };
-        self.controller
-            .flush_port(self.port_num as usize, command, false)
+        self.controller.flush_port(self.port_num as usize, command)
     }
 }
 

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -55,6 +55,7 @@ pub struct LockedAhciDisk {
     port_num: u8,
     capacity_lba: usize,
     flush_command: Option<u8>,
+    reliable_flush: bool,
     open_count: AtomicU32,
     mount_holder_count: AtomicU32,
 }
@@ -350,9 +351,12 @@ impl LockedAhciDisk {
     }
 
     fn sync_disk(&self) -> Result<(), SystemError> {
-        let command = self
-            .flush_command
-            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        // If IDENTIFY selected no flush command, completed DMA writes are still
+        // successful; only the power-loss durability guarantee is unavailable,
+        // which `supports_reliable_flush()` reports separately to filesystems.
+        let Some(command) = self.flush_command else {
+            return Ok(());
+        };
         self.controller
             .flush_port(self.port_num as usize, command, false)
     }
@@ -387,6 +391,7 @@ impl LockedAhciDisk {
             port_num,
             capacity_lba: identify.capacity_lba,
             flush_command: identify.flush_command,
+            reliable_flush: identify.reliable_flush,
             open_count: AtomicU32::new(0),
             mount_holder_count: AtomicU32::new(0),
         });
@@ -576,7 +581,7 @@ impl BlockDevice for LockedAhciDisk {
     }
 
     fn supports_reliable_flush(&self) -> bool {
-        self.flush_command.is_some()
+        self.reliable_flush
     }
 
     #[inline]

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -195,7 +195,7 @@ impl LockedAhciDisk {
                                                      // 等待操作完成
         if let Err(err) = AhciController::wait_slot(port, slot) {
             self.controller
-                .abort_failed_command(self.port_num as usize, Some(dma));
+                .recover_or_fail_command(self.port_num as usize, Some(dma));
             return Err(err);
         }
         compiler_fence(Ordering::Acquire);
@@ -330,7 +330,7 @@ impl LockedAhciDisk {
         // 等待操作完成
         if let Err(err) = AhciController::wait_slot(port, slot) {
             self.controller
-                .abort_failed_command(self.port_num as usize, Some(dma));
+                .recover_or_fail_command(self.port_num as usize, Some(dma));
             return Err(err);
         }
         compiler_fence(Ordering::Acquire);

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -1,4 +1,4 @@
-use super::{_port, hba::HbaCmdTable};
+use super::{hba::HbaCmdTable, AhciController, AhciIdentify};
 use crate::arch::MMArch;
 use crate::driver::base::block::block_device::{BlockDevice, BlockId, GeneralBlockRange};
 use crate::driver::base::block::disk_info::Partition;
@@ -8,30 +8,30 @@ use crate::driver::base::device::bus::Bus;
 
 use crate::driver::base::device::device_number::Major;
 use crate::driver::base::device::driver::Driver;
-use crate::driver::base::device::{DevName, Device, DeviceType, IdTable};
-use crate::driver::base::kobject::{KObjType, KObject, KObjectState};
+use crate::driver::base::device::{DevName, Device, DeviceCommonData, DeviceType, IdTable};
+use crate::driver::base::kobject::{
+    KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState,
+};
 use crate::driver::base::kset::KSet;
-use crate::driver::disk::ahci::HBA_PxIS_TFES;
-
 use crate::driver::scsi::scsi_manager;
 use crate::filesystem::kernfs::KernFSInode;
-use crate::filesystem::mbr::MbrDiskPartionTable;
+use crate::filesystem::vfs::{file::FileFlags, FilePrivateData};
 
 use crate::driver::disk::ahci::hba::{
-    FisRegH2D, FisType, HbaCmdHeader, ATA_CMD_READ_DMA_EXT, ATA_CMD_WRITE_DMA_EXT, ATA_DEV_BUSY,
-    ATA_DEV_DRQ,
+    FisRegH2D, FisType, HbaCmdHeader, ATA_CMD_READ_DMA_EXT, ATA_CMD_WRITE_DMA_EXT,
 };
+use crate::libs::mutex::{Mutex, MutexGuard};
 use crate::libs::rwsem::{RwSemReadGuard, RwSemWriteGuard};
-use crate::libs::spinlock::{SpinLock, SpinLockGuard};
-use crate::mm::{access_ok, MemoryManagementArch, PhysAddr, VirtAddr};
+use crate::mm::{dma::DmaDirection, MemoryManagementArch, PhysAddr};
 use log::error;
 use system_error::SystemError;
 
+use alloc::string::ToString;
 use alloc::sync::Weak;
 use alloc::{sync::Arc, vec::Vec};
 
 use core::fmt::Debug;
-use core::sync::atomic::{compiler_fence, Ordering};
+use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
 use core::{mem::size_of, ptr::write_bytes};
 
 /// @brief: 只支持MBR分区格式的磁盘结构体
@@ -39,8 +39,8 @@ pub struct AhciDisk {
     // 磁盘的状态flags
     pub partitions: Vec<Arc<Partition>>, // 磁盘分区数组
     // port: &'static mut HbaPort,      // 控制硬盘的端口
-    pub ctrl_num: u8,
-    pub port_num: u8,
+    device_common: DeviceCommonData,
+    kobject_common: KObjectCommonData,
     /// 指向LockAhciDisk的弱引用
     self_ref: Weak<LockedAhciDisk>,
 }
@@ -49,12 +49,36 @@ pub struct AhciDisk {
 #[derive(Debug)]
 pub struct LockedAhciDisk {
     blkdev_meta: BlockDevMeta,
-    inner: SpinLock<AhciDisk>,
+    inner: Mutex<AhciDisk>,
+    kobj_state: LockedKObjectState,
+    controller: Arc<AhciController>,
+    port_num: u8,
+    capacity_lba: usize,
+    flush_command: Option<u8>,
+    open_count: AtomicU32,
+    mount_holder_count: AtomicU32,
 }
 
 impl LockedAhciDisk {
-    pub fn inner(&self) -> SpinLockGuard<'_, AhciDisk> {
+    pub fn inner(&self) -> MutexGuard<'_, AhciDisk> {
         self.inner.lock()
+    }
+
+    pub(crate) fn has_holders(&self) -> bool {
+        self.open_count.load(Ordering::Acquire) != 0
+            || self.mount_holder_count.load(Ordering::Acquire) != 0
+    }
+
+    pub(crate) fn needs_flush(&self) -> bool {
+        self.flush_command.is_some()
+    }
+
+    pub(crate) fn flush_for_teardown(&self) -> Result<(), SystemError> {
+        let Some(command) = self.flush_command else {
+            return Ok(());
+        };
+        self.controller
+            .flush_port(self.port_num as usize, command, true)
     }
 }
 
@@ -65,74 +89,70 @@ impl Debug for AhciDisk {
     }
 }
 
-impl AhciDisk {
+impl LockedAhciDisk {
     fn read_at(
         &self,
         lba_id_start: BlockId, // 起始lba编号
         count: usize,          // 读取lba的数量
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
-        assert!((buf.len() & 511) == 0);
+        if count == 0 {
+            return Ok(0);
+        }
+        if buf.len() & 511 != 0 {
+            return Err(SystemError::EINVAL);
+        }
         compiler_fence(Ordering::SeqCst);
         let check_length = ((count - 1) >> 4) + 1; // prdt length
-        if count * 512 > buf.len() || check_length > 8_usize {
+        if count.checked_mul(512).ok_or(SystemError::EOVERFLOW)? > buf.len()
+            || lba_id_start
+                .checked_add(count)
+                .ok_or(SystemError::EOVERFLOW)?
+                > self.capacity_lba
+            || check_length > 8_usize
+        {
             error!("ahci read: e2big");
             // 不可能的操作
             return Err(SystemError::E2BIG);
-        } else if count == 0 {
-            return Ok(0);
         }
+        let _port_guard = self.controller.lock_port_for_io(self.port_num as usize)?;
 
-        let port = _port(self.ctrl_num, self.port_num);
+        let port = unsafe { &mut *self.controller.port_ptr(self.port_num as usize) };
         volatile_write!(port.is, u32::MAX); // Clear pending interrupt bits
 
-        let slot = port.find_cmdslot().unwrap_or(u32::MAX);
+        let slot = port
+            .find_cmdslot(self.controller.command_slots)
+            .unwrap_or(u32::MAX);
 
         if slot == u32::MAX {
             return Err(SystemError::EIO);
         }
 
-        #[allow(unused_unsafe)]
+        let clb = volatile_read!(port.clb);
         let cmdheader: &mut HbaCmdHeader = unsafe {
-            (MMArch::phys_2_virt(PhysAddr::new(
-                volatile_read!(port.clb) as usize + slot as usize * size_of::<HbaCmdHeader>(),
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(
+                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
             ))
-            .unwrap()
+            .ok_or(SystemError::EFAULT)?
             .data() as *mut HbaCmdHeader)
-                .as_mut()
-                .unwrap()
         };
 
         cmdheader.cfl = (size_of::<FisRegH2D>() / size_of::<u32>()) as u8;
-
-        volatile_set_bit!(cmdheader.cfl, 1 << 6, false); //  Read/Write bit : Read from device
+        volatile_write!(cmdheader._pm, 0);
+        volatile_write!(cmdheader._prdbc, 0);
         volatile_write!(cmdheader.prdtl, check_length as u16); // PRDT entries count
 
         // 设置数据存放地址
-        let mut buf_ptr = buf as *mut [u8] as *mut usize as usize;
+        let mut dma = self
+            .controller
+            .allocate_dma(count * 512, DmaDirection::FromDevice)?;
+        let mut buf_paddr = dma.paddr();
 
-        // 由于目前的内存管理机制无法把用户空间的内存地址转换为物理地址，所以只能先把数据拷贝到内核空间
-        // TODO：在内存管理重构后，可以直接使用用户空间的内存地址
-
-        let user_buf = access_ok(VirtAddr::new(buf_ptr), buf.len()).is_ok();
-        let mut kbuf = if user_buf {
-            let x: Vec<u8> = vec![0; buf.len()];
-            Some(x)
-        } else {
-            None
-        };
-
-        if let Some(buf) = &mut kbuf {
-            buf_ptr = buf.as_mut_ptr() as usize;
-        }
-
-        #[allow(unused_unsafe)]
+        let ctba = volatile_read!(cmdheader.ctba);
         let cmdtbl = unsafe {
-            (MMArch::phys_2_virt(PhysAddr::new(volatile_read!(cmdheader.ctba) as usize))
-                .unwrap()
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
+                .ok_or(SystemError::EFAULT)?
                 .data() as *mut HbaCmdTable)
-                .as_mut()
-                .unwrap() // 必须使用 as_mut ，得到的才是原来的变量
         };
         let mut tmp_count = count;
 
@@ -144,32 +164,22 @@ impl AhciDisk {
 
         // 8K bytes (16 sectors) per PRDT
         for i in 0..((volatile_read!(cmdheader.prdtl) - 1) as usize) {
-            volatile_write!(
-                cmdtbl.prdt_entry[i].dba,
-                MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
-            );
+            volatile_write!(cmdtbl.prdt_entry[i].dba, buf_paddr as u64);
             cmdtbl.prdt_entry[i].dbc = 8 * 1024 - 1;
             volatile_set_bit!(cmdtbl.prdt_entry[i].dbc, 1 << 31, true); // 允许中断 prdt_entry.i
-            buf_ptr += 8 * 1024;
+            buf_paddr += 8 * 1024;
             tmp_count -= 16;
         }
 
         // Last entry
         let las = (volatile_read!(cmdheader.prdtl) - 1) as usize;
-        volatile_write!(
-            cmdtbl.prdt_entry[las].dba,
-            MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
-        );
+        volatile_write!(cmdtbl.prdt_entry[las].dba, buf_paddr as u64);
         cmdtbl.prdt_entry[las].dbc = ((tmp_count << 9) - 1) as u32; // 数据长度
 
         volatile_set_bit!(cmdtbl.prdt_entry[las].dbc, 1 << 31, true); // 允许中断
 
         // 设置命令
-        let cmdfis = unsafe {
-            ((&mut cmdtbl.cfis) as *mut [u8] as *mut usize as *mut FisRegH2D)
-                .as_mut()
-                .unwrap()
-        };
+        let cmdfis = unsafe { &mut *(cmdtbl.cfis.as_mut_ptr() as *mut FisRegH2D) };
         volatile_write!(cmdfis.fis_type, FisType::RegH2D as u8);
         volatile_set_bit!(cmdfis.pm, 1 << 7, true); // command_bit set
         volatile_write!(cmdfis.command, ATA_CMD_READ_DMA_EXT);
@@ -186,36 +196,19 @@ impl AhciDisk {
 
         volatile_write!(cmdfis.device, 1 << 6); // LBA Mode
 
-        // 等待之前的操作完成
-        let mut spin_count = 0;
-        const SPIN_LIMIT: u32 = 10000;
+        AhciController::wait_tfd_ready(port)?;
 
-        while (volatile_read!(port.tfd) as u8 & (ATA_DEV_BUSY | ATA_DEV_DRQ)) > 0
-            && spin_count < SPIN_LIMIT
-        {
-            spin_count += 1;
-        }
-
-        if spin_count == SPIN_LIMIT {
-            error!("Port is hung");
-            return Err(SystemError::EIO);
-        }
-
+        compiler_fence(Ordering::Release);
         volatile_set_bit!(port.ci, 1 << slot, true); // Issue command
                                                      // debug!("To wait ahci read complete.");
                                                      // 等待操作完成
-        loop {
-            if (volatile_read!(port.ci) & (1 << slot)) == 0 {
-                break;
-            }
-            if (volatile_read!(port.is) & HBA_PxIS_TFES) > 0 {
-                error!("Read disk error");
-                return Err(SystemError::EIO);
-            }
+        if let Err(err) = AhciController::wait_slot(port, slot) {
+            self.controller
+                .abort_failed_dma(self.port_num as usize, dma);
+            return Err(err);
         }
-        if let Some(kbuf) = &kbuf {
-            buf.copy_from_slice(kbuf);
-        }
+        compiler_fence(Ordering::Acquire);
+        buf[..count * 512].copy_from_slice(&dma.as_mut_slice()[..count * 512]);
 
         compiler_fence(Ordering::SeqCst);
         // successfully read
@@ -228,75 +221,71 @@ impl AhciDisk {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
-        assert!((buf.len() & 511) == 0);
-        compiler_fence(Ordering::SeqCst);
-        let check_length = ((count - 1) >> 4) + 1; // prdt length
-        if count * 512 > buf.len() || check_length > 8 {
-            // 不可能的操作
-            return Err(SystemError::E2BIG);
-        } else if count == 0 {
+        if count == 0 {
             return Ok(0);
         }
+        if buf.len() & 511 != 0 {
+            return Err(SystemError::EINVAL);
+        }
+        compiler_fence(Ordering::SeqCst);
+        let check_length = ((count - 1) >> 4) + 1; // prdt length
+        if count.checked_mul(512).ok_or(SystemError::EOVERFLOW)? > buf.len()
+            || lba_id_start
+                .checked_add(count)
+                .ok_or(SystemError::EOVERFLOW)?
+                > self.capacity_lba
+            || check_length > 8
+        {
+            // 不可能的操作
+            return Err(SystemError::E2BIG);
+        }
+        let _port_guard = self.controller.lock_port_for_io(self.port_num as usize)?;
 
-        let port = _port(self.ctrl_num, self.port_num);
+        let port = unsafe { &mut *self.controller.port_ptr(self.port_num as usize) };
 
         volatile_write!(port.is, u32::MAX); // Clear pending interrupt bits
 
-        let slot = port.find_cmdslot().unwrap_or(u32::MAX);
+        let slot = port
+            .find_cmdslot(self.controller.command_slots)
+            .unwrap_or(u32::MAX);
 
         if slot == u32::MAX {
             return Err(SystemError::EIO);
         }
 
         compiler_fence(Ordering::SeqCst);
-        #[allow(unused_unsafe)]
+        let clb = volatile_read!(port.clb);
         let cmdheader: &mut HbaCmdHeader = unsafe {
-            (MMArch::phys_2_virt(PhysAddr::new(
-                volatile_read!(port.clb) as usize + slot as usize * size_of::<HbaCmdHeader>(),
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(
+                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
             ))
-            .unwrap()
+            .ok_or(SystemError::EFAULT)?
             .data() as *mut HbaCmdHeader)
-                .as_mut()
-                .unwrap()
         };
         compiler_fence(Ordering::SeqCst);
 
-        volatile_write_bit!(
+        // DW0: CFL in bits 0..4, W in bit 6. This is an ATA write, not ATAPI.
+        volatile_write!(
             cmdheader.cfl,
-            (1 << 5) - 1_u8,
-            (size_of::<FisRegH2D>() / size_of::<u32>()) as u8
-        ); // Command FIS size
-
-        volatile_set_bit!(cmdheader.cfl, 7 << 5, true); // (p,c,w)都设置为1, Read/Write bit :  Write from device
+            (size_of::<FisRegH2D>() / size_of::<u32>()) as u8 | (1 << 6)
+        );
+        volatile_write!(cmdheader._pm, 0);
+        volatile_write!(cmdheader._prdbc, 0);
         volatile_write!(cmdheader.prdtl, check_length as u16); // PRDT entries count
 
         // 设置数据存放地址
         compiler_fence(Ordering::SeqCst);
-        let mut buf_ptr = buf as *const [u8] as *mut usize as usize;
+        let mut dma = self
+            .controller
+            .allocate_dma(count * 512, DmaDirection::ToDevice)?;
+        dma.as_mut_slice()[..count * 512].copy_from_slice(&buf[..count * 512]);
+        let mut buf_paddr = dma.paddr();
 
-        // 由于目前的内存管理机制无法把用户空间的内存地址转换为物理地址，所以只能先把数据拷贝到内核空间
-        // TODO：在内存管理重构后，可以直接使用用户空间的内存地址
-        let user_buf = access_ok(VirtAddr::new(buf_ptr), buf.len()).is_ok();
-        let mut kbuf = if user_buf {
-            let mut x: Vec<u8> = vec![0; buf.len()];
-            x.resize(buf.len(), 0);
-            x.copy_from_slice(buf);
-            Some(x)
-        } else {
-            None
-        };
-
-        if let Some(buf) = &mut kbuf {
-            buf_ptr = buf.as_mut_ptr() as usize;
-        }
-
-        #[allow(unused_unsafe)]
+        let ctba = volatile_read!(cmdheader.ctba);
         let cmdtbl = unsafe {
-            (MMArch::phys_2_virt(PhysAddr::new(volatile_read!(cmdheader.ctba) as usize))
-                .unwrap()
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
+                .ok_or(SystemError::EFAULT)?
                 .data() as *mut HbaCmdTable)
-                .as_mut()
-                .unwrap()
         };
         let mut tmp_count = count;
         compiler_fence(Ordering::SeqCst);
@@ -308,22 +297,16 @@ impl AhciDisk {
 
         // 8K bytes (16 sectors) per PRDT
         for i in 0..((volatile_read!(cmdheader.prdtl) - 1) as usize) {
-            volatile_write!(
-                cmdtbl.prdt_entry[i].dba,
-                MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
-            );
+            volatile_write!(cmdtbl.prdt_entry[i].dba, buf_paddr as u64);
             volatile_write_bit!(cmdtbl.prdt_entry[i].dbc, (1 << 22) - 1, 8 * 1024 - 1); // 数据长度
             volatile_set_bit!(cmdtbl.prdt_entry[i].dbc, 1 << 31, true); // 允许中断
-            buf_ptr += 8 * 1024;
+            buf_paddr += 8 * 1024;
             tmp_count -= 16;
         }
 
         // Last entry
         let las = (volatile_read!(cmdheader.prdtl) - 1) as usize;
-        volatile_write!(
-            cmdtbl.prdt_entry[las].dba,
-            MMArch::virt_2_phys(VirtAddr::new(buf_ptr)).unwrap().data() as u64
-        );
+        volatile_write!(cmdtbl.prdt_entry[las].dba, buf_paddr as u64);
         volatile_set_bit!(cmdtbl.prdt_entry[las].dbc, 1 << 31, true); // 允许中断
         volatile_write_bit!(
             cmdtbl.prdt_entry[las].dbc,
@@ -332,11 +315,7 @@ impl AhciDisk {
         ); // 数据长度
 
         // 设置命令
-        let cmdfis = unsafe {
-            ((&mut cmdtbl.cfis) as *mut [u8] as *mut usize as *mut FisRegH2D)
-                .as_mut()
-                .unwrap()
-        };
+        let cmdfis = unsafe { &mut *(cmdtbl.cfis.as_mut_ptr() as *mut FisRegH2D) };
         volatile_write!(cmdfis.fis_type, FisType::RegH2D as u8);
         volatile_set_bit!(cmdfis.pm, 1 << 7, true); // command_bit set
         volatile_write!(cmdfis.command, ATA_CMD_WRITE_DMA_EXT);
@@ -353,56 +332,71 @@ impl AhciDisk {
 
         volatile_write!(cmdfis.device, 1 << 6); // LBA Mode
 
+        AhciController::wait_tfd_ready(port)?;
+        compiler_fence(Ordering::Release);
         volatile_set_bit!(port.ci, 1 << slot, true); // Issue command
 
         // 等待操作完成
-        loop {
-            if (volatile_read!(port.ci) & (1 << slot)) == 0 {
-                break;
-            }
-            if (volatile_read!(port.is) & HBA_PxIS_TFES) > 0 {
-                error!("Write disk error");
-                return Err(SystemError::EIO);
-            }
+        if let Err(err) = AhciController::wait_slot(port, slot) {
+            self.controller
+                .abort_failed_dma(self.port_num as usize, dma);
+            return Err(err);
         }
+        compiler_fence(Ordering::Acquire);
 
         compiler_fence(Ordering::SeqCst);
         // successfully read
         return Ok(count * 512);
     }
 
-    fn sync(&self) -> Result<(), SystemError> {
-        // 由于目前没有block cache, 因此sync返回成功即可
-        return Ok(());
+    fn sync_disk(&self) -> Result<(), SystemError> {
+        let command = self
+            .flush_command
+            .ok_or(SystemError::EOPNOTSUPP_OR_ENOTSUP)?;
+        self.controller
+            .flush_port(self.port_num as usize, command, false)
     }
 }
 
 impl LockedAhciDisk {
-    pub fn new(ctrl_num: u8, port_num: u8) -> Result<Arc<LockedAhciDisk>, SystemError> {
+    pub fn new(
+        controller: Arc<AhciController>,
+        port_num: u8,
+        identify: AhciIdentify,
+    ) -> Result<Arc<LockedAhciDisk>, SystemError> {
         let devname = scsi_manager().alloc_id().ok_or(SystemError::EBUSY)?;
+        let parent_device: Arc<dyn Device> = controller.device.clone();
+        let parent_kobject: Arc<dyn KObject> = controller.device.clone();
         // 构建磁盘结构体
         let result: Arc<LockedAhciDisk> = Arc::new_cyclic(|self_ref| LockedAhciDisk {
             blkdev_meta: BlockDevMeta::new(devname, Major::AHCI_BLK_MAJOR),
-            inner: SpinLock::new(AhciDisk {
+            inner: Mutex::new(AhciDisk {
                 partitions: Vec::new(),
-                ctrl_num,
-                port_num,
+                device_common: DeviceCommonData {
+                    parent: Some(Arc::downgrade(&parent_device)),
+                    ..Default::default()
+                },
+                kobject_common: KObjectCommonData {
+                    parent: Some(Arc::downgrade(&parent_kobject)),
+                    ..Default::default()
+                },
                 self_ref: self_ref.clone(),
             }),
+            kobj_state: LockedKObjectState::default(),
+            controller,
+            port_num,
+            capacity_lba: identify.capacity_lba,
+            flush_command: identify.flush_command,
+            open_count: AtomicU32::new(0),
+            mount_holder_count: AtomicU32::new(0),
         });
-        let table: MbrDiskPartionTable = result.read_mbr_table()?;
-
-        // 求出有多少可用分区
-        let partitions = table.partitions(Arc::downgrade(&result) as Weak<dyn BlockDevice>);
-        result.inner().partitions = partitions;
-
         return Ok(result);
     }
+}
 
-    /// @brief: 从磁盘中读取 MBR 分区表结构体
-    pub fn read_mbr_table(&self) -> Result<MbrDiskPartionTable, SystemError> {
-        let disk = self.inner().self_ref.upgrade().unwrap() as Arc<dyn BlockDevice>;
-        MbrDiskPartionTable::from_disk(disk)
+impl Drop for LockedAhciDisk {
+    fn drop(&mut self) {
+        scsi_manager().free_id(self.blkdev_meta.devname.id());
     }
 }
 
@@ -412,55 +406,53 @@ impl KObject for LockedAhciDisk {
     }
 
     fn inode(&self) -> Option<Arc<KernFSInode>> {
-        todo!()
+        self.inner().kobject_common.kern_inode.clone()
     }
 
     fn kobj_type(&self) -> Option<&'static dyn KObjType> {
-        todo!()
+        self.inner().kobject_common.kobj_type
     }
 
     fn kset(&self) -> Option<Arc<KSet>> {
-        todo!()
+        self.inner().kobject_common.kset.clone()
     }
 
     fn parent(&self) -> Option<Weak<dyn KObject>> {
-        todo!()
+        self.inner().kobject_common.parent.clone()
     }
 
-    fn set_inode(&self, _inode: Option<Arc<KernFSInode>>) {
-        todo!()
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.inner().kobject_common.kern_inode = inode;
     }
 
     fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
-        todo!()
+        self.kobj_state.read()
     }
 
     fn kobj_state_mut(&self) -> RwSemWriteGuard<'_, KObjectState> {
-        todo!()
+        self.kobj_state.write()
     }
 
-    fn set_kobj_state(&self, _state: KObjectState) {
-        todo!()
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.kobj_state.write() = state;
     }
 
     fn name(&self) -> alloc::string::String {
-        todo!()
+        self.dev_name().to_string()
     }
 
-    fn set_name(&self, _name: alloc::string::String) {
-        todo!()
+    fn set_name(&self, _name: alloc::string::String) {}
+
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.inner().kobject_common.kset = kset;
     }
 
-    fn set_kset(&self, _kset: Option<Arc<KSet>>) {
-        todo!()
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.inner().kobject_common.parent = parent;
     }
 
-    fn set_parent(&self, _parent: Option<Weak<dyn KObject>>) {
-        todo!()
-    }
-
-    fn set_kobj_type(&self, _ktype: Option<&'static dyn KObjType>) {
-        todo!()
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.inner().kobject_common.kobj_type = ktype;
     }
 }
 
@@ -470,55 +462,92 @@ impl Device for LockedAhciDisk {
     }
 
     fn id_table(&self) -> IdTable {
-        todo!()
+        IdTable::new("ahci".to_string(), None)
     }
 
     fn bus(&self) -> Option<Weak<dyn Bus>> {
-        todo!("LockedAhciDisk::bus()")
+        self.inner().device_common.bus.clone()
     }
 
-    fn set_bus(&self, _bus: Option<Weak<dyn Bus>>) {
-        todo!("LockedAhciDisk::set_bus()")
+    fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
+        self.inner().device_common.bus = bus;
     }
 
     fn driver(&self) -> Option<Arc<dyn Driver>> {
-        todo!("LockedAhciDisk::driver()")
+        let mut inner = self.inner();
+        let driver = inner.device_common.driver.clone()?.upgrade();
+        if driver.is_none() {
+            inner.device_common.driver = None;
+        }
+        driver
     }
 
     fn is_dead(&self) -> bool {
         false
     }
 
-    fn set_driver(&self, _driver: Option<Weak<dyn Driver>>) {
-        todo!("LockedAhciDisk::set_driver()")
+    fn set_driver(&self, driver: Option<Weak<dyn Driver>>) {
+        self.inner().device_common.driver = driver;
     }
 
     fn can_match(&self) -> bool {
-        todo!()
+        self.inner().device_common.can_match
     }
 
-    fn set_can_match(&self, _can_match: bool) {
-        todo!()
+    fn set_can_match(&self, can_match: bool) {
+        self.inner().device_common.can_match = can_match;
     }
 
     fn state_synced(&self) -> bool {
-        todo!()
+        true
     }
 
-    fn set_class(&self, _class: Option<Weak<dyn Class>>) {
-        todo!()
+    fn class(&self) -> Option<Arc<dyn Class>> {
+        let mut inner = self.inner();
+        let class = inner.device_common.class.clone()?.upgrade();
+        if class.is_none() {
+            inner.device_common.class = None;
+        }
+        class
+    }
+
+    fn set_class(&self, class: Option<Weak<dyn Class>>) {
+        self.inner().device_common.class = class;
     }
 
     fn dev_parent(&self) -> Option<Weak<dyn Device>> {
-        None
+        self.inner().device_common.get_parent_weak_or_clear()
     }
 
-    fn set_dev_parent(&self, _dev_parent: Option<Weak<dyn Device>>) {
-        todo!()
+    fn set_dev_parent(&self, dev_parent: Option<Weak<dyn Device>>) {
+        self.inner().device_common.parent = dev_parent;
     }
 }
 
 impl BlockDevice for LockedAhciDisk {
+    fn file_open(
+        &self,
+        _data: MutexGuard<FilePrivateData>,
+        _flags: &FileFlags,
+    ) -> Result<(), SystemError> {
+        self.controller.acquire_holder(&self.open_count)
+    }
+
+    fn file_close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        let previous = self.open_count.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "AHCI open count underflow");
+        Ok(())
+    }
+
+    fn mount_holder_acquire(&self) -> Result<(), SystemError> {
+        self.controller.acquire_holder(&self.mount_holder_count)
+    }
+
+    fn mount_holder_release(&self) {
+        let previous = self.mount_holder_count.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0, "AHCI mount holder count underflow");
+    }
+
     fn dev_name(&self) -> &DevName {
         &self.blkdev_meta.devname
     }
@@ -528,7 +557,8 @@ impl BlockDevice for LockedAhciDisk {
     }
 
     fn disk_range(&self) -> GeneralBlockRange {
-        todo!("Get ahci blk disk range")
+        GeneralBlockRange::new(0, self.capacity_lba)
+            .expect("IDENTIFY returned a non-zero AHCI capacity")
     }
 
     #[inline]
@@ -542,11 +572,11 @@ impl BlockDevice for LockedAhciDisk {
     }
 
     fn sync(&self) -> Result<(), SystemError> {
-        return self.inner().sync();
+        self.sync_disk()
     }
 
     fn supports_reliable_flush(&self) -> bool {
-        false
+        self.flush_command.is_some()
     }
 
     #[inline]
@@ -555,7 +585,7 @@ impl BlockDevice for LockedAhciDisk {
     }
 
     fn block_size(&self) -> usize {
-        todo!()
+        512
     }
 
     fn partitions(&self) -> Vec<Arc<Partition>> {
@@ -569,7 +599,7 @@ impl BlockDevice for LockedAhciDisk {
         count: usize,          // 读取lba的数量
         buf: &mut [u8],
     ) -> Result<usize, SystemError> {
-        self.inner().read_at(lba_id_start, count, buf)
+        self.read_at(lba_id_start, count, buf)
     }
 
     #[inline]
@@ -579,6 +609,6 @@ impl BlockDevice for LockedAhciDisk {
         count: usize,
         buf: &[u8],
     ) -> Result<usize, SystemError> {
-        self.inner().write_at(lba_id_start, count, buf)
+        self.write_at(lba_id_start, count, buf)
     }
 }

--- a/kernel/src/driver/disk/ahci/ahcidisk.rs
+++ b/kernel/src/driver/disk/ahci/ahcidisk.rs
@@ -31,7 +31,7 @@ use alloc::sync::Weak;
 use alloc::{sync::Arc, vec::Vec};
 
 use core::fmt::Debug;
-use core::sync::atomic::{compiler_fence, AtomicU32, Ordering};
+use core::sync::atomic::{compiler_fence, Ordering};
 use core::{mem::size_of, ptr::write_bytes};
 
 /// @brief: 只支持MBR分区格式的磁盘结构体
@@ -56,18 +56,11 @@ pub struct LockedAhciDisk {
     capacity_lba: usize,
     flush_command: Option<u8>,
     reliable_flush: bool,
-    open_count: AtomicU32,
-    mount_holder_count: AtomicU32,
 }
 
 impl LockedAhciDisk {
     pub fn inner(&self) -> MutexGuard<'_, AhciDisk> {
         self.inner.lock()
-    }
-
-    pub(crate) fn has_holders(&self) -> bool {
-        self.open_count.load(Ordering::Acquire) != 0
-            || self.mount_holder_count.load(Ordering::Acquire) != 0
     }
 
     pub(crate) fn needs_flush(&self) -> bool {
@@ -392,8 +385,6 @@ impl LockedAhciDisk {
             capacity_lba: identify.capacity_lba,
             flush_command: identify.flush_command,
             reliable_flush: identify.reliable_flush,
-            open_count: AtomicU32::new(0),
-            mount_holder_count: AtomicU32::new(0),
         });
         return Ok(result);
     }
@@ -535,22 +526,11 @@ impl BlockDevice for LockedAhciDisk {
         _data: MutexGuard<FilePrivateData>,
         _flags: &FileFlags,
     ) -> Result<(), SystemError> {
-        self.controller.acquire_holder(&self.open_count)
-    }
-
-    fn file_close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
-        let previous = self.open_count.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "AHCI open count underflow");
-        Ok(())
+        self.controller.acquire_holder()
     }
 
     fn mount_holder_acquire(&self) -> Result<(), SystemError> {
-        self.controller.acquire_holder(&self.mount_holder_count)
-    }
-
-    fn mount_holder_release(&self) {
-        let previous = self.mount_holder_count.fetch_sub(1, Ordering::AcqRel);
-        debug_assert!(previous > 0, "AHCI mount holder count underflow");
+        self.controller.acquire_holder()
     }
 
     fn dev_name(&self) -> &DevName {

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -174,7 +174,7 @@ impl HbaPort {
         }
     }
 
-    /// Begin COMRESET after a controller-wide reset has stopped all engines.
+    /// Begin COMRESET after this port's command and FIS engines have stopped.
     /// Returns the virtual address of the received-FIS area used for polling.
     pub fn begin_link_reset(&mut self, fb: u64) -> Result<usize, SystemError> {
         volatile_write!(self.fb, fb);

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -163,11 +163,9 @@ impl HbaPort {
         }
     }
 
-    /// Re-establish a non-empty SATA link before trusting PxSIG.  A small
-    /// received-FIS area is active while COMRESET runs, then the port is
-    /// stopped again so the normal command-memory setup can take ownership.
-    pub fn reset_and_classify(&mut self, fb: u64) -> Result<HbaPortType, SystemError> {
-        self.stop()?;
+    /// Begin COMRESET after a controller-wide reset has stopped all engines.
+    /// Returns the virtual address of the received-FIS area used for polling.
+    pub fn begin_link_reset(&mut self, fb: u64) -> Result<usize, SystemError> {
         volatile_write!(self.fb, fb);
         let fb_vaddr = unsafe { MMArch::phys_2_virt(PhysAddr::new(fb as usize)) }
             .ok_or(SystemError::EFAULT)?;
@@ -180,46 +178,57 @@ impl HbaPort {
         let sctl = volatile_read!(self.sctl) & !0xf;
         volatile_write!(self.sctl, sctl | 1);
         if volatile_read!(self.sctl) & 0xf != 1 {
-            self.stop()?;
             return Err(SystemError::EIO);
         }
-        let assert_until = Instant::now() + Duration::from_millis(1);
-        while Instant::now() < assert_until {
-            core::hint::spin_loop();
-        }
+        Ok(fb_vaddr.data())
+    }
+
+    pub fn finish_link_reset_assertion(&mut self) {
+        let sctl = volatile_read!(self.sctl) & !0xf;
         volatile_write!(self.sctl, sctl);
         let _ = volatile_read!(self.sctl);
+    }
 
-        let link_deadline = Instant::now() + Duration::from_secs(2);
-        let mut stable_since = None;
-        loop {
-            if volatile_read!(self.ssts) & 0xf == HBA_SSTS_PRESENT {
-                let since = *stable_since.get_or_insert_with(Instant::now);
-                if Instant::now() >= since + Duration::from_millis(100) {
-                    break;
-                }
-            } else {
-                stable_since = None;
-            }
-            if Instant::now() >= link_deadline {
-                self.stop()?;
-                return Err(SystemError::ETIMEDOUT);
-            }
-            core::hint::spin_loop();
+    /// Start stopping the provisional receive-FIS engine without waiting.
+    /// Multiple ports can be stopped concurrently by advancing them together.
+    pub fn begin_provisional_stop(&mut self) {
+        let cmd = volatile_read!(self.cmd);
+        volatile_write!(self.cmd, cmd & !HBA_PORT_CMD_ST);
+    }
+
+    /// Advance the AHCI-mandated ST/CR then FRE/FR stop sequence.
+    /// Returns true once this port can no longer DMA into its FIS buffer.
+    pub fn advance_provisional_stop(&mut self) -> bool {
+        let cmd = volatile_read!(self.cmd);
+        if cmd & HBA_PORT_CMD_CR != 0 {
+            return false;
         }
-        // PxSIG is only trustworthy after this reset produced a fresh
-        // device-to-host register FIS in the newly zeroed receive area.
-        let d2h_fis_type = (fb_vaddr.data() + 0x40) as *const u8;
-        while unsafe { core::ptr::read_volatile(d2h_fis_type) } != FisType::RegD2H as u8 {
-            if Instant::now() >= link_deadline {
-                self.stop()?;
-                return Err(SystemError::ETIMEDOUT);
-            }
-            core::hint::spin_loop();
+        if cmd & HBA_PORT_CMD_FRE != 0 {
+            volatile_write!(self.cmd, cmd & !HBA_PORT_CMD_FRE);
         }
-        let port_type = self.check_type();
-        self.stop()?;
-        Ok(port_type)
+        volatile_read!(self.cmd) & HBA_PORT_CMD_FR == 0
+    }
+
+    /// Poll one link without blocking other ports that are training in the
+    /// same controller-wide window.
+    pub fn classify_reset_link(
+        &mut self,
+        received_fis_vaddr: usize,
+        stable_since: &mut Option<Instant>,
+    ) -> Option<HbaPortType> {
+        if volatile_read!(self.ssts) & 0xf != HBA_SSTS_PRESENT {
+            *stable_since = None;
+            return None;
+        }
+        let since = *stable_since.get_or_insert_with(Instant::now);
+        if Instant::now() < since + Duration::from_millis(100) {
+            return None;
+        }
+        let d2h_fis_type = (received_fis_vaddr + 0x40) as *const u8;
+        if unsafe { core::ptr::read_volatile(d2h_fis_type) } != FisType::RegD2H as u8 {
+            return None;
+        }
+        Some(self.check_type())
     }
 
     /// 启动该端口的命令引擎

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -33,10 +33,14 @@ pub const HBA_PORT_CMD_CR: u32 = 1 << 15;
 pub const HBA_PORT_CMD_FR: u32 = 1 << 14;
 pub const HBA_PORT_CMD_FRE: u32 = 1 << 4;
 pub const HBA_PORT_CMD_ST: u32 = 1;
-/// PxIS bits which Linux 6.6 treats as command errors (`PORT_IRQ_ERROR`).
-/// Non-fatal interface and overflow notifications are intentionally excluded.
+/// PxIS bits which make an in-flight command unsafe to report as successful.
+///
+/// This includes Linux 6.6's `PORT_IRQ_ERROR` set plus OFS: AHCI 1.3.1
+/// requires software to use OFS to detect data received beyond the PRD table.
+/// INFS remains excluded because it reports an interface error from which the
+/// controller was able to continue.
 pub const HBA_PORT_IS_ERR: u32 =
-    1 << 30 | 1 << 29 | 1 << 28 | 1 << 27 | 1 << 23 | 1 << 22 | 1 << 6 | 1 << 4;
+    1 << 30 | 1 << 29 | 1 << 28 | 1 << 27 | 1 << 24 | 1 << 23 | 1 << 22 | 1 << 6 | 1 << 4;
 pub const HBA_PORT_IS_TFES: u32 = 1 << 30;
 pub const HBA_SSTS_PRESENT: u32 = 0x3;
 pub const HBA_SIG_ATA: u16 = 0x0000;

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -196,16 +196,18 @@ impl HbaPort {
         volatile_write!(self.cmd, cmd & !HBA_PORT_CMD_ST);
     }
 
-    /// Advance the AHCI-mandated ST/CR then FRE/FR stop sequence.
-    /// Returns true once this port can no longer DMA into its FIS buffer.
-    pub fn advance_provisional_stop(&mut self) -> bool {
+    pub fn provisional_command_stopped(&self) -> bool {
+        volatile_read!(self.cmd) & HBA_PORT_CMD_CR == 0
+    }
+
+    /// Disable receive-FIS only after CR has cleared on every participating
+    /// port; callers enforce that controller-wide phase boundary.
+    pub fn begin_fis_receive_stop(&mut self) {
         let cmd = volatile_read!(self.cmd);
-        if cmd & HBA_PORT_CMD_CR != 0 {
-            return false;
-        }
-        if cmd & HBA_PORT_CMD_FRE != 0 {
-            volatile_write!(self.cmd, cmd & !HBA_PORT_CMD_FRE);
-        }
+        volatile_write!(self.cmd, cmd & !HBA_PORT_CMD_FRE);
+    }
+
+    pub fn fis_receive_stopped(&self) -> bool {
         volatile_read!(self.cmd) & HBA_PORT_CMD_FR == 0
     }
 

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -8,6 +8,8 @@ use crate::mm::{MemoryManagementArch, PhysAddr};
 use crate::time::{Duration, Instant};
 use system_error::SystemError;
 
+use super::cooperative_poll_step;
+
 /// 根据 AHCI 写出 HBA 的 Command
 pub const ATA_CMD_READ_DMA_EXT: u8 = 0x25; // 读操作，并且退出
 pub const ATA_CMD_WRITE_DMA_EXT: u8 = 0x35; // 写操作，并且退出
@@ -20,7 +22,12 @@ pub const ATA_CMD_IDENTIFY_PACKET: u8 = 0xA1;
 #[allow(dead_code)]
 pub const ATA_CMD_PACKET: u8 = 0xA0;
 pub const ATA_DEV_BUSY: u8 = 0x80;
+pub const ATA_DEV_READY: u8 = 0x40;
+pub const ATA_DEV_FAULT: u8 = 0x20;
 pub const ATA_DEV_DRQ: u8 = 0x08;
+pub const ATA_DEV_ERR: u8 = 0x01;
+pub const ATA_ERR_ICRC: u8 = 0x80;
+pub const ATA_ERR_UNC: u8 = 0x40;
 
 pub const HBA_PORT_CMD_CR: u32 = 1 << 15;
 pub const HBA_PORT_CMD_FR: u32 = 1 << 14;
@@ -30,6 +37,7 @@ pub const HBA_PORT_CMD_ST: u32 = 1;
 /// Non-fatal interface and overflow notifications are intentionally excluded.
 pub const HBA_PORT_IS_ERR: u32 =
     1 << 30 | 1 << 29 | 1 << 28 | 1 << 27 | 1 << 23 | 1 << 22 | 1 << 6 | 1 << 4;
+pub const HBA_PORT_IS_TFES: u32 = 1 << 30;
 pub const HBA_SSTS_PRESENT: u32 = 0x3;
 pub const HBA_SIG_ATA: u16 = 0x0000;
 pub const HBA_SIG_ATAPI: u16 = 0xEB14;
@@ -136,6 +144,7 @@ pub struct HbaCmdHeader {
 impl HbaPort {
     fn wait_cmd_clear(&self, mask: u32) -> Result<(), SystemError> {
         let deadline = Instant::now() + Duration::from_millis(500);
+        let mut iteration = 0usize;
         loop {
             if volatile_read!(self.cmd) & mask == 0 {
                 return Ok(());
@@ -143,7 +152,7 @@ impl HbaPort {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            core::hint::spin_loop();
+            cooperative_poll_step(&mut iteration);
         }
     }
 
@@ -238,13 +247,27 @@ impl HbaPort {
     /// 启动该端口的命令引擎
     pub fn start(&mut self) -> Result<(), SystemError> {
         self.wait_cmd_clear(HBA_PORT_CMD_CR)?;
-        let val: u32 = volatile_read!(self.cmd) | HBA_PORT_CMD_FRE | HBA_PORT_CMD_ST;
-        volatile_write!(self.cmd, val);
+        let cmd = volatile_read!(self.cmd) | HBA_PORT_CMD_FRE;
+        volatile_write!(self.cmd, cmd);
+        let _ = volatile_read!(self.cmd);
+        volatile_write!(self.cmd, cmd | HBA_PORT_CMD_ST);
+        let started = volatile_read!(self.cmd);
+        if started == u32::MAX
+            || started & (HBA_PORT_CMD_FRE | HBA_PORT_CMD_ST)
+                != (HBA_PORT_CMD_FRE | HBA_PORT_CMD_ST)
+        {
+            if started != u32::MAX {
+                let _ = self.stop();
+            }
+            return Err(SystemError::EIO);
+        }
         Ok(())
     }
 
-    /// 关闭该端口的命令引擎
-    pub fn stop(&mut self) -> Result<(), SystemError> {
+    /// Stop command-list processing. Once CR clears, command payloads are no
+    /// longer DMA targets; FIS receive may remain enabled for light-weight
+    /// command-error recovery.
+    pub fn stop_command_engine(&mut self) -> Result<(), SystemError> {
         #[allow(unused_unsafe)]
         {
             volatile_write!(
@@ -253,7 +276,12 @@ impl HbaPort {
             );
         }
 
-        self.wait_cmd_clear(HBA_PORT_CMD_CR)?;
+        self.wait_cmd_clear(HBA_PORT_CMD_CR)
+    }
+
+    /// 关闭该端口的命令引擎和 FIS 接收引擎
+    pub fn stop(&mut self) -> Result<(), SystemError> {
+        self.stop_command_engine()?;
 
         #[allow(unused_unsafe)]
         {

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -26,8 +26,10 @@ pub const HBA_PORT_CMD_CR: u32 = 1 << 15;
 pub const HBA_PORT_CMD_FR: u32 = 1 << 14;
 pub const HBA_PORT_CMD_FRE: u32 = 1 << 4;
 pub const HBA_PORT_CMD_ST: u32 = 1;
-#[allow(dead_code)]
-pub const HBA_PORT_IS_ERR: u32 = 1 << 30 | 1 << 29 | 1 << 28 | 1 << 27;
+/// PxIS bits which Linux 6.6 treats as command errors (`PORT_IRQ_ERROR`).
+/// Non-fatal interface and overflow notifications are intentionally excluded.
+pub const HBA_PORT_IS_ERR: u32 =
+    1 << 30 | 1 << 29 | 1 << 28 | 1 << 27 | 1 << 23 | 1 << 22 | 1 << 6 | 1 << 4;
 pub const HBA_SSTS_PRESENT: u32 = 0x3;
 pub const HBA_SIG_ATA: u16 = 0x0000;
 pub const HBA_SIG_ATAPI: u16 = 0xEB14;

--- a/kernel/src/driver/disk/ahci/hba.rs
+++ b/kernel/src/driver/disk/ahci/hba.rs
@@ -5,10 +5,14 @@ use core::sync::atomic::compiler_fence;
 
 use crate::arch::MMArch;
 use crate::mm::{MemoryManagementArch, PhysAddr};
+use crate::time::{Duration, Instant};
+use system_error::SystemError;
 
 /// 根据 AHCI 写出 HBA 的 Command
 pub const ATA_CMD_READ_DMA_EXT: u8 = 0x25; // 读操作，并且退出
 pub const ATA_CMD_WRITE_DMA_EXT: u8 = 0x35; // 写操作，并且退出
+pub const ATA_CMD_FLUSH_CACHE: u8 = 0xE7;
+pub const ATA_CMD_FLUSH_CACHE_EXT: u8 = 0xEA;
 #[allow(dead_code)]
 pub const ATA_CMD_IDENTIFY: u8 = 0xEC;
 #[allow(dead_code)]
@@ -25,20 +29,20 @@ pub const HBA_PORT_CMD_ST: u32 = 1;
 #[allow(dead_code)]
 pub const HBA_PORT_IS_ERR: u32 = 1 << 30 | 1 << 29 | 1 << 28 | 1 << 27;
 pub const HBA_SSTS_PRESENT: u32 = 0x3;
-pub const HBA_SIG_ATA: u32 = 0x00000101;
-pub const HBA_SIG_ATAPI: u32 = 0xEB140101;
-pub const HBA_SIG_PM: u32 = 0x96690101;
-pub const HBA_SIG_SEMB: u32 = 0xC33C0101;
+pub const HBA_SIG_ATA: u16 = 0x0000;
+pub const HBA_SIG_ATAPI: u16 = 0xEB14;
+pub const HBA_SIG_PM: u16 = 0x9669;
+pub const HBA_SIG_SEMB: u16 = 0xC33C;
 
 /// 接入 Port 的 不同设备类型
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum HbaPortType {
     None,
     Unknown(u32),
-    SATA,
-    SATAPI,
-    PM,
-    SEMB,
+    Sata,
+    Satapi,
+    PortMultiplier,
+    EnclosureManagement,
 }
 
 /// 声明了 HBA 的所有属性
@@ -128,33 +132,106 @@ pub struct HbaCmdHeader {
 
 /// Port 的函数实现
 impl HbaPort {
+    fn wait_cmd_clear(&self, mask: u32) -> Result<(), SystemError> {
+        let deadline = Instant::now() + Duration::from_millis(500);
+        loop {
+            if volatile_read!(self.cmd) & mask == 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SystemError::ETIMEDOUT);
+            }
+            core::hint::spin_loop();
+        }
+    }
+
     /// 获取设备类型
     pub fn check_type(&mut self) -> HbaPortType {
-        if volatile_read!(self.ssts) & HBA_SSTS_PRESENT > 0 {
-            let sig = volatile_read!(self.sig);
-            match sig {
-                HBA_SIG_ATA => HbaPortType::SATA,
-                HBA_SIG_ATAPI => HbaPortType::SATAPI,
-                HBA_SIG_PM => HbaPortType::PM,
-                HBA_SIG_SEMB => HbaPortType::SEMB,
-                _ => HbaPortType::Unknown(sig),
+        if volatile_read!(self.ssts) & 0xf == HBA_SSTS_PRESENT {
+            let raw_sig = volatile_read!(self.sig);
+            // ATA only requires the LBA mid/high signature bytes to classify
+            // a device.  The low 16 bits are not reliable on all hardware.
+            match (raw_sig >> 16) as u16 {
+                HBA_SIG_ATA => HbaPortType::Sata,
+                HBA_SIG_ATAPI => HbaPortType::Satapi,
+                HBA_SIG_PM => HbaPortType::PortMultiplier,
+                HBA_SIG_SEMB => HbaPortType::EnclosureManagement,
+                _ => HbaPortType::Unknown(raw_sig),
             }
         } else {
             HbaPortType::None
         }
     }
 
-    /// 启动该端口的命令引擎
-    pub fn start(&mut self) {
-        while volatile_read!(self.cmd) & HBA_PORT_CMD_CR > 0 {
+    /// Re-establish a non-empty SATA link before trusting PxSIG.  A small
+    /// received-FIS area is active while COMRESET runs, then the port is
+    /// stopped again so the normal command-memory setup can take ownership.
+    pub fn reset_and_classify(&mut self, fb: u64) -> Result<HbaPortType, SystemError> {
+        self.stop()?;
+        volatile_write!(self.fb, fb);
+        let fb_vaddr = unsafe { MMArch::phys_2_virt(PhysAddr::new(fb as usize)) }
+            .ok_or(SystemError::EFAULT)?;
+        unsafe { ptr::write_bytes(fb_vaddr.data() as *mut u8, 0, 256) };
+        volatile_write!(self.serr, u32::MAX);
+        volatile_write!(self.is, u32::MAX);
+        let cmd = volatile_read!(self.cmd);
+        volatile_write!(self.cmd, cmd | HBA_PORT_CMD_FRE);
+
+        let sctl = volatile_read!(self.sctl) & !0xf;
+        volatile_write!(self.sctl, sctl | 1);
+        if volatile_read!(self.sctl) & 0xf != 1 {
+            self.stop()?;
+            return Err(SystemError::EIO);
+        }
+        let assert_until = Instant::now() + Duration::from_millis(1);
+        while Instant::now() < assert_until {
             core::hint::spin_loop();
         }
+        volatile_write!(self.sctl, sctl);
+        let _ = volatile_read!(self.sctl);
+
+        let link_deadline = Instant::now() + Duration::from_secs(2);
+        let mut stable_since = None;
+        loop {
+            if volatile_read!(self.ssts) & 0xf == HBA_SSTS_PRESENT {
+                let since = *stable_since.get_or_insert_with(Instant::now);
+                if Instant::now() >= since + Duration::from_millis(100) {
+                    break;
+                }
+            } else {
+                stable_since = None;
+            }
+            if Instant::now() >= link_deadline {
+                self.stop()?;
+                return Err(SystemError::ETIMEDOUT);
+            }
+            core::hint::spin_loop();
+        }
+        // PxSIG is only trustworthy after this reset produced a fresh
+        // device-to-host register FIS in the newly zeroed receive area.
+        let d2h_fis_type = (fb_vaddr.data() + 0x40) as *const u8;
+        while unsafe { core::ptr::read_volatile(d2h_fis_type) } != FisType::RegD2H as u8 {
+            if Instant::now() >= link_deadline {
+                self.stop()?;
+                return Err(SystemError::ETIMEDOUT);
+            }
+            core::hint::spin_loop();
+        }
+        let port_type = self.check_type();
+        self.stop()?;
+        Ok(port_type)
+    }
+
+    /// 启动该端口的命令引擎
+    pub fn start(&mut self) -> Result<(), SystemError> {
+        self.wait_cmd_clear(HBA_PORT_CMD_CR)?;
         let val: u32 = volatile_read!(self.cmd) | HBA_PORT_CMD_FRE | HBA_PORT_CMD_ST;
         volatile_write!(self.cmd, val);
+        Ok(())
     }
 
     /// 关闭该端口的命令引擎
-    pub fn stop(&mut self) {
+    pub fn stop(&mut self) -> Result<(), SystemError> {
         #[allow(unused_unsafe)]
         {
             volatile_write!(
@@ -163,11 +240,7 @@ impl HbaPort {
             );
         }
 
-        while volatile_read!(self.cmd) & (HBA_PORT_CMD_FR | HBA_PORT_CMD_CR)
-            == (HBA_PORT_CMD_FR | HBA_PORT_CMD_CR)
-        {
-            core::hint::spin_loop();
-        }
+        self.wait_cmd_clear(HBA_PORT_CMD_CR)?;
 
         #[allow(unused_unsafe)]
         {
@@ -176,18 +249,19 @@ impl HbaPort {
                 (u32::MAX ^ HBA_PORT_CMD_FRE) & volatile_read!(self.cmd)
             );
         }
+        self.wait_cmd_clear(HBA_PORT_CMD_FR)
     }
 
     /// @return: 返回一个空闲 cmd table 的 id; 如果没有，则返回 Option::None
-    pub fn find_cmdslot(&self) -> Option<u32> {
+    pub fn find_cmdslot(&self, command_slots: u8) -> Option<u32> {
         let slots = volatile_read!(self.sact) | volatile_read!(self.ci);
-        (0..32).find(|&i| slots & 1 << i == 0)
+        (0..u32::from(command_slots.min(32))).find(|&i| slots & 1 << i == 0)
     }
 
     /// 初始化,  把 CmdList 等变量的地址赋值到 HbaPort 上 - 这些空间由操作系统分配且固定
     /// 等价于原C版本的 port_rebase 函数
-    pub fn init(&mut self, clb: u64, fb: u64, ctbas: &[u64]) {
-        self.stop(); // 先暂停端口
+    pub fn init(&mut self, clb: u64, fb: u64, ctbas: &[u64]) -> Result<(), SystemError> {
+        self.stop()?; // 先暂停端口
 
         // 赋值 command list base address
         // Command list offset: 1K*portno
@@ -196,54 +270,32 @@ impl HbaPort {
         // Command list maxim size = 32*32 = 1K per port
         volatile_write!(self.clb, clb);
 
-        unsafe {
-            compiler_fence(core::sync::atomic::Ordering::SeqCst);
-            ptr::write_bytes(
-                MMArch::phys_2_virt(PhysAddr::new(clb as usize))
-                    .unwrap()
-                    .data() as *mut u64,
-                0,
-                1024,
-            );
-        }
+        let clb_vaddr = unsafe { MMArch::phys_2_virt(PhysAddr::new(clb as usize)) }
+            .ok_or(SystemError::EFAULT)?;
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        unsafe { ptr::write_bytes(clb_vaddr.data() as *mut u8, 0, 1024) };
 
         // 赋值 fis base address
         // FIS offset: 32K+256*portno
         // FIS entry size = 256 bytes per port
         volatile_write!(self.fb, fb);
-        unsafe {
-            compiler_fence(core::sync::atomic::Ordering::SeqCst);
-            ptr::write_bytes(
-                MMArch::phys_2_virt(PhysAddr::new(fb as usize))
-                    .unwrap()
-                    .data() as *mut u64,
-                0,
-                256,
-            );
-        }
+        let fb_vaddr = unsafe { MMArch::phys_2_virt(PhysAddr::new(fb as usize)) }
+            .ok_or(SystemError::EFAULT)?;
+        compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        unsafe { ptr::write_bytes(fb_vaddr.data() as *mut u8, 0, 256) };
 
         // 赋值 command table base address
         // Command table offset: 40K + 8K*portno
         // Command table size = 256*32 = 8K per port
-        let mut cmdheaders = unsafe {
-            MMArch::phys_2_virt(PhysAddr::new(clb as usize))
-                .unwrap()
-                .data()
-        } as *mut u64 as *mut HbaCmdHeader;
+        let mut cmdheaders = clb_vaddr.data() as *mut HbaCmdHeader;
         for ctbas_value in ctbas.iter().take(32) {
             volatile_write!((*cmdheaders).prdtl, 0); // 一开始没有询问，prdtl = 0（预留了8个PRDT项的空间）
             volatile_write!((*cmdheaders).ctba, *ctbas_value);
             // 这里限制了 prdtl <= 8, 所以一共用了256bytes，如果需要修改，可以修改这里
             compiler_fence(core::sync::atomic::Ordering::SeqCst);
-            unsafe {
-                ptr::write_bytes(
-                    MMArch::phys_2_virt(PhysAddr::new(*ctbas_value as usize))
-                        .unwrap()
-                        .data() as *mut u64,
-                    0,
-                    256,
-                );
-            }
+            let table_vaddr = unsafe { MMArch::phys_2_virt(PhysAddr::new(*ctbas_value as usize)) }
+                .ok_or(SystemError::EFAULT)?;
+            unsafe { ptr::write_bytes(table_vaddr.data() as *mut u8, 0, size_of::<HbaCmdTable>()) };
             cmdheaders = (cmdheaders as usize + size_of::<HbaCmdHeader>()) as *mut HbaCmdHeader;
         }
 
@@ -261,7 +313,7 @@ impl HbaPort {
             // Power on and spin up device
             volatile_write!(self.cmd, volatile_read!(self.cmd) | 1 << 2 | 1 << 1);
         }
-        self.start(); // 重新开启端口
+        self.start() // 重新开启端口
     }
 }
 

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -266,6 +266,14 @@ const _: () = {
         AtaCommandStatus::Error
     ));
     assert!(matches!(
+        classify_command_status(1 << 24, 0, 0),
+        AtaCommandStatus::Error
+    ));
+    assert!(matches!(
+        classify_command_status(1 << 26, 0, 0),
+        AtaCommandStatus::Complete
+    ));
+    assert!(matches!(
         classify_command_status(0, 0, 0),
         AtaCommandStatus::Complete
     ));

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -66,10 +66,26 @@ use self::{
     },
 };
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) struct AhciIdentify {
+    serial: [u16; 10],
+    model: [u16; 20],
+    wwn: Option<[u16; 4]>,
     capacity_lba: usize,
     flush_command: Option<u8>,
     reliable_flush: bool,
+}
+
+impl AhciIdentify {
+    pub(crate) fn has_stable_identity(&self) -> bool {
+        self.wwn.is_some_and(|wwn| {
+            wwn.iter().any(|word| *word != 0) && wwn.iter().any(|word| *word != u16::MAX)
+        }) || self
+            .serial
+            .iter()
+            .flat_map(|word| word.to_be_bytes())
+            .any(|byte| byte != 0 && byte != b' ' && byte != u8::MAX)
+    }
 }
 
 struct PendingAtaCommand {
@@ -775,11 +791,63 @@ impl AhciController {
             .paddr();
         let fb = base + (32 << 10) + (port_no << 8);
         let clb = base + (port_no << 10);
-        let ctbas = (0..32)
-            .map(|slot| (base + (40 << 10) + (port_no << 13) + (slot << 8)) as u64)
-            .collect::<Vec<_>>();
+        let ctbas: [u64; 32] =
+            core::array::from_fn(|slot| (base + (40 << 10) + (port_no << 13) + (slot << 8)) as u64);
 
         unsafe { &mut *self.port_ptr(port_no) }.init(clb as u64, fb as u64, &ctbas)
+    }
+
+    /// Return CPU pointers only for command memory owned by this controller.
+    /// Device-returned CLB/CTBA values are consistency checks, never pointer
+    /// sources.
+    pub(crate) fn command_slot_ptrs(
+        &self,
+        port_no: usize,
+        slot: u32,
+        observed_clb: u64,
+    ) -> Result<(*mut HbaCmdHeader, *mut HbaCmdTable), SystemError> {
+        if port_no >= self.port_count || slot >= u32::from(self.command_slots.min(32)) {
+            return Err(SystemError::EINVAL);
+        }
+        let (base, len) = self
+            .command_memory
+            .lock()
+            .as_ref()
+            .map(|memory| (memory.paddr(), memory.len()))
+            .ok_or(SystemError::ENOMEM)?;
+        let arena_end = base.checked_add(len).ok_or(SystemError::EOVERFLOW)?;
+        let clb = base
+            .checked_add(port_no << 10)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let header_paddr = clb
+            .checked_add(slot as usize * size_of::<HbaCmdHeader>())
+            .ok_or(SystemError::EOVERFLOW)?;
+        let table_paddr = base
+            .checked_add(40 << 10)
+            .and_then(|address| address.checked_add(port_no << 13))
+            .and_then(|address| address.checked_add(slot as usize * 256))
+            .ok_or(SystemError::EOVERFLOW)?;
+        if observed_clb != clb as u64
+            || header_paddr
+                .checked_add(size_of::<HbaCmdHeader>())
+                .is_none_or(|end| end > arena_end)
+            || table_paddr
+                .checked_add(size_of::<HbaCmdTable>())
+                .is_none_or(|end| end > arena_end)
+        {
+            return Err(SystemError::EIO);
+        }
+
+        let header = unsafe { MMArch::phys_2_virt(PhysAddr::new(header_paddr)) }
+            .ok_or(SystemError::EFAULT)?
+            .data() as *mut HbaCmdHeader;
+        if volatile_read!((*header).ctba) != table_paddr as u64 {
+            return Err(SystemError::EIO);
+        }
+        let table = unsafe { MMArch::phys_2_virt(PhysAddr::new(table_paddr)) }
+            .ok_or(SystemError::EFAULT)?
+            .data() as *mut HbaCmdTable;
+        Ok((header, table))
     }
 
     fn publish_identified(
@@ -923,20 +991,9 @@ impl AhciController {
             .ok_or(SystemError::EBUSY)?;
         volatile_write!(port.is, u32::MAX);
 
-        let clb = volatile_read!(port.clb);
-        let header = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(
-                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ))
-            .ok_or(SystemError::EFAULT)?
-            .data() as *mut HbaCmdHeader)
-        };
-        let ctba = volatile_read!(header.ctba);
-        let table = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
-                .ok_or(SystemError::EFAULT)?
-                .data() as *mut HbaCmdTable)
-        };
+        let (header, table) = self.command_slot_ptrs(port_no, slot, volatile_read!(port.clb))?;
+        let header = unsafe { &mut *header };
+        let table = unsafe { &mut *table };
         unsafe { write_bytes(table, 0, 1) };
         volatile_write!(
             header.cfl,
@@ -1014,6 +1071,10 @@ impl AhciController {
             None
         };
         Ok(AhciIdentify {
+            serial: core::array::from_fn(|index| word(10 + index)),
+            model: core::array::from_fn(|index| word(27 + index)),
+            wwn: ((word87 & 0xc100) == 0x4100)
+                .then(|| core::array::from_fn(|index| word(108 + index))),
             capacity_lba,
             flush_command,
             reliable_flush: has_flush_ext || has_flush,
@@ -1205,20 +1266,9 @@ impl AhciController {
         let slot = port
             .find_cmdslot(self.command_slots)
             .ok_or(SystemError::EBUSY)?;
-        let clb = volatile_read!(port.clb);
-        let header = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(
-                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
-            ))
-            .ok_or(SystemError::EFAULT)?
-            .data() as *mut HbaCmdHeader)
-        };
-        let ctba = volatile_read!(header.ctba);
-        let table = unsafe {
-            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
-                .ok_or(SystemError::EFAULT)?
-                .data() as *mut HbaCmdTable)
-        };
+        let (header, table) = self.command_slot_ptrs(port_no, slot, volatile_read!(port.clb))?;
+        let header = unsafe { &mut *header };
+        let table = unsafe { &mut *table };
         unsafe { write_bytes(table, 0, 1) };
         volatile_write!(
             header.cfl,
@@ -1241,8 +1291,8 @@ impl AhciController {
     pub(crate) fn flush_port(&self, port_no: usize, command: u8) -> Result<(), SystemError> {
         let _guard = self.lock_port_for_io(port_no)?;
         let mut pending = self.prepare_flush_command(port_no, command)?;
+        self.wait_tfd_ready_or_recover(port_no)?;
         let port = unsafe { &mut *self.port_ptr(port_no) };
-        Self::wait_tfd_ready(port)?;
         core::sync::atomic::compiler_fence(Ordering::Release);
         let ci = volatile_read!(port.ci);
         volatile_write!(port.ci, ci | (1 << pending.slot));
@@ -1267,6 +1317,144 @@ impl AhciController {
             }
             cooperative_poll_step(&mut iteration);
         }
+    }
+
+    pub(crate) fn wait_tfd_ready_or_recover(&self, port_no: usize) -> Result<(), SystemError> {
+        let port = unsafe { &*self.port_ptr(port_no) };
+        if let Err(err) = Self::wait_tfd_ready(port) {
+            if let Err(recovery_err) = self.recover_unready_port(port_no) {
+                log::warn!(
+                    "AHCI {} port {} recovery after ready timeout failed: {:?}",
+                    self.pci.common_header.bus_device_function,
+                    port_no,
+                    recovery_err
+                );
+            }
+            // Recovery only makes a later request safe. The prepared command
+            // table was reinitialized and this request must never be replayed.
+            return Err(err);
+        }
+        Ok(())
+    }
+
+    fn identify_port_for_revalidation(&self, port_no: usize) -> Result<AhciIdentify, SystemError> {
+        let mut pending = self.prepare_identify(port_no)?;
+        let port = unsafe { &mut *self.port_ptr(port_no) };
+        Self::wait_tfd_ready(port)?;
+        core::sync::atomic::compiler_fence(Ordering::Release);
+        let ci = volatile_read!(port.ci);
+        volatile_write!(port.ci, ci | (1 << pending.command.slot));
+        pending.command.issued = true;
+        if let Err(err) = Self::wait_slot(port, pending.command.slot) {
+            if port.stop().is_err() {
+                if let Some(buffer) = pending.buffer.take() {
+                    self.quarantined_dma.lock().push(buffer);
+                }
+            }
+            return Err(err);
+        }
+        core::sync::atomic::compiler_fence(Ordering::Acquire);
+        Self::parse_identify(pending.buffer.take().ok_or(SystemError::EIO)?)
+    }
+
+    /// Recover a port whose device never became ready before command issue.
+    /// The caller holds the per-port I/O mutex and no payload has been issued.
+    fn recover_unready_port(&self, port_no: usize) -> Result<(), SystemError> {
+        let expected = self
+            .disks
+            .lock()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .find(|disk| disk.port_num() == port_no)
+            .ok_or(SystemError::ENODEV)?;
+        let result = (|| {
+            let port = unsafe { &mut *self.port_ptr(port_no) };
+            port.stop()?;
+            if !self.accepting_io.load(Ordering::Acquire) {
+                return Err(SystemError::ESHUTDOWN);
+            }
+
+            // Never trust a device-returned PxFB as a CPU write target. The
+            // receive-FIS area is owned by our command arena at a fixed,
+            // checked offset; an unexpected register value fails recovery.
+            let (arena_base, arena_len) = self
+                .command_memory
+                .lock()
+                .as_ref()
+                .map(|memory| (memory.paddr(), memory.len()))
+                .ok_or(SystemError::ENOMEM)?;
+            let fb = arena_base
+                .checked_add(32 << 10)
+                .and_then(|base| base.checked_add(port_no << 8))
+                .ok_or(SystemError::EOVERFLOW)?;
+            let arena_end = arena_base
+                .checked_add(arena_len)
+                .ok_or(SystemError::EOVERFLOW)?;
+            if fb.checked_add(256).is_none_or(|end| end > arena_end)
+                || fb & 0xff != 0
+                || volatile_read!(port.fb) != fb as u64
+            {
+                return Err(SystemError::EIO);
+            }
+            let received_fis_vaddr = match port.begin_link_reset(fb as u64) {
+                Ok(address) => address,
+                Err(err) => {
+                    port.finish_link_reset_assertion();
+                    return Err(err);
+                }
+            };
+            let assert_until = Instant::now() + Duration::from_millis(1);
+            let mut iteration = 0usize;
+            while Instant::now() < assert_until {
+                cooperative_poll_step(&mut iteration);
+            }
+            port.finish_link_reset_assertion();
+
+            let deadline = Instant::now() + Duration::from_millis(AHCI_LINK_TIMEOUT_MS);
+            let mut stable_since = None;
+            let port_type = loop {
+                if !self.accepting_io.load(Ordering::Acquire) {
+                    return Err(SystemError::ESHUTDOWN);
+                }
+                if let Some(port_type) =
+                    port.classify_reset_link(received_fis_vaddr, &mut stable_since)
+                {
+                    break port_type;
+                }
+                if Instant::now() >= deadline {
+                    return Err(SystemError::ETIMEDOUT);
+                }
+                cooperative_poll_step(&mut iteration);
+            };
+            if port_type != HbaPortType::Sata {
+                return Err(SystemError::ENODEV);
+            }
+
+            // Stop FIS DMA before initialize_port clears the shared command
+            // arena, and reject any stale command ownership after COMRESET.
+            port.stop()?;
+            if volatile_read!(port.ci) != 0
+                || volatile_read!(port.sact) != 0
+                || !link_is_present(volatile_read!(port.ssts))
+            {
+                return Err(SystemError::EIO);
+            }
+            if !self.accepting_io.load(Ordering::Acquire) {
+                return Err(SystemError::ESHUTDOWN);
+            }
+            self.initialize_port(port_no)?;
+            let actual = self.identify_port_for_revalidation(port_no)?;
+            if !expected.matches_identify(actual) {
+                return Err(SystemError::ENODEV);
+            }
+            Ok(())
+        })();
+
+        if result.is_err() {
+            let _ = unsafe { &mut *self.port_ptr(port_no) }.stop();
+            self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
+        }
+        result
     }
 
     pub(crate) fn wait_slot(port: &HbaPort, slot: u32) -> Result<(), SystemError> {
@@ -1488,16 +1676,13 @@ impl AhciController {
     }
 
     fn unregister_disks(&self) {
-        let disks = self
-            .disks
-            .lock()
-            .iter()
-            .filter_map(Weak::upgrade)
-            .collect::<Vec<_>>();
+        let disks = core::mem::take(&mut *self.disks.lock());
         for disk in disks {
-            block_dev_manager().unregister_detached(
-                &(disk as Arc<dyn crate::driver::base::block::block_device::BlockDevice>),
-            );
+            if let Some(disk) = disk.upgrade() {
+                block_dev_manager().unregister_detached(
+                    &(disk as Arc<dyn crate::driver::base::block::block_device::BlockDevice>),
+                );
+            }
         }
     }
 

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -87,14 +87,38 @@ const AHCI_PXCMD_ICC_MASK: u32 = 0xf << 28;
 const AHCI_PXCMD_ICC_ACTIVE: u32 = 1 << 28;
 const AHCI_PXCMD_POD: u32 = 1 << 2;
 const AHCI_PXCMD_SUD: u32 = 1 << 1;
+const AHCI_MAX_SECTORS: u64 = 1u64 << 48;
+const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
+const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
 // 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
 // 32 * 32 command tables (256 KiB), rounded to the allocator's power of two.
 const AHCI_COMMAND_ARENA_SIZE: usize = 1 << 19;
 
+const fn capacity_is_addressable(capacity: u64) -> bool {
+    capacity != 0 && capacity <= AHCI_MAX_SECTORS
+}
+
+const fn poll_should_yield(iteration: usize) -> bool {
+    iteration != 0 && iteration.is_multiple_of(AHCI_POLL_YIELD_INTERVAL)
+}
+
+// These protocol boundaries are checked by every kernel build, including
+// architectures that do not instantiate the x86-only AHCI driver.
+const _: () = {
+    assert!(!capacity_is_addressable(0));
+    assert!(capacity_is_addressable(AHCI_MAX_SECTORS));
+    assert!(!capacity_is_addressable(AHCI_MAX_SECTORS + 1));
+    assert!(!poll_should_yield(0));
+    assert!(!poll_should_yield(AHCI_POLL_YIELD_INTERVAL - 1));
+    assert!(poll_should_yield(AHCI_POLL_YIELD_INTERVAL));
+};
+
 lazy_static! {
-    /// Last-resort owner for DMA memory if a controller object is destroyed
-    /// without proof that all posted transactions have drained.
-    static ref AHCI_DMA_QUARANTINE: SpinLock<Vec<DmaBuffer>> = SpinLock::new(Vec::new());
+    /// DMA memory whose controller could not be stopped or reset. Entries are
+    /// keyed by PCI device name and reclaimed after that controller next
+    /// completes a successful HBA reset with Bus Master disabled.
+    static ref AHCI_DMA_QUARANTINE: Mutex<HashMap<String, Vec<DmaBuffer>>> =
+        Mutex::new(HashMap::new());
 }
 
 /// Resources owned by one bound PCI AHCI controller.
@@ -106,12 +130,13 @@ pub struct AhciController {
     original_command: Command,
     dma_mask: u64,
     command_slots: u8,
-    command_memory: Option<DmaBuffer>,
+    command_memory: Mutex<Option<DmaBuffer>>,
     disks: SpinLock<Vec<Weak<LockedAhciDisk>>>,
     accepting_io: AtomicBool,
     failed_ports: AtomicU32,
     quarantined_dma: SpinLock<Vec<DmaBuffer>>,
     hardware_stopped: AtomicBool,
+    detached: AtomicBool,
     port_locks: Vec<Mutex<()>>,
     lifecycle: Mutex<ControllerState>,
 }
@@ -132,7 +157,7 @@ impl core::fmt::Debug for AhciController {
             .field("abar", &self.abar)
             .field("port_count", &self.port_count)
             .field("command_slots", &self.command_slots)
-            .field("has_command_memory", &self.command_memory.is_some())
+            .field("has_command_memory", &self.command_memory.lock().is_some())
             .finish()
     }
 }
@@ -162,6 +187,7 @@ impl AhciController {
             drop(bars);
             let hba = abar as *mut HbaMem;
             Self::initialize_hba(hba, &pci)?;
+            Self::reclaim_quarantined_dma(&device.name());
 
             let cap = volatile_read!((*hba).cap);
             let pi = volatile_read!((*hba).pi);
@@ -231,10 +257,12 @@ impl AhciController {
                     _ => training_ports.push(port_no),
                 }
             }
-            // Ready links are handled before training/faulty links, and each
-            // port gets its own deadline so one bad port cannot starve a disk.
-            online_ports.extend(training_ports);
-            let candidate_ports = online_ports;
+            // Ready links are considered first, but all candidates train in
+            // one interleaved window below rather than serial per-port waits.
+            let candidate_ports = online_ports
+                .into_iter()
+                .chain(training_ports)
+                .collect::<Vec<_>>();
 
             // Empty controllers are normal and do not need command DMA memory.
             let dma_mask = if cap & (1 << 31) != 0 {
@@ -263,12 +291,13 @@ impl AhciController {
                 original_command,
                 dma_mask,
                 command_slots,
-                command_memory,
+                command_memory: Mutex::new(command_memory),
                 disks: SpinLock::new(Vec::new()),
                 accepting_io: AtomicBool::new(true),
                 failed_ports: AtomicU32::new(0),
                 quarantined_dma: SpinLock::new(Vec::new()),
                 hardware_stopped: AtomicBool::new(false),
+                detached: AtomicBool::new(false),
                 port_locks: (0..32).map(|_| Mutex::new(())).collect(),
                 lifecycle: Mutex::new(ControllerState::Running),
             });
@@ -277,19 +306,23 @@ impl AhciController {
                 let command = pci.status_command().1;
                 pci.set_command(command | Command::BUS_MASTER);
             }
+            let mut link_states = Vec::new();
+            let mut provisional_ports = Vec::new();
             for port_no in candidate_ports {
-                if !controller.accepting_io.load(Ordering::Acquire) {
-                    break;
-                }
-                let arena = controller
+                let base = controller
                     .command_memory
+                    .lock()
                     .as_ref()
-                    .ok_or(SystemError::ENOMEM)?;
-                let fb = arena.paddr() + (32 << 10) + (port_no << 8);
-                let port_type = match unsafe { &mut *controller.port_ptr(port_no) }
-                    .reset_and_classify(fb as u64)
-                {
-                    Ok(port_type) => port_type,
+                    .ok_or(SystemError::ENOMEM)?
+                    .paddr();
+                let fb = base + (32 << 10) + (port_no << 8);
+                // Keep every attempted port so even a partially failed setup
+                // has its provisional FIS receiver stopped below.
+                provisional_ports.push(port_no);
+                match unsafe { &mut *controller.port_ptr(port_no) }.begin_link_reset(fb as u64) {
+                    Ok(received_fis_vaddr) => {
+                        link_states.push((port_no, received_fis_vaddr, None, None));
+                    }
                     Err(err) => {
                         controller
                             .failed_ports
@@ -300,10 +333,105 @@ impl AhciController {
                             port_no,
                             err
                         );
+                    }
+                }
+            }
+
+            // AHCI requires COMRESET to remain asserted for at least 1 ms.
+            // Asserting every port first lets all links recover concurrently.
+            let assert_until = Instant::now() + Duration::from_millis(1);
+            while Instant::now() < assert_until {
+                core::hint::spin_loop();
+            }
+            for port_no in &provisional_ports {
+                unsafe { &mut *controller.port_ptr(*port_no) }.finish_link_reset_assertion();
+            }
+
+            let link_deadline = Instant::now() + Duration::from_millis(AHCI_LINK_TIMEOUT_MS);
+            let mut link_iteration = 0usize;
+            loop {
+                let mut pending = false;
+                for (port_no, received_fis_vaddr, stable_since, port_type) in &mut link_states {
+                    if port_type.is_some() {
                         continue;
                     }
-                };
-                if port_type != HbaPortType::Sata {
+                    *port_type = unsafe { &mut *controller.port_ptr(*port_no) }
+                        .classify_reset_link(*received_fis_vaddr, stable_since);
+                    pending |= port_type.is_none();
+                }
+                if !pending || Instant::now() >= link_deadline {
+                    break;
+                }
+                if poll_should_yield(link_iteration) {
+                    crate::sched::sched_yield();
+                } else {
+                    core::hint::spin_loop();
+                }
+                link_iteration = link_iteration.wrapping_add(1);
+            }
+
+            for (port_no, _, _, port_type) in &link_states {
+                if port_type.is_none() {
+                    controller
+                        .failed_ports
+                        .fetch_or(1 << *port_no, Ordering::AcqRel);
+                    log::warn!(
+                        "AHCI {} port {} link initialization timed out",
+                        controller.pci.common_header.bus_device_function,
+                        port_no
+                    );
+                }
+            }
+
+            // Stop all temporary FIS receivers concurrently.  A successful
+            // classification remains valid because the normal path does not
+            // reset the links again before IDENTIFY.
+            for port_no in &provisional_ports {
+                unsafe { &mut *controller.port_ptr(*port_no) }.begin_provisional_stop();
+            }
+            let stop_deadline = Instant::now() + Duration::from_millis(500);
+            let mut stop_iteration = 0usize;
+            loop {
+                let mut all_stopped = true;
+                for port_no in &provisional_ports {
+                    // Do not short-circuit: every port must advance during
+                    // every scan so one slow CR bit cannot serialize FRE stop.
+                    all_stopped &= unsafe {
+                        &mut *controller.port_ptr(*port_no)
+                    }
+                    .advance_provisional_stop();
+                }
+                if all_stopped {
+                    break;
+                }
+                if Instant::now() >= stop_deadline {
+                    // Do not publish using classifications obtained before a
+                    // recovery reset.  Reset only proves DMA is stopped; this
+                    // probe fails and a later probe must classify afresh.
+                    let command = pci.status_command().1;
+                    pci.set_command(command & !Command::BUS_MASTER);
+                    if Self::reset_hba(hba).is_ok() {
+                        controller.hardware_stopped.store(true, Ordering::Release);
+                    }
+                    return Err(SystemError::ETIMEDOUT);
+                }
+                if poll_should_yield(stop_iteration) {
+                    crate::sched::sched_yield();
+                } else {
+                    core::hint::spin_loop();
+                }
+                stop_iteration = stop_iteration.wrapping_add(1);
+            }
+
+            let has_sata = link_states
+                .iter()
+                .any(|(_, _, _, port_type)| *port_type == Some(HbaPortType::Sata));
+            if has_sata {
+                let command = pci.status_command().1;
+                pci.set_command(command | Command::BUS_MASTER);
+            }
+            for (port_no, _, _, port_type) in link_states {
+                if port_type != Some(HbaPortType::Sata) {
                     continue;
                 }
                 if let Err(err) = controller.publish_port(port_no) {
@@ -325,7 +453,7 @@ impl AhciController {
             Ok(controller)
         })();
         if result.is_err() {
-            pci.set_command(original_command);
+            pci.set_command(original_command & !Command::BUS_MASTER);
         }
         result
     }
@@ -351,7 +479,14 @@ impl AhciController {
         let command = pci.status_command().1;
         pci.set_command(command & !Command::BUS_MASTER);
 
+        Self::reset_hba(hba)
+    }
+
+    fn reset_hba(hba: *mut HbaMem) -> Result<(), SystemError> {
         let ghc = volatile_read!((*hba).ghc);
+        if ghc == u32::MAX {
+            return Err(SystemError::ENODEV);
+        }
         volatile_write!((*hba).ghc, ghc | AHCI_GHC_AE);
         if volatile_read!((*hba).ghc) & AHCI_GHC_AE == 0 {
             return Err(SystemError::EIO);
@@ -374,9 +509,19 @@ impl AhciController {
         Ok(())
     }
 
+    fn reclaim_quarantined_dma(device_name: &str) {
+        let retired = AHCI_DMA_QUARANTINE.lock().remove(device_name);
+        // Do not run the DMA allocator while holding the quarantine mutex.
+        drop(retired);
+    }
+
     fn publish_port(self: &Arc<Self>, port_no: usize) -> Result<(), SystemError> {
-        let arena = self.command_memory.as_ref().ok_or(SystemError::ENOMEM)?;
-        let base = arena.paddr();
+        let base = self
+            .command_memory
+            .lock()
+            .as_ref()
+            .ok_or(SystemError::ENOMEM)?
+            .paddr();
         let fb = base + (32 << 10) + (port_no << 8);
         let clb = base + (port_no << 10);
         let ctbas = (0..32)
@@ -425,18 +570,17 @@ impl AhciController {
         Ok(guard)
     }
 
-    pub(crate) fn acquire_holder(&self, counter: &AtomicU32) -> Result<(), SystemError> {
+    pub(crate) fn acquire_holder(&self) -> Result<(), SystemError> {
         let state = self.lifecycle.lock();
         if *state != ControllerState::Running || !self.accepting_io.load(Ordering::Acquire) {
             return Err(SystemError::ENODEV);
         }
-        counter.fetch_add(1, Ordering::AcqRel);
         Ok(())
     }
 
     /// Stop a failed port before releasing a buffer that may still be a DMA
-    /// target. If the engine cannot be stopped, disable PCI bus mastering for
-    /// the whole controller before the buffer is released.
+    /// target. If the engine cannot be stopped, retain the buffer until a
+    /// controller-wide reset proves that old DMA state is gone.
     pub(crate) fn abort_failed_dma(&self, port_no: usize, buffer: DmaBuffer) {
         self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
         if unsafe { &mut *self.port_ptr(port_no) }.stop().is_err() {
@@ -444,6 +588,8 @@ impl AhciController {
             let command = self.pci.status_command().1;
             self.pci.set_command(command & !Command::BUS_MASTER);
             self.quarantined_dma.lock().push(buffer);
+        } else {
+            drop(buffer);
         }
     }
 
@@ -533,8 +679,15 @@ impl AhciController {
             | u64::from(word(101)) << 16
             | u64::from(word(102)) << 32
             | u64::from(word(103)) << 48;
-        if capacity == 0 {
-            return Err(SystemError::EIO);
+        // READ/WRITE DMA EXT carries a 48-bit LBA, so at most 2^48 sectors
+        // (ending at LBA 2^48 - 1) are addressable. A larger IDENTIFY value
+        // would pass the range check but be truncated while building the FIS.
+        if !capacity_is_addressable(capacity) {
+            return Err(if capacity == 0 {
+                SystemError::EIO
+            } else {
+                SystemError::EOVERFLOW
+            });
         }
         let capacity_lba = usize::try_from(capacity).map_err(|_| SystemError::EOVERFLOW)?;
         let has_flush_ext = word83 & (1 << 13) != 0;
@@ -624,7 +777,7 @@ impl AhciController {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            if iteration & 0x3ff == 0 {
+            if poll_should_yield(iteration) {
                 crate::sched::sched_yield();
             } else {
                 core::hint::spin_loop();
@@ -646,7 +799,7 @@ impl AhciController {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            if iteration & 0x3ff == 0 {
+            if poll_should_yield(iteration) {
                 crate::sched::sched_yield();
             } else {
                 core::hint::spin_loop();
@@ -664,6 +817,14 @@ impl AhciController {
         }
     }
 
+    fn hba_accessible(&self) -> bool {
+        let hba = self.abar as *mut HbaMem;
+        // GHC contains reserved-zero bits, so an all-ones read is a reliable
+        // sign that the BAR no longer responds.  PI is a full 32-bit bitmap:
+        // all ones is valid for a controller implementing every port.
+        volatile_read!((*hba).ghc) != u32::MAX
+    }
+
     fn stop_quiesced(&self) -> Result<(), SystemError> {
         let pi = volatile_read!((*(self.abar as *mut HbaMem)).pi);
         let mut first_error = None;
@@ -678,12 +839,25 @@ impl AhciController {
         if let Some(err) = first_error {
             let command = self.pci.status_command().1;
             self.pci.set_command(command & !Command::BUS_MASTER);
-            Err(err)
+            if Self::reset_hba(self.abar as *mut HbaMem).is_err() {
+                Err(err)
+            } else {
+                self.hardware_stopped.store(true, Ordering::Release);
+                self.release_quarantined_dma();
+                Ok(())
+            }
         } else {
             self.hardware_stopped.store(true, Ordering::Release);
-            self.quarantined_dma.lock().clear();
+            self.release_quarantined_dma();
             Ok(())
         }
+    }
+
+    fn release_quarantined_dma(&self) {
+        let mut guard = self.quarantined_dma.lock();
+        let retired = core::mem::take(&mut *guard);
+        drop(guard);
+        drop(retired);
     }
 
     fn flush_disks(&self) -> Result<(), SystemError> {
@@ -712,15 +886,7 @@ impl AhciController {
         first_error.map_or(Ok(()), Err)
     }
 
-    fn has_holders(&self) -> bool {
-        self.disks
-            .lock()
-            .iter()
-            .filter_map(Weak::upgrade)
-            .any(|disk| disk.has_holders())
-    }
-
-    fn unregister_disks(&self) -> Result<(), SystemError> {
+    fn unregister_disks(&self) {
         let disks = self
             .disks
             .lock()
@@ -728,35 +894,47 @@ impl AhciController {
             .filter_map(Weak::upgrade)
             .collect::<Vec<_>>();
         for disk in disks {
-            let result = block_dev_manager().unregister(
+            block_dev_manager().unregister_detached(
                 &(disk as Arc<dyn crate::driver::base::block::block_device::BlockDevice>),
             );
-            if let Err(err) = result {
-                if err != SystemError::ENOENT {
-                    return Err(err);
-                }
-            }
         }
-        Ok(())
+    }
+
+    fn retire_dma(&self, safe_to_release: bool) {
+        let mut local_guard = self.quarantined_dma.lock();
+        let mut retired = core::mem::take(&mut *local_guard);
+        drop(local_guard);
+        if let Some(memory) = self.command_memory.lock().take() {
+            retired.push(memory);
+        }
+        if safe_to_release || retired.is_empty() {
+            drop(retired);
+            return;
+        }
+        AHCI_DMA_QUARANTINE
+            .lock()
+            .entry(self.device.name())
+            .or_default()
+            .extend(retired);
     }
 }
 
 impl Drop for AhciController {
     fn drop(&mut self) {
+        if self.detached.load(Ordering::Acquire) {
+            return;
+        }
+        if self.hardware_stopped.load(Ordering::Acquire) {
+            self.pci
+                .set_command(self.original_command & !Command::BUS_MASTER);
+            return;
+        }
         self.quiesce();
         let _ = self.flush_disks();
         if self.stop_quiesced().is_err() {
-            // A failed engine stop must not turn into either DMA-after-free or
-            // a permanent allocation leak.  PCI Bus Master disable cuts off
-            // DMA before owned buffers are dropped.
             self.pci
                 .set_command(self.original_command & !Command::BUS_MASTER);
-            if let Some(memory) = self.command_memory.take() {
-                AHCI_DMA_QUARANTINE.lock().push(memory);
-            }
-            AHCI_DMA_QUARANTINE
-                .lock()
-                .extend(self.quarantined_dma.lock().drain(..));
+            self.retire_dma(false);
             return;
         }
         // A detached storage controller must not regain DMA permission merely
@@ -819,43 +997,61 @@ impl PciDriver for AhciPciDriver {
         }
     }
 
-    fn remove(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
+    fn remove(&self, device: &Arc<dyn PciDevice>) {
         let name = device.name();
-        let controller = self
-            .controllers
-            .read()
-            .get(&name)
-            .and_then(Option::clone)
-            .ok_or(SystemError::ENODEV)?;
+        let Some(controller) = self.controllers.read().get(&name).and_then(Option::clone) else {
+            return;
+        };
         let mut state = controller.lifecycle.lock();
-        if !matches!(
-            *state,
-            ControllerState::Running | ControllerState::RemovalFailed
-        ) {
-            return Err(SystemError::EBUSY);
+        if controller.detached.load(Ordering::Acquire) {
+            self.controllers.write().remove(&name);
+            return;
         }
-        if controller.has_holders() {
-            return Err(SystemError::EBUSY);
+        let already_stopped = *state == ControllerState::Stopped;
+        if !already_stopped
+            && !matches!(
+                *state,
+                ControllerState::Running | ControllerState::RemovalFailed
+            )
+        {
+            log::warn!(
+                "AHCI {} detach observed unexpected state {:?}",
+                name,
+                *state
+            );
         }
-        *state = ControllerState::Detaching;
-        controller.quiesce();
-        let flush_result = controller.flush_disks();
-        let unregister_result = controller.unregister_disks();
-        let stop_result = controller.stop_quiesced();
-        if let Err(err) = stop_result {
-            *state = ControllerState::RemovalFailed;
-            return Err(err);
-        }
-        if let Err(err) = unregister_result {
-            *state = ControllerState::RemovalFailed;
-            return Err(err);
-        }
+
+        let mut flush_result = Ok(());
+        let stop_result = if already_stopped {
+            Ok(())
+        } else {
+            *state = ControllerState::Detaching;
+            controller.quiesce();
+            if controller.hba_accessible() {
+                flush_result = controller.flush_disks();
+                controller.stop_quiesced()
+            } else {
+                Err(SystemError::ENODEV)
+            }
+        };
+        controller.unregister_disks();
+
+        // This is the final PCI configuration access by this controller. The
+        // detached flag makes delayed Drop from an open mount hardware-silent.
+        let command = controller.pci.status_command().1;
+        controller.pci.set_command(command & !Command::BUS_MASTER);
+        controller.detached.store(true, Ordering::Release);
         *state = ControllerState::Stopped;
+        controller.retire_dma(stop_result.is_ok());
         self.controllers.write().remove(&name);
         if let Err(err) = flush_result {
             log::warn!("AHCI {} detach flush failed: {:?}", name, err);
         }
-        Ok(())
+        if let Err(err) = stop_result {
+            // The I/O gate is closed and all DMA allocations remain owned by
+            // this controller or its keyed quarantine until a reset succeeds.
+            log::warn!("AHCI {} command-engine stop failed: {:?}", name, err);
+        }
     }
 
     fn shutdown(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
@@ -880,10 +1076,14 @@ impl PciDriver for AhciPciDriver {
             let flush_result = controller.flush_disks();
             match controller.stop_quiesced() {
                 Ok(()) => {
+                    let command = controller.pci.status_command().1;
+                    controller.pci.set_command(command & !Command::BUS_MASTER);
                     *state = ControllerState::Stopped;
                     flush_result?;
                 }
                 Err(err) => {
+                    let command = controller.pci.status_command().1;
+                    controller.pci.set_command(command & !Command::BUS_MASTER);
                     *state = ControllerState::RemovalFailed;
                     return Err(err);
                 }

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -61,6 +61,7 @@ use self::{
     hba::{
         FisRegH2D, FisType, HbaCmdHeader, HbaCmdTable, HbaMem, HbaPort, HbaPortType,
         ATA_CMD_FLUSH_CACHE, ATA_CMD_FLUSH_CACHE_EXT, ATA_CMD_IDENTIFY, ATA_DEV_BUSY, ATA_DEV_DRQ,
+        HBA_PORT_IS_ERR,
     },
 };
 
@@ -70,8 +71,30 @@ pub(crate) struct AhciIdentify {
     reliable_flush: bool,
 }
 
-/* TFES - Task File Error Status */
-pub const HBA_PXIS_TFES: u32 = 1 << 30;
+struct PendingAtaCommand {
+    port_no: usize,
+    slot: u32,
+    issued: bool,
+}
+
+struct PendingIdentify {
+    command: PendingAtaCommand,
+    buffer: Option<DmaBuffer>,
+    result: Option<Result<AhciIdentify, SystemError>>,
+}
+
+struct PendingFlush {
+    command: PendingAtaCommand,
+    result: Option<Result<(), SystemError>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum AtaCommandStatus {
+    Pending,
+    Complete,
+    Error,
+}
+
 const AHCI_CLASS_CODE: u32 = 0x010601;
 const AHCI_CLASS_MASK: u32 = 0x00ff_ffff;
 const AHCI_GHC_AE: u32 = 1 << 31;
@@ -91,6 +114,7 @@ const AHCI_MAX_SECTORS: u64 = 1u64 << 48;
 const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
 const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
 const AHCI_PORT_STOP_TIMEOUT_MS: u64 = 500;
+const AHCI_COMMAND_TIMEOUT_MS: u64 = 30_000;
 // 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
 // 32 * 32 command tables (256 KiB), rounded to the allocator's power of two.
 const AHCI_COMMAND_ARENA_SIZE: usize = 1 << 19;
@@ -103,6 +127,24 @@ const fn poll_should_yield(iteration: usize) -> bool {
     iteration != 0 && iteration.is_multiple_of(AHCI_POLL_YIELD_INTERVAL)
 }
 
+const fn classify_command_status(port_is: u32, port_ci: u32, slot: u32) -> AtaCommandStatus {
+    if port_is & HBA_PORT_IS_ERR != 0 {
+        AtaCommandStatus::Error
+    } else if port_ci & (1 << slot) == 0 {
+        AtaCommandStatus::Complete
+    } else {
+        AtaCommandStatus::Pending
+    }
+}
+
+fn read_command_status(port: &HbaPort, slot: u32) -> AtaCommandStatus {
+    // Read CI first. If the device completes with an error between these two
+    // MMIO reads, the later, latched PxIS read still makes the result fail.
+    let port_ci = volatile_read!(port.ci);
+    let port_is = volatile_read!(port.is);
+    classify_command_status(port_is, port_ci, slot)
+}
+
 // These protocol boundaries are checked by every kernel build, including
 // architectures that do not instantiate the x86-only AHCI driver.
 const _: () = {
@@ -112,6 +154,18 @@ const _: () = {
     assert!(!poll_should_yield(0));
     assert!(!poll_should_yield(AHCI_POLL_YIELD_INTERVAL - 1));
     assert!(poll_should_yield(AHCI_POLL_YIELD_INTERVAL));
+    assert!(matches!(
+        classify_command_status(HBA_PORT_IS_ERR, 0, 0),
+        AtaCommandStatus::Error
+    ));
+    assert!(matches!(
+        classify_command_status(0, 0, 0),
+        AtaCommandStatus::Complete
+    ));
+    assert!(matches!(
+        classify_command_status(0, 1, 0),
+        AtaCommandStatus::Pending
+    ));
 };
 
 lazy_static! {
@@ -296,7 +350,10 @@ impl AhciController {
                 disks: SpinLock::new(Vec::new()),
                 accepting_io: AtomicBool::new(true),
                 failed_ports: AtomicU32::new(0),
-                quarantined_dma: SpinLock::new(Vec::new()),
+                // At most one command can be active on each serialized port.
+                // Reserve all possible entries before any fault path so DMA
+                // quarantine never allocates after a command-engine failure.
+                quarantined_dma: SpinLock::new(Vec::with_capacity(32)),
                 hardware_stopped: AtomicBool::new(false),
                 detached: AtomicBool::new(false),
                 port_locks: (0..32).map(|_| Mutex::new(())).collect(),
@@ -409,27 +466,13 @@ impl AhciController {
                 let command = pci.status_command().1;
                 pci.set_command(command | Command::BUS_MASTER);
             }
-            for (port_no, _, _, port_type) in link_states {
-                if port_type != Some(HbaPortType::Sata) {
-                    continue;
-                }
-                if let Err(err) = controller.publish_port(port_no) {
-                    log::error!(
-                        "AHCI {} port {} initialization failed: {:?}",
-                        controller.pci.common_header.bus_device_function,
-                        port_no,
-                        err
-                    );
-                    if !controller.accepting_io.load(Ordering::Acquire) {
-                        // A failed port stop disables DMA for the whole HBA.
-                        // Complete a terminal detach before releasing the BDF
-                        // reservation, so stale mounts cannot later touch a
-                        // controller owned by a new probe generation.
-                        controller.rollback_failed_probe();
-                        return Err(err);
-                    }
-                }
-            }
+            let sata_ports = link_states
+                .into_iter()
+                .filter_map(|(port_no, _, _, port_type)| {
+                    (port_type == Some(HbaPortType::Sata)).then_some(port_no)
+                })
+                .collect::<Vec<_>>();
+            controller.probe_sata_ports(&sata_ports);
             if controller.disks.lock().is_empty() {
                 let command = pci.status_command().1;
                 pci.set_command(command & !Command::BUS_MASTER);
@@ -499,7 +542,7 @@ impl AhciController {
         drop(retired);
     }
 
-    fn publish_port(self: &Arc<Self>, port_no: usize) -> Result<(), SystemError> {
+    fn initialize_port(&self, port_no: usize) -> Result<(), SystemError> {
         let base = self
             .command_memory
             .lock()
@@ -512,9 +555,15 @@ impl AhciController {
             .map(|slot| (base + (40 << 10) + (port_no << 13) + (slot << 8)) as u64)
             .collect::<Vec<_>>();
 
+        unsafe { &mut *self.port_ptr(port_no) }.init(clb as u64, fb as u64, &ctbas)
+    }
+
+    fn publish_identified(
+        self: &Arc<Self>,
+        port_no: usize,
+        identify: AhciIdentify,
+    ) -> Result<(), SystemError> {
         let result = (|| {
-            unsafe { &mut *self.port_ptr(port_no) }.init(clb as u64, fb as u64, &ctbas)?;
-            let identify = self.identify(port_no)?;
             let disk = LockedAhciDisk::new(self.clone(), port_no as u8, identify)?;
             block_dev_manager().register(disk.clone())?;
             self.disks.lock().push(Arc::downgrade(&disk));
@@ -551,6 +600,10 @@ impl AhciController {
             drop(guard);
             return Err(SystemError::ESHUTDOWN);
         }
+        if self.failed_ports.load(Ordering::Acquire) & (1 << port_no) != 0 {
+            drop(guard);
+            return Err(SystemError::EIO);
+        }
         Ok(guard)
     }
 
@@ -562,16 +615,15 @@ impl AhciController {
         Ok(())
     }
 
-    /// Stop a failed port before releasing a buffer that may still be a DMA
-    /// target. If the engine cannot be stopped, retain the buffer until a
-    /// controller-wide reset proves that old DMA state is gone.
-    pub(crate) fn abort_failed_dma(&self, port_no: usize, buffer: DmaBuffer) {
+    /// Freeze one failed port. A controller-wide Bus Master shutdown would
+    /// interrupt unrelated ports, so a buffer which may still be a DMA target
+    /// remains owned by this controller until teardown stops or resets the HBA.
+    pub(crate) fn abort_failed_command(&self, port_no: usize, buffer: Option<DmaBuffer>) {
         self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
         if unsafe { &mut *self.port_ptr(port_no) }.stop().is_err() {
-            self.accepting_io.store(false, Ordering::Release);
-            let command = self.pci.status_command().1;
-            self.pci.set_command(command & !Command::BUS_MASTER);
-            self.quarantined_dma.lock().push(buffer);
+            if let Some(buffer) = buffer {
+                self.quarantined_dma.lock().push(buffer);
+            }
         } else {
             drop(buffer);
         }
@@ -593,9 +645,9 @@ impl AhciController {
         Ok(buffer)
     }
 
-    fn identify(&self, port_no: usize) -> Result<AhciIdentify, SystemError> {
+    fn prepare_identify(&self, port_no: usize) -> Result<PendingIdentify, SystemError> {
         let port = unsafe { &mut *self.port_ptr(port_no) };
-        let mut identify = self.allocate_dma(512, DmaDirection::FromDevice)?;
+        let identify = self.allocate_dma(512, DmaDirection::FromDevice)?;
         let slot = port
             .find_cmdslot(self.command_slots)
             .ok_or(SystemError::EBUSY)?;
@@ -630,16 +682,18 @@ impl AhciController {
         volatile_write!(fis.pm, 1 << 7);
         volatile_write!(fis.command, ATA_CMD_IDENTIFY);
 
-        Self::wait_tfd_ready(port)?;
-        core::sync::atomic::compiler_fence(Ordering::Release);
-        let ci = volatile_read!(port.ci);
-        volatile_write!(port.ci, ci | (1 << slot));
-        if let Err(err) = Self::wait_slot(port, slot) {
-            self.abort_failed_dma(port_no, identify);
-            return Err(err);
-        }
-        core::sync::atomic::compiler_fence(Ordering::Acquire);
+        Ok(PendingIdentify {
+            command: PendingAtaCommand {
+                port_no,
+                slot,
+                issued: false,
+            },
+            buffer: Some(identify),
+            result: None,
+        })
+    }
 
+    fn parse_identify(mut identify: DmaBuffer) -> Result<AhciIdentify, SystemError> {
         let bytes = identify.as_mut_slice();
         let word = |index: usize| u16::from_le_bytes([bytes[index * 2], bytes[index * 2 + 1]]);
         if word(49) & (1 << 8) == 0 {
@@ -696,17 +750,191 @@ impl AhciController {
         })
     }
 
-    pub(crate) fn flush_port(
+    /// Advance one already prepared command without waiting on another port.
+    /// This keeps controller-wide probe and teardown budgets fair when one
+    /// device remains BUSY forever.
+    fn advance_prepared_command(
+        &self,
+        command: &mut PendingAtaCommand,
+    ) -> Result<bool, SystemError> {
+        let port = unsafe { &mut *self.port_ptr(command.port_no) };
+        if read_command_status(port, command.slot) == AtaCommandStatus::Error {
+            return Err(SystemError::EIO);
+        }
+        if !command.issued {
+            if volatile_read!(port.tfd) as u8 & (ATA_DEV_BUSY | ATA_DEV_DRQ) != 0 {
+                return Ok(false);
+            }
+            core::sync::atomic::compiler_fence(Ordering::Release);
+            let ci = volatile_read!(port.ci);
+            volatile_write!(port.ci, ci | (1 << command.slot));
+            command.issued = true;
+        }
+        match read_command_status(port, command.slot) {
+            AtaCommandStatus::Error => return Err(SystemError::EIO),
+            AtaCommandStatus::Complete => {
+                core::sync::atomic::compiler_fence(Ordering::Acquire);
+                return Ok(true);
+            }
+            AtaCommandStatus::Pending => {}
+        }
+        Ok(false)
+    }
+
+    fn fail_pending_identify(pending: &mut PendingIdentify, err: SystemError) {
+        pending.result = Some(Err(err));
+    }
+
+    fn stop_failed_batch(&self, ports: &[usize]) -> bool {
+        let failed_mask = ports.iter().fold(0, |mask, port_no| mask | 1 << port_no);
+        self.failed_ports.fetch_or(failed_mask, Ordering::AcqRel);
+        self.stop_ports_concurrently(ports).is_ok()
+    }
+
+    /// Prepare every SATA port before polling any of them. All ports therefore
+    /// receive a chance to complete IDENTIFY within one controller budget.
+    fn probe_sata_ports(self: &Arc<Self>, ports: &[usize]) {
+        let mut pending = Vec::with_capacity(ports.len());
+        let mut setup_failed = Vec::new();
+        for &port_no in ports {
+            let prepared = self
+                .initialize_port(port_no)
+                .and_then(|()| self.prepare_identify(port_no));
+            match prepared {
+                Ok(command) => pending.push(command),
+                Err(err) => {
+                    setup_failed.push(port_no);
+                    log::error!(
+                        "AHCI {} port {} initialization failed: {:?}",
+                        self.pci.common_header.bus_device_function,
+                        port_no,
+                        err
+                    );
+                }
+            }
+        }
+        if !setup_failed.is_empty() {
+            self.stop_failed_batch(&setup_failed);
+        }
+
+        // Link reset and the concurrent provisional stop already established
+        // the setup bound. Start the IDENTIFY command budget only after every
+        // usable port is prepared, so setup failure on a low-numbered port
+        // cannot consume a healthy higher-numbered port's command window.
+        let deadline = Instant::now() + Duration::from_millis(AHCI_COMMAND_TIMEOUT_MS);
+        let mut remaining = pending.len();
+        let mut iteration = 0usize;
+        while remaining != 0 && Instant::now() < deadline {
+            for item in &mut pending {
+                if item.result.is_some() {
+                    continue;
+                }
+                match self.advance_prepared_command(&mut item.command) {
+                    Ok(false) => {}
+                    Ok(true) => {
+                        let result = item
+                            .buffer
+                            .take()
+                            .ok_or(SystemError::EIO)
+                            .and_then(Self::parse_identify);
+                        if result.is_err() {
+                            self.failed_ports
+                                .fetch_or(1 << item.command.port_no, Ordering::AcqRel);
+                        }
+                        item.result = Some(result);
+                        remaining -= 1;
+                    }
+                    Err(err) => {
+                        Self::fail_pending_identify(item, err);
+                        remaining -= 1;
+                    }
+                }
+            }
+            if remaining != 0 {
+                if poll_should_yield(iteration) {
+                    crate::sched::sched_yield();
+                } else {
+                    core::hint::spin_loop();
+                }
+                iteration = iteration.wrapping_add(1);
+            }
+        }
+        // A scheduler yield may return after the deadline even though hardware
+        // completed before it. Observe already-issued commands once more, but
+        // never submit a previously BUSY command after its budget expired.
+        for item in &mut pending {
+            if item.result.is_some() || !item.command.issued {
+                continue;
+            }
+            let port = unsafe { &*self.port_ptr(item.command.port_no) };
+            match read_command_status(port, item.command.slot) {
+                AtaCommandStatus::Complete => {
+                    core::sync::atomic::compiler_fence(Ordering::Acquire);
+                    let result = item
+                        .buffer
+                        .take()
+                        .ok_or(SystemError::EIO)
+                        .and_then(Self::parse_identify);
+                    item.result = Some(result);
+                }
+                AtaCommandStatus::Error => item.result = Some(Err(SystemError::EIO)),
+                AtaCommandStatus::Pending => {}
+            }
+        }
+        for item in &mut pending {
+            if item.result.is_none() {
+                Self::fail_pending_identify(item, SystemError::ETIMEDOUT);
+            }
+        }
+
+        let failed = pending
+            .iter()
+            .filter_map(|item| {
+                item.result
+                    .as_ref()
+                    .is_some_and(Result::is_err)
+                    .then_some(item.command.port_no)
+            })
+            .collect::<Vec<_>>();
+        if !failed.is_empty() && !self.stop_failed_batch(&failed) {
+            let mut quarantine = self.quarantined_dma.lock();
+            for item in &mut pending {
+                if item.command.issued && item.result.as_ref().is_some_and(Result::is_err) {
+                    if let Some(buffer) = item.buffer.take() {
+                        quarantine.push(buffer);
+                    }
+                }
+            }
+        }
+
+        for item in pending {
+            let port_no = item.command.port_no;
+            match item.result.unwrap_or(Err(SystemError::EIO)) {
+                Ok(identify) => {
+                    if let Err(err) = self.publish_identified(port_no, identify) {
+                        log::error!(
+                            "AHCI {} port {} publication failed: {:?}",
+                            self.pci.common_header.bus_device_function,
+                            port_no,
+                            err
+                        );
+                    }
+                }
+                Err(err) => log::error!(
+                    "AHCI {} port {} IDENTIFY failed: {:?}",
+                    self.pci.common_header.bus_device_function,
+                    port_no,
+                    err
+                ),
+            }
+        }
+    }
+
+    fn prepare_flush_command(
         &self,
         port_no: usize,
         command: u8,
-        teardown: bool,
-    ) -> Result<(), SystemError> {
-        let _guard = if teardown {
-            self.port_locks[port_no].lock()
-        } else {
-            self.lock_port_for_io(port_no)?
-        };
+    ) -> Result<PendingAtaCommand, SystemError> {
         let port = unsafe { &mut *self.port_ptr(port_no) };
         volatile_write!(port.is, u32::MAX);
         let slot = port
@@ -738,13 +966,24 @@ impl AhciController {
         volatile_write!(fis.fis_type, FisType::RegH2D as u8);
         volatile_write!(fis.pm, 1 << 7);
         volatile_write!(fis.command, command);
+        Ok(PendingAtaCommand {
+            port_no,
+            slot,
+            issued: false,
+        })
+    }
+
+    pub(crate) fn flush_port(&self, port_no: usize, command: u8) -> Result<(), SystemError> {
+        let _guard = self.lock_port_for_io(port_no)?;
+        let mut pending = self.prepare_flush_command(port_no, command)?;
+        let port = unsafe { &mut *self.port_ptr(port_no) };
         Self::wait_tfd_ready(port)?;
         core::sync::atomic::compiler_fence(Ordering::Release);
         let ci = volatile_read!(port.ci);
-        volatile_write!(port.ci, ci | (1 << slot));
-        if let Err(err) = Self::wait_slot(port, slot) {
-            self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
-            let _ = port.stop();
+        volatile_write!(port.ci, ci | (1 << pending.slot));
+        pending.issued = true;
+        if let Err(err) = Self::wait_slot(port, pending.slot) {
+            self.abort_failed_command(port_no, None);
             return Err(err);
         }
         core::sync::atomic::compiler_fence(Ordering::Acquire);
@@ -771,14 +1010,13 @@ impl AhciController {
     }
 
     pub(crate) fn wait_slot(port: &HbaPort, slot: u32) -> Result<(), SystemError> {
-        let deadline = Instant::now() + Duration::from_secs(30);
+        let deadline = Instant::now() + Duration::from_millis(AHCI_COMMAND_TIMEOUT_MS);
         let mut iteration = 0usize;
         loop {
-            if volatile_read!(port.is) & HBA_PXIS_TFES != 0 {
-                return Err(SystemError::EIO);
-            }
-            if volatile_read!(port.ci) & (1 << slot) == 0 {
-                return Ok(());
+            match read_command_status(port, slot) {
+                AtaCommandStatus::Error => return Err(SystemError::EIO),
+                AtaCommandStatus::Complete => return Ok(()),
+                AtaCommandStatus::Pending => {}
             }
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
@@ -854,21 +1092,6 @@ impl AhciController {
         }
     }
 
-    /// Finish a failed initial probe before its BDF reservation is released.
-    /// Published nodes may already have mount holders, so this must make their
-    /// delayed controller Drop permanently hardware-silent.
-    fn rollback_failed_probe(&self) {
-        self.quiesce();
-        let stop_result = if self.hba_accessible() {
-            self.stop_quiesced()
-        } else {
-            Err(SystemError::ENODEV)
-        };
-        *self.lifecycle.lock() = ControllerState::Stopped;
-        self.finalize_detach(stop_result.is_ok());
-        self.unregister_disks();
-    }
-
     fn stop_quiesced(&self) -> Result<(), SystemError> {
         let pi = volatile_read!((*(self.abar as *mut HbaMem)).pi);
         let ports = (0..self.port_count)
@@ -916,10 +1139,100 @@ impl AhciController {
             };
         }
         let mut first_error = None;
+        let mut pending = Vec::with_capacity(disks.len());
+        let mut failed = Vec::new();
         for disk in disks {
-            if let Err(err) = disk.flush_for_teardown() {
-                first_error.get_or_insert(err);
+            let Some((port_no, command)) = disk.teardown_flush_command() else {
+                continue;
+            };
+            if self.failed_ports.load(Ordering::Acquire) & (1 << port_no) != 0 {
+                first_error.get_or_insert(SystemError::EIO);
+                failed.push(port_no);
+                log::warn!(
+                    "AHCI {} port {} teardown FLUSH skipped: port already failed",
+                    self.pci.common_header.bus_device_function,
+                    port_no
+                );
+                continue;
             }
+            match self.prepare_flush_command(port_no, command) {
+                Ok(command) => pending.push(PendingFlush {
+                    command,
+                    result: None,
+                }),
+                Err(err) => {
+                    failed.push(port_no);
+                    first_error.get_or_insert(err.clone());
+                    log::warn!(
+                        "AHCI {} port {} teardown FLUSH preparation failed: {:?}",
+                        self.pci.common_header.bus_device_function,
+                        port_no,
+                        err
+                    );
+                }
+            }
+        }
+
+        let deadline = Instant::now() + Duration::from_millis(AHCI_COMMAND_TIMEOUT_MS);
+        let mut remaining = pending.len();
+        let mut iteration = 0usize;
+        while remaining != 0 && Instant::now() < deadline {
+            for item in &mut pending {
+                if item.result.is_some() {
+                    continue;
+                }
+                match self.advance_prepared_command(&mut item.command) {
+                    Ok(false) => {}
+                    Ok(true) => {
+                        item.result = Some(Ok(()));
+                        remaining -= 1;
+                    }
+                    Err(err) => {
+                        item.result = Some(Err(err));
+                        remaining -= 1;
+                    }
+                }
+            }
+            if remaining != 0 {
+                if poll_should_yield(iteration) {
+                    crate::sched::sched_yield();
+                } else {
+                    core::hint::spin_loop();
+                }
+                iteration = iteration.wrapping_add(1);
+            }
+        }
+        for item in &mut pending {
+            if item.result.is_some() || !item.command.issued {
+                continue;
+            }
+            let port = unsafe { &*self.port_ptr(item.command.port_no) };
+            item.result = match read_command_status(port, item.command.slot) {
+                AtaCommandStatus::Complete => {
+                    core::sync::atomic::compiler_fence(Ordering::Acquire);
+                    Some(Ok(()))
+                }
+                AtaCommandStatus::Error => Some(Err(SystemError::EIO)),
+                AtaCommandStatus::Pending => None,
+            };
+        }
+        for item in &mut pending {
+            if item.result.is_none() {
+                item.result = Some(Err(SystemError::ETIMEDOUT));
+            }
+            if let Some(Err(err)) = &item.result {
+                first_error.get_or_insert(err.clone());
+                failed.push(item.command.port_no);
+                log::warn!(
+                    "AHCI {} port {} teardown FLUSH failed: {:?}",
+                    self.pci.common_header.bus_device_function,
+                    item.command.port_no,
+                    err
+                );
+            }
+        }
+        if !failed.is_empty() {
+            self.stop_failed_batch(&failed);
         }
         first_error.map_or(Ok(()), Err)
     }

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -665,6 +665,10 @@ impl AhciController {
             DmaAllocOptions {
                 direction,
                 dma_mask: Some(self.dma_mask),
+                // A host-to-device payload is fully initialized before the
+                // command is issued. Device-written and shared buffers still
+                // start zeroed so stale kernel data is never exposed.
+                zeroed: direction != DmaDirection::ToDevice,
                 ..Default::default()
             },
         )?;
@@ -1438,12 +1442,16 @@ impl PciDriver for AhciPciDriver {
     }
 
     fn shutdown(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
-        if let Some(controller) = self
+        // Drop the controller-table read guard before taking the per-controller
+        // lifecycle lock. remove() takes those locks in the opposite phases
+        // (lifecycle first, table write last), so retaining both would deadlock
+        // concurrent shutdown and hot removal.
+        let controller = self
             .controllers
             .read()
             .get(&device.name())
-            .and_then(Option::clone)
-        {
+            .and_then(Option::clone);
+        if let Some(controller) = controller {
             let mut state = controller.lifecycle.lock();
             if *state == ControllerState::Stopped {
                 return Ok(());

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -67,6 +67,7 @@ use self::{
 pub(crate) struct AhciIdentify {
     capacity_lba: usize,
     flush_command: Option<u8>,
+    reliable_flush: bool,
 }
 
 /* TFES - Task File Error Status */
@@ -536,9 +537,17 @@ impl AhciController {
             return Err(SystemError::EIO);
         }
         let capacity_lba = usize::try_from(capacity).map_err(|_| SystemError::EOVERFLOW)?;
-        let flush_command = if word83 & (1 << 13) != 0 {
+        let has_flush_ext = word83 & (1 << 13) != 0;
+        let has_flush = word83 & (1 << 12) != 0;
+        let word87 = word(87);
+        let write_cache_enabled = word87 & 0xc000 == 0x4000 && word(85) & (1 << 5) != 0;
+        // Linux also attempts the base FLUSH CACHE command when write cache is
+        // enabled but the capability bits are absent.  This makes a broken or
+        // incomplete IDENTIFY response fail visibly instead of silently
+        // treating volatile cached writes as synchronized.
+        let flush_command = if has_flush_ext {
             Some(ATA_CMD_FLUSH_CACHE_EXT)
-        } else if word83 & (1 << 12) != 0 {
+        } else if has_flush || write_cache_enabled {
             Some(ATA_CMD_FLUSH_CACHE)
         } else {
             None
@@ -546,6 +555,7 @@ impl AhciController {
         Ok(AhciIdentify {
             capacity_lba,
             flush_command,
+            reliable_flush: has_flush_ext || has_flush,
         })
     }
 

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -90,6 +90,7 @@ const AHCI_PXCMD_SUD: u32 = 1 << 1;
 const AHCI_MAX_SECTORS: u64 = 1u64 << 48;
 const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
 const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
+const AHCI_PORT_STOP_TIMEOUT_MS: u64 = 500;
 // 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
 // 32 * 32 command tables (256 KiB), rounded to the allocator's power of two.
 const AHCI_COMMAND_ARENA_SIZE: usize = 1 << 19;
@@ -386,39 +387,19 @@ impl AhciController {
             // Stop all temporary FIS receivers concurrently.  A successful
             // classification remains valid because the normal path does not
             // reset the links again before IDENTIFY.
-            for port_no in &provisional_ports {
-                unsafe { &mut *controller.port_ptr(*port_no) }.begin_provisional_stop();
-            }
-            let stop_deadline = Instant::now() + Duration::from_millis(500);
-            let mut stop_iteration = 0usize;
-            loop {
-                let mut all_stopped = true;
-                for port_no in &provisional_ports {
-                    // Do not short-circuit: every port must advance during
-                    // every scan so one slow CR bit cannot serialize FRE stop.
-                    all_stopped &=
-                        unsafe { &mut *controller.port_ptr(*port_no) }.advance_provisional_stop();
+            if controller
+                .stop_ports_concurrently(&provisional_ports)
+                .is_err()
+            {
+                // Do not publish using classifications obtained before a
+                // recovery reset.  Reset only proves DMA is stopped; this
+                // probe fails and a later probe must classify afresh.
+                let command = pci.status_command().1;
+                pci.set_command(command & !Command::BUS_MASTER);
+                if Self::reset_hba(hba).is_ok() {
+                    controller.hardware_stopped.store(true, Ordering::Release);
                 }
-                if all_stopped {
-                    break;
-                }
-                if Instant::now() >= stop_deadline {
-                    // Do not publish using classifications obtained before a
-                    // recovery reset.  Reset only proves DMA is stopped; this
-                    // probe fails and a later probe must classify afresh.
-                    let command = pci.status_command().1;
-                    pci.set_command(command & !Command::BUS_MASTER);
-                    if Self::reset_hba(hba).is_ok() {
-                        controller.hardware_stopped.store(true, Ordering::Release);
-                    }
-                    return Err(SystemError::ETIMEDOUT);
-                }
-                if poll_should_yield(stop_iteration) {
-                    crate::sched::sched_yield();
-                } else {
-                    core::hint::spin_loop();
-                }
-                stop_iteration = stop_iteration.wrapping_add(1);
+                return Err(SystemError::ETIMEDOUT);
             }
 
             let has_sata = link_states
@@ -440,7 +421,12 @@ impl AhciController {
                         err
                     );
                     if !controller.accepting_io.load(Ordering::Acquire) {
-                        break;
+                        // A failed port stop disables DMA for the whole HBA.
+                        // Complete a terminal detach before releasing the BDF
+                        // reservation, so stale mounts cannot later touch a
+                        // controller owned by a new probe generation.
+                        controller.rollback_failed_probe();
+                        return Err(err);
                     }
                 }
             }
@@ -823,18 +809,72 @@ impl AhciController {
         volatile_read!((*hba).ghc) != u32::MAX
     }
 
+    /// Stop every listed command/FIS engine within one controller-wide
+    /// deadline. Each scan advances all ports, so a stuck port cannot make
+    /// later ports wait for a separate timeout.
+    fn stop_ports_concurrently(&self, ports: &[usize]) -> Result<(), SystemError> {
+        for port_no in ports {
+            unsafe { &mut *self.port_ptr(*port_no) }.begin_provisional_stop();
+        }
+        let mut iteration = 0usize;
+        let mut deadline = Instant::now() + Duration::from_millis(AHCI_PORT_STOP_TIMEOUT_MS);
+        let mut stopping_fis_receive = false;
+        loop {
+            let mut all_stopped = true;
+            for port_no in ports {
+                // Intentionally non-short-circuiting: advance every port on
+                // every scan within each controller-wide phase.
+                let port = unsafe { &mut *self.port_ptr(*port_no) };
+                all_stopped &= if stopping_fis_receive {
+                    port.fis_receive_stopped()
+                } else {
+                    port.provisional_command_stopped()
+                };
+            }
+            if all_stopped {
+                if stopping_fis_receive {
+                    return Ok(());
+                }
+                for port_no in ports {
+                    unsafe { &mut *self.port_ptr(*port_no) }.begin_fis_receive_stop();
+                }
+                stopping_fis_receive = true;
+                deadline = Instant::now() + Duration::from_millis(AHCI_PORT_STOP_TIMEOUT_MS);
+                continue;
+            }
+            if Instant::now() >= deadline {
+                return Err(SystemError::ETIMEDOUT);
+            }
+            if poll_should_yield(iteration) {
+                crate::sched::sched_yield();
+            } else {
+                core::hint::spin_loop();
+            }
+            iteration = iteration.wrapping_add(1);
+        }
+    }
+
+    /// Finish a failed initial probe before its BDF reservation is released.
+    /// Published nodes may already have mount holders, so this must make their
+    /// delayed controller Drop permanently hardware-silent.
+    fn rollback_failed_probe(&self) {
+        self.quiesce();
+        let stop_result = if self.hba_accessible() {
+            self.stop_quiesced()
+        } else {
+            Err(SystemError::ENODEV)
+        };
+        *self.lifecycle.lock() = ControllerState::Stopped;
+        self.finalize_detach(stop_result.is_ok());
+        self.unregister_disks();
+    }
+
     fn stop_quiesced(&self) -> Result<(), SystemError> {
         let pi = volatile_read!((*(self.abar as *mut HbaMem)).pi);
-        let mut first_error = None;
-        for port_no in 0..self.port_count {
-            if pi & (1 << port_no) != 0 {
-                let _guard = self.port_locks[port_no].lock();
-                if let Err(err) = unsafe { &mut *self.port_ptr(port_no) }.stop() {
-                    first_error.get_or_insert(err);
-                }
-            }
-        }
-        if let Some(err) = first_error {
+        let ports = (0..self.port_count)
+            .filter(|port_no| pi & (1 << port_no) != 0)
+            .collect::<Vec<_>>();
+        if let Err(err) = self.stop_ports_concurrently(&ports) {
             let command = self.pci.status_command().1;
             self.pci.set_command(command & !Command::BUS_MASTER);
             if Self::reset_hba(self.abar as *mut HbaMem).is_err() {
@@ -896,6 +936,15 @@ impl AhciController {
                 &(disk as Arc<dyn crate::driver::base::block::block_device::BlockDevice>),
             );
         }
+    }
+
+    /// Perform the final PCI access and transfer all DMA ownership before any
+    /// stale reference is allowed to outlive this controller generation.
+    fn finalize_detach(&self, safe_to_release_dma: bool) {
+        let command = self.pci.status_command().1;
+        self.pci.set_command(command & !Command::BUS_MASTER);
+        self.detached.store(true, Ordering::Release);
+        self.retire_dma(safe_to_release_dma);
     }
 
     fn retire_dma(&self, safe_to_release: bool) {
@@ -1036,11 +1085,8 @@ impl PciDriver for AhciPciDriver {
 
         // This is the final PCI configuration access by this controller. The
         // detached flag makes delayed Drop from an open mount hardware-silent.
-        let command = controller.pci.status_command().1;
-        controller.pci.set_command(command & !Command::BUS_MASTER);
-        controller.detached.store(true, Ordering::Release);
+        controller.finalize_detach(stop_result.is_ok());
         *state = ControllerState::Stopped;
-        controller.retire_dma(stop_result.is_ok());
         self.controllers.write().remove(&name);
         if let Err(err) = flush_result {
             log::warn!("AHCI {} detach flush failed: {:?}", name, err);

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -396,10 +396,8 @@ impl AhciController {
                 for port_no in &provisional_ports {
                     // Do not short-circuit: every port must advance during
                     // every scan so one slow CR bit cannot serialize FRE stop.
-                    all_stopped &= unsafe {
-                        &mut *controller.port_ptr(*port_no)
-                    }
-                    .advance_provisional_stop();
+                    all_stopped &=
+                        unsafe { &mut *controller.port_ptr(*port_no) }.advance_provisional_stop();
                 }
                 if all_stopped {
                     break;

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -1,143 +1,989 @@
-// 导出 ahci 相关的 module
+//! AHCI PCI driver.
+//!
+//! AHCI controllers are discovered by the PCI bus.  An empty controller is a
+//! valid device and remains bound without publishing a block device.
+
 pub mod ahcidisk;
 pub mod hba;
-use crate::arch::MMArch;
-use crate::driver::base::block::manager::block_dev_manager;
-use crate::driver::disk::ahci::ahcidisk::LockedAhciDisk;
-use crate::driver::pci::pci::{
-    get_pci_device_structure_mut, PciDeviceLinkedList, PciDeviceStructure, PCI_DEVICE_LINKEDLIST,
-};
-use alloc::sync::Arc;
 
-use crate::driver::disk::ahci::{
-    hba::HbaMem,
-    hba::{HbaPort, HbaPortType},
+use alloc::{
+    string::{String, ToString},
+    sync::{Arc, Weak},
+    vec::Vec,
 };
-use crate::libs::spinlock::{SpinLock, SpinLockGuard};
-use crate::mm::{MemoryManagementArch, VirtAddr};
-use alloc::{boxed::Box, vec::Vec};
-use core::sync::atomic::compiler_fence;
-use log::debug;
+use hashbrown::HashMap;
 use system_error::SystemError;
+use unified_init::macros::unified_init;
 
-// 仅module内可见 全局数据区  hbr_port, disks
-static LOCKED_HBA_MEM_LIST: SpinLock<Vec<&mut HbaMem>> = SpinLock::new(Vec::new());
+use core::{
+    mem::size_of,
+    ptr::write_bytes,
+    sync::atomic::{AtomicBool, AtomicU32, Ordering},
+};
 
-const AHCI_CLASS: u8 = 0x1;
-const AHCI_SUBCLASS: u8 = 0x6;
+use crate::{
+    arch::MMArch,
+    driver::{
+        base::{
+            block::manager::block_dev_manager,
+            device::{
+                bus::Bus,
+                driver::{Driver, DriverCommonData},
+                Device, IdTable,
+            },
+            kobject::{KObjType, KObject, KObjectCommonData, KObjectState, LockedKObjectState},
+            kset::KSet,
+        },
+        pci::{
+            dev_id::PciDeviceID,
+            device::PciDevice,
+            driver::{pci_driver_manager, PciDriver},
+            pci::{Command, PciDeviceStructure, PciDeviceStructureGeneralDevice},
+        },
+    },
+    filesystem::kernfs::KernFSInode,
+    init::initcall::INITCALL_DEVICE,
+    libs::{
+        mutex::{Mutex, MutexGuard},
+        rwlock::RwLock,
+        rwsem::{RwSemReadGuard, RwSemWriteGuard},
+        spinlock::SpinLock,
+    },
+    mm::{
+        dma::{DmaAllocOptions, DmaBuffer, DmaDirection},
+        MemoryManagementArch, PhysAddr,
+    },
+    time::{Duration, Instant},
+};
 
-/* TFES - Task File Error Status */
-#[allow(non_upper_case_globals)]
-pub const HBA_PxIS_TFES: u32 = 1 << 30;
+use self::{
+    ahcidisk::LockedAhciDisk,
+    hba::{
+        FisRegH2D, FisType, HbaCmdHeader, HbaCmdTable, HbaMem, HbaPort, HbaPortType,
+        ATA_CMD_FLUSH_CACHE, ATA_CMD_FLUSH_CACHE_EXT, ATA_CMD_IDENTIFY, ATA_DEV_BUSY, ATA_DEV_DRQ,
+    },
+};
 
-/// @brief 寻找所有的ahci设备
-/// @param list 链表的写锁
-/// @return Result<Vec<&'a mut Box<dyn PciDeviceStructure>>, SystemError>   成功则返回包含所有ahci设备结构体的可变引用的链表，失败则返回err
-fn ahci_device_search(
-    list: &PciDeviceLinkedList,
-) -> Result<Vec<Arc<dyn PciDeviceStructure>>, SystemError> {
-    let result = get_pci_device_structure_mut(list, AHCI_CLASS, AHCI_SUBCLASS);
-
-    if result.is_empty() {
-        return Err(SystemError::ENODEV);
-    }
-
-    return Ok(result);
+pub(crate) struct AhciIdentify {
+    capacity_lba: usize,
+    flush_command: Option<u8>,
 }
 
-/// @brief: 初始化 ahci
-pub fn ahci_init() -> Result<(), SystemError> {
-    let list = &*PCI_DEVICE_LINKEDLIST;
-    let ahci_device = ahci_device_search(list)?;
+/* TFES - Task File Error Status */
+pub const HBA_PXIS_TFES: u32 = 1 << 30;
+const AHCI_CLASS_CODE: u32 = 0x010601;
+const AHCI_CLASS_MASK: u32 = 0x00ff_ffff;
+const AHCI_GHC_AE: u32 = 1 << 31;
+const AHCI_GHC_HR: u32 = 1;
+const AHCI_CAP2_BOH: u32 = 1;
+const AHCI_BOHC_BOS: u32 = 1;
+const AHCI_BOHC_OOS: u32 = 1 << 1;
+const AHCI_BOHC_BB: u32 = 1 << 4;
+const AHCI_CAP_SSS: u32 = 1 << 27;
+const AHCI_CAP_CPD: u32 = 1 << 20;
+const AHCI_PXCMD_CPD: u32 = 1 << 20;
+const AHCI_PXCMD_ICC_MASK: u32 = 0xf << 28;
+const AHCI_PXCMD_ICC_ACTIVE: u32 = 1 << 28;
+const AHCI_PXCMD_POD: u32 = 1 << 2;
+const AHCI_PXCMD_SUD: u32 = 1 << 1;
+// 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
+// 32 * 32 command tables (256 KiB), rounded to the allocator's power of two.
+const AHCI_COMMAND_ARENA_SIZE: usize = 1 << 19;
 
-    for device in ahci_device {
-        let standard_device = device.as_standard_device().unwrap();
-        standard_device.bar_ioremap();
-        // 对于每一个ahci控制器分配一块空间
-        // let ahci_port_base_vaddr =
-        //     Box::leak(Box::new([0u8; (1 << 20) as usize])) as *mut u8 as usize;
-        let buffer = Box::leak(vec![0u8; (1 << 20) as usize].into_boxed_slice());
-        let ahci_port_base_vaddr = buffer.as_mut_ptr() as usize;
+lazy_static! {
+    /// Last-resort owner for DMA memory if a controller object is destroyed
+    /// without proof that all posted transactions have drained.
+    static ref AHCI_DMA_QUARANTINE: SpinLock<Vec<DmaBuffer>> = SpinLock::new(Vec::new());
+}
 
-        let virtaddr = standard_device
-            .bar()
-            .ok_or(SystemError::EACCES)?
-            .read()
-            .get_bar(5)
-            .or(Err(SystemError::EACCES))?
-            .virtual_address()
-            .unwrap();
-        // 最后把这个引用列表放入到全局列表
-        let mut hba_mem_list = LOCKED_HBA_MEM_LIST.lock();
-        //这里两次unsafe转引用规避rust只能有一个可变引用的检查，提高运行速度
-        let hba_mem = unsafe { (virtaddr.data() as *mut HbaMem).as_mut().unwrap() };
-        hba_mem_list.push(unsafe { (virtaddr.data() as *mut HbaMem).as_mut().unwrap() });
-        let pi = volatile_read!(hba_mem.pi);
-        let hba_mem_index = hba_mem_list.len() - 1;
-        drop(hba_mem_list);
-        // 初始化所有的port
-        for j in 0..32 {
-            if (pi >> j) & 1 > 0 {
-                let hba_mem_list = LOCKED_HBA_MEM_LIST.lock();
-                let hba_mem_port = &mut hba_mem.ports[j];
-                let tp = hba_mem_port.check_type();
-                match tp {
-                    HbaPortType::None => {
-                        debug!("<ahci_rust_init> Find a None type Disk.");
+/// Resources owned by one bound PCI AHCI controller.
+pub struct AhciController {
+    device: Arc<dyn PciDevice>,
+    pci: Arc<PciDeviceStructureGeneralDevice>,
+    abar: usize,
+    port_count: usize,
+    original_command: Command,
+    dma_mask: u64,
+    command_slots: u8,
+    command_memory: Option<DmaBuffer>,
+    disks: SpinLock<Vec<Weak<LockedAhciDisk>>>,
+    accepting_io: AtomicBool,
+    failed_ports: AtomicU32,
+    quarantined_dma: SpinLock<Vec<DmaBuffer>>,
+    hardware_stopped: AtomicBool,
+    port_locks: Vec<Mutex<()>>,
+    lifecycle: Mutex<ControllerState>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ControllerState {
+    Running,
+    Detaching,
+    RemovalFailed,
+    Stopping,
+    Stopped,
+}
+
+impl core::fmt::Debug for AhciController {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("AhciController")
+            .field("bdf", &self.pci.common_header.bus_device_function)
+            .field("abar", &self.abar)
+            .field("port_count", &self.port_count)
+            .field("command_slots", &self.command_slots)
+            .field("has_command_memory", &self.command_memory.is_some())
+            .finish()
+    }
+}
+
+impl AhciController {
+    fn probe(
+        device: Arc<dyn PciDevice>,
+        pci: Arc<PciDeviceStructureGeneralDevice>,
+    ) -> Result<Arc<Self>, SystemError> {
+        let original_command = pci.status_command().1;
+        // Preserve firmware's Bus Master state until BIOS/OS handoff finishes;
+        // clearing it earlier can prevent firmware transactions from draining.
+        pci.set_command(original_command | Command::MEMORY_SPACE);
+        let result = (|| {
+            if pci.bar_ioremap().ok_or(SystemError::EINVAL)?.is_err() {
+                return Err(SystemError::EIO);
+            }
+
+            let bars = pci.bar().ok_or(SystemError::EACCES)?;
+            let bars = bars.read();
+            let abar = bars
+                .get_bar(5)
+                .map_err(|_| SystemError::EACCES)?
+                .virtual_address_at(0, 0x100)
+                .ok_or(SystemError::EACCES)?
+                .data();
+            drop(bars);
+            let hba = abar as *mut HbaMem;
+            Self::initialize_hba(hba, &pci)?;
+
+            let cap = volatile_read!((*hba).cap);
+            let pi = volatile_read!((*hba).pi);
+            let pi_ports = if pi == 0 {
+                0
+            } else {
+                32 - pi.leading_zeros() as usize
+            };
+            let port_count = (((cap & 0x1f) + 1) as usize).max(pi_ports).min(32);
+            let required_len = 0x100usize
+                .checked_add(
+                    port_count
+                        .checked_mul(size_of::<HbaPort>())
+                        .ok_or(SystemError::EOVERFLOW)?,
+                )
+                .ok_or(SystemError::EOVERFLOW)?;
+            let bars = pci.bar().ok_or(SystemError::EACCES)?;
+            if bars
+                .read()
+                .get_bar(5)
+                .map_err(|_| SystemError::EACCES)?
+                .virtual_address_at(0, required_len)
+                .is_none()
+            {
+                return Err(SystemError::EACCES);
+            }
+            let mut online_ports = Vec::new();
+            let mut training_ports = Vec::new();
+            for port_no in 0..port_count {
+                if pi & (1 << port_no) == 0 {
+                    continue;
+                }
+                let port = unsafe {
+                    core::ptr::addr_of_mut!((*hba).ports)
+                        .cast::<HbaPort>()
+                        .add(port_no)
+                };
+                let mut cmd = volatile_read!((*port).cmd);
+                if cap & AHCI_CAP_SSS != 0 {
+                    cmd |= AHCI_PXCMD_SUD;
+                }
+                if cap & AHCI_CAP_CPD != 0 && cmd & AHCI_PXCMD_CPD != 0 {
+                    cmd |= AHCI_PXCMD_POD;
+                }
+                cmd = (cmd & !AHCI_PXCMD_ICC_MASK) | AHCI_PXCMD_ICC_ACTIVE;
+                volatile_write!((*port).cmd, cmd);
+                let _ = volatile_read!((*port).cmd);
+            }
+            if cap & (AHCI_CAP_SSS | AHCI_CAP_CPD) != 0 {
+                let settle_until = Instant::now() + Duration::from_millis(100);
+                while Instant::now() < settle_until {
+                    core::hint::spin_loop();
+                }
+            }
+            for port_no in 0..port_count {
+                if pi & (1 << port_no) == 0 {
+                    continue;
+                }
+                let port = unsafe {
+                    core::ptr::addr_of_mut!((*hba).ports)
+                        .cast::<HbaPort>()
+                        .add(port_no)
+                };
+                match volatile_read!((*port).ssts) & 0xf {
+                    3 => online_ports.push(port_no),
+                    0 => {}
+                    _ => training_ports.push(port_no),
+                }
+            }
+            // Ready links are handled before training/faulty links, and each
+            // port gets its own deadline so one bad port cannot starve a disk.
+            online_ports.extend(training_ports);
+            let candidate_ports = online_ports;
+
+            // Empty controllers are normal and do not need command DMA memory.
+            let dma_mask = if cap & (1 << 31) != 0 {
+                u64::MAX
+            } else {
+                u32::MAX.into()
+            };
+            let command_slots = (((cap >> 8) & 0x1f) + 1) as u8;
+            let command_memory = if candidate_ports.is_empty() {
+                None
+            } else {
+                let options = DmaAllocOptions {
+                    dma_mask: Some(dma_mask),
+                    use_pool: false,
+                    ..Default::default()
+                };
+                let memory = DmaBuffer::try_alloc_bytes(AHCI_COMMAND_ARENA_SIZE, options)?;
+                Some(memory)
+            };
+
+            let controller = Arc::new(Self {
+                device,
+                pci: pci.clone(),
+                abar,
+                port_count,
+                original_command,
+                dma_mask,
+                command_slots,
+                command_memory,
+                disks: SpinLock::new(Vec::new()),
+                accepting_io: AtomicBool::new(true),
+                failed_ports: AtomicU32::new(0),
+                quarantined_dma: SpinLock::new(Vec::new()),
+                hardware_stopped: AtomicBool::new(false),
+                port_locks: (0..32).map(|_| Mutex::new(())).collect(),
+                lifecycle: Mutex::new(ControllerState::Running),
+            });
+
+            if !candidate_ports.is_empty() {
+                let command = pci.status_command().1;
+                pci.set_command(command | Command::BUS_MASTER);
+            }
+            for port_no in candidate_ports {
+                if !controller.accepting_io.load(Ordering::Acquire) {
+                    break;
+                }
+                let arena = controller
+                    .command_memory
+                    .as_ref()
+                    .ok_or(SystemError::ENOMEM)?;
+                let fb = arena.paddr() + (32 << 10) + (port_no << 8);
+                let port_type = match unsafe { &mut *controller.port_ptr(port_no) }
+                    .reset_and_classify(fb as u64)
+                {
+                    Ok(port_type) => port_type,
+                    Err(err) => {
+                        controller
+                            .failed_ports
+                            .fetch_or(1 << port_no, Ordering::AcqRel);
+                        log::warn!(
+                            "AHCI {} port {} link initialization failed: {:?}",
+                            controller.pci.common_header.bus_device_function,
+                            port_no,
+                            err
+                        );
+                        continue;
                     }
-                    HbaPortType::Unknown(err) => {
-                        debug!("<ahci_rust_init> Find a Unknown({:?}) type Disk.", err);
-                    }
-                    _ => {
-                        debug!("<ahci_rust_init> Find a {:?} type Disk.", tp);
-
-                        // 计算地址
-                        let fb = unsafe {
-                            MMArch::virt_2_phys(VirtAddr::new(
-                                ahci_port_base_vaddr + (32 << 10) + (j << 8),
-                            ))
-                        }
-                        .unwrap()
-                        .data();
-                        let clb = unsafe {
-                            MMArch::virt_2_phys(VirtAddr::new(ahci_port_base_vaddr + (j << 10)))
-                                .unwrap()
-                                .data()
-                        };
-                        let ctbas = (0..32)
-                            .map(|x| unsafe {
-                                MMArch::virt_2_phys(VirtAddr::new(
-                                    ahci_port_base_vaddr + (40 << 10) + (j << 13) + (x << 8),
-                                ))
-                                .unwrap()
-                                .data() as u64
-                            })
-                            .collect::<Vec<_>>();
-
-                        // 初始化 port
-                        hba_mem_port.init(clb as u64, fb as u64, &ctbas);
-                        drop(hba_mem_list);
-                        compiler_fence(core::sync::atomic::Ordering::SeqCst);
-                        let ahci_disk = LockedAhciDisk::new(hba_mem_index as u8, j as u8)?;
-                        block_dev_manager()
-                            .register(ahci_disk)
-                            .expect("register ahci disk failed");
-
-                        debug!("start register ahci device");
+                };
+                if port_type != HbaPortType::Sata {
+                    continue;
+                }
+                if let Err(err) = controller.publish_port(port_no) {
+                    log::error!(
+                        "AHCI {} port {} initialization failed: {:?}",
+                        controller.pci.common_header.bus_device_function,
+                        port_no,
+                        err
+                    );
+                    if !controller.accepting_io.load(Ordering::Acquire) {
+                        break;
                     }
                 }
+            }
+            if controller.disks.lock().is_empty() {
+                let command = pci.status_command().1;
+                pci.set_command(command & !Command::BUS_MASTER);
+            }
+            Ok(controller)
+        })();
+        if result.is_err() {
+            pci.set_command(original_command);
+        }
+        result
+    }
+
+    fn initialize_hba(
+        hba: *mut HbaMem,
+        pci: &PciDeviceStructureGeneralDevice,
+    ) -> Result<(), SystemError> {
+        if volatile_read!((*hba).cap2) & AHCI_CAP2_BOH != 0 {
+            let bohc = volatile_read!((*hba).bohc);
+            volatile_write!((*hba).bohc, bohc | AHCI_BOHC_OOS);
+            let deadline = Instant::now() + Duration::from_secs(2);
+            while volatile_read!((*hba).bohc) & (AHCI_BOHC_BOS | AHCI_BOHC_BB) != 0 {
+                if Instant::now() >= deadline {
+                    return Err(SystemError::ETIMEDOUT);
+                }
+                core::hint::spin_loop();
+            }
+        }
+
+        // Firmware ownership is now released. Disable old DMA before reset
+        // invalidates firmware command-list addresses.
+        let command = pci.status_command().1;
+        pci.set_command(command & !Command::BUS_MASTER);
+
+        let ghc = volatile_read!((*hba).ghc);
+        volatile_write!((*hba).ghc, ghc | AHCI_GHC_AE);
+        if volatile_read!((*hba).ghc) & AHCI_GHC_AE == 0 {
+            return Err(SystemError::EIO);
+        }
+        let ghc = volatile_read!((*hba).ghc);
+        volatile_write!((*hba).ghc, ghc | AHCI_GHC_HR);
+        let _ = volatile_read!((*hba).ghc);
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while volatile_read!((*hba).ghc) & AHCI_GHC_HR != 0 {
+            if Instant::now() >= deadline {
+                return Err(SystemError::ETIMEDOUT);
+            }
+            core::hint::spin_loop();
+        }
+        let ghc = volatile_read!((*hba).ghc);
+        volatile_write!((*hba).ghc, ghc | AHCI_GHC_AE);
+        if volatile_read!((*hba).ghc) & AHCI_GHC_AE == 0 {
+            return Err(SystemError::EIO);
+        }
+        Ok(())
+    }
+
+    fn publish_port(self: &Arc<Self>, port_no: usize) -> Result<(), SystemError> {
+        let arena = self.command_memory.as_ref().ok_or(SystemError::ENOMEM)?;
+        let base = arena.paddr();
+        let fb = base + (32 << 10) + (port_no << 8);
+        let clb = base + (port_no << 10);
+        let ctbas = (0..32)
+            .map(|slot| (base + (40 << 10) + (port_no << 13) + (slot << 8)) as u64)
+            .collect::<Vec<_>>();
+
+        let result = (|| {
+            unsafe { &mut *self.port_ptr(port_no) }.init(clb as u64, fb as u64, &ctbas)?;
+            let identify = self.identify(port_no)?;
+            let disk = LockedAhciDisk::new(self.clone(), port_no as u8, identify)?;
+            block_dev_manager().register(disk.clone())?;
+            self.disks.lock().push(Arc::downgrade(&disk));
+            Ok(())
+        })();
+        if result.is_err() {
+            self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
+            let _ = unsafe { &mut *self.port_ptr(port_no) }.stop();
+        }
+        result
+    }
+
+    pub(crate) fn port_ptr(&self, port_no: usize) -> *mut HbaPort {
+        debug_assert!(port_no < self.port_count);
+        unsafe {
+            core::ptr::addr_of_mut!((*(self.abar as *mut HbaMem)).ports)
+                .cast::<HbaPort>()
+                .add(port_no)
+        }
+    }
+
+    pub(crate) fn lock_port_for_io(
+        &self,
+        port_no: usize,
+    ) -> Result<MutexGuard<'_, ()>, SystemError> {
+        if !self.accepting_io.load(Ordering::Acquire) {
+            return Err(SystemError::ESHUTDOWN);
+        }
+        if self.failed_ports.load(Ordering::Acquire) & (1 << port_no) != 0 {
+            return Err(SystemError::EIO);
+        }
+        let guard = self.port_locks[port_no].lock();
+        if !self.accepting_io.load(Ordering::Acquire) {
+            drop(guard);
+            return Err(SystemError::ESHUTDOWN);
+        }
+        Ok(guard)
+    }
+
+    pub(crate) fn acquire_holder(&self, counter: &AtomicU32) -> Result<(), SystemError> {
+        let state = self.lifecycle.lock();
+        if *state != ControllerState::Running || !self.accepting_io.load(Ordering::Acquire) {
+            return Err(SystemError::ENODEV);
+        }
+        counter.fetch_add(1, Ordering::AcqRel);
+        Ok(())
+    }
+
+    /// Stop a failed port before releasing a buffer that may still be a DMA
+    /// target. If the engine cannot be stopped, disable PCI bus mastering for
+    /// the whole controller before the buffer is released.
+    pub(crate) fn abort_failed_dma(&self, port_no: usize, buffer: DmaBuffer) {
+        self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
+        if unsafe { &mut *self.port_ptr(port_no) }.stop().is_err() {
+            self.accepting_io.store(false, Ordering::Release);
+            let command = self.pci.status_command().1;
+            self.pci.set_command(command & !Command::BUS_MASTER);
+            self.quarantined_dma.lock().push(buffer);
+        }
+    }
+
+    pub(crate) fn allocate_dma(
+        &self,
+        size: usize,
+        direction: DmaDirection,
+    ) -> Result<DmaBuffer, SystemError> {
+        let buffer = DmaBuffer::try_alloc_bytes(
+            size,
+            DmaAllocOptions {
+                direction,
+                dma_mask: Some(self.dma_mask),
+                ..Default::default()
+            },
+        )?;
+        Ok(buffer)
+    }
+
+    fn identify(&self, port_no: usize) -> Result<AhciIdentify, SystemError> {
+        let port = unsafe { &mut *self.port_ptr(port_no) };
+        let mut identify = self.allocate_dma(512, DmaDirection::FromDevice)?;
+        let slot = port
+            .find_cmdslot(self.command_slots)
+            .ok_or(SystemError::EBUSY)?;
+        volatile_write!(port.is, u32::MAX);
+
+        let clb = volatile_read!(port.clb);
+        let header = unsafe {
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(
+                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
+            ))
+            .ok_or(SystemError::EFAULT)?
+            .data() as *mut HbaCmdHeader)
+        };
+        let ctba = volatile_read!(header.ctba);
+        let table = unsafe {
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
+                .ok_or(SystemError::EFAULT)?
+                .data() as *mut HbaCmdTable)
+        };
+        unsafe { write_bytes(table, 0, 1) };
+        volatile_write!(
+            header.cfl,
+            (size_of::<FisRegH2D>() / size_of::<u32>()) as u8
+        );
+        volatile_write!(header._pm, 0);
+        volatile_write!(header._prdbc, 0);
+        volatile_write!(header.prdtl, 1);
+        volatile_write!(table.prdt_entry[0].dba, identify.paddr() as u64);
+        volatile_write!(table.prdt_entry[0].dbc, 511);
+        let fis = unsafe { &mut *(table.cfis.as_mut_ptr() as *mut FisRegH2D) };
+        volatile_write!(fis.fis_type, FisType::RegH2D as u8);
+        volatile_write!(fis.pm, 1 << 7);
+        volatile_write!(fis.command, ATA_CMD_IDENTIFY);
+
+        Self::wait_tfd_ready(port)?;
+        core::sync::atomic::compiler_fence(Ordering::Release);
+        let ci = volatile_read!(port.ci);
+        volatile_write!(port.ci, ci | (1 << slot));
+        if let Err(err) = Self::wait_slot(port, slot) {
+            self.abort_failed_dma(port_no, identify);
+            return Err(err);
+        }
+        core::sync::atomic::compiler_fence(Ordering::Acquire);
+
+        let bytes = identify.as_mut_slice();
+        let word = |index: usize| u16::from_le_bytes([bytes[index * 2], bytes[index * 2 + 1]]);
+        if word(49) & (1 << 8) == 0 {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        let word83 = word(83);
+        if word83 & 0xc000 != 0x4000 || word83 & (1 << 10) == 0 {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        let logical_sector_size = if word(106) & 0xd000 == 0x5000 {
+            (u32::from(word(118)) << 16 | u32::from(word(117)))
+                .checked_mul(2)
+                .ok_or(SystemError::EOVERFLOW)?
+        } else {
+            512
+        };
+        if logical_sector_size != 512 {
+            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        }
+        let capacity = u64::from(word(100))
+            | u64::from(word(101)) << 16
+            | u64::from(word(102)) << 32
+            | u64::from(word(103)) << 48;
+        if capacity == 0 {
+            return Err(SystemError::EIO);
+        }
+        let capacity_lba = usize::try_from(capacity).map_err(|_| SystemError::EOVERFLOW)?;
+        let flush_command = if word83 & (1 << 13) != 0 {
+            Some(ATA_CMD_FLUSH_CACHE_EXT)
+        } else if word83 & (1 << 12) != 0 {
+            Some(ATA_CMD_FLUSH_CACHE)
+        } else {
+            None
+        };
+        Ok(AhciIdentify {
+            capacity_lba,
+            flush_command,
+        })
+    }
+
+    pub(crate) fn flush_port(
+        &self,
+        port_no: usize,
+        command: u8,
+        teardown: bool,
+    ) -> Result<(), SystemError> {
+        let _guard = if teardown {
+            self.port_locks[port_no].lock()
+        } else {
+            self.lock_port_for_io(port_no)?
+        };
+        let port = unsafe { &mut *self.port_ptr(port_no) };
+        volatile_write!(port.is, u32::MAX);
+        let slot = port
+            .find_cmdslot(self.command_slots)
+            .ok_or(SystemError::EBUSY)?;
+        let clb = volatile_read!(port.clb);
+        let header = unsafe {
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(
+                clb as usize + slot as usize * size_of::<HbaCmdHeader>(),
+            ))
+            .ok_or(SystemError::EFAULT)?
+            .data() as *mut HbaCmdHeader)
+        };
+        let ctba = volatile_read!(header.ctba);
+        let table = unsafe {
+            &mut *(MMArch::phys_2_virt(PhysAddr::new(ctba as usize))
+                .ok_or(SystemError::EFAULT)?
+                .data() as *mut HbaCmdTable)
+        };
+        unsafe { write_bytes(table, 0, 1) };
+        volatile_write!(
+            header.cfl,
+            (size_of::<FisRegH2D>() / size_of::<u32>()) as u8
+        );
+        volatile_write!(header._pm, 0);
+        volatile_write!(header._prdbc, 0);
+        volatile_write!(header.prdtl, 0);
+        let fis = unsafe { &mut *(table.cfis.as_mut_ptr() as *mut FisRegH2D) };
+        volatile_write!(fis.fis_type, FisType::RegH2D as u8);
+        volatile_write!(fis.pm, 1 << 7);
+        volatile_write!(fis.command, command);
+        Self::wait_tfd_ready(port)?;
+        core::sync::atomic::compiler_fence(Ordering::Release);
+        let ci = volatile_read!(port.ci);
+        volatile_write!(port.ci, ci | (1 << slot));
+        if let Err(err) = Self::wait_slot(port, slot) {
+            self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
+            let _ = port.stop();
+            return Err(err);
+        }
+        core::sync::atomic::compiler_fence(Ordering::Acquire);
+        Ok(())
+    }
+
+    pub(crate) fn wait_tfd_ready(port: &HbaPort) -> Result<(), SystemError> {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let mut iteration = 0usize;
+        loop {
+            if volatile_read!(port.tfd) as u8 & (ATA_DEV_BUSY | ATA_DEV_DRQ) == 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SystemError::ETIMEDOUT);
+            }
+            if iteration & 0x3ff == 0 {
+                crate::sched::sched_yield();
+            } else {
+                core::hint::spin_loop();
+            }
+            iteration = iteration.wrapping_add(1);
+        }
+    }
+
+    pub(crate) fn wait_slot(port: &HbaPort, slot: u32) -> Result<(), SystemError> {
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let mut iteration = 0usize;
+        loop {
+            if volatile_read!(port.is) & HBA_PXIS_TFES != 0 {
+                return Err(SystemError::EIO);
+            }
+            if volatile_read!(port.ci) & (1 << slot) == 0 {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                return Err(SystemError::ETIMEDOUT);
+            }
+            if iteration & 0x3ff == 0 {
+                crate::sched::sched_yield();
+            } else {
+                core::hint::spin_loop();
+            }
+            iteration = iteration.wrapping_add(1);
+        }
+    }
+
+    fn quiesce(&self) {
+        self.accepting_io.store(false, Ordering::Release);
+        // Taking each port lock waits for an already submitted command to
+        // finish before the command engine is stopped.
+        for lock in &self.port_locks {
+            drop(lock.lock());
+        }
+    }
+
+    fn stop_quiesced(&self) -> Result<(), SystemError> {
+        let pi = volatile_read!((*(self.abar as *mut HbaMem)).pi);
+        let mut first_error = None;
+        for port_no in 0..self.port_count {
+            if pi & (1 << port_no) != 0 {
+                let _guard = self.port_locks[port_no].lock();
+                if let Err(err) = unsafe { &mut *self.port_ptr(port_no) }.stop() {
+                    first_error.get_or_insert(err);
+                }
+            }
+        }
+        if let Some(err) = first_error {
+            let command = self.pci.status_command().1;
+            self.pci.set_command(command & !Command::BUS_MASTER);
+            Err(err)
+        } else {
+            self.hardware_stopped.store(true, Ordering::Release);
+            self.quarantined_dma.lock().clear();
+            Ok(())
+        }
+    }
+
+    fn flush_disks(&self) -> Result<(), SystemError> {
+        if self.hardware_stopped.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let disks = self
+            .disks
+            .lock()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+        if !self.pci.status_command().1.contains(Command::BUS_MASTER) {
+            return if disks.iter().any(|disk| disk.needs_flush()) {
+                Err(SystemError::EIO)
+            } else {
+                Ok(())
+            };
+        }
+        let mut first_error = None;
+        for disk in disks {
+            if let Err(err) = disk.flush_for_teardown() {
+                first_error.get_or_insert(err);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
+
+    fn has_holders(&self) -> bool {
+        self.disks
+            .lock()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .any(|disk| disk.has_holders())
+    }
+
+    fn unregister_disks(&self) -> Result<(), SystemError> {
+        let disks = self
+            .disks
+            .lock()
+            .iter()
+            .filter_map(Weak::upgrade)
+            .collect::<Vec<_>>();
+        for disk in disks {
+            let result = block_dev_manager().unregister(
+                &(disk as Arc<dyn crate::driver::base::block::block_device::BlockDevice>),
+            );
+            if let Err(err) = result {
+                if err != SystemError::ENOENT {
+                    return Err(err);
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Drop for AhciController {
+    fn drop(&mut self) {
+        self.quiesce();
+        let _ = self.flush_disks();
+        if self.stop_quiesced().is_err() {
+            // A failed engine stop must not turn into either DMA-after-free or
+            // a permanent allocation leak.  PCI Bus Master disable cuts off
+            // DMA before owned buffers are dropped.
+            self.pci
+                .set_command(self.original_command & !Command::BUS_MASTER);
+            if let Some(memory) = self.command_memory.take() {
+                AHCI_DMA_QUARANTINE.lock().push(memory);
+            }
+            AHCI_DMA_QUARANTINE
+                .lock()
+                .extend(self.quarantined_dma.lock().drain(..));
+            return;
+        }
+        // A detached storage controller must not regain DMA permission merely
+        // because firmware happened to leave Bus Master set before binding.
+        self.pci
+            .set_command(self.original_command & !Command::BUS_MASTER);
+    }
+}
+
+#[derive(Debug)]
+#[cast_to([sync] PciDriver)]
+struct AhciPciDriver {
+    driver_data: RwLock<DriverCommonData>,
+    kobj_data: RwLock<KObjectCommonData>,
+    kobj_state: LockedKObjectState,
+    ids: RwLock<Vec<Arc<PciDeviceID>>>,
+    // None reserves a BDF while probe is running, preventing duplicate probe.
+    controllers: RwLock<HashMap<String, Option<Arc<AhciController>>>>,
+}
+
+impl AhciPciDriver {
+    fn new() -> Self {
+        Self {
+            driver_data: RwLock::new(DriverCommonData::default()),
+            kobj_data: RwLock::new(KObjectCommonData::default()),
+            kobj_state: LockedKObjectState::new(None),
+            ids: RwLock::new(vec![Arc::new(PciDeviceID::class_match(
+                AHCI_CLASS_CODE,
+                AHCI_CLASS_MASK,
+            ))]),
+            controllers: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl PciDriver for AhciPciDriver {
+    fn probe(&self, device: &Arc<dyn PciDevice>, _id: &PciDeviceID) -> Result<(), SystemError> {
+        let name = device.name();
+        {
+            let mut controllers = self.controllers.write();
+            if controllers.contains_key(&name) {
+                return Err(SystemError::EBUSY);
+            }
+            controllers.insert(name.clone(), None);
+        }
+        let result = device
+            .standard_device()
+            .ok_or(SystemError::EINVAL)
+            .and_then(|pci| AhciController::probe(device.clone(), pci));
+        let mut controllers = self.controllers.write();
+        match result {
+            Ok(controller) => {
+                controllers.insert(name, Some(controller));
+                Ok(())
+            }
+            Err(err) => {
+                controllers.remove(&name);
+                Err(err)
             }
         }
     }
 
-    compiler_fence(core::sync::atomic::Ordering::SeqCst);
-    return Ok(());
+    fn remove(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
+        let name = device.name();
+        let controller = self
+            .controllers
+            .read()
+            .get(&name)
+            .and_then(Option::clone)
+            .ok_or(SystemError::ENODEV)?;
+        let mut state = controller.lifecycle.lock();
+        if !matches!(
+            *state,
+            ControllerState::Running | ControllerState::RemovalFailed
+        ) {
+            return Err(SystemError::EBUSY);
+        }
+        if controller.has_holders() {
+            return Err(SystemError::EBUSY);
+        }
+        *state = ControllerState::Detaching;
+        controller.quiesce();
+        let flush_result = controller.flush_disks();
+        let unregister_result = controller.unregister_disks();
+        let stop_result = controller.stop_quiesced();
+        if let Err(err) = stop_result {
+            *state = ControllerState::RemovalFailed;
+            return Err(err);
+        }
+        if let Err(err) = unregister_result {
+            *state = ControllerState::RemovalFailed;
+            return Err(err);
+        }
+        *state = ControllerState::Stopped;
+        self.controllers.write().remove(&name);
+        if let Err(err) = flush_result {
+            log::warn!("AHCI {} detach flush failed: {:?}", name, err);
+        }
+        Ok(())
+    }
+
+    fn shutdown(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
+        if let Some(controller) = self
+            .controllers
+            .read()
+            .get(&device.name())
+            .and_then(Option::clone)
+        {
+            let mut state = controller.lifecycle.lock();
+            if *state == ControllerState::Stopped {
+                return Ok(());
+            }
+            if !matches!(
+                *state,
+                ControllerState::Running | ControllerState::RemovalFailed
+            ) {
+                return Err(SystemError::EBUSY);
+            }
+            *state = ControllerState::Stopping;
+            controller.quiesce();
+            let flush_result = controller.flush_disks();
+            match controller.stop_quiesced() {
+                Ok(()) => {
+                    *state = ControllerState::Stopped;
+                    flush_result?;
+                }
+                Err(err) => {
+                    *state = ControllerState::RemovalFailed;
+                    return Err(err);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn suspend(&self, _device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
+        Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
+
+    fn resume(&self, _device: &Arc<dyn PciDevice>) -> Result<(), SystemError> {
+        Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
+
+    fn add_dynid(&mut self, id: PciDeviceID) -> Result<(), SystemError> {
+        self.ids.write().push(Arc::new(id));
+        Ok(())
+    }
+
+    fn locked_dynid_list(&self) -> Option<Vec<Arc<PciDeviceID>>> {
+        Some(self.ids.read().clone())
+    }
 }
 
-/// @brief: 通过 ctrl_num 和 port_num 获取 port
-fn _port(ctrl_num: u8, port_num: u8) -> &'static mut HbaPort {
-    let list: SpinLockGuard<Vec<&mut HbaMem>> = LOCKED_HBA_MEM_LIST.lock();
-    let port: &HbaPort = &list[ctrl_num as usize].ports[port_num as usize];
+impl Driver for AhciPciDriver {
+    fn id_table(&self) -> Option<IdTable> {
+        Some(IdTable::new("ahci".to_string(), None))
+    }
 
-    return unsafe { (port as *const HbaPort as *mut HbaPort).as_mut().unwrap() };
+    fn devices(&self) -> Vec<Arc<dyn Device>> {
+        self.driver_data.read().devices.clone()
+    }
+
+    fn add_device(&self, device: Arc<dyn Device>) {
+        self.driver_data.write().push_device(device);
+    }
+
+    fn delete_device(&self, device: &Arc<dyn Device>) {
+        self.driver_data.write().delete_device(device);
+    }
+
+    fn set_bus(&self, bus: Option<Weak<dyn Bus>>) {
+        self.driver_data.write().bus = bus;
+    }
+
+    fn bus(&self) -> Option<Weak<dyn Bus>> {
+        self.driver_data.read().bus.clone()
+    }
+}
+
+impl KObject for AhciPciDriver {
+    fn as_any_ref(&self) -> &dyn core::any::Any {
+        self
+    }
+
+    fn set_inode(&self, inode: Option<Arc<KernFSInode>>) {
+        self.kobj_data.write().kern_inode = inode;
+    }
+
+    fn inode(&self) -> Option<Arc<KernFSInode>> {
+        self.kobj_data.read().kern_inode.clone()
+    }
+
+    fn parent(&self) -> Option<Weak<dyn KObject>> {
+        self.kobj_data.read().parent.clone()
+    }
+
+    fn set_parent(&self, parent: Option<Weak<dyn KObject>>) {
+        self.kobj_data.write().parent = parent;
+    }
+
+    fn kset(&self) -> Option<Arc<KSet>> {
+        self.kobj_data.read().kset.clone()
+    }
+
+    fn set_kset(&self, kset: Option<Arc<KSet>>) {
+        self.kobj_data.write().kset = kset;
+    }
+
+    fn kobj_type(&self) -> Option<&'static dyn KObjType> {
+        self.kobj_data.read().kobj_type
+    }
+
+    fn set_kobj_type(&self, ktype: Option<&'static dyn KObjType>) {
+        self.kobj_data.write().kobj_type = ktype;
+    }
+
+    fn name(&self) -> String {
+        "ahci".to_string()
+    }
+
+    fn set_name(&self, _name: String) {}
+
+    fn kobj_state(&self) -> RwSemReadGuard<'_, KObjectState> {
+        self.kobj_state.read()
+    }
+
+    fn kobj_state_mut(&self) -> RwSemWriteGuard<'_, KObjectState> {
+        self.kobj_state.write()
+    }
+
+    fn set_kobj_state(&self, state: KObjectState) {
+        *self.kobj_state.write() = state;
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[unified_init(INITCALL_DEVICE)]
+fn ahci_driver_init() -> Result<(), SystemError> {
+    pci_driver_manager().register(Arc::new(AhciPciDriver::new()))
 }

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -104,12 +104,13 @@ const AHCI_BOHC_BOS: u32 = 1;
 const AHCI_BOHC_OOS: u32 = 1 << 1;
 const AHCI_BOHC_BB: u32 = 1 << 4;
 const AHCI_CAP_SSS: u32 = 1 << 27;
-const AHCI_CAP_CPD: u32 = 1 << 20;
 const AHCI_PXCMD_CPD: u32 = 1 << 20;
+const AHCI_PXCMD_CPS: u32 = 1 << 16;
 const AHCI_PXCMD_ICC_MASK: u32 = 0xf << 28;
 const AHCI_PXCMD_ICC_ACTIVE: u32 = 1 << 28;
 const AHCI_PXCMD_POD: u32 = 1 << 2;
 const AHCI_PXCMD_SUD: u32 = 1 << 1;
+const AHCI_PXCMD_POWER_MASK: u32 = AHCI_PXCMD_POD | AHCI_PXCMD_SUD;
 const AHCI_MAX_SECTORS: u64 = 1u64 << 48;
 const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
 const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
@@ -127,6 +128,29 @@ const fn capacity_is_addressable(capacity: u64) -> bool {
 
 const fn poll_should_yield(iteration: usize) -> bool {
     iteration != 0 && iteration.is_multiple_of(AHCI_POLL_YIELD_INTERVAL)
+}
+
+#[inline]
+fn cooperative_poll_step(iteration: &mut usize) {
+    if poll_should_yield(*iteration) {
+        crate::sched::sched_yield();
+    } else {
+        core::hint::spin_loop();
+    }
+    *iteration = (*iteration).wrapping_add(1);
+}
+
+const fn prepare_port_power_command(cap: u32, cmd: u32) -> (u32, bool) {
+    let mut configured = cmd;
+    if cap & AHCI_CAP_SSS != 0 {
+        configured |= AHCI_PXCMD_SUD;
+    }
+    if cmd & (AHCI_PXCMD_CPD | AHCI_PXCMD_CPS) == (AHCI_PXCMD_CPD | AHCI_PXCMD_CPS) {
+        configured |= AHCI_PXCMD_POD;
+    }
+    configured = (configured & !AHCI_PXCMD_ICC_MASK) | AHCI_PXCMD_ICC_ACTIVE;
+    let power_transitioned = (configured ^ cmd) & AHCI_PXCMD_POWER_MASK != 0;
+    (configured, power_transitioned)
 }
 
 const fn classify_command_status(port_is: u32, port_ci: u32, slot: u32) -> AtaCommandStatus {
@@ -156,6 +180,23 @@ const _: () = {
     assert!(!poll_should_yield(0));
     assert!(!poll_should_yield(AHCI_POLL_YIELD_INTERVAL - 1));
     assert!(poll_should_yield(AHCI_POLL_YIELD_INTERVAL));
+    let (cmd, power_changed) = prepare_port_power_command(AHCI_CAP_SSS, 0);
+    assert!(cmd & AHCI_PXCMD_SUD != 0);
+    assert!(power_changed);
+    let (cmd, power_changed) = prepare_port_power_command(0, AHCI_PXCMD_CPD | AHCI_PXCMD_CPS);
+    assert!(cmd & AHCI_PXCMD_POD != 0);
+    assert!(power_changed);
+    let (cmd, power_changed) = prepare_port_power_command(0, AHCI_PXCMD_CPD);
+    assert!(cmd & AHCI_PXCMD_POD == 0);
+    assert!(!power_changed);
+    let (cmd, power_changed) = prepare_port_power_command(0, AHCI_PXCMD_CPS);
+    assert!(cmd & AHCI_PXCMD_POD == 0);
+    assert!(!power_changed);
+    let (_, power_changed) = prepare_port_power_command(AHCI_CAP_SSS, AHCI_PXCMD_SUD);
+    assert!(!power_changed);
+    let (_, power_changed) =
+        prepare_port_power_command(0, AHCI_PXCMD_CPD | AHCI_PXCMD_CPS | AHCI_PXCMD_POD);
+    assert!(!power_changed);
     assert!(matches!(
         classify_command_status(HBA_PORT_IS_ERR, 0, 0),
         AtaCommandStatus::Error
@@ -284,6 +325,7 @@ impl AhciController {
             }
             let mut online_ports = Vec::new();
             let mut training_ports = Vec::new();
+            let mut needs_power_settle = false;
             for port_no in 0..port_count {
                 if pi & (1 << port_no) == 0 {
                     continue;
@@ -293,21 +335,19 @@ impl AhciController {
                         .cast::<HbaPort>()
                         .add(port_no)
                 };
-                let mut cmd = volatile_read!((*port).cmd);
-                if cap & AHCI_CAP_SSS != 0 {
-                    cmd |= AHCI_PXCMD_SUD;
-                }
-                if cap & AHCI_CAP_CPD != 0 && cmd & AHCI_PXCMD_CPD != 0 {
-                    cmd |= AHCI_PXCMD_POD;
-                }
-                cmd = (cmd & !AHCI_PXCMD_ICC_MASK) | AHCI_PXCMD_ICC_ACTIVE;
+                let (cmd, power_transitioned) =
+                    prepare_port_power_command(cap, volatile_read!((*port).cmd));
+                needs_power_settle |= power_transitioned;
                 volatile_write!((*port).cmd, cmd);
                 let _ = volatile_read!((*port).cmd);
             }
-            if cap & (AHCI_CAP_SSS | AHCI_CAP_CPD) != 0 {
+            if needs_power_settle {
+                // Give a newly powered or spun-up device a brief stabilization
+                // window before sampling its link state.
                 let settle_until = Instant::now() + Duration::from_millis(100);
+                let mut iteration = 0usize;
                 while Instant::now() < settle_until {
-                    core::hint::spin_loop();
+                    cooperative_poll_step(&mut iteration);
                 }
             }
             for port_no in 0..port_count {
@@ -443,12 +483,7 @@ impl AhciController {
                 if !pending || Instant::now() >= link_deadline {
                     break;
                 }
-                if poll_should_yield(link_iteration) {
-                    crate::sched::sched_yield();
-                } else {
-                    core::hint::spin_loop();
-                }
-                link_iteration = link_iteration.wrapping_add(1);
+                cooperative_poll_step(&mut link_iteration);
             }
 
             for (port_no, _, _, port_type) in &link_states {
@@ -523,6 +558,7 @@ impl AhciController {
             // cleanup busy. If it does, preserve its DMA permission for at
             // least another two seconds before forcing the OS takeover.
             let busy_deadline = Instant::now() + Duration::from_millis(25);
+            let mut iteration = 0usize;
             loop {
                 let bohc = volatile_read!((*hba).bohc);
                 if bohc & AHCI_BOHC_BOS == 0 {
@@ -532,19 +568,20 @@ impl AhciController {
                     break;
                 }
                 if Instant::now() >= busy_deadline {
-                    log::warn!("AHCI BIOS handoff did not enter busy state; forcing OS ownership");
+                    log::debug!("AHCI BIOS handoff busy bit remained clear; assuming OS ownership");
                     return;
                 }
-                core::hint::spin_loop();
+                cooperative_poll_step(&mut iteration);
             }
 
             let release_deadline = Instant::now() + Duration::from_secs(2);
+            iteration = 0;
             while volatile_read!((*hba).bohc) & AHCI_BOHC_BOS != 0 {
                 if Instant::now() >= release_deadline {
                     log::warn!("AHCI BIOS handoff timed out; forcing OS ownership");
                     return;
                 }
-                core::hint::spin_loop();
+                cooperative_poll_step(&mut iteration);
             }
         }
     }
@@ -562,11 +599,12 @@ impl AhciController {
         volatile_write!((*hba).ghc, ghc | AHCI_GHC_HR);
         let _ = volatile_read!((*hba).ghc);
         let deadline = Instant::now() + Duration::from_secs(1);
+        let mut iteration = 0usize;
         while volatile_read!((*hba).ghc) & AHCI_GHC_HR != 0 {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            core::hint::spin_loop();
+            cooperative_poll_step(&mut iteration);
         }
         let ghc = volatile_read!((*hba).ghc);
         volatile_write!((*hba).ghc, ghc | AHCI_GHC_AE);
@@ -914,12 +952,7 @@ impl AhciController {
                 }
             }
             if remaining != 0 {
-                if poll_should_yield(iteration) {
-                    crate::sched::sched_yield();
-                } else {
-                    core::hint::spin_loop();
-                }
-                iteration = iteration.wrapping_add(1);
+                cooperative_poll_step(&mut iteration);
             }
         }
         // A scheduler yield may return after the deadline even though hardware
@@ -1063,12 +1096,7 @@ impl AhciController {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            if poll_should_yield(iteration) {
-                crate::sched::sched_yield();
-            } else {
-                core::hint::spin_loop();
-            }
-            iteration = iteration.wrapping_add(1);
+            cooperative_poll_step(&mut iteration);
         }
     }
 
@@ -1084,12 +1112,7 @@ impl AhciController {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            if poll_should_yield(iteration) {
-                crate::sched::sched_yield();
-            } else {
-                core::hint::spin_loop();
-            }
-            iteration = iteration.wrapping_add(1);
+            cooperative_poll_step(&mut iteration);
         }
     }
 
@@ -1146,12 +1169,7 @@ impl AhciController {
             if Instant::now() >= deadline {
                 return Err(SystemError::ETIMEDOUT);
             }
-            if poll_should_yield(iteration) {
-                crate::sched::sched_yield();
-            } else {
-                core::hint::spin_loop();
-            }
-            iteration = iteration.wrapping_add(1);
+            cooperative_poll_step(&mut iteration);
         }
     }
 
@@ -1262,12 +1280,7 @@ impl AhciController {
                 }
             }
             if remaining != 0 {
-                if poll_should_yield(iteration) {
-                    crate::sched::sched_yield();
-                } else {
-                    core::hint::spin_loop();
-                }
-                iteration = iteration.wrapping_add(1);
+                cooperative_poll_step(&mut iteration);
             }
         }
         for item in &mut pending {

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -115,6 +115,8 @@ const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
 const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
 const AHCI_PORT_STOP_TIMEOUT_MS: u64 = 500;
 const AHCI_COMMAND_TIMEOUT_MS: u64 = 30_000;
+// One in-flight payload per serialized port, plus the controller command arena.
+const AHCI_DMA_QUARANTINE_CAPACITY: usize = 32 + 1;
 // 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
 // 32 * 32 command tables (256 KiB), rounded to the allocator's power of two.
 const AHCI_COMMAND_ARENA_SIZE: usize = 1 << 19;
@@ -179,6 +181,7 @@ lazy_static! {
 /// Resources owned by one bound PCI AHCI controller.
 pub struct AhciController {
     device: Arc<dyn PciDevice>,
+    device_name: String,
     pci: Arc<PciDeviceStructureGeneralDevice>,
     abar: usize,
     port_count: usize,
@@ -251,7 +254,8 @@ impl AhciController {
             let command = pci.status_command().1;
             pci.set_command(command & !Command::BUS_MASTER);
             Self::reset_hba(hba)?;
-            Self::reclaim_quarantined_dma(&device.name());
+            let device_name = device.name();
+            Self::reclaim_quarantined_dma(&device_name);
 
             let cap = volatile_read!((*hba).cap);
             let pi = volatile_read!((*hba).pi);
@@ -347,8 +351,19 @@ impl AhciController {
                 Some(memory)
             };
 
+            let mut local_dma_quarantine = Vec::new();
+            local_dma_quarantine
+                .try_reserve_exact(AHCI_DMA_QUARANTINE_CAPACITY)
+                .map_err(|_| SystemError::ENOMEM)?;
+
+            // All allocations needed to retain DMA ownership happen while the
+            // controller is healthy. Teardown may run after an HBA fault when
+            // the allocator itself cannot make progress.
+            Self::prepare_dma_quarantine(&device_name)?;
+
             let controller = Arc::new(Self {
                 device,
+                device_name,
                 pci: pci.clone(),
                 abar,
                 port_count,
@@ -359,10 +374,9 @@ impl AhciController {
                 disks: SpinLock::new(Vec::new()),
                 accepting_io: AtomicBool::new(true),
                 failed_ports: AtomicU32::new(0),
-                // At most one command can be active on each serialized port.
-                // Reserve all possible entries before any fault path so DMA
-                // quarantine never allocates after a command-engine failure.
-                quarantined_dma: SpinLock::new(Vec::with_capacity(32)),
+                // At most one command can be active on each serialized port;
+                // teardown can additionally retain the command arena.
+                quarantined_dma: SpinLock::new(local_dma_quarantine),
                 hardware_stopped: AtomicBool::new(false),
                 detached: AtomicBool::new(false),
                 port_locks: (0..32).map(|_| Mutex::new(())).collect(),
@@ -566,6 +580,25 @@ impl AhciController {
         let retired = AHCI_DMA_QUARANTINE.lock().remove(device_name);
         // Do not run the DMA allocator while holding the quarantine mutex.
         drop(retired);
+    }
+
+    fn prepare_dma_quarantine(device_name: &str) -> Result<(), SystemError> {
+        let mut slot = Vec::new();
+        slot.try_reserve_exact(AHCI_DMA_QUARANTINE_CAPACITY)
+            .map_err(|_| SystemError::ENOMEM)?;
+
+        let mut key = String::new();
+        key.try_reserve_exact(device_name.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        key.push_str(device_name);
+
+        let mut quarantine = AHCI_DMA_QUARANTINE.lock();
+        if quarantine.contains_key(device_name) {
+            return Err(SystemError::EBUSY);
+        }
+        quarantine.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+        quarantine.insert(key, slot);
+        Ok(())
     }
 
     fn initialize_port(&self, port_no: usize) -> Result<(), SystemError> {
@@ -1145,10 +1178,15 @@ impl AhciController {
     }
 
     fn release_quarantined_dma(&self) {
-        let mut guard = self.quarantined_dma.lock();
-        let retired = core::mem::take(&mut *guard);
-        drop(guard);
-        drop(retired);
+        loop {
+            let retired = self.quarantined_dma.lock().pop();
+            let Some(retired) = retired else {
+                return;
+            };
+            // Keep allocator lock ordering independent from the quarantine
+            // lock while preserving the queue's preallocated capacity.
+            drop(retired);
+        }
     }
 
     fn flush_disks(&self) -> Result<(), SystemError> {
@@ -1295,17 +1333,52 @@ impl AhciController {
         let mut retired = core::mem::take(&mut *local_guard);
         drop(local_guard);
         if let Some(memory) = self.command_memory.lock().take() {
-            retired.push(memory);
+            if retired.len() < retired.capacity() {
+                retired.push(memory);
+            } else {
+                if safe_to_release {
+                    drop(memory);
+                } else {
+                    log::error!(
+                        "AHCI {} local DMA quarantine capacity invariant failed; leaking command arena",
+                        self.device_name
+                    );
+                    core::mem::forget(memory);
+                }
+            }
         }
-        if safe_to_release || retired.is_empty() {
+        if safe_to_release {
             drop(retired);
+            Self::reclaim_quarantined_dma(&self.device_name);
             return;
         }
-        AHCI_DMA_QUARANTINE
-            .lock()
-            .entry(self.device.name())
-            .or_default()
-            .extend(retired);
+        if retired.is_empty() {
+            Self::reclaim_quarantined_dma(&self.device_name);
+            return;
+        }
+
+        let mut quarantine = AHCI_DMA_QUARANTINE.lock();
+        let Some(slot) = quarantine.get_mut(&self.device_name) else {
+            drop(quarantine);
+            log::error!(
+                "AHCI {} has no preallocated DMA quarantine; leaking DMA ownership",
+                self.device_name
+            );
+            core::mem::forget(retired);
+            return;
+        };
+        if slot.capacity().saturating_sub(slot.len()) < retired.len() {
+            drop(quarantine);
+            log::error!(
+                "AHCI {} DMA quarantine capacity invariant failed; leaking DMA ownership",
+                self.device_name
+            );
+            core::mem::forget(retired);
+            return;
+        }
+        slot.append(&mut retired);
+        drop(quarantine);
+        drop(retired);
     }
 }
 
@@ -1317,6 +1390,7 @@ impl Drop for AhciController {
         if self.hardware_stopped.load(Ordering::Acquire) {
             self.pci
                 .set_command(self.original_command & !Command::BUS_MASTER);
+            self.retire_dma(true);
             return;
         }
         self.quiesce();
@@ -1331,6 +1405,7 @@ impl Drop for AhciController {
         // because firmware happened to leave Bus Master set before binding.
         self.pci
             .set_command(self.original_command & !Command::BUS_MASTER);
+        self.retire_dma(true);
     }
 }
 

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -61,7 +61,8 @@ use self::{
     hba::{
         FisRegH2D, FisType, HbaCmdHeader, HbaCmdTable, HbaMem, HbaPort, HbaPortType,
         ATA_CMD_FLUSH_CACHE, ATA_CMD_FLUSH_CACHE_EXT, ATA_CMD_IDENTIFY, ATA_DEV_BUSY, ATA_DEV_DRQ,
-        HBA_PORT_IS_ERR,
+        ATA_DEV_ERR, ATA_DEV_FAULT, ATA_DEV_READY, ATA_ERR_ICRC, ATA_ERR_UNC, HBA_PORT_IS_ERR,
+        HBA_PORT_IS_TFES, HBA_SSTS_PRESENT,
     },
 };
 
@@ -116,6 +117,11 @@ const AHCI_POLL_YIELD_INTERVAL: usize = 1 << 10;
 const AHCI_LINK_TIMEOUT_MS: u64 = 2_000;
 const AHCI_PORT_STOP_TIMEOUT_MS: u64 = 500;
 const AHCI_COMMAND_TIMEOUT_MS: u64 = 30_000;
+// Normal command/FIS completion notifications which may be latched together
+// with TFES. Any other PxIS bit blocks light-weight error recovery.
+const AHCI_PORT_IS_BENIGN_COMMAND_EVENTS: u32 = 1 << 5 | 1 << 3 | 1 << 2 | 1 << 1 | 1 << 0;
+// Linux 6.6 ata_eh_analyze_serror() requests reset for these SError classes.
+const AHCI_SERR_REQUIRES_RESET: u32 = 1 << 8 | 1 << 9 | 1 << 10 | 1 << 11 | 1 << 16 | 1 << 26;
 // One in-flight payload per serialized port, plus the controller command arena.
 const AHCI_DMA_QUARANTINE_CAPACITY: usize = 32 + 1;
 // 32 command lists (32 KiB) + 32 received-FIS areas (8 KiB) +
@@ -171,6 +177,48 @@ fn read_command_status(port: &HbaPort, slot: u32) -> AtaCommandStatus {
     classify_command_status(port_is, port_ci, slot)
 }
 
+const fn command_error_is_recoverable(
+    port_is: u32,
+    port_serr: u32,
+    port_tfd: u32,
+    port_ci: u32,
+    port_sact: u32,
+) -> bool {
+    let status = port_tfd as u8;
+    let error = (port_tfd >> 8) as u8;
+    port_is & HBA_PORT_IS_TFES != 0
+        && port_is & !(HBA_PORT_IS_TFES | AHCI_PORT_IS_BENIGN_COMMAND_EVENTS) == 0
+        && port_serr & AHCI_SERR_REQUIRES_RESET == 0
+        && status & (ATA_DEV_BUSY | ATA_DEV_DRQ | ATA_DEV_READY) == ATA_DEV_READY
+        && status & (ATA_DEV_ERR | ATA_DEV_FAULT) == ATA_DEV_ERR
+        && error != 0
+        && error & ATA_ERR_ICRC == 0
+        && port_ci == 0
+        && port_sact == 0
+}
+
+const fn recovered_port_is_idle(
+    port_is: u32,
+    port_serr: u32,
+    port_tfd: u32,
+    port_ci: u32,
+    port_sact: u32,
+) -> bool {
+    let status = port_tfd as u8;
+    let error = (port_tfd >> 8) as u8;
+    port_is & !AHCI_PORT_IS_BENIGN_COMMAND_EVENTS == 0
+        && port_serr == 0
+        && status & (ATA_DEV_BUSY | ATA_DEV_DRQ | ATA_DEV_READY) == ATA_DEV_READY
+        && status & ATA_DEV_FAULT == 0
+        && error & ATA_ERR_ICRC == 0
+        && port_ci == 0
+        && port_sact == 0
+}
+
+const fn link_is_present(port_ssts: u32) -> bool {
+    port_ssts & 0xf == HBA_SSTS_PRESENT
+}
+
 // These protocol boundaries are checked by every kernel build, including
 // architectures that do not instantiate the x86-only AHCI driver.
 const _: () = {
@@ -209,6 +257,85 @@ const _: () = {
         classify_command_status(0, 1, 0),
         AtaCommandStatus::Pending
     ));
+    assert!(command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES | (1 << 29),
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        1 << 8,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        1,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_ICRC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        1,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        1
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES | (1 << 24),
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!command_error_is_recoverable(
+        HBA_PORT_IS_TFES,
+        0,
+        ATA_DEV_ERR as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(recovered_port_is_idle(
+        0,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(!recovered_port_is_idle(
+        HBA_PORT_IS_TFES,
+        0,
+        (ATA_DEV_READY | ATA_DEV_ERR) as u32 | ((ATA_ERR_UNC as u32) << 8),
+        0,
+        0
+    ));
+    assert!(link_is_present(HBA_SSTS_PRESENT));
+    assert!(!link_is_present(0));
 };
 
 lazy_static! {
@@ -712,18 +839,60 @@ impl AhciController {
         Ok(())
     }
 
-    /// Freeze one failed port. A controller-wide Bus Master shutdown would
-    /// interrupt unrelated ports, so a buffer which may still be a DMA target
-    /// remains owned by this controller until teardown stops or resets the HBA.
-    pub(crate) fn abort_failed_command(&self, port_no: usize, buffer: Option<DmaBuffer>) {
-        self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
-        if unsafe { &mut *self.port_ptr(port_no) }.stop().is_err() {
+    /// Stop a failed command and reopen the port only for an isolated ATA
+    /// device error. More serious errors keep the port stopped. If the command
+    /// engine cannot stop, the payload may still be a DMA target and remains
+    /// quarantined until controller teardown.
+    pub(crate) fn recover_or_fail_command(&self, port_no: usize, buffer: Option<DmaBuffer>) {
+        let port = unsafe { &mut *self.port_ptr(port_no) };
+        if port.stop_command_engine().is_err() {
+            self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
             if let Some(buffer) = buffer {
                 self.quarantined_dma.lock().push(buffer);
             }
-        } else {
-            drop(buffer);
+            return;
         }
+        let _payload_guard = buffer;
+
+        // Use one coherent stopped-state snapshot for both classification and
+        // W1C. CR is clear, so the payload can no longer be a DMA target.
+        let port_is = volatile_read!(port.is);
+        let port_serr = volatile_read!(port.serr);
+        let port_tfd = volatile_read!(port.tfd);
+        let port_ci = volatile_read!(port.ci);
+        let port_sact = volatile_read!(port.sact);
+        let port_ssts = volatile_read!(port.ssts);
+
+        if link_is_present(port_ssts)
+            && command_error_is_recoverable(port_is, port_serr, port_tfd, port_ci, port_sact)
+        {
+            // PxSERR and PxIS are write-one-to-clear. Clear only the state
+            // observed above, then make sure a new error did not arrive while
+            // recovery was in progress.
+            volatile_write!(port.serr, port_serr);
+            volatile_write!(port.is, port_is);
+            let remaining_serr = volatile_read!(port.serr);
+            let remaining_is = volatile_read!(port.is);
+            if remaining_serr == 0
+                && remaining_is & !AHCI_PORT_IS_BENIGN_COMMAND_EVENTS == 0
+                && port.start().is_ok()
+                && link_is_present(volatile_read!(port.ssts))
+                && recovered_port_is_idle(
+                    volatile_read!(port.is),
+                    volatile_read!(port.serr),
+                    volatile_read!(port.tfd),
+                    volatile_read!(port.ci),
+                    volatile_read!(port.sact),
+                )
+            {
+                return;
+            }
+        }
+
+        // A failed recovery must converge back to the stopped-port state.
+        // This is best effort if the controller has become inaccessible.
+        let _ = port.stop();
+        self.failed_ports.fetch_or(1 << port_no, Ordering::AcqRel);
     }
 
     pub(crate) fn allocate_dma(
@@ -1079,7 +1248,7 @@ impl AhciController {
         volatile_write!(port.ci, ci | (1 << pending.slot));
         pending.issued = true;
         if let Err(err) = Self::wait_slot(port, pending.slot) {
-            self.abort_failed_command(port_no, None);
+            self.recover_or_fail_command(port_no, None);
             return Err(err);
         }
         core::sync::atomic::compiler_fence(Ordering::Acquire);

--- a/kernel/src/driver/disk/ahci/mod.rs
+++ b/kernel/src/driver/disk/ahci/mod.rs
@@ -226,6 +226,7 @@ impl AhciController {
         // Preserve firmware's Bus Master state until BIOS/OS handoff finishes;
         // clearing it earlier can prevent firmware transactions from draining.
         pci.set_command(original_command | Command::MEMORY_SPACE);
+        let mut os_ownership_assumed = false;
         let result = (|| {
             if pci.bar_ioremap().ok_or(SystemError::EINVAL)?.is_err() {
                 return Err(SystemError::EIO);
@@ -241,7 +242,15 @@ impl AhciController {
                 .data();
             drop(bars);
             let hba = abar as *mut HbaMem;
-            Self::initialize_hba(hba, &pci)?;
+            Self::acquire_firmware_ownership(hba);
+            os_ownership_assumed = true;
+
+            // Firmware has either released ownership or exhausted its handoff
+            // grace period. Disable old DMA before reset invalidates firmware
+            // command-list addresses.
+            let command = pci.status_command().1;
+            pci.set_command(command & !Command::BUS_MASTER);
+            Self::reset_hba(hba)?;
             Self::reclaim_quarantined_dma(&device.name());
 
             let cap = volatile_read!((*hba).cap);
@@ -480,33 +489,50 @@ impl AhciController {
             Ok(controller)
         })();
         if result.is_err() {
-            pci.set_command(original_command & !Command::BUS_MASTER);
+            if os_ownership_assumed {
+                pci.set_command(original_command & !Command::BUS_MASTER);
+            } else {
+                // The controller still belongs to firmware. Restore the exact
+                // entry state instead of interrupting firmware DMA.
+                pci.set_command(original_command);
+            }
         }
         result
     }
 
-    fn initialize_hba(
-        hba: *mut HbaMem,
-        pci: &PciDeviceStructureGeneralDevice,
-    ) -> Result<(), SystemError> {
+    fn acquire_firmware_ownership(hba: *mut HbaMem) {
         if volatile_read!((*hba).cap2) & AHCI_CAP2_BOH != 0 {
             let bohc = volatile_read!((*hba).bohc);
             volatile_write!((*hba).bohc, bohc | AHCI_BOHC_OOS);
-            let deadline = Instant::now() + Duration::from_secs(2);
-            while volatile_read!((*hba).bohc) & (AHCI_BOHC_BOS | AHCI_BOHC_BB) != 0 {
-                if Instant::now() >= deadline {
-                    return Err(SystemError::ETIMEDOUT);
+
+            // AHCI 1.3.1 section 10.6 gives firmware 25 ms to declare
+            // cleanup busy. If it does, preserve its DMA permission for at
+            // least another two seconds before forcing the OS takeover.
+            let busy_deadline = Instant::now() + Duration::from_millis(25);
+            loop {
+                let bohc = volatile_read!((*hba).bohc);
+                if bohc & AHCI_BOHC_BOS == 0 {
+                    return;
+                }
+                if bohc & AHCI_BOHC_BB != 0 {
+                    break;
+                }
+                if Instant::now() >= busy_deadline {
+                    log::warn!("AHCI BIOS handoff did not enter busy state; forcing OS ownership");
+                    return;
+                }
+                core::hint::spin_loop();
+            }
+
+            let release_deadline = Instant::now() + Duration::from_secs(2);
+            while volatile_read!((*hba).bohc) & AHCI_BOHC_BOS != 0 {
+                if Instant::now() >= release_deadline {
+                    log::warn!("AHCI BIOS handoff timed out; forcing OS ownership");
+                    return;
                 }
                 core::hint::spin_loop();
             }
         }
-
-        // Firmware ownership is now released. Disable old DMA before reset
-        // invalidates firmware command-list addresses.
-        let command = pci.status_command().1;
-        pci.set_command(command & !Command::BUS_MASTER);
-
-        Self::reset_hba(hba)
     }
 
     fn reset_hba(hba: *mut HbaMem) -> Result<(), SystemError> {
@@ -1254,8 +1280,8 @@ impl AhciController {
     /// Perform the final PCI access and transfer all DMA ownership before any
     /// stale reference is allowed to outlive this controller generation.
     fn finalize_detach(&self, safe_to_release_dma: bool) {
-        let command = self.pci.status_command().1;
-        self.pci.set_command(command & !Command::BUS_MASTER);
+        self.pci
+            .set_command(self.original_command & !Command::BUS_MASTER);
         self.detached.store(true, Ordering::Release);
         self.retire_dma(safe_to_release_dma);
     }

--- a/kernel/src/driver/pci/dev_id.rs
+++ b/kernel/src/driver/pci/dev_id.rs
@@ -28,19 +28,54 @@ impl PciDeviceID {
         self.special_data = Some(data);
     }
 
-    pub fn dummpy() -> Self {
-        return Self {
+    /// Match any PCI device. This is intended for tests and deliberately
+    /// uses a zero class mask; a wildcard value with an all-ones mask would
+    /// only match a device whose class itself is all ones.
+    #[cfg(test)]
+    pub fn any() -> Self {
+        Self {
             vendor: PCI_ANY_ID,
             device_id: PCI_ANY_ID,
             subvendor: PCI_ANY_ID,
             subdevice: PCI_ANY_ID,
-            class: PCI_ANY_ID,
-            class_mask: PCI_ANY_ID,
+            class: 0,
+            class_mask: 0,
             _driver_data: 0,
             _override_only: PCI_ANY_ID,
             special_data: None,
-        };
+        }
     }
+
+    /// Construct the identity carried by an enumerated PCI function.
+    pub fn device(vendor: u16, device_id: u16, subvendor: u16, subdevice: u16, class: u32) -> Self {
+        Self {
+            vendor: vendor.into(),
+            device_id: device_id.into(),
+            subvendor: subvendor.into(),
+            subdevice: subdevice.into(),
+            class,
+            class_mask: u32::MAX,
+            _driver_data: 0,
+            _override_only: 0,
+            special_data: None,
+        }
+    }
+
+    /// Construct a driver match entry for a 24-bit PCI class code.
+    pub fn class_match(class: u32, class_mask: u32) -> Self {
+        Self {
+            vendor: PCI_ANY_ID,
+            device_id: PCI_ANY_ID,
+            subvendor: PCI_ANY_ID,
+            subdevice: PCI_ANY_ID,
+            class: class & 0x00ff_ffff,
+            class_mask: class_mask & 0x00ff_ffff,
+            _driver_data: 0,
+            _override_only: 0,
+            special_data: None,
+        }
+    }
+
     pub fn match_dev(&self, dev: &Arc<dyn PciDevice>) -> bool {
         if let Some(d_data) = &dev.dynid().special_data {
             return d_data.match_dev(self.special_data);

--- a/kernel/src/driver/pci/device.rs
+++ b/kernel/src/driver/pci/device.rs
@@ -21,6 +21,7 @@ use crate::{
 
 use super::{
     dev_id::PciDeviceID,
+    pci::PciDeviceStructureGeneralDevice,
     pci_irq::IrqType,
     subsys::{pci_bus, pci_bus_device},
 };
@@ -90,6 +91,12 @@ pub trait PciDevice: Device {
     fn irq_line(&self) -> u8;
     fn subclass(&self) -> u8;
     fn interface_code(&self) -> u8;
+
+    /// Return the standard PCI header and BAR resource object created by PCI
+    /// enumeration. Non-standard headers do not expose this resource type.
+    fn standard_device(&self) -> Option<Arc<PciDeviceStructureGeneralDevice>> {
+        None
+    }
 }
 
 /// #结构功能

--- a/kernel/src/driver/pci/driver.rs
+++ b/kernel/src/driver/pci/driver.rs
@@ -25,7 +25,10 @@ pub trait PciDriver: Driver {
     /// - Ok:probe成功
     /// - Err:probe失败
     fn probe(&self, device: &Arc<dyn PciDevice>, id: &PciDeviceID) -> Result<(), SystemError>;
-    fn remove(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError>;
+    /// Final notification that the PCI function is being detached. Physical
+    /// removal cannot be vetoed, so implementations must quiesce resources and
+    /// leave stale references unable to access hardware.
+    fn remove(&self, device: &Arc<dyn PciDevice>);
     fn shutdown(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError>;
     fn suspend(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError>;
     fn resume(&self, device: &Arc<dyn PciDevice>) -> Result<(), SystemError>;

--- a/kernel/src/driver/pci/mod.rs
+++ b/kernel/src/driver/pci/mod.rs
@@ -9,4 +9,5 @@ pub mod pci_irq;
 pub mod raw_device;
 pub mod root;
 pub mod subsys;
+#[cfg(test)]
 pub mod test;

--- a/kernel/src/driver/pci/raw_device.rs
+++ b/kernel/src/driver/pci/raw_device.rs
@@ -43,7 +43,16 @@ impl From<Arc<PciDeviceStructureGeneralDevice>> for PciGeneralDevice {
         // let value = Arc::new(value.clone());
         let name: String = value.common_header.bus_device_function.into();
         let kobj_state = LockedKObjectState::new(None);
-        let dev_id = PciDeviceID::dummpy();
+        let class = u32::from(value.common_header.class_code) << 16
+            | u32::from(value.common_header.subclass) << 8
+            | u32::from(value.common_header.prog_if);
+        let dev_id = PciDeviceID::device(
+            value.common_header.vendor_id,
+            value.common_header.device_id,
+            value.subsystem_vendor_id,
+            value.subsystem_id,
+            class,
+        );
 
         // dev_id.set_special(PciSpecifiedData::Virtio());
         let res = Self {
@@ -104,6 +113,10 @@ impl PciDevice for PciGeneralDevice {
 
     fn subclass(&self) -> u8 {
         self.header.common_header.subclass
+    }
+
+    fn standard_device(&self) -> Option<Arc<PciDeviceStructureGeneralDevice>> {
+        Some(self.header.clone())
     }
 }
 

--- a/kernel/src/driver/pci/subsys.rs
+++ b/kernel/src/driver/pci/subsys.rs
@@ -123,7 +123,8 @@ impl Bus for PciBus {
             );
             SystemError::EINVAL
         })?;
-        pci_drv.remove(&pci_dev)
+        pci_drv.remove(&pci_dev);
+        Ok(())
     }
 
     fn sync_state(&self, _device: &Arc<dyn Device>) {

--- a/kernel/src/driver/pci/subsys.rs
+++ b/kernel/src/driver/pci/subsys.rs
@@ -23,7 +23,6 @@ use crate::{
 use super::{
     device::{PciBusDevice, PciDevice},
     driver::PciDriver,
-    test::pt_init,
 };
 
 static mut PCI_BUS_DEVICE: Option<Arc<PciBusDevice>> = None;
@@ -226,6 +225,5 @@ pub(super) fn pci_bus_subsys_init() -> Result<(), SystemError> {
 
     set_pci_bus(pci_bus.clone());
     let r = bus_register(pci_bus.clone() as Arc<dyn Bus>);
-    pt_init()?;
     return r;
 }

--- a/kernel/src/driver/pci/test/mod.rs
+++ b/kernel/src/driver/pci/test/mod.rs
@@ -17,7 +17,7 @@ static mut TEST_DEVICE: Option<Arc<TestDevice>> = None;
 pub fn pt_init() -> Result<(), SystemError> {
     let tdev = Arc::new(TestDevice::new());
     let mut drv = TestDriver::new();
-    drv.add_dynid(PciDeviceID::dummpy())?;
+    drv.add_dynid(PciDeviceID::any())?;
     let tdrv = Arc::new(drv);
 
     let _ = pci_device_manager().device_add(tdev.clone());

--- a/kernel/src/driver/pci/test/pt_device.rs
+++ b/kernel/src/driver/pci/test/pt_device.rs
@@ -55,7 +55,7 @@ impl TestDevice {
 
 impl PciDevice for TestDevice {
     fn dynid(&self) -> PciDeviceID {
-        PciDeviceID::dummpy()
+        PciDeviceID::any()
     }
 
     fn vendor(&self) -> u16 {

--- a/kernel/src/driver/pci/test/pt_driver.rs
+++ b/kernel/src/driver/pci/test/pt_driver.rs
@@ -63,9 +63,7 @@ impl PciDriver for TestDriver {
         Ok(())
     }
 
-    fn remove(&self, _device: &Arc<dyn PciDevice>) -> Result<(), system_error::SystemError> {
-        Ok(())
-    }
+    fn remove(&self, _device: &Arc<dyn PciDevice>) {}
 
     fn resume(&self, _device: &Arc<dyn PciDevice>) -> Result<(), system_error::SystemError> {
         Ok(())

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -72,11 +72,6 @@ fn kernel_init() -> Result<(), SystemError> {
     rcu::start_worker();
     kenrel_init_freeable()?;
     set_system_state(SystemState::FreeingInitMem);
-    #[cfg(target_arch = "x86_64")]
-    crate::driver::disk::ahci::ahci_init()
-        .inspect_err(|e| log::error!("ahci_init failed: {:?}", e))
-        .ok();
-
     if super::initramfs_enabled() {
         // 使用 initramfs, 迁移文件系统
         #[cfg(feature = "initram")]

--- a/kernel/src/mm/allocator/buddy.rs
+++ b/kernel/src/mm/allocator/buddy.rs
@@ -7,10 +7,11 @@ use log::{debug, warn};
 /// @Description: 伙伴分配器
 use crate::arch::MMArch;
 use crate::mm::allocator::bump::BumpAllocator;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 use crate::mm::allocator::page_frame::{
-    allocate_page_frames, deallocate_page_frames, FrameAllocator, PageFrameCount, PageFrameUsage,
-    PhysPageFrame,
+    allocate_page_frames, deallocate_page_frames, PhysPageFrame,
 };
+use crate::mm::allocator::page_frame::{FrameAllocator, PageFrameCount, PageFrameUsage};
 use crate::mm::{MemoryManagementArch, PhysAddr, PhysMemoryArea, VirtAddr};
 
 use core::cmp::min;
@@ -641,6 +642,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
 /// The live allocator only supplies one aligned backing block.  All operations
 /// under test use a separate `BuddyAllocator`, so their exact addresses are
 /// deterministic and concurrent kernel allocations cannot affect the result.
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool) {
     const BACKING_PAGES: usize = 64;
     const ARENA_OFFSET_PAGES: usize = 32;

--- a/kernel/src/mm/allocator/buddy.rs
+++ b/kernel/src/mm/allocator/buddy.rs
@@ -7,7 +7,10 @@ use log::{debug, warn};
 /// @Description: 伙伴分配器
 use crate::arch::MMArch;
 use crate::mm::allocator::bump::BumpAllocator;
-use crate::mm::allocator::page_frame::{FrameAllocator, PageFrameCount, PageFrameUsage};
+use crate::mm::allocator::page_frame::{
+    allocate_page_frames, deallocate_page_frames, FrameAllocator, PageFrameCount, PageFrameUsage,
+    PhysPageFrame,
+};
 use crate::mm::{MemoryManagementArch, PhysAddr, PhysMemoryArea, VirtAddr};
 
 use core::cmp::min;
@@ -356,6 +359,69 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
             .map(|addr| (addr, PageFrameCount::new(1 << (order as usize - MIN_ORDER))));
     }
 
+    /// Allocate from a free block whose returned range fits below a physical
+    /// address limit. The selected larger buddy block may cross the limit;
+    /// only its low split is returned and the remaining halves go back to the
+    /// normal free lists.
+    pub fn buddy_alloc_below(
+        &mut self,
+        count: PageFrameCount,
+        max_phys_addr: PhysAddr,
+    ) -> Option<(PhysAddr, PageFrameCount)> {
+        assert!(count.data().is_power_of_two());
+        let requested_bytes = count.data().checked_mul(A::PAGE_SIZE)?;
+        let requested_order = (log2(count.data()) + MIN_ORDER) as u8;
+        if requested_order as usize >= MAX_ORDER {
+            return None;
+        }
+
+        for current_order in requested_order as usize..MAX_ORDER {
+            let mut list_addr = self.free_area[Self::order2index(current_order as u8)];
+            loop {
+                let mut list: PageList<A> = Self::read_page(list_addr);
+                for index in 0..list.entry_num {
+                    let entry_addr = Self::entry_virt_addr(list_addr, index);
+                    let entry: PhysAddr = unsafe { A::read(entry_addr) };
+                    let fits = entry
+                        .data()
+                        .checked_add(requested_bytes - 1)
+                        .is_some_and(|end| end <= max_phys_addr.data());
+                    if !fits {
+                        continue;
+                    }
+
+                    let last_index = list.entry_num - 1;
+                    if index != last_index {
+                        let last: PhysAddr =
+                            unsafe { A::read(Self::entry_virt_addr(list_addr, last_index)) };
+                        unsafe { A::write(entry_addr, last) };
+                    }
+                    unsafe {
+                        A::write(
+                            Self::entry_virt_addr(list_addr, last_index),
+                            PhysAddr::new(0),
+                        )
+                    };
+                    list.entry_num -= 1;
+                    Self::write_page(list_addr, list);
+
+                    let base = entry;
+                    let mut split_order = current_order;
+                    while split_order > requested_order as usize {
+                        split_order -= 1;
+                        unsafe { self.buddy_free(base + (1 << split_order), split_order as u8) };
+                    }
+                    return Some((base, count));
+                }
+                if list.next_page.is_null() {
+                    break;
+                }
+                list_addr = list.next_page;
+            }
+        }
+        None
+    }
+
     /// 释放一个块
     ///
     /// ## 参数
@@ -568,6 +634,144 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         // 走到这一步，order应该为MAX_ORDER-1
         assert!(order == MAX_ORDER - 1);
     }
+}
+
+/// Exercise bounded allocation, splitting, and merging on a private arena.
+///
+/// The live allocator only supplies one aligned backing block.  All operations
+/// under test use a separate `BuddyAllocator`, so their exact addresses are
+/// deterministic and concurrent kernel allocations cannot affect the result.
+pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool) {
+    const BACKING_PAGES: usize = 64;
+    const ARENA_OFFSET_PAGES: usize = 32;
+    const ARENA_PAGES: usize = 16;
+
+    let Some((backing, backing_count)) =
+        (unsafe { allocate_page_frames(PageFrameCount::new(BACKING_PAGES)) })
+    else {
+        return (false, false, false);
+    };
+
+    unsafe fn empty_isolated_allocator(backing: PhysAddr) -> BuddyAllocator<MMArch> {
+        let mut free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        for (index, area) in free_area.iter_mut().enumerate() {
+            *area = backing + index * MMArch::PAGE_SIZE;
+            core::ptr::write_bytes(
+                MMArch::phys_2_virt(*area).unwrap().as_ptr::<u8>(),
+                0,
+                MMArch::PAGE_SIZE,
+            );
+            BuddyAllocator::<MMArch>::write_page(*area, PageList::new(0, PhysAddr::new(0)));
+        }
+        BuddyAllocator {
+            free_area,
+            total: PageFrameCount::new(ARENA_PAGES),
+            phantom: PhantomData,
+        }
+    }
+
+    unsafe fn isolated_allocator(backing: PhysAddr) -> BuddyAllocator<MMArch> {
+        let mut allocator = empty_isolated_allocator(backing);
+        allocator.buddy_free(
+            backing + ARENA_OFFSET_PAGES * MMArch::PAGE_SIZE,
+            (MIN_ORDER + ARENA_PAGES.trailing_zeros() as usize) as u8,
+        );
+        allocator
+    }
+
+    let arena = backing + ARENA_OFFSET_PAGES * MMArch::PAGE_SIZE;
+    let arena_max = arena + ARENA_PAGES * MMArch::PAGE_SIZE - 1;
+
+    let bounded_selection_ok = {
+        let mut allocator = unsafe { empty_isolated_allocator(backing) };
+        let low = arena;
+        let high = arena + ARENA_PAGES * MMArch::PAGE_SIZE;
+        // Insert the out-of-mask block first so the bounded search has to skip
+        // it rather than succeeding accidentally on the first entry.
+        unsafe {
+            allocator.free(high, PageFrameCount::new(8));
+            allocator.free(low, PageFrameCount::new(8));
+        }
+        let low_max = low + 8 * MMArch::PAGE_SIZE - 1;
+        let selected = allocator.buddy_alloc_below(PageFrameCount::new(8), low_max);
+        let remaining =
+            allocator.buddy_alloc_below(PageFrameCount::new(8), high + 8 * MMArch::PAGE_SIZE - 1);
+        selected.is_some_and(|(base, count)| base == low && count.data() == 8)
+            && remaining.is_some_and(|(base, count)| base == high && count.data() == 8)
+    };
+
+    let split_merge_ok = {
+        let mut allocator = unsafe { isolated_allocator(backing) };
+        let first = allocator.buddy_alloc_below(PageFrameCount::new(8), arena_max);
+        let second = allocator.buddy_alloc_below(PageFrameCount::new(8), arena_max);
+        match (first, second) {
+            (Some((first, first_count)), Some((second, second_count))) => {
+                let exact_split = first_count.data() == 8
+                    && second_count.data() == 8
+                    && min(first, second) == arena
+                    && core::cmp::max(first, second) == arena + 8 * MMArch::PAGE_SIZE;
+                unsafe {
+                    allocator.free(first, first_count);
+                    allocator.free(second, second_count);
+                }
+                let merged = allocator.buddy_alloc_below(PageFrameCount::new(16), arena_max);
+                exact_split
+                    && merged.is_some_and(|(base, count)| base == arena && count.data() == 16)
+            }
+            _ => false,
+        }
+    };
+
+    let fragmented_ok = {
+        let mut allocator = unsafe { isolated_allocator(backing) };
+        let mut pages = alloc::vec::Vec::with_capacity(ARENA_PAGES);
+        for _ in 0..ARENA_PAGES {
+            let Some((base, count)) = allocator.buddy_alloc_below(PageFrameCount::ONE, arena_max)
+            else {
+                break;
+            };
+            if count != PageFrameCount::ONE {
+                break;
+            }
+            pages.push(base);
+        }
+        pages.sort_unstable();
+        let exact_pages = pages.len() == ARENA_PAGES
+            && pages
+                .iter()
+                .enumerate()
+                .all(|(index, base)| *base == arena + index * MMArch::PAGE_SIZE);
+
+        if exact_pages {
+            for index in (0..ARENA_PAGES).step_by(2) {
+                unsafe { allocator.free(pages[index], PageFrameCount::ONE) };
+            }
+            let fragmented_rejects_pair = allocator
+                .buddy_alloc_below(PageFrameCount::new(2), arena_max)
+                .is_none();
+
+            unsafe { allocator.free(pages[1], PageFrameCount::ONE) };
+            let pair = allocator.buddy_alloc_below(PageFrameCount::new(2), arena_max);
+            let exact_pair = pair.is_some_and(|(base, count)| base == arena && count.data() == 2);
+            if let Some((base, count)) = pair {
+                unsafe { allocator.free(base, count) };
+            }
+            for index in (3..ARENA_PAGES).step_by(2) {
+                unsafe { allocator.free(pages[index], PageFrameCount::ONE) };
+            }
+            let merged = allocator.buddy_alloc_below(PageFrameCount::new(16), arena_max);
+            fragmented_rejects_pair
+                && exact_pair
+                && merged.is_some_and(|(base, count)| base == arena && count.data() == 16)
+        } else {
+            false
+        }
+    };
+
+    unsafe {
+        deallocate_page_frames(PhysPageFrame::new(backing), backing_count);
+    }
+    (bounded_selection_ok, split_merge_ok, fragmented_ok)
 }
 
 impl<A: MemoryManagementArch> FrameAllocator for BuddyAllocator<A> {

--- a/kernel/src/mm/allocator/buddy.rs
+++ b/kernel/src/mm/allocator/buddy.rs
@@ -24,6 +24,17 @@ use core::{marker::PhantomData, mem};
 const MAX_ORDER: usize = 31;
 // 4KB
 const MIN_ORDER: usize = 12;
+const DMA32_LIMIT: usize = u32::MAX as usize;
+/// Keep 16 MiB of low memory available for devices which cannot address
+/// Normal memory when an unrestricted allocation falls back to DMA32.
+const DMA32_FALLBACK_RESERVE_PAGES: usize = (16 * 1024 * 1024) >> MIN_ORDER;
+const DMA32_ALLOCATION_METADATA_HEADROOM: usize = MAX_ORDER - MIN_ORDER;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum BuddyZone {
+    Dma32,
+    Normal,
+}
 
 /// 保存buddy算法中每一页存放的BuddyEntry的信息，占据每个页的起始位置
 #[derive(Debug)]
@@ -69,8 +80,19 @@ impl<A> PageList<A> {
 #[repr(C)]
 #[derive(Debug)]
 pub struct BuddyAllocator<A> {
-    // 存放每个阶的空闲“链表”的头部地址
-    free_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
+    // DMA32 and normal memory have separate free lists.  This keeps a
+    // 32-bit DMA allocation bounded by the number of buddy orders instead of
+    // scanning every high-memory free block while interrupts are disabled.
+    dma32_free_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
+    normal_free_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
+    dma32_empty_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
+    normal_empty_area: [PhysAddr; MAX_ORDER - MIN_ORDER],
+    dma32_free_pages: usize,
+    normal_free_pages: usize,
+    /// Whether this allocator has ever managed memory above 4 GiB.  Most
+    /// current systems are DMA32-only; avoid probing every empty Normal order
+    /// on their hot allocation path.
+    has_normal_memory: bool,
     /// 总页数
     total: PageFrameCount,
     phantom: PhantomData<A>,
@@ -88,11 +110,16 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         debug!("Free pages before init buddy: {:?}", initial_free_pages);
         // debug!("Buddy entries: {}", Self::BUDDY_ENTRIES);
 
-        let mut free_area: [PhysAddr; MAX_ORDER - MIN_ORDER] =
-            [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let dma32_free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let normal_free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let mut dma32_empty_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let mut normal_empty_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
 
         // Buddy初始占用的空间从bump分配
-        for f in free_area.iter_mut() {
+        for f in dma32_empty_area
+            .iter_mut()
+            .chain(normal_empty_area.iter_mut())
+        {
             let curr_page = bump_allocator.allocate_one();
             // 保存每个阶的空闲链表的头部地址
             *f = curr_page.unwrap();
@@ -104,7 +131,13 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         }
 
         let mut allocator = Self {
-            free_area,
+            dma32_free_area,
+            normal_free_area,
+            dma32_empty_area,
+            normal_empty_area,
+            dma32_free_pages: 0,
+            normal_free_pages: 0,
+            has_normal_memory: false,
             total: PageFrameCount::new(0),
             phantom: PhantomData,
         };
@@ -223,72 +256,232 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         order as usize - MIN_ORDER
     }
 
+    #[inline]
+    fn zone_for(base: PhysAddr, order: usize) -> BuddyZone {
+        let end = base
+            .data()
+            .checked_add((1usize << order) - 1)
+            .expect("buddy block address overflow");
+        assert!(
+            base.data() > DMA32_LIMIT || end <= DMA32_LIMIT,
+            "buddy block crosses the DMA32 boundary"
+        );
+        if end <= DMA32_LIMIT {
+            BuddyZone::Dma32
+        } else {
+            BuddyZone::Normal
+        }
+    }
+
+    #[inline]
+    fn free_area(&self, zone: BuddyZone, order: u8) -> PhysAddr {
+        let index = Self::order2index(order);
+        match zone {
+            BuddyZone::Dma32 => self.dma32_free_area[index],
+            BuddyZone::Normal => self.normal_free_area[index],
+        }
+    }
+
+    #[inline]
+    fn set_free_area(&mut self, zone: BuddyZone, order: u8, value: PhysAddr) {
+        let index = Self::order2index(order);
+        match zone {
+            BuddyZone::Dma32 => self.dma32_free_area[index] = value,
+            BuddyZone::Normal => self.normal_free_area[index] = value,
+        }
+    }
+
+    #[inline]
+    fn empty_area(&self, zone: BuddyZone, order: u8) -> PhysAddr {
+        let index = Self::order2index(order);
+        match zone {
+            BuddyZone::Dma32 => self.dma32_empty_area[index],
+            BuddyZone::Normal => self.normal_empty_area[index],
+        }
+    }
+
+    #[inline]
+    fn set_empty_area(&mut self, zone: BuddyZone, order: u8, value: PhysAddr) {
+        let index = Self::order2index(order);
+        match zone {
+            BuddyZone::Dma32 => self.dma32_empty_area[index] = value,
+            BuddyZone::Normal => self.normal_empty_area[index] = value,
+        }
+    }
+
+    #[inline]
+    fn adjust_free_pages(&mut self, zone: BuddyZone, pages: usize, add: bool) {
+        let free_pages = match zone {
+            BuddyZone::Dma32 => &mut self.dma32_free_pages,
+            BuddyZone::Normal => &mut self.normal_free_pages,
+        };
+        if add {
+            *free_pages = free_pages
+                .checked_add(pages)
+                .expect("buddy free count overflow");
+        } else {
+            *free_pages = free_pages
+                .checked_sub(pages)
+                .expect("buddy free count underflow");
+        }
+    }
+
+    fn recycle_empty_metadata(
+        &mut self,
+        zone: BuddyZone,
+        order: u8,
+        page_addr: PhysAddr,
+        next_nonempty: PhysAddr,
+    ) {
+        debug_assert_eq!(self.free_area(zone, order), page_addr);
+        self.set_free_area(zone, order, next_nonempty);
+        let empty_head = self.empty_area(zone, order);
+        Self::write_page(page_addr, PageList::new(0, empty_head));
+        self.set_empty_area(zone, order, page_addr);
+    }
+
+    /// Remove one entry from the non-empty chain head.  If the head becomes
+    /// empty it is unlinked immediately and moved to the reusable metadata
+    /// chain, so allocation never walks historical empty pages.
+    fn remove_entry(
+        &mut self,
+        zone: BuddyZone,
+        order: u8,
+        target_page_addr: PhysAddr,
+        target_index: usize,
+    ) -> PhysAddr {
+        let mut target_page: PageList<A> = Self::read_page(target_page_addr);
+        assert!(target_index < target_page.entry_num);
+        let removed: PhysAddr =
+            unsafe { A::read(Self::entry_virt_addr(target_page_addr, target_index)) };
+        let first_addr = self.free_area(zone, order);
+        assert!(!first_addr.is_null());
+        let mut first: PageList<A> = Self::read_page(first_addr);
+        assert!(first.entry_num > 0);
+        let last_index = first.entry_num - 1;
+        let last: PhysAddr = unsafe { A::read(Self::entry_virt_addr(first_addr, last_index)) };
+
+        if target_page_addr == first_addr {
+            if target_index != last_index {
+                unsafe {
+                    A::write(Self::entry_virt_addr(first_addr, target_index), last);
+                }
+            }
+            first.entry_num -= 1;
+            unsafe {
+                A::write(
+                    Self::entry_virt_addr(first_addr, first.entry_num),
+                    PhysAddr::new(0),
+                );
+            }
+            let next_nonempty = first.next_page;
+            Self::write_page(first_addr, first);
+            if last_index == 0 {
+                self.recycle_empty_metadata(zone, order, first_addr, next_nonempty);
+            }
+        } else {
+            unsafe {
+                A::write(Self::entry_virt_addr(target_page_addr, target_index), last);
+                A::write(
+                    Self::entry_virt_addr(first_addr, last_index),
+                    PhysAddr::new(0),
+                );
+            }
+            first.entry_num -= 1;
+            let next_nonempty = first.next_page;
+            Self::write_page(first_addr, first);
+            if last_index == 0 {
+                self.recycle_empty_metadata(zone, order, first_addr, next_nonempty);
+            }
+            // The target page remains non-empty because the removed slot was
+            // replaced from the first non-empty page.
+            target_page = Self::read_page(target_page_addr);
+            debug_assert!(target_page.entry_num > 0);
+        }
+
+        self.adjust_free_pages(zone, 1usize << (order as usize - MIN_ORDER), false);
+        removed
+    }
+
+    /// Insert a block whose buddy is known to be allocated.  This is used for
+    /// halves produced by an allocation split, avoiding a pointless linear
+    /// buddy search on the IRQ-off allocation path.
+    unsafe fn insert_without_merge(&mut self, base: PhysAddr, order: u8) {
+        let zone = Self::zone_for(base, order as usize);
+        if zone == BuddyZone::Normal {
+            self.has_normal_memory = true;
+        }
+        let mut first_addr = self.free_area(zone, order);
+        let needs_metadata = first_addr.is_null()
+            || Self::read_page::<PageList<A>>(first_addr).entry_num == Self::BUDDY_ENTRIES;
+
+        if needs_metadata {
+            let empty_head = self.empty_area(zone, order);
+            let new_page_addr = if !empty_head.is_null() {
+                let empty: PageList<A> = Self::read_page(empty_head);
+                self.set_empty_area(zone, order, empty.next_page);
+                empty_head
+            } else if order as usize == MIN_ORDER {
+                base
+            } else {
+                // The current order is full, so consume one block from this
+                // same order as metadata and return all but its first page to
+                // strictly lower orders.  This keeps metadata recursion
+                // bounded and never searches/merges on the allocation path.
+                let metadata_base = self
+                    .pop_front(zone, order)
+                    .expect("full buddy order has no metadata source");
+                let mut split_order = order as usize;
+                while split_order > MIN_ORDER {
+                    split_order -= 1;
+                    self.insert_without_merge(
+                        metadata_base + (1 << split_order),
+                        split_order as u8,
+                    );
+                }
+                metadata_base
+            };
+            core::ptr::write_bytes(
+                A::phys_2_virt(new_page_addr).unwrap().as_ptr::<u8>(),
+                0,
+                A::PAGE_SIZE,
+            );
+            if new_page_addr == base {
+                let empty_head = self.empty_area(zone, order);
+                Self::write_page(new_page_addr, PageList::new(0, empty_head));
+                self.set_empty_area(zone, order, new_page_addr);
+                return;
+            }
+            Self::write_page(new_page_addr, PageList::new(0, first_addr));
+            self.set_free_area(zone, order, new_page_addr);
+            first_addr = new_page_addr;
+        }
+
+        let mut first = Self::read_page::<PageList<A>>(first_addr);
+        debug_assert!(first.entry_num < Self::BUDDY_ENTRIES);
+        A::write(Self::entry_virt_addr(first_addr, first.entry_num), base);
+        first.entry_num += 1;
+        Self::write_page(first_addr, first);
+        self.adjust_free_pages(zone, 1usize << (order as usize - MIN_ORDER), true);
+    }
+
     /// 从空闲链表的开头，取出1个指定阶数的伙伴块，如果没有，则返回None
     ///
     /// ## 参数
     ///
     /// - `order` - 伙伴块的阶数
-    fn pop_front(&mut self, order: u8) -> Option<PhysAddr> {
-        let alloc_in_specific_order = |spec_order: u8| {
-            // 先尝试在order阶的“空闲链表”的开头位置分配一个伙伴块
-            let mut page_list_addr = self.free_area[Self::order2index(spec_order)];
-            let mut page_list: PageList<A> = Self::read_page(page_list_addr);
-
-            // 循环跳过头部的空闲链表页（不删除它们，避免在buddy_free过程中触发buddy_alloc导致递归死锁）
-            while page_list.entry_num == 0 {
-                let next_page_list_addr = page_list.next_page;
-                // 找完了，都是空的
-                if next_page_list_addr.is_null() {
-                    return None;
-                }
-
-                // 直接跳过空页，不释放它们，避免触发buddy_free导致递归
-                page_list_addr = next_page_list_addr;
-                page_list = Self::read_page(page_list_addr);
+    fn pop_front(&mut self, zone: BuddyZone, order: u8) -> Option<PhysAddr> {
+        let mut alloc_in_specific_order = |spec_order: u8| {
+            let page_list_addr = self.free_area(zone, spec_order);
+            if page_list_addr.is_null() {
+                return None;
             }
-
-            // 有空闲页面，直接分配
-            if page_list.entry_num > 0 {
-                let entry: PhysAddr = unsafe {
-                    A::read(Self::entry_virt_addr(
-                        page_list_addr,
-                        page_list.entry_num - 1,
-                    ))
-                };
-                // 清除该entry
-                unsafe {
-                    A::write(
-                        Self::entry_virt_addr(page_list_addr, page_list.entry_num - 1),
-                        PhysAddr::new(0),
-                    )
-                };
-                if entry.is_null() {
-                    panic!(
-                        "entry is null, entry={:?}, order={}, entry_num = {}",
-                        entry,
-                        spec_order,
-                        page_list.entry_num - 1
-                    );
-                }
-                // debug!("entry={entry:?}");
-
-                // 更新page_list的entry_num
-                page_list.entry_num -= 1;
-                let tmp_current_entry_num = page_list.entry_num;
-                // 无论entry_num是否为0，都需要写回更新后的page_list
-                // 即使变为空页，也保留在链表中，避免触发buddy_free导致递归死锁
-                Self::write_page(page_list_addr, page_list);
-
-                // 检测entry 是否对齐
-                if !entry.check_aligned(1 << spec_order) {
-                    panic!(
-                        "entry={:?} is not aligned, spec_order={spec_order}, page_list.entry_num={}",
-                        entry, tmp_current_entry_num
-                    );
-                }
-                return Some(entry);
-            }
-            return None;
+            let page_list: PageList<A> = Self::read_page(page_list_addr);
+            let entry =
+                self.remove_entry(zone, spec_order, page_list_addr, page_list.entry_num - 1);
+            assert!(!entry.is_null());
+            assert!(entry.check_aligned(1 << spec_order));
+            Some(entry)
         };
         let result: Option<PhysAddr> = alloc_in_specific_order(order);
         // debug!("result={:?}", result);
@@ -319,7 +512,7 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
                 let buddy = x + (1 << current_order);
                 // debug!("x={:?}, buddy={:?}", x, buddy);
                 // debug!("current_order={:?}, buddy={:?}", current_order, buddy);
-                unsafe { self.buddy_free(buddy, current_order as u8) };
+                unsafe { self.insert_without_merge(buddy, current_order as u8) };
             }
             return Some(x);
         }
@@ -350,7 +543,23 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
 
         // debug!("buddy_alloc: order = {}", order);
         // 获取该阶数的一个空闲页面
-        let free_addr = self.pop_front(order);
+        // Preserve scarce DMA32 memory while normal memory is available.
+        let normal = if self.has_normal_memory {
+            self.pop_front(BuddyZone::Normal, order)
+        } else {
+            None
+        };
+        let dma32_fallback_allowed = !self.has_normal_memory
+            || self.dma32_free_pages
+                >= count
+                    .data()
+                    .saturating_add(DMA32_FALLBACK_RESERVE_PAGES)
+                    .saturating_add(DMA32_ALLOCATION_METADATA_HEADROOM);
+        let free_addr = normal.or_else(|| {
+            dma32_fallback_allowed
+                .then(|| self.pop_front(BuddyZone::Dma32, order))
+                .flatten()
+        });
         // debug!(
         //     "buddy_alloc: order = {}, free_addr = {:?}",
         //     order,
@@ -376,48 +585,57 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
             return None;
         }
 
-        for current_order in requested_order as usize..MAX_ORDER {
-            let mut list_addr = self.free_area[Self::order2index(current_order as u8)];
-            loop {
-                let mut list: PageList<A> = Self::read_page(list_addr);
-                for index in 0..list.entry_num {
-                    let entry_addr = Self::entry_virt_addr(list_addr, index);
-                    let entry: PhysAddr = unsafe { A::read(entry_addr) };
-                    let fits = entry
-                        .data()
-                        .checked_add(requested_bytes - 1)
-                        .is_some_and(|end| end <= max_phys_addr.data());
-                    if !fits {
-                        continue;
-                    }
+        if max_phys_addr.data() == usize::MAX {
+            return self.buddy_alloc(count);
+        }
+        if max_phys_addr.data() == DMA32_LIMIT {
+            return self
+                .pop_front(BuddyZone::Dma32, requested_order)
+                .map(|base| (base, count));
+        }
 
-                    let last_index = list.entry_num - 1;
-                    if index != last_index {
-                        let last: PhysAddr =
-                            unsafe { A::read(Self::entry_virt_addr(list_addr, last_index)) };
-                        unsafe { A::write(entry_addr, last) };
-                    }
-                    unsafe {
-                        A::write(
-                            Self::entry_virt_addr(list_addr, last_index),
-                            PhysAddr::new(0),
-                        )
-                    };
-                    list.entry_num -= 1;
-                    Self::write_page(list_addr, list);
+        let zones: &[BuddyZone] = if max_phys_addr.data() < DMA32_LIMIT {
+            &[BuddyZone::Dma32]
+        } else {
+            &[BuddyZone::Normal, BuddyZone::Dma32]
+        };
+        for &zone in zones {
+            for current_order in requested_order as usize..MAX_ORDER {
+                let mut list_addr = self.free_area(zone, current_order as u8);
+                if list_addr.is_null() {
+                    continue;
+                }
+                loop {
+                    let list: PageList<A> = Self::read_page(list_addr);
+                    for index in 0..list.entry_num {
+                        let entry_addr = Self::entry_virt_addr(list_addr, index);
+                        let entry: PhysAddr = unsafe { A::read(entry_addr) };
+                        let fits = entry
+                            .data()
+                            .checked_add(requested_bytes - 1)
+                            .is_some_and(|end| end <= max_phys_addr.data());
+                        if !fits {
+                            continue;
+                        }
 
-                    let base = entry;
-                    let mut split_order = current_order;
-                    while split_order > requested_order as usize {
-                        split_order -= 1;
-                        unsafe { self.buddy_free(base + (1 << split_order), split_order as u8) };
+                        let base = self.remove_entry(zone, current_order as u8, list_addr, index);
+                        let mut split_order = current_order;
+                        while split_order > requested_order as usize {
+                            split_order -= 1;
+                            unsafe {
+                                self.insert_without_merge(
+                                    base + (1 << split_order),
+                                    split_order as u8,
+                                )
+                            };
+                        }
+                        return Some((base, count));
                     }
-                    return Some((base, count));
+                    if list.next_page.is_null() {
+                        break;
+                    }
+                    list_addr = list.next_page;
                 }
-                if list.next_page.is_null() {
-                    break;
-                }
-                list_addr = list.next_page;
             }
         }
         None
@@ -434,6 +652,10 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
         let mut order = order as usize;
 
         while order < MAX_ORDER {
+            let zone = Self::zone_for(base, order);
+            if zone == BuddyZone::Normal {
+                self.has_normal_memory = true;
+            }
             // 检测地址是否合法
             if base.data() & ((1 << (order)) - 1) != 0 {
                 panic!(
@@ -447,22 +669,19 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
             // 伙伴块的地址是base ^ (1 << order)
             let buddy_addr = PhysAddr::new(base.data() ^ (1 << order));
 
-            let first_page_list_paddr = self.free_area[Self::order2index(order as u8)];
-            let mut page_list_paddr = first_page_list_paddr;
-            let mut page_list: PageList<A> = Self::read_page(page_list_paddr);
-            let first_page_list = page_list.clone();
-
-            let mut buddy_entry_virt_vaddr = None;
+            let mut page_list_paddr = self.free_area(zone, order as u8);
+            let mut buddy_entry_index = None;
             let mut buddy_entry_page_list_paddr = None;
             // 除非order是最大的，否则尝试查找伙伴块
-            if likely(order != MAX_ORDER - 1) {
+            if likely(order != MAX_ORDER - 1) && !page_list_paddr.is_null() {
                 'outer: loop {
+                    let page_list: PageList<A> = Self::read_page(page_list_paddr);
                     for i in 0..page_list.entry_num {
                         let entry_virt_addr = Self::entry_virt_addr(page_list_paddr, i);
                         let entry: PhysAddr = unsafe { A::read(entry_virt_addr) };
                         if entry == buddy_addr {
                             // 找到了伙伴块，记录该entry相关信息，然后退出查找
-                            buddy_entry_virt_vaddr = Some(entry_virt_addr);
+                            buddy_entry_index = Some(i);
                             buddy_entry_page_list_paddr = Some(page_list_paddr);
                             break 'outer;
                         }
@@ -471,162 +690,19 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
                         break;
                     }
                     page_list_paddr = page_list.next_page;
-                    page_list = Self::read_page(page_list_paddr);
                 }
             }
 
-            if let Some(buddy_entry_virt_addr) = buddy_entry_virt_vaddr {
-                // 如果找到了伙伴块，合并，向上递归
-
-                // 伙伴块所在的page_list的物理地址
-                let buddy_entry_page_list_paddr = buddy_entry_page_list_paddr.unwrap();
-
-                let mut page_list_paddr = self.free_area[Self::order2index(order as u8)];
-                let mut page_list = Self::read_page::<PageList<A>>(page_list_paddr);
-                // 找第一个有空闲块的链表页。跳过空闲链表页。不进行回收的原因是担心出现死循环
-                while page_list.entry_num == 0 {
-                    if page_list.next_page.is_null() {
-                        panic!(
-                            "buddy_free: page_list.entry_num == 0 && page_list.next_page.is_null()"
-                        );
-                    }
-                    page_list_paddr = page_list.next_page;
-                    page_list = Self::read_page(page_list_paddr);
-                }
-
-                // 如果伙伴块不在第一个链表页，则把第一个链表中的某个空闲块替换到伙伴块的位置
-                if page_list_paddr != buddy_entry_page_list_paddr {
-                    let entry: PhysAddr = unsafe {
-                        A::read(Self::entry_virt_addr(
-                            page_list_paddr,
-                            page_list.entry_num - 1,
-                        ))
-                    };
-                    // 把这个空闲块写入到伙伴块的位置
-                    unsafe {
-                        A::write(buddy_entry_virt_addr, entry);
-                    }
-                    // 设置刚才那个entry为空
-                    unsafe {
-                        A::write(
-                            Self::entry_virt_addr(page_list_paddr, page_list.entry_num - 1),
-                            PhysAddr::new(0),
-                        );
-                    }
-                    // 更新当前链表页的统计数据
-                    page_list.entry_num -= 1;
-                    Self::write_page(page_list_paddr, page_list);
-                } else {
-                    // 伙伴块所在的链表页就是第一个链表页
-                    let last_entry: PhysAddr = unsafe {
-                        A::read(Self::entry_virt_addr(
-                            page_list_paddr,
-                            page_list.entry_num - 1,
-                        ))
-                    };
-
-                    // 如果最后一个空闲块不是伙伴块，则把最后一个空闲块移动到伙伴块的位置
-                    // 否则后面的操作也将删除这个伙伴块
-                    if last_entry != buddy_addr {
-                        unsafe {
-                            A::write(buddy_entry_virt_addr, last_entry);
-                            A::write(
-                                Self::entry_virt_addr(page_list_paddr, page_list.entry_num - 1),
-                                PhysAddr::new(0),
-                            );
-                        }
-                    } else {
-                        unsafe {
-                            A::write(
-                                Self::entry_virt_addr(page_list_paddr, page_list.entry_num - 1),
-                                PhysAddr::new(0),
-                            );
-                        }
-                    }
-                    // 更新当前链表页的统计数据
-                    page_list.entry_num -= 1;
-                    Self::write_page(page_list_paddr, page_list);
-                }
-            } else {
-                assert!(
-                    page_list.entry_num <= Self::BUDDY_ENTRIES,
-                    "buddy_free: page_list.entry_num > Self::BUDDY_ENTRIES"
+            if let Some(buddy_entry_index) = buddy_entry_index {
+                let removed = self.remove_entry(
+                    zone,
+                    order as u8,
+                    buddy_entry_page_list_paddr.unwrap(),
+                    buddy_entry_index,
                 );
-
-                // 当前第一个page_list没有空间了
-                if first_page_list.entry_num == Self::BUDDY_ENTRIES {
-                    // 如果当前order是最小的，那么就把这个块当作新的page_list使用
-                    let new_page_list_addr = if order == MIN_ORDER {
-                        base
-                    } else {
-                        // 否则分配新的page_list
-                        // 请注意，分配之后，有可能当前的entry_num会减1（伙伴块分裂），造成出现整个链表为null的entry数量为Self::BUDDY_ENTRIES+1的情况
-                        // 但是不影响，我们在后面插入链表项的时候，会处理这种情况，检查链表中的第2个页是否有空位
-                        self.buddy_alloc(PageFrameCount::new(1))
-                            .expect("buddy_alloc failed: no enough memory")
-                            .0
-                    };
-
-                    // 清空这个页面：注意这里只分配了1页作为page_list元数据页，
-                    // 因此清零长度应固定为一页大小，而非按当前order的块大小。
-                    core::ptr::write_bytes(
-                        A::phys_2_virt(new_page_list_addr)
-                            .expect(
-                                "Buddy free: failed to get virt address of [new_page_list_addr]",
-                            )
-                            .as_ptr::<u8>(),
-                        0,
-                        A::PAGE_SIZE,
-                    );
-                    assert!(
-                        first_page_list_paddr == self.free_area[Self::order2index(order as u8)]
-                    );
-                    // 初始化新的page_list
-                    let new_page_list = PageList::new(0, first_page_list_paddr);
-                    Self::write_page(new_page_list_addr, new_page_list);
-                    self.free_area[Self::order2index(order as u8)] = new_page_list_addr;
-
-                    if new_page_list_addr == base {
-                        return;
-                    }
-                }
-
-                // 由于上面可能更新了第一个链表页，因此需要重新获取这个值
-                let first_page_list_paddr = self.free_area[Self::order2index(order as u8)];
-                let first_page_list: PageList<A> = Self::read_page(first_page_list_paddr);
-
-                // 找到第一个有空位的page_list（可能是第一个或第二个）
-                let (paddr, mut page_list) = if first_page_list.entry_num < Self::BUDDY_ENTRIES {
-                    // 第一个page_list有空位，直接使用
-                    (first_page_list_paddr, first_page_list)
-                } else if !first_page_list.next_page.is_null() {
-                    // 第一个满了，尝试第二个
-                    let second_page_list_paddr = first_page_list.next_page;
-                    let second_page_list = Self::read_page::<PageList<A>>(second_page_list_paddr);
-                    if second_page_list.entry_num < Self::BUDDY_ENTRIES {
-                        // 第二个有空位
-                        (second_page_list_paddr, second_page_list)
-                    } else {
-                        // 两个都满了，这不应该发生，因为我们在上面应该已经分配了新的page_list
-                        panic!(
-                            "buddy_free: both first and second page_list are full, order={}",
-                            order
-                        );
-                    }
-                } else {
-                    // 只有第一个page_list且已满，这不应该发生
-                    panic!(
-                        "buddy_free: first page_list is full and no second page_list, order={}",
-                        order
-                    );
-                };
-
-                // debug!("to write entry, page_list_base={paddr:?}, page_list.entry_num={}, value={base:?}", page_list.entry_num);
-                assert!(page_list.entry_num < Self::BUDDY_ENTRIES);
-                // 把要归还的块，写入到链表项中
-                unsafe { A::write(Self::entry_virt_addr(paddr, page_list.entry_num), base) }
-                page_list.entry_num += 1;
-                Self::write_page(paddr, page_list);
+                debug_assert_eq!(removed, buddy_addr);
+            } else {
+                self.insert_without_merge(base, order as u8);
                 return;
             }
             base = min(base, buddy_addr);
@@ -643,20 +719,27 @@ impl<A: MemoryManagementArch> BuddyAllocator<A> {
 /// under test use a separate `BuddyAllocator`, so their exact addresses are
 /// deterministic and concurrent kernel allocations cannot affect the result.
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
-pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool) {
-    const BACKING_PAGES: usize = 64;
-    const ARENA_OFFSET_PAGES: usize = 32;
+pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool, bool, bool) {
+    const BACKING_PAGES: usize = 128;
+    const ARENA_OFFSET_PAGES: usize = 64;
     const ARENA_PAGES: usize = 16;
 
     let Some((backing, backing_count)) =
         (unsafe { allocate_page_frames(PageFrameCount::new(BACKING_PAGES)) })
     else {
-        return (false, false, false);
+        return (false, false, false, false, false);
     };
 
     unsafe fn empty_isolated_allocator(backing: PhysAddr) -> BuddyAllocator<MMArch> {
-        let mut free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
-        for (index, area) in free_area.iter_mut().enumerate() {
+        let dma32_free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let normal_free_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let mut dma32_empty_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        let mut normal_empty_area = [PhysAddr::new(0); MAX_ORDER - MIN_ORDER];
+        for (index, area) in dma32_empty_area
+            .iter_mut()
+            .chain(normal_empty_area.iter_mut())
+            .enumerate()
+        {
             *area = backing + index * MMArch::PAGE_SIZE;
             core::ptr::write_bytes(
                 MMArch::phys_2_virt(*area).unwrap().as_ptr::<u8>(),
@@ -666,7 +749,13 @@ pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool) {
             BuddyAllocator::<MMArch>::write_page(*area, PageList::new(0, PhysAddr::new(0)));
         }
         BuddyAllocator {
-            free_area,
+            dma32_free_area,
+            normal_free_area,
+            dma32_empty_area,
+            normal_empty_area,
+            dma32_free_pages: 0,
+            normal_free_pages: 0,
+            has_normal_memory: false,
             total: PageFrameCount::new(ARENA_PAGES),
             phantom: PhantomData,
         }
@@ -770,10 +859,112 @@ pub(crate) fn deterministic_buddy_selftest() -> (bool, bool, bool) {
         }
     };
 
+    let dma32_zone_ok = {
+        let mut allocator = unsafe { empty_isolated_allocator(backing) };
+        let count = PageFrameCount::new(8);
+        let bytes = count.data() * MMArch::PAGE_SIZE;
+        let low = PhysAddr::new((1usize << 32) - bytes);
+        let high = PhysAddr::new(1usize << 32);
+        unsafe {
+            allocator.free(high, count);
+            allocator.free(low, count);
+        }
+        let dma32 = allocator.buddy_alloc_below(count, PhysAddr::new(DMA32_LIMIT));
+        let normal = unsafe { allocator.allocate(count) };
+        let selection_ok = dma32.is_some_and(|(base, allocated)| base == low && allocated == count)
+            && normal.is_some_and(|(base, allocated)| base == high && allocated == count);
+
+        let mut reserve_allocator = unsafe { empty_isolated_allocator(backing) };
+        let reserve_low = PhysAddr::new(2usize << 30);
+        let reserve_count = PageFrameCount::new(DMA32_FALLBACK_RESERVE_PAGES);
+        let one_high = PhysAddr::new(1usize << 32);
+        unsafe {
+            reserve_allocator.free(reserve_low, reserve_count);
+            reserve_allocator.free(one_high, PageFrameCount::ONE);
+        }
+        let normal_first = unsafe { reserve_allocator.allocate(PageFrameCount::ONE) };
+        let reserve_blocks_fallback = unsafe { reserve_allocator.allocate(PageFrameCount::ONE) };
+        let dma_still_available =
+            reserve_allocator.buddy_alloc_below(PageFrameCount::ONE, PhysAddr::new(DMA32_LIMIT));
+        let reserve_ok = normal_first.is_some_and(|(base, _)| base == one_high)
+            && reserve_blocks_fallback.is_none()
+            && dma_still_available.is_some_and(|(base, _)| base == reserve_low);
+
+        selection_ok && reserve_ok
+    };
+
+    let metadata_reuse_ok = {
+        let mut allocator = unsafe { empty_isolated_allocator(backing) };
+        let list_pages = [
+            backing + 40 * MMArch::PAGE_SIZE,
+            backing + 41 * MMArch::PAGE_SIZE,
+            backing + 42 * MMArch::PAGE_SIZE,
+        ];
+        for (page_index, &page) in list_pages.iter().enumerate() {
+            let next = list_pages
+                .get(page_index + 1)
+                .copied()
+                .unwrap_or(PhysAddr::new(0));
+            BuddyAllocator::<MMArch>::write_page(
+                page,
+                PageList::new(BuddyAllocator::<MMArch>::BUDDY_ENTRIES, next),
+            );
+            for entry_index in 0..BuddyAllocator::<MMArch>::BUDDY_ENTRIES {
+                let ordinal = page_index * BuddyAllocator::<MMArch>::BUDDY_ENTRIES + entry_index;
+                unsafe {
+                    MMArch::write(
+                        BuddyAllocator::<MMArch>::entry_virt_addr(page, entry_index),
+                        PhysAddr::new(0x1000_0000 + ordinal * 2 * MMArch::PAGE_SIZE),
+                    );
+                }
+            }
+        }
+        allocator.dma32_free_area[0] = list_pages[0];
+        allocator.dma32_free_pages = list_pages.len() * BuddyAllocator::<MMArch>::BUDDY_ENTRIES;
+
+        let mut drained = 0;
+        while allocator
+            .pop_front(BuddyZone::Dma32, MIN_ORDER as u8)
+            .is_some()
+        {
+            drained += 1;
+        }
+        let expected = list_pages.len() * BuddyAllocator::<MMArch>::BUDDY_ENTRIES;
+        let first_drain_ok = drained == expected
+            && allocator.dma32_free_area[0].is_null()
+            && allocator.dma32_free_pages == 0;
+
+        for index in 0..16 {
+            unsafe {
+                allocator.insert_without_merge(
+                    PhysAddr::new(0x3000_0000 + index * 2 * MMArch::PAGE_SIZE),
+                    MIN_ORDER as u8,
+                );
+            }
+        }
+        let mut redrained = 0;
+        while allocator
+            .pop_front(BuddyZone::Dma32, MIN_ORDER as u8)
+            .is_some()
+        {
+            redrained += 1;
+        }
+        first_drain_ok
+            && redrained == 16
+            && allocator.dma32_free_area[0].is_null()
+            && allocator.dma32_free_pages == 0
+    };
+
     unsafe {
         deallocate_page_frames(PhysPageFrame::new(backing), backing_count);
     }
-    (bounded_selection_ok, split_merge_ok, fragmented_ok)
+    (
+        bounded_selection_ok,
+        split_merge_ok,
+        fragmented_ok,
+        dma32_zone_ok,
+        metadata_reuse_ok,
+    )
 }
 
 impl<A: MemoryManagementArch> FrameAllocator for BuddyAllocator<A> {
@@ -806,18 +997,7 @@ impl<A: MemoryManagementArch> FrameAllocator for BuddyAllocator<A> {
     }
 
     unsafe fn usage(&self) -> PageFrameUsage {
-        let mut free_page_num: usize = 0;
-        for index in 0..(MAX_ORDER - MIN_ORDER) {
-            let mut pagelist: PageList<A> = Self::read_page(self.free_area[index]);
-            loop {
-                free_page_num += pagelist.entry_num << index;
-                if pagelist.next_page.is_null() {
-                    break;
-                }
-                pagelist = Self::read_page(pagelist.next_page);
-            }
-        }
-        let free = PageFrameCount::new(free_page_num);
+        let free = PageFrameCount::new(self.dma32_free_pages + self.normal_free_pages);
         PageFrameUsage::new(self.total - free, self.total)
     }
 }

--- a/kernel/src/mm/allocator/page_frame.rs
+++ b/kernel/src/mm/allocator/page_frame.rs
@@ -310,6 +310,17 @@ pub trait FrameAllocator {
     // @brief 分配count个页帧
     unsafe fn allocate(&mut self, count: PageFrameCount) -> Option<(PhysAddr, PageFrameCount)>;
 
+    /// Allocate contiguous frames whose complete byte range is no higher than
+    /// `max_phys_addr`. Allocators without bounded-placement support fail
+    /// explicitly instead of returning an out-of-range block.
+    unsafe fn allocate_below(
+        &mut self,
+        _count: PageFrameCount,
+        _max_phys_addr: PhysAddr,
+    ) -> Option<(PhysAddr, PageFrameCount)> {
+        None
+    }
+
     // @brief 通过地址释放count个页帧
     unsafe fn free(&mut self, address: PhysAddr, count: PageFrameCount);
     // @brief 分配一个页帧
@@ -328,6 +339,13 @@ pub trait FrameAllocator {
 impl<T: FrameAllocator> FrameAllocator for &mut T {
     unsafe fn allocate(&mut self, count: PageFrameCount) -> Option<(PhysAddr, PageFrameCount)> {
         return T::allocate(self, count);
+    }
+    unsafe fn allocate_below(
+        &mut self,
+        count: PageFrameCount,
+        max_phys_addr: PhysAddr,
+    ) -> Option<(PhysAddr, PageFrameCount)> {
+        return T::allocate_below(self, count, max_phys_addr);
     }
     unsafe fn free(&mut self, address: PhysAddr, count: PageFrameCount) {
         return T::free(self, address, count);
@@ -348,6 +366,13 @@ impl<T: FrameAllocator> FrameAllocator for &mut T {
 /// @param count 请求分配的页帧数量
 pub unsafe fn allocate_page_frames(count: PageFrameCount) -> Option<(PhysAddr, PageFrameCount)> {
     unsafe { LockedFrameAllocator.allocate(count) }
+}
+
+pub unsafe fn allocate_page_frames_below(
+    count: PageFrameCount,
+    max_phys_addr: PhysAddr,
+) -> Option<(PhysAddr, PageFrameCount)> {
+    unsafe { LockedFrameAllocator.allocate_below(count, max_phys_addr) }
 }
 
 pub fn retry_oom_victim_page_frame_alloc<F>(

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -1,17 +1,19 @@
-use alloc::{format, string::String, vec::Vec};
+use alloc::vec::Vec;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+use alloc::{format, string::String};
 use core::ptr::NonNull;
 use system_error::SystemError;
 
 use crate::arch::MMArch;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 use crate::libs::mutex::Mutex;
 use crate::libs::spinlock::SpinLock;
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+use crate::mm::allocator::buddy::deterministic_buddy_selftest;
 use crate::mm::{
-    allocator::{
-        buddy::deterministic_buddy_selftest,
-        page_frame::{
-            allocate_page_frames, allocate_page_frames_below, deallocate_page_frames,
-            PageFrameCount, PhysPageFrame,
-        },
+    allocator::page_frame::{
+        allocate_page_frames, allocate_page_frames_below, deallocate_page_frames, PageFrameCount,
+        PhysPageFrame,
     },
     MemoryManagementArch, PhysAddr,
 };
@@ -394,6 +396,10 @@ const DMA_POOL_CLASSES: &[usize] = &[1, 2, 4, 8, 16];
 
 lazy_static! {
     static ref DMA_ALLOCATOR: DmaAllocator = DmaAllocator::new();
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+lazy_static! {
     static ref DMA_SELFTEST_LOCK: Mutex<()> = Mutex::new(());
 }
 
@@ -401,16 +407,19 @@ fn dma_allocator() -> &'static DmaAllocator {
     &DMA_ALLOCATOR
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 fn release_raw(raw: DmaRawAllocation) {
     unsafe {
         deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
     }
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 fn raw_fits_mask(raw: &DmaRawAllocation, mask: u64) -> bool {
     allocation_fits_mask(raw, Some(mask))
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 fn selftest_bounded_orders() -> bool {
     let options = DmaAllocOptions {
         zeroed: false,
@@ -432,6 +441,7 @@ fn selftest_bounded_orders() -> bool {
     true
 }
 
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 fn selftest_pool_mask_separation() -> bool {
     let allocator = DmaAllocator::new();
     let unbounded = DmaAllocOptions {
@@ -491,6 +501,7 @@ fn selftest_pool_mask_separation() -> bool {
 /// Run allocator checks against the live buddy allocator.  Every successful
 /// allocation is released before the function returns, so reading the report
 /// does not reserve memory or grow the normal DMA pools.
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 pub(crate) fn dma_allocator_selftest_report() -> String {
     let _guard = DMA_SELFTEST_LOCK.lock();
     let (bounded_candidate_selection, split_free_merge, fragmented_arena) =

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -518,13 +518,20 @@ fn selftest_pool_mask_separation() -> bool {
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 pub(crate) fn dma_allocator_selftest_report() -> String {
     let _guard = DMA_SELFTEST_LOCK.lock();
-    let (bounded_candidate_selection, split_free_merge, fragmented_arena) =
-        deterministic_buddy_selftest();
+    let (
+        bounded_candidate_selection,
+        split_free_merge,
+        fragmented_arena,
+        dma32_zone,
+        metadata_reuse,
+    ) = deterministic_buddy_selftest();
     let cases = [
         ("bounded_orders", selftest_bounded_orders()),
         ("bounded_candidate_selection", bounded_candidate_selection),
         ("split_free_merge", split_free_merge),
         ("fragmented_arena", fragmented_arena),
+        ("dma32_zone", dma32_zone),
+        ("metadata_reuse", metadata_reuse),
         ("pool_mask_separation", selftest_pool_mask_separation()),
     ];
     let failed = cases.iter().filter(|(_, passed)| !passed).count();

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -306,9 +306,30 @@ impl DmaAllocator {
                 return Ok(raw);
             }
         }
-        // Do not borrow from another DMA domain on a cache miss. The buddy
-        // allocator owns the low-memory fallback policy and its DMA32 reserve.
-        self.try_alloc_raw(page_count, options)
+        match self.try_alloc_raw(page_count, options) {
+            Ok(raw) => Ok(raw),
+            Err(SystemError::ENOMEM)
+                if pool_key.is_some_and(|key| key.domain == DmaPoolDomain::Dma32) =>
+            {
+                // Preserve the normal hot-path partition between wide and
+                // DMA32 users. Only after the constrained buddy allocation is
+                // exhausted may a DMA32 request reclaim a compatible low
+                // buffer cached by a wide request. The caller's Dma32 key then
+                // makes this a one-way migration on Drop.
+                let key = DmaPoolKey {
+                    pages: page_count.data(),
+                    domain: DmaPoolDomain::Unrestricted,
+                };
+                let raw = self
+                    .take_from_pool(key, options.dma_mask)
+                    .ok_or(SystemError::ENOMEM)?;
+                if options.zeroed {
+                    self.zero_raw(&raw);
+                }
+                Ok(raw)
+            }
+            Err(err) => Err(err),
+        }
     }
 
     fn try_alloc_raw(
@@ -649,12 +670,34 @@ fn selftest_pool_domain_separation() -> bool {
             .put(DmaPoolDomain::Unrestricted, selftest_raw(0x6000, 1))
             .is_err();
 
+    // Under DMA32 pressure, a compatible low allocation may migrate out of
+    // the wide-request cache without discarding an incompatible high entry.
+    let mut migration_pool = DmaPool::new(1, DMA_POOL_MAX_PER_DOMAIN);
+    let migration_setup = migration_pool
+        .put(DmaPoolDomain::Unrestricted, selftest_raw(0x7000, 1))
+        .is_ok()
+        && migration_pool
+            .put(DmaPoolDomain::Unrestricted, selftest_raw(1usize << 32, 1))
+            .is_ok();
+    let migrated = migration_pool.take(DmaPoolDomain::Unrestricted, Some(u32::MAX as u64));
+    let incompatible_preserved = migration_pool.unrestricted_free_list.len() == 1;
+    let migration_returned = migrated
+        .map(|raw| migration_pool.put(DmaPoolDomain::Dma32, raw).is_ok())
+        .unwrap_or(false);
+    let migrated_reused = migration_pool
+        .take(DmaPoolDomain::Dma32, Some(u32::MAX as u64))
+        .is_some_and(|raw| raw.paddr.data() == 0x7000);
+
     low.is_some_and(|raw| raw.paddr.data() == 0x1000)
         && high_untouched
         && high.is_some_and(|raw| raw.paddr.data() == 1usize << 32)
         && dma32_did_not_cross
         && low_wide_reused.is_some_and(|raw| raw.paddr.data() == 0x2000)
         && per_domain_capacity
+        && migration_setup
+        && incompatible_preserved
+        && migration_returned
+        && migrated_reused
 }
 
 /// Run allocator checks against the live buddy allocator.  Every successful

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -1,12 +1,17 @@
-use alloc::vec::Vec;
+use alloc::{format, string::String, vec::Vec};
 use core::ptr::NonNull;
 use system_error::SystemError;
 
 use crate::arch::MMArch;
+use crate::libs::mutex::Mutex;
 use crate::libs::spinlock::SpinLock;
 use crate::mm::{
-    allocator::page_frame::{
-        allocate_page_frames, deallocate_page_frames, PageFrameCount, PhysPageFrame,
+    allocator::{
+        buddy::deterministic_buddy_selftest,
+        page_frame::{
+            allocate_page_frames, allocate_page_frames_below, deallocate_page_frames,
+            PageFrameCount, PhysPageFrame,
+        },
     },
     MemoryManagementArch, PhysAddr,
 };
@@ -219,18 +224,7 @@ impl DmaAllocator {
         // cache maintenance and cannot be emulated by rewriting PTE flags.
         validate_cache_policy(options.cache_policy)?;
         let pool_pages = self.pool_pages_for(page_count.data(), options.use_pool);
-        let raw = if let Some(pages) = pool_pages {
-            if let Some(raw) = self.take_from_pool(pages) {
-                if options.zeroed {
-                    self.zero_raw(&raw);
-                }
-                raw
-            } else {
-                self.try_alloc_raw(page_count, &options)?
-            }
-        } else {
-            self.try_alloc_raw(page_count, &options)?
-        };
+        let raw = self.try_alloc_from_pool_or_raw(page_count, pool_pages, &options)?;
         Ok(DmaBuffer {
             paddr: raw.paddr.data(),
             vaddr: raw.vaddr,
@@ -240,14 +234,48 @@ impl DmaAllocator {
         })
     }
 
+    fn try_alloc_from_pool_or_raw(
+        &self,
+        page_count: PageFrameCount,
+        pool_pages: Option<usize>,
+        options: &DmaAllocOptions,
+    ) -> Result<DmaRawAllocation, SystemError> {
+        if let Some(pages) = pool_pages {
+            if let Some(raw) = self.take_from_pool(pages) {
+                if allocation_fits_mask(&raw, options.dma_mask) {
+                    if options.zeroed {
+                        self.zero_raw(&raw);
+                    }
+                    Ok(raw)
+                } else {
+                    // This pool entry cannot satisfy the caller. Return it to
+                    // the global allocator before making a bounded request.
+                    unsafe {
+                        deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
+                    }
+                    self.try_alloc_raw(page_count, options)
+                }
+            } else {
+                self.try_alloc_raw(page_count, options)
+            }
+        } else {
+            self.try_alloc_raw(page_count, options)
+        }
+    }
+
     fn try_alloc_raw(
         &self,
         page_count: PageFrameCount,
         options: &DmaAllocOptions,
     ) -> Result<DmaRawAllocation, SystemError> {
         validate_cache_policy(options.cache_policy)?;
-        let (paddr, count) =
-            unsafe { allocate_page_frames(page_count) }.ok_or(SystemError::ENOMEM)?;
+        let allocation = if let Some(mask) = options.dma_mask {
+            let max = usize::try_from(mask).unwrap_or(usize::MAX);
+            unsafe { allocate_page_frames_below(page_count, PhysAddr::new(max)) }
+        } else {
+            unsafe { allocate_page_frames(page_count) }
+        };
+        let (paddr, count) = allocation.ok_or(SystemError::ENOMEM)?;
         let virt = match unsafe { MMArch::phys_2_virt(paddr) } {
             Some(virt) => virt,
             None => {
@@ -312,6 +340,16 @@ impl DmaAllocator {
     }
 }
 
+fn allocation_fits_mask(allocation: &DmaRawAllocation, mask: Option<u64>) -> bool {
+    mask.is_none_or(|mask| {
+        allocation
+            .paddr
+            .data()
+            .checked_add(allocation.page_count.bytes().saturating_sub(1))
+            .is_some_and(|end| end as u64 <= mask)
+    })
+}
+
 pub fn dma_alloc_pages_raw(pages: usize, mut options: DmaAllocOptions) -> (usize, NonNull<u8>) {
     options.use_pool = false;
     let page_count = page_count_from_pages(pages).expect("invalid dma page count");
@@ -356,8 +394,122 @@ const DMA_POOL_CLASSES: &[usize] = &[1, 2, 4, 8, 16];
 
 lazy_static! {
     static ref DMA_ALLOCATOR: DmaAllocator = DmaAllocator::new();
+    static ref DMA_SELFTEST_LOCK: Mutex<()> = Mutex::new(());
 }
 
 fn dma_allocator() -> &'static DmaAllocator {
     &DMA_ALLOCATOR
+}
+
+fn release_raw(raw: DmaRawAllocation) {
+    unsafe {
+        deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
+    }
+}
+
+fn raw_fits_mask(raw: &DmaRawAllocation, mask: u64) -> bool {
+    allocation_fits_mask(raw, Some(mask))
+}
+
+fn selftest_bounded_orders() -> bool {
+    let options = DmaAllocOptions {
+        zeroed: false,
+        dma_mask: Some(u32::MAX as u64),
+        use_pool: false,
+        ..Default::default()
+    };
+
+    for pages in [1, 2, 4, 8, 16] {
+        let Ok(raw) = dma_allocator().try_alloc_raw(PageFrameCount::new(pages), &options) else {
+            return false;
+        };
+        let ok = raw.page_count.data() == pages && raw_fits_mask(&raw, u32::MAX as u64);
+        release_raw(raw);
+        if !ok {
+            return false;
+        }
+    }
+    true
+}
+
+fn selftest_pool_mask_separation() -> bool {
+    let allocator = DmaAllocator::new();
+    let unbounded = DmaAllocOptions {
+        zeroed: false,
+        use_pool: false,
+        ..Default::default()
+    };
+    let Ok(first) = allocator.try_alloc_raw(PageFrameCount::ONE, &unbounded) else {
+        return false;
+    };
+    let Ok(second) = allocator.try_alloc_raw(PageFrameCount::ONE, &unbounded) else {
+        release_raw(first);
+        return false;
+    };
+    let (lower, higher) = if first.paddr < second.paddr {
+        (first, second)
+    } else {
+        (second, first)
+    };
+    let Some(mask) = lower
+        .paddr
+        .data()
+        .checked_add(lower.page_count.bytes().saturating_sub(1))
+        .map(|end| end as u64)
+    else {
+        release_raw(lower);
+        release_raw(higher);
+        return false;
+    };
+    let higher_copy = DmaRawAllocation {
+        paddr: higher.paddr,
+        vaddr: higher.vaddr,
+        page_count: higher.page_count,
+    };
+    if !allocator.return_to_pool(higher) {
+        release_raw(lower);
+        release_raw(higher_copy);
+        return false;
+    }
+    release_raw(lower);
+
+    let bounded = DmaAllocOptions {
+        dma_mask: Some(mask),
+        use_pool: true,
+        ..unbounded
+    };
+    match allocator.try_alloc_from_pool_or_raw(PageFrameCount::ONE, Some(1), &bounded) {
+        Ok(raw) => {
+            let ok = raw_fits_mask(&raw, mask);
+            release_raw(raw);
+            ok
+        }
+        Err(_) => false,
+    }
+}
+
+/// Run allocator checks against the live buddy allocator.  Every successful
+/// allocation is released before the function returns, so reading the report
+/// does not reserve memory or grow the normal DMA pools.
+pub(crate) fn dma_allocator_selftest_report() -> String {
+    let _guard = DMA_SELFTEST_LOCK.lock();
+    let (bounded_candidate_selection, split_free_merge, fragmented_arena) =
+        deterministic_buddy_selftest();
+    let cases = [
+        ("bounded_orders", selftest_bounded_orders()),
+        ("bounded_candidate_selection", bounded_candidate_selection),
+        ("split_free_merge", split_free_merge),
+        ("fragmented_arena", fragmented_arena),
+        ("pool_mask_separation", selftest_pool_mask_separation()),
+    ];
+    let failed = cases.iter().filter(|(_, passed)| !passed).count();
+    let mut report = format!("status={}\n", if failed == 0 { "ok" } else { "fail" });
+    for (name, passed) in cases {
+        report.push_str(&format!("{name}={}\n", if passed { "ok" } else { "fail" }));
+    }
+    report.push_str(&format!(
+        "summary_pass={}\nsummary_fail={failed}\n",
+        cases.len() - failed
+    ));
+    report
 }

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -68,7 +68,7 @@ pub struct DmaBuffer {
     vaddr: NonNull<u8>,
     len: usize,
     page_count: PageFrameCount,
-    pool_pages: Option<usize>,
+    pool_key: Option<DmaPoolKey>,
 }
 
 unsafe impl Send for DmaBuffer {}
@@ -129,16 +129,20 @@ impl DmaBuffer {
 
 impl Drop for DmaBuffer {
     fn drop(&mut self) {
-        if self.pool_pages.is_some()
-            && dma_allocator().return_to_pool(DmaRawAllocation {
-                paddr: PhysAddr::new(self.paddr),
-                vaddr: self.vaddr,
-                page_count: self.page_count,
-            })
-        {
-            return;
-        }
-        unsafe { dma_dealloc_pages_raw(self.paddr, self.vaddr, self.page_count.data()) };
+        let raw = DmaRawAllocation {
+            paddr: PhysAddr::new(self.paddr),
+            vaddr: self.vaddr,
+            page_count: self.page_count,
+        };
+        let raw = if let Some(key) = self.pool_key {
+            match dma_allocator().return_to_pool(key, raw) {
+                Ok(()) => return,
+                Err(raw) => raw,
+            }
+        } else {
+            raw
+        };
+        unsafe { dma_dealloc_pages_raw(raw.paddr.data(), raw.vaddr, raw.page_count.data()) };
     }
 }
 
@@ -151,31 +155,83 @@ struct DmaRawAllocation {
 
 unsafe impl Send for DmaRawAllocation {}
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DmaPoolDomain {
+    Dma32,
+    Unrestricted,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct DmaPoolKey {
+    pages: usize,
+    domain: DmaPoolDomain,
+}
+
 struct DmaPool {
     pages: usize,
     max: usize,
-    free_list: Vec<DmaRawAllocation>,
+    dma32_free_list: Vec<DmaRawAllocation>,
+    unrestricted_free_list: Vec<DmaRawAllocation>,
 }
 
 impl DmaPool {
     fn new(pages: usize, max: usize) -> Self {
+        let mut dma32_free_list = Vec::new();
+        let mut unrestricted_free_list = Vec::new();
+        // Pool metadata is optional. If reservation fails, put() observes the
+        // zero capacity and the allocator safely falls back to the buddy path.
+        let _ = dma32_free_list.try_reserve_exact(max);
+        let _ = unrestricted_free_list.try_reserve_exact(max);
         Self {
             pages,
             max,
-            free_list: Vec::new(),
+            dma32_free_list,
+            unrestricted_free_list,
         }
     }
 
-    fn take(&mut self) -> Option<DmaRawAllocation> {
-        self.free_list.pop()
+    fn take_fitting(
+        free_list: &mut Vec<DmaRawAllocation>,
+        mask: Option<u64>,
+    ) -> Option<DmaRawAllocation> {
+        let index = free_list
+            .iter()
+            .rposition(|alloc| allocation_fits_mask(alloc, mask))?;
+        Some(free_list.swap_remove(index))
     }
 
-    fn put(&mut self, alloc: DmaRawAllocation) -> bool {
-        if self.free_list.len() >= self.max {
-            return false;
+    fn take(&mut self, domain: DmaPoolDomain, mask: Option<u64>) -> Option<DmaRawAllocation> {
+        let free_list = match domain {
+            DmaPoolDomain::Dma32 => &mut self.dma32_free_list,
+            DmaPoolDomain::Unrestricted => &mut self.unrestricted_free_list,
+        };
+        Self::take_fitting(free_list, mask)
+    }
+
+    fn put(
+        &mut self,
+        domain: DmaPoolDomain,
+        alloc: DmaRawAllocation,
+    ) -> Result<(), DmaRawAllocation> {
+        if alloc.page_count.data() != self.pages {
+            return Err(alloc);
         }
-        self.free_list.push(alloc);
-        true
+        let Some(end) = allocation_end(&alloc) else {
+            return Err(alloc);
+        };
+        let free_list = match domain {
+            DmaPoolDomain::Dma32 if usize::BITS > 32 && end > u32::MAX as usize => {
+                return Err(alloc)
+            }
+            DmaPoolDomain::Dma32 => &mut self.dma32_free_list,
+            DmaPoolDomain::Unrestricted => &mut self.unrestricted_free_list,
+        };
+        if free_list.len() >= self.max || free_list.len() == free_list.capacity() {
+            return Err(alloc);
+        }
+        debug_assert!(free_list.len() < free_list.capacity());
+        free_list.push(alloc);
+        Ok(())
     }
 }
 
@@ -187,7 +243,7 @@ impl DmaAllocator {
     fn new() -> Self {
         let mut pools = Vec::new();
         for pages in DMA_POOL_CLASSES {
-            pools.push(SpinLock::new(DmaPool::new(*pages, DMA_POOL_MAX_PER_CLASS)));
+            pools.push(SpinLock::new(DmaPool::new(*pages, DMA_POOL_MAX_PER_DOMAIN)));
         }
         Self { pools }
     }
@@ -225,41 +281,33 @@ impl DmaAllocator {
         // devices; changing PAT/cacheability requires architecture-specific
         // cache maintenance and cannot be emulated by rewriting PTE flags.
         validate_cache_policy(options.cache_policy)?;
-        let pool_pages = self.pool_pages_for(page_count.data(), options.use_pool);
-        let raw = self.try_alloc_from_pool_or_raw(page_count, pool_pages, &options)?;
+        let pool_key = Self::pool_key_for(page_count.data(), options.use_pool, options.dma_mask);
+        let raw = self.try_alloc_from_pool_or_raw(page_count, pool_key, &options)?;
         Ok(DmaBuffer {
             paddr: raw.paddr.data(),
             vaddr: raw.vaddr,
             len,
             page_count: raw.page_count,
-            pool_pages,
+            pool_key,
         })
     }
 
     fn try_alloc_from_pool_or_raw(
         &self,
         page_count: PageFrameCount,
-        pool_pages: Option<usize>,
+        pool_key: Option<DmaPoolKey>,
         options: &DmaAllocOptions,
     ) -> Result<DmaRawAllocation, SystemError> {
-        if let Some(pages) = pool_pages {
-            while let Some(raw) = self.take_from_pool(pages) {
-                if allocation_fits_mask(&raw, options.dma_mask) {
-                    if options.zeroed {
-                        self.zero_raw(&raw);
-                    }
-                    return Ok(raw);
+        if let Some(key) = pool_key {
+            if let Some(raw) = self.take_from_pool(key, options.dma_mask) {
+                if options.zeroed {
+                    self.zero_raw(&raw);
                 }
-
-                // Keep scanning the bounded pool: a compatible low-address
-                // entry may sit below this one in the LIFO free list. Returning
-                // incompatible entries to the buddy allocator also prevents
-                // them from repeatedly blocking future bounded callers.
-                unsafe {
-                    deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
-                }
+                return Ok(raw);
             }
         }
+        // Do not borrow from another DMA domain on a cache miss. The buddy
+        // allocator owns the low-memory fallback policy and its DMA32 reserve.
         self.try_alloc_raw(page_count, options)
     }
 
@@ -307,47 +355,63 @@ impl DmaAllocator {
         }
     }
 
-    fn pool_pages_for(&self, pages: usize, use_pool: bool) -> Option<usize> {
+    fn pool_key_for(pages: usize, use_pool: bool, mask: Option<u64>) -> Option<DmaPoolKey> {
         if !use_pool {
             return None;
         }
         for class in DMA_POOL_CLASSES {
             if pages == *class {
-                return Some(*class);
+                let domain = if usize::BITS > 32 && mask.is_some_and(|mask| mask <= u32::MAX as u64)
+                {
+                    DmaPoolDomain::Dma32
+                } else {
+                    DmaPoolDomain::Unrestricted
+                };
+                return Some(DmaPoolKey {
+                    pages: *class,
+                    domain,
+                });
             }
         }
         None
     }
 
-    fn take_from_pool(&self, pages: usize) -> Option<DmaRawAllocation> {
-        for pool in &self.pools {
-            let mut guard = pool.lock_irqsave();
-            if guard.pages == pages {
-                return guard.take();
-            }
-        }
-        None
+    fn pool_for_pages(&self, pages: usize) -> Option<&SpinLock<DmaPool>> {
+        let index = DMA_POOL_CLASSES.iter().position(|class| *class == pages)?;
+        self.pools.get(index)
     }
 
-    fn return_to_pool(&self, alloc: DmaRawAllocation) -> bool {
-        for pool in &self.pools {
-            let mut guard = pool.lock_irqsave();
-            if guard.pages == alloc.page_count.data() {
-                return guard.put(alloc);
-            }
-        }
-        false
+    fn take_from_pool(&self, key: DmaPoolKey, mask: Option<u64>) -> Option<DmaRawAllocation> {
+        self.pool_for_pages(key.pages)?
+            .lock_irqsave()
+            .take(key.domain, mask)
+    }
+
+    fn return_to_pool(
+        &self,
+        key: DmaPoolKey,
+        alloc: DmaRawAllocation,
+    ) -> Result<(), DmaRawAllocation> {
+        let Some(pool) = self.pool_for_pages(key.pages) else {
+            return Err(alloc);
+        };
+        pool.lock_irqsave().put(key.domain, alloc)
     }
 }
 
+fn allocation_end(allocation: &DmaRawAllocation) -> Option<usize> {
+    let bytes = allocation
+        .page_count
+        .data()
+        .checked_mul(MMArch::PAGE_SIZE)?;
+    allocation.paddr.data().checked_add(bytes.checked_sub(1)?)
+}
+
 fn allocation_fits_mask(allocation: &DmaRawAllocation, mask: Option<u64>) -> bool {
-    mask.is_none_or(|mask| {
-        allocation
-            .paddr
-            .data()
-            .checked_add(allocation.page_count.bytes().saturating_sub(1))
-            .is_some_and(|end| end as u64 <= mask)
-    })
+    let Some(end) = allocation_end(allocation).and_then(|end| u64::try_from(end).ok()) else {
+        return false;
+    };
+    mask.is_none_or(|mask| end <= mask)
 }
 
 pub fn dma_alloc_pages_raw(pages: usize, mut options: DmaAllocOptions) -> (usize, NonNull<u8>) {
@@ -389,7 +453,9 @@ fn page_count_from_bytes(size: usize) -> Option<PageFrameCount> {
     page_count_from_pages(pages)
 }
 
-const DMA_POOL_MAX_PER_CLASS: usize = 64;
+/// Each size class keeps independent bounded caches for DMA32-constrained and
+/// wider requests. On 64-bit systems the combined worst-case cache is 15.5 MiB.
+const DMA_POOL_MAX_PER_DOMAIN: usize = 64;
 const DMA_POOL_CLASSES: &[usize] = &[1, 2, 4, 8, 16];
 
 lazy_static! {
@@ -440,76 +506,155 @@ fn selftest_bounded_orders() -> bool {
 }
 
 #[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+fn selftest_raw(paddr: usize, pages: usize) -> DmaRawAllocation {
+    DmaRawAllocation {
+        paddr: PhysAddr::new(paddr),
+        vaddr: NonNull::dangling(),
+        page_count: PageFrameCount::new(pages),
+    }
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
 fn selftest_pool_mask_separation() -> bool {
-    let allocator = DmaAllocator::new();
-    let unbounded = DmaAllocOptions {
-        zeroed: false,
-        use_pool: false,
-        ..Default::default()
-    };
-    let Ok(first) = allocator.try_alloc_raw(PageFrameCount::ONE, &unbounded) else {
-        return false;
-    };
-    let Ok(second) = allocator.try_alloc_raw(PageFrameCount::ONE, &unbounded) else {
-        release_raw(first);
-        return false;
-    };
-    let (lower, higher) = if first.paddr < second.paddr {
-        (first, second)
-    } else {
-        (second, first)
-    };
-    let Some(mask) = lower
-        .paddr
-        .data()
-        .checked_add(lower.page_count.bytes().saturating_sub(1))
-        .map(|end| end as u64)
-    else {
-        release_raw(lower);
-        release_raw(higher);
-        return false;
-    };
-    let lower_copy = DmaRawAllocation {
-        paddr: lower.paddr,
-        vaddr: lower.vaddr,
-        page_count: lower.page_count,
-    };
-    if !allocator.return_to_pool(lower) {
-        release_raw(lower_copy);
-        release_raw(higher);
+    let mut pool = DmaPool::new(1, DMA_POOL_MAX_PER_DOMAIN);
+
+    // A narrow mask must skip, but not discard, an incompatible DMA32 entry.
+    if pool
+        .put(DmaPoolDomain::Dma32, selftest_raw(0x1000, 1))
+        .is_err()
+        || pool
+            .put(DmaPoolDomain::Dma32, selftest_raw(0x2000, 1))
+            .is_err()
+    {
         return false;
     }
-    let higher_copy = DmaRawAllocation {
-        paddr: higher.paddr,
-        vaddr: higher.vaddr,
-        page_count: higher.page_count,
-    };
-    if !allocator.return_to_pool(higher) {
-        if let Some(pooled_lower) = allocator.take_from_pool(1) {
-            release_raw(pooled_lower);
-        }
-        release_raw(higher_copy);
+    let narrow = pool.take(DmaPoolDomain::Dma32, Some(0x1fff));
+    let narrow_preserved = pool.dma32_free_list.len() == 1;
+    let remaining_dma32 = pool.take(DmaPoolDomain::Dma32, Some(u32::MAX as u64));
+
+    // A finite mask above 32 bits still needs exact range filtering inside
+    // the unrestricted domain.
+    let forty_bit_mask = (1u64 << 40) - 1;
+    if pool
+        .put(DmaPoolDomain::Unrestricted, selftest_raw(1usize << 32, 1))
+        .is_err()
+        || pool
+            .put(DmaPoolDomain::Unrestricted, selftest_raw(1usize << 40, 1))
+            .is_err()
+    {
+        return false;
+    }
+    let forty_bit = pool.take(DmaPoolDomain::Unrestricted, Some(forty_bit_mask));
+    let forty_bit_preserved = pool.unrestricted_free_list.len() == 1;
+    let remaining_unrestricted = pool.take(DmaPoolDomain::Unrestricted, None);
+
+    // DMA32 admission uses the inclusive end of the whole allocation, not
+    // just its first page. Arithmetic overflow is never admitted to a pool.
+    let mut two_page_pool = DmaPool::new(2, DMA_POOL_MAX_PER_DOMAIN);
+    let crosses_dma32 = u32::MAX as usize - MMArch::PAGE_SIZE + 1;
+    let crossing_rejected_by_dma32 = two_page_pool
+        .put(DmaPoolDomain::Dma32, selftest_raw(crosses_dma32, 2))
+        .is_err();
+    let crossing_put =
+        two_page_pool.put(DmaPoolDomain::Unrestricted, selftest_raw(crosses_dma32, 2));
+    let crossing_available_unrestricted = two_page_pool
+        .take(DmaPoolDomain::Unrestricted, None)
+        .is_some();
+    let overflow_rejected = two_page_pool
+        .put(
+            DmaPoolDomain::Unrestricted,
+            selftest_raw(usize::MAX - MMArch::PAGE_SIZE + 1, 2),
+        )
+        .is_err();
+
+    narrow.is_some_and(|raw| raw.paddr.data() == 0x1000)
+        && narrow_preserved
+        && remaining_dma32.is_some_and(|raw| raw.paddr.data() == 0x2000)
+        && forty_bit.is_some_and(|raw| raw.paddr.data() == 1usize << 32)
+        && forty_bit_preserved
+        && remaining_unrestricted.is_some_and(|raw| raw.paddr.data() == 1usize << 40)
+        && crossing_put.is_ok()
+        && crossing_rejected_by_dma32
+        && crossing_available_unrestricted
+        && overflow_rejected
+}
+
+#[cfg(any(target_arch = "x86_64", target_arch = "riscv64"))]
+fn selftest_pool_domain_separation() -> bool {
+    let key_selection_ok = DmaAllocator::pool_key_for(1, true, Some(u32::MAX as u64))
+        == Some(DmaPoolKey {
+            pages: 1,
+            domain: DmaPoolDomain::Dma32,
+        })
+        && DmaAllocator::pool_key_for(1, true, Some((1u64 << 40) - 1))
+            == Some(DmaPoolKey {
+                pages: 1,
+                domain: DmaPoolDomain::Unrestricted,
+            })
+        && DmaAllocator::pool_key_for(1, true, None)
+            == Some(DmaPoolKey {
+                pages: 1,
+                domain: DmaPoolDomain::Unrestricted,
+            })
+        && DmaAllocator::pool_key_for(1, true, Some(u64::MAX))
+            == Some(DmaPoolKey {
+                pages: 1,
+                domain: DmaPoolDomain::Unrestricted,
+            })
+        && DmaAllocator::pool_key_for(3, true, None).is_none()
+        && DmaAllocator::pool_key_for(1, false, None).is_none();
+    if !key_selection_ok {
         return false;
     }
 
-    let bounded = DmaAllocOptions {
-        dma_mask: Some(mask),
-        use_pool: true,
-        ..unbounded
-    };
-    match allocator.try_alloc_from_pool_or_raw(PageFrameCount::ONE, Some(1), &bounded) {
-        Ok(raw) => {
-            let ok = raw.paddr == lower_copy.paddr && raw_fits_mask(&raw, mask);
-            release_raw(raw);
-            ok
-        }
-        Err(_) => {
-            while let Some(raw) = allocator.take_from_pool(1) {
-                release_raw(raw);
-            }
-            false
-        }
+    let mut pool = DmaPool::new(1, 1);
+    if pool
+        .put(DmaPoolDomain::Dma32, selftest_raw(0x1000, 1))
+        .is_err()
+        || pool
+            .put(DmaPoolDomain::Unrestricted, selftest_raw(1usize << 32, 1))
+            .is_err()
+    {
+        return false;
     }
+
+    let low = pool.take(DmaPoolDomain::Dma32, Some(u32::MAX as u64));
+    let high_untouched = pool.unrestricted_free_list.len() == 1;
+    let high = pool.take(DmaPoolDomain::Unrestricted, Some(u64::MAX));
+
+    // A wide request may receive low physical memory on a small system. It
+    // remains reusable in its logical domain without becoming visible to a
+    // DMA32 request.
+    if pool
+        .put(DmaPoolDomain::Unrestricted, selftest_raw(0x2000, 1))
+        .is_err()
+    {
+        return false;
+    }
+    let dma32_did_not_cross = pool
+        .take(DmaPoolDomain::Dma32, Some(u32::MAX as u64))
+        .is_none();
+    let low_wide_reused = pool.take(DmaPoolDomain::Unrestricted, None);
+
+    let per_domain_capacity = pool
+        .put(DmaPoolDomain::Dma32, selftest_raw(0x3000, 1))
+        .is_ok()
+        && pool
+            .put(DmaPoolDomain::Dma32, selftest_raw(0x4000, 1))
+            .is_err()
+        && pool
+            .put(DmaPoolDomain::Unrestricted, selftest_raw(0x5000, 1))
+            .is_ok()
+        && pool
+            .put(DmaPoolDomain::Unrestricted, selftest_raw(0x6000, 1))
+            .is_err();
+
+    low.is_some_and(|raw| raw.paddr.data() == 0x1000)
+        && high_untouched
+        && high.is_some_and(|raw| raw.paddr.data() == 1usize << 32)
+        && dma32_did_not_cross
+        && low_wide_reused.is_some_and(|raw| raw.paddr.data() == 0x2000)
+        && per_domain_capacity
 }
 
 /// Run allocator checks against the live buddy allocator.  Every successful
@@ -533,6 +678,7 @@ pub(crate) fn dma_allocator_selftest_report() -> String {
         ("dma32_zone", dma32_zone),
         ("metadata_reuse", metadata_reuse),
         ("pool_mask_separation", selftest_pool_mask_separation()),
+        ("pool_domain_separation", selftest_pool_domain_separation()),
     ];
     let failed = cases.iter().filter(|(_, passed)| !passed).count();
     let mut report = format!("status={}\n", if failed == 0 { "ok" } else { "fail" });

--- a/kernel/src/mm/dma.rs
+++ b/kernel/src/mm/dma.rs
@@ -243,26 +243,24 @@ impl DmaAllocator {
         options: &DmaAllocOptions,
     ) -> Result<DmaRawAllocation, SystemError> {
         if let Some(pages) = pool_pages {
-            if let Some(raw) = self.take_from_pool(pages) {
+            while let Some(raw) = self.take_from_pool(pages) {
                 if allocation_fits_mask(&raw, options.dma_mask) {
                     if options.zeroed {
                         self.zero_raw(&raw);
                     }
-                    Ok(raw)
-                } else {
-                    // This pool entry cannot satisfy the caller. Return it to
-                    // the global allocator before making a bounded request.
-                    unsafe {
-                        deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
-                    }
-                    self.try_alloc_raw(page_count, options)
+                    return Ok(raw);
                 }
-            } else {
-                self.try_alloc_raw(page_count, options)
+
+                // Keep scanning the bounded pool: a compatible low-address
+                // entry may sit below this one in the LIFO free list. Returning
+                // incompatible entries to the buddy allocator also prevents
+                // them from repeatedly blocking future bounded callers.
+                unsafe {
+                    deallocate_page_frames(PhysPageFrame::new(raw.paddr), raw.page_count);
+                }
             }
-        } else {
-            self.try_alloc_raw(page_count, options)
         }
+        self.try_alloc_raw(page_count, options)
     }
 
     fn try_alloc_raw(
@@ -471,17 +469,28 @@ fn selftest_pool_mask_separation() -> bool {
         release_raw(higher);
         return false;
     };
+    let lower_copy = DmaRawAllocation {
+        paddr: lower.paddr,
+        vaddr: lower.vaddr,
+        page_count: lower.page_count,
+    };
+    if !allocator.return_to_pool(lower) {
+        release_raw(lower_copy);
+        release_raw(higher);
+        return false;
+    }
     let higher_copy = DmaRawAllocation {
         paddr: higher.paddr,
         vaddr: higher.vaddr,
         page_count: higher.page_count,
     };
     if !allocator.return_to_pool(higher) {
-        release_raw(lower);
+        if let Some(pooled_lower) = allocator.take_from_pool(1) {
+            release_raw(pooled_lower);
+        }
         release_raw(higher_copy);
         return false;
     }
-    release_raw(lower);
 
     let bounded = DmaAllocOptions {
         dma_mask: Some(mask),
@@ -490,11 +499,16 @@ fn selftest_pool_mask_separation() -> bool {
     };
     match allocator.try_alloc_from_pool_or_raw(PageFrameCount::ONE, Some(1), &bounded) {
         Ok(raw) => {
-            let ok = raw_fits_mask(&raw, mask);
+            let ok = raw.paddr == lower_copy.paddr && raw_fits_mask(&raw, mask);
             release_raw(raw);
             ok
         }
-        Err(_) => false,
+        Err(_) => {
+            while let Some(raw) = allocator.take_from_pool(1) {
+                release_raw(raw);
+            }
+            false
+        }
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
@@ -1,0 +1,70 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr const char* kSelftestPath = "/sys/kernel/debug/mm/dma_allocator_selftest";
+
+std::string ReadAll() {
+    int fd = open(kSelftestPath, O_RDONLY);
+    EXPECT_GE(fd, 0) << strerror(errno);
+    if (fd < 0) {
+        return {};
+    }
+
+    std::string report;
+    char buf[256];
+    while (true) {
+        const ssize_t n = read(fd, buf, sizeof(buf));
+        if (n == 0) {
+            break;
+        }
+        EXPECT_GT(n, 0) << strerror(errno);
+        if (n < 0) {
+            close(fd);
+            return {};
+        }
+        report.append(buf, static_cast<size_t>(n));
+    }
+    EXPECT_EQ(close(fd), 0) << strerror(errno);
+    return report;
+}
+
+void ExpectSuccessfulReport(const std::string& report) {
+    EXPECT_NE(report.find("status=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("bounded_orders=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("bounded_candidate_selection=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("split_free_merge=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("fragmented_arena=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("pool_mask_separation=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("summary_fail=0\n"), std::string::npos) << report;
+}
+
+}  // namespace
+
+TEST(DmaAllocatorSelftest, BoundedAllocationAndReusePass) {
+    const std::string report = ReadAll();
+    ASSERT_FALSE(report.empty());
+    ExpectSuccessfulReport(report);
+}
+
+TEST(DmaAllocatorSelftest, RepeatedRunsRemainSuccessful) {
+    const std::string first = ReadAll();
+    const std::string second = ReadAll();
+    ASSERT_FALSE(first.empty());
+    ASSERT_FALSE(second.empty());
+    ExpectSuccessfulReport(first);
+    ExpectSuccessfulReport(second);
+    EXPECT_EQ(first, second);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
@@ -45,6 +45,7 @@ void ExpectSuccessfulReport(const std::string& report) {
     EXPECT_NE(report.find("dma32_zone=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("metadata_reuse=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("pool_mask_separation=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("pool_domain_separation=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("summary_fail=0\n"), std::string::npos) << report;
 }
 

--- a/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/dma_allocator_selftest.cc
@@ -42,6 +42,8 @@ void ExpectSuccessfulReport(const std::string& report) {
     EXPECT_NE(report.find("bounded_candidate_selection=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("split_free_merge=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("fragmented_arena=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("dma32_zone=ok\n"), std::string::npos) << report;
+    EXPECT_NE(report.find("metadata_reuse=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("pool_mask_separation=ok\n"), std::string::npos) << report;
     EXPECT_NE(report.find("summary_fail=0\n"), std::string::npos) << report;
 }

--- a/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/loop_semantics.cc
@@ -153,6 +153,32 @@ TEST(LoopSemantics, GetFreeReturnsRegisteredDevice) {
     EXPECT_EQ(close(control_fd), 0) << strerror(errno);
 }
 
+TEST(LoopSemantics, ZeroCapacityDeviceRegistersBeforeBackingIsAttached) {
+    int control_fd = open("/dev/loop-control", O_RDWR);
+    ASSERT_GE(control_fd, 0) << strerror(errno);
+    const int minor = ioctl(control_fd, kLoopCtlAdd, UINT32_MAX);
+    ASSERT_GE(minor, 0) << strerror(errno);
+
+    char path[64];
+    snprintf(path, sizeof(path), "/dev/loop%d", minor);
+    int loop_fd = open(path, O_RDWR);
+    EXPECT_GE(loop_fd, 0) << "zero-capacity loop device was not published: " << strerror(errno);
+    if (loop_fd < 0) {
+        EXPECT_EQ(ioctl(control_fd, kLoopCtlRemove, minor), 0) << strerror(errno);
+        EXPECT_EQ(close(control_fd), 0) << strerror(errno);
+        return;
+    }
+
+    unsigned char sector[512] = {};
+    errno = 0;
+    EXPECT_EQ(pread(loop_fd, sector, sizeof(sector), 0), -1);
+    EXPECT_EQ(errno, ENODEV);
+
+    EXPECT_EQ(close(loop_fd), 0) << strerror(errno);
+    EXPECT_EQ(ioctl(control_fd, kLoopCtlRemove, minor), 0) << strerror(errno);
+    EXPECT_EQ(close(control_fd), 0) << strerror(errno);
+}
+
 TEST(LoopSemantics, SyncIoRetainsBackingOpenFileDescription) {
     LoopDevice device;
     ASSERT_NO_FATAL_FAILURE(device.SetUp(O_RDWR | O_SYNC));

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -73,6 +73,7 @@ normal/wait_rusage
 normal/sysfs_cgroup2_mount
 normal/devfs_ptmx_unlink
 normal/devtmpfs_semantics
+normal/dma_allocator_selftest
 normal/mknod_socket
 normal/pmem_block
 normal/page_cache_accounting

--- a/user/dadk/config/all/musl_1_2_4.toml
+++ b/user/dadk/config/all/musl_1_2_4.toml
@@ -21,9 +21,9 @@ type = "build-from-source"
 # "install_from_prebuilt" 可选值："local", "archive"
 source = "archive"
 # 路径或URL
-source-path = "https://github.com/ifduyue/musl/archive/refs/tags/v1.2.4.tar.gz"
+source-path = "https://github.com/ifduyue/musl/archive/f5f55d6589940fd2c2188d76686efe3a530e64e0.tar.gz"
 # 把压缩包中的哪个目录作为根目录（可选）,仅当 source = "archive" 时生效
-archive-rootdir = "musl-1.2.4"
+archive-rootdir = "musl-f5f55d6589940fd2c2188d76686efe3a530e64e0"
 
 # 构建相关信息
 [build]

--- a/user/dadk/config/all/musl_1_2_4.toml
+++ b/user/dadk/config/all/musl_1_2_4.toml
@@ -21,7 +21,7 @@ type = "build-from-source"
 # "install_from_prebuilt" 可选值："local", "archive"
 source = "archive"
 # 路径或URL
-source-path = "https://musl.libc.org/releases/musl-1.2.4.tar.gz"
+source-path = "https://sources.buildroot.net/musl/musl-1.2.4.tar.gz"
 # 把压缩包中的哪个目录作为根目录（可选）,仅当 source = "archive" 时生效
 archive-rootdir = "musl-1.2.4"
 

--- a/user/dadk/config/all/musl_1_2_4.toml
+++ b/user/dadk/config/all/musl_1_2_4.toml
@@ -21,7 +21,7 @@ type = "build-from-source"
 # "install_from_prebuilt" 可选值："local", "archive"
 source = "archive"
 # 路径或URL
-source-path = "https://sources.buildroot.net/musl/musl-1.2.4.tar.gz"
+source-path = "https://github.com/ifduyue/musl/archive/refs/tags/v1.2.4.tar.gz"
 # 把压缩包中的哪个目录作为根目录（可选）,仅当 source = "archive" 时生效
 archive-rootdir = "musl-1.2.4"
 

--- a/user/dadk/config/all/musl_1_2_4.toml
+++ b/user/dadk/config/all/musl_1_2_4.toml
@@ -21,9 +21,9 @@ type = "build-from-source"
 # "install_from_prebuilt" 可选值："local", "archive"
 source = "archive"
 # 路径或URL
-source-path = "https://github.com/ifduyue/musl/archive/f5f55d6589940fd2c2188d76686efe3a530e64e0.tar.gz"
+source-path = "https://mirrors.dragonos.org.cn/pub/third_party/musl/musl-1.2.4.tar.gz"
 # 把压缩包中的哪个目录作为根目录（可选）,仅当 source = "archive" 时生效
-archive-rootdir = "musl-f5f55d6589940fd2c2188d76686efe3a530e64e0"
+archive-rootdir = "musl-1.2.4"
 
 # 构建相关信息
 [build]

--- a/user/dadk/config/all/musl_1_2_4.toml
+++ b/user/dadk/config/all/musl_1_2_4.toml
@@ -21,7 +21,7 @@ type = "build-from-source"
 # "install_from_prebuilt" 可选值："local", "archive"
 source = "archive"
 # 路径或URL
-source-path = "https://mirrors.dragonos.org.cn/pub/third_party/musl/musl-1.2.4.tar.gz"
+source-path = "https://musl.libc.org/releases/musl-1.2.4.tar.gz"
 # 把压缩包中的哪个目录作为根目录（可选）,仅当 source = "archive" 时生效
 archive-rootdir = "musl-1.2.4"
 


### PR DESCRIPTION
## Summary

- register AHCI controllers through the standard PCI driver model instead of scanning them from the startup thread
- treat a present controller with no online SATA device as a normal state without emitting a misleading initialization error
- give controller, port, disk, command memory, and I/O DMA buffers explicit ownership and bounded teardown behavior
- enforce DMA address masks in the page allocator and reject incompatible cached DMA buffers
- align whole-disk and MBR partition publication with Linux semantics
- add on-demand DMA allocator self-tests and zero-capacity loop-device regression coverage

## Root cause

The previous AHCI path mixed PCI discovery, controller initialization, disk construction, partition probing, and block-device publication in one startup-time flow. An empty AHCI port could therefore reach disk I/O and surface `EIO` as if driver initialization had failed. The same path also lacked a reliable physical-address bound for DMA allocations and had ambiguous ownership during failure and removal.

## Behavior after this change

- no AHCI controller: no probe and no error
- AHCI controller with no attached disk: controller remains bound and empty ports stay silent
- online SATA disk: identify, capacity validation, DMA setup, and block-device publication proceed per port
- one failing port does not discard other usable ports
- the whole-disk node remains visible if partition scanning or an individual partition publication fails
- MBR slot numbers and end-of-device boundaries are preserved

## Validation

- `make kernel`
- `git diff --check`
- `DUNITEST_PATTERN=dma_allocator_selftest make test-dunit` — 2 tests passed
- `DUNITEST_PATTERN=loop_semantics make test-dunit` — 7 tests passed
- QEMU Q35 boot with an empty AHCI controller — no AHCI initialization error
- QEMU SATA matrix with valid MBR, invalid MBR, sparse MBR slots, and injected LBA0 `EIO`
- adversarial architecture, lifecycle/safety, and Linux 6.6 semantic reviews completed with no remaining blocking findings

## Scope

This change intentionally does not add IRQ-driven completion, NCQ, hotplug, or full runtime error recovery. Those are separate performance and feature projects and are not required to correct empty-controller discovery and ownership semantics.
