### PR TITLE
ci: temporarily disable claude-review workflow job

### DIFF
--- a/.github/workflows/claude-cr.yml
+++ b/.github/workflows/claude-cr.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   claude-review:
+    # 暂时禁用：当前 CI 中该机器人报错，恢复时删除下一行即可
+    if: false
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## 摘要

当前 CI 中 claude-review 机器人报错，暂时禁用该 workflow job。

- `.github/workflows/claude-cr.yml` 中添加 `if: false`
- 恢复时删除 `if: false` 一行即可

## 影响

无功能影响，仅暂停 CI 中一个自动化审查任务。