### PR TITLE
fix(tty): support virtual consoles without framebuffer

### DIFF
--- a/kernel/src/driver/tty/tty_driver.rs
+++ b/kernel/src/driver/tty/tty_driver.rs
@@ -312,21 +312,30 @@ impl TtyDriver {
     }
 
     pub fn init_tty_device(&self, index: Option<usize>) -> Result<Arc<TtyCore>, SystemError> {
-        // 如果传入的index为None，那么就自动分配index
-        let idx: usize;
-        if let Some(i) = index {
+        // Dynamic drivers (PTY, serial and virtio console) own explicit index
+        // lifetimes outside this IDA. Only an automatically allocated index is
+        // owned by this call and can be rolled back here.
+        let (idx, auto_allocated) = if let Some(i) = index {
+            if i >= self.device_count as usize {
+                return Err(SystemError::EINVAL);
+            }
             if self.ida.lock().exists(i) {
                 return Err(SystemError::EINVAL);
             }
-            idx = i;
+            (i, false)
         } else {
-            idx = self.ida.lock().alloc().ok_or(SystemError::EBUSY)?;
-        }
+            (self.ida.lock().alloc().ok_or(SystemError::EBUSY)?, true)
+        };
         // log::debug!("init_tty_device: create TtyCore");
         let tty = TtyCore::new(self.self_ref(), idx);
 
         // log::debug!("init_tty_device: to driver_install_tty");
-        self.driver_install_tty(tty.clone())?;
+        if let Err(err) = self.driver_install_tty(tty.clone()) {
+            if auto_allocated {
+                self.ida.lock().free(idx);
+            }
+            return Err(err);
+        }
         // log::debug!(
         //     "init_tty_device: driver_install_tty done, index: {}, dev_name: {:?}",
         //     idx,

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -10,11 +10,8 @@ use system_error::SystemError;
 use unified_init::macros::unified_init;
 
 use crate::{
-    driver::base::device::{
-        device_number::{DeviceNumber, Major},
-        device_register, IdTable,
-    },
-    filesystem::devfs::{devfs_register, devfs_unregister},
+    driver::base::device::device_number::{DeviceNumber, Major},
+    filesystem::devfs::{devfs_add_symlink, devfs_remove_symlink_if_same, LockedDevFSInode},
     init::initcall::INITCALL_LATE,
     libs::{lazy_init::Lazy, rwlock::RwLock, spinlock::SpinLock},
 };
@@ -25,7 +22,6 @@ use super::{
     console::ConsoleSwitch,
     termios::{InputMode, TTY_STD_TERMIOS},
     tty_core::{TtyCore, TtyCoreData},
-    tty_device::{TtyDevice, TtyType},
     tty_driver::{TtyDriver, TtyDriverManager, TtyDriverType, TtyOperation},
     tty_port::{DefaultTtyPort, TtyPort},
 };
@@ -71,7 +67,7 @@ pub struct VirtConsole {
 }
 
 struct InnerVirtConsole {
-    vcdev: Option<Arc<TtyDevice>>,
+    vc_alias: Option<(String, Arc<LockedDevFSInode>)>,
     devfs_removing: bool,
 }
 
@@ -82,7 +78,7 @@ impl VirtConsole {
             port: Arc::new(DefaultTtyPort::new()),
             index: Lazy::new(),
             inner: SpinLock::new(InnerVirtConsole {
-                vcdev: None,
+                vc_alias: None,
                 devfs_removing: false,
             }),
         })
@@ -107,41 +103,31 @@ impl VirtConsole {
             .internal_tty()
             .ok_or(SystemError::ENODEV)?;
         let tty_core_data = tty_core.core();
-        let devnum = *tty_core_data.device_number();
-        let vcname = format!("vc{}", self.index.get());
-
-        // 注册虚拟终端设备并将虚拟终端设备加入到文件系统
-        let vcdev = TtyDevice::new(
-            vcname.clone(),
-            IdTable::new(vcname, Some(devnum)),
-            TtyType::Tty,
-        );
-
-        device_register(vcdev.clone())?;
-        devfs_register(vcdev.name_ref(), vcdev.clone())?;
+        let vcname = format!("vc{}", tty_core_data.index());
+        let alias = devfs_add_symlink(&vcname, tty_core_data.name())?;
         tty_core_data.set_vc_index(*self.index.get());
-        self.inner.lock().vcdev = Some(vcdev);
+        self.inner.lock().vc_alias = Some((vcname, alias));
 
         Ok(())
     }
 
     fn devfs_remove(&self) -> Result<bool, SystemError> {
-        let vcdev = {
+        let vc_alias = {
             let mut inner = self.inner.lock();
             if inner.devfs_removing {
                 return Ok(false);
             }
-            let Some(vcdev) = inner.vcdev.take() else {
+            let Some(vc_alias) = inner.vc_alias.take() else {
                 return Ok(true);
             };
             inner.devfs_removing = true;
-            vcdev
+            vc_alias
         };
-        let result = devfs_unregister(vcdev.name_ref(), vcdev.clone());
+        let result = devfs_remove_symlink_if_same(&vc_alias.0, &vc_alias.1);
         let mut inner = self.inner.lock();
         inner.devfs_removing = false;
         if let Err(e) = result {
-            inner.vcdev = Some(vcdev);
+            inner.vc_alias = Some(vc_alias);
             return Err(e);
         }
         Ok(true)
@@ -333,7 +319,7 @@ impl Color {
 }
 
 pub struct TtyConsoleDriverInner {
-    console: Arc<dyn ConsoleSwitch>,
+    console: SpinLock<Option<Arc<dyn ConsoleSwitch>>>,
 }
 
 impl core::fmt::Debug for TtyConsoleDriverInner {
@@ -343,27 +329,54 @@ impl core::fmt::Debug for TtyConsoleDriverInner {
 }
 
 impl TtyConsoleDriverInner {
-    pub fn new() -> Result<Self, SystemError> {
-        let console = {
+    pub fn new() -> Self {
+        Self {
+            console: SpinLock::new(None),
+        }
+    }
+
+    fn select_console(&self) -> Result<Arc<dyn ConsoleSwitch>, SystemError> {
+        if let Some(console) = self.console.lock().as_ref().cloned() {
+            return Ok(console);
+        }
+
+        let candidate: Arc<dyn ConsoleSwitch> = {
             #[cfg(not(target_arch = "riscv64"))]
             {
-                Arc::new(crate::driver::video::fbdev::base::fbcon::framebuffer_console::BlittingFbConsole::new()?)
+                use crate::driver::video::fbdev::base::{
+                    fbcon::framebuffer_console::BlittingFbConsole, fbmem::frame_buffer_manager,
+                    FbId,
+                };
+
+                match frame_buffer_manager().find_fb_by_id(FbId::new(0))? {
+                    Some(fb) => Arc::new(BlittingFbConsole::new(fb)),
+                    None => crate::driver::video::console::dummycon::dummy_console(),
+                }
             }
 
             #[cfg(target_arch = "riscv64")]
             crate::driver::video::console::dummycon::dummy_console()
         };
 
-        Ok(Self { console })
+        let mut console = self.console.lock();
+        if console.is_none() {
+            *console = Some(candidate);
+        }
+        Ok(console.as_ref().unwrap().clone())
     }
 
-    fn do_install(&self, tty: Arc<TtyCore>, vc: &Arc<VirtConsole>) -> Result<(), SystemError> {
+    fn do_install(
+        &self,
+        tty: Arc<TtyCore>,
+        vc: &Arc<VirtConsole>,
+        console: &Arc<dyn ConsoleSwitch>,
+    ) -> Result<(), SystemError> {
         let tty_core = tty.core();
 
         let binding = vc.vc_data().unwrap();
         let mut vc_data = binding.lock();
 
-        self.console.con_init(vc, &mut vc_data, true)?;
+        console.con_init(vc, &mut vc_data, true)?;
         if vc_data.complement_mask == 0 {
             vc_data.complement_mask = if vc_data.color_mode { 0x7700 } else { 0x0800 };
         }
@@ -371,10 +384,6 @@ impl TtyConsoleDriverInner {
         // vc_data.bytes_per_row = vc_data.cols << 1;
         vc_data.index = tty_core.index();
         vc_data.bottom = vc_data.rows;
-        vc_data.set_driver_funcs(Arc::downgrade(
-            &(self.console.clone() as Arc<dyn ConsoleSwitch>),
-        ));
-
         // todo: unicode字符集处理？
 
         if vc_data.cols > VC_MAXCOL || vc_data.rows > VC_MAXROW {
@@ -409,11 +418,12 @@ impl TtyConsoleDriverInner {
 
 impl TtyOperation for TtyConsoleDriverInner {
     fn install(&self, _driver: Arc<TtyDriver>, tty: Arc<TtyCore>) -> Result<(), SystemError> {
-        let vc = VirtConsole::new(Some(Arc::new(SpinLock::new(VirtualConsoleData::new(
-            usize::MAX,
-        )))));
+        let console = self.select_console()?;
+        let vc_data = Arc::new(SpinLock::new(VirtualConsoleData::new(usize::MAX)));
+        vc_data.lock().set_driver_funcs(Arc::downgrade(&console));
+        let vc = VirtConsole::new(Some(vc_data));
         vc_manager().alloc(vc.clone()).ok_or(SystemError::EBUSY)?;
-        self.do_install(tty, &vc)
+        self.do_install(tty, &vc, &console)
             .inspect_err(|_| vc_manager().free(vc.index().unwrap()))?;
 
         Ok(())
@@ -501,24 +511,22 @@ pub struct DrawRegion {
 // 初始化虚拟终端
 #[inline(never)]
 pub fn vty_init() -> Result<(), SystemError> {
-    if let Ok(tty_console_driver_inner) = TtyConsoleDriverInner::new() {
-        const NAME: &str = "tty";
-        let console_driver = TtyDriver::new(
-            MAX_NR_CONSOLES,
-            NAME,
-            0,
-            Major::TTY_MAJOR,
-            0,
-            TtyDriverType::Console,
-            *TTY_STD_TERMIOS,
-            Arc::new(tty_console_driver_inner),
-            None,
-        );
+    const NAME: &str = "tty";
+    let console_driver = TtyDriver::new(
+        MAX_NR_CONSOLES,
+        NAME,
+        0,
+        Major::TTY_MAJOR,
+        0,
+        TtyDriverType::Console,
+        *TTY_STD_TERMIOS,
+        Arc::new(TtyConsoleDriverInner::new()),
+        None,
+    );
 
-        TtyDriverManager::tty_register_driver(console_driver).inspect_err(|e| {
-            log::error!("tty console: register driver {} failed: {:?}", NAME, e);
-        })?;
-    }
+    TtyDriverManager::tty_register_driver(console_driver).inspect_err(|e| {
+        log::error!("tty console: register driver {} failed: {:?}", NAME, e);
+    })?;
 
     Ok(())
 }
@@ -528,8 +536,8 @@ fn vty_late_init() -> Result<(), SystemError> {
     let (_, console_driver) =
         TtyDriverManager::lookup_tty_driver(DeviceNumber::new(Major::TTY_MAJOR, 0))
             .ok_or(SystemError::ENODEV)?;
-    console_driver.init_tty_device(None).ok();
+    let tty_result = console_driver.init_tty_device(None).map(|_| ());
 
     vc_manager().setup_default_vc();
-    Ok(())
+    tty_result
 }

--- a/kernel/src/driver/video/fbdev/base/fbcon/framebuffer_console.rs
+++ b/kernel/src/driver/video/fbdev/base/fbcon/framebuffer_console.rs
@@ -13,7 +13,7 @@ use crate::{
         },
         video::fbdev::base::{
             CopyAreaData, FbCursor, FbCursorSetMode, FbImage, FbVisual, FillRectData, FillRectROP,
-            FrameBuffer, ScrollMode, FRAME_BUFFER_SET,
+            FrameBuffer, ScrollMode,
         },
     },
     libs::{
@@ -26,7 +26,7 @@ use super::{FbConAttr, FrameBufferConsole, FrameBufferConsoleData};
 
 #[derive(Debug)]
 pub struct BlittingFbConsole {
-    fb: SpinLock<Option<Arc<dyn FrameBuffer>>>,
+    fb: Arc<dyn FrameBuffer>,
     fbcon_data: SpinLock<FrameBufferConsoleData>,
 }
 
@@ -34,15 +34,15 @@ unsafe impl Send for BlittingFbConsole {}
 unsafe impl Sync for BlittingFbConsole {}
 
 impl BlittingFbConsole {
-    pub fn new() -> Result<Self, SystemError> {
-        Ok(Self {
-            fb: SpinLock::new(None),
+    pub fn new(fb: Arc<dyn FrameBuffer>) -> Self {
+        Self {
+            fb,
             fbcon_data: SpinLock::new(FrameBufferConsoleData::default()),
-        })
+        }
     }
 
     fn fb(&self) -> Arc<dyn FrameBuffer> {
-        self.fb.lock().clone().unwrap()
+        self.fb.clone()
     }
 
     fn get_color(&self, vc_data: &VirtualConsoleData, c: u16, is_fg: bool) -> u32 {
@@ -178,22 +178,7 @@ impl ConsoleSwitch for BlittingFbConsole {
         vc_data: &mut VirtualConsoleData,
         init: bool,
     ) -> Result<(), system_error::SystemError> {
-        let fb_set_guard = FRAME_BUFFER_SET.read();
-        let fb = fb_set_guard.get(vc_data.index);
-        if fb.is_none() {
-            return Err(SystemError::EINVAL);
-        }
-        let fb = fb.unwrap();
-        if fb.is_none() {
-            log::warn!(
-                "The Framebuffer with FbID {} has not been initialized yet.",
-                vc_data.index
-            );
-
-            return Err(SystemError::ENODEV);
-        }
-
-        let fb = fb.as_ref().unwrap().clone();
+        let fb = self.fb();
 
         if init {
             // 初始化字体
@@ -232,9 +217,6 @@ impl ConsoleSwitch for BlittingFbConsole {
         } else {
             unimplemented!("Resize is not supported at the moment!");
         }
-
-        // 初始化fb
-        *self.fb.lock() = Some(fb);
 
         Ok(())
     }

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -350,6 +350,34 @@ impl DevFS {
             .and_then(|entries| entries.first().cloned())
     }
 
+    fn create_symlink(
+        &self,
+        link_name: &str,
+        target: &str,
+    ) -> Result<Arc<LockedDevFSInode>, SystemError> {
+        let _guard = self.operation_lock.lock();
+        let path = DevNodePath::parse(link_name)?;
+        let parent = self.root_inode.ensure_kernel_parent_dir(&path)?;
+        parent.create_dev_symlink(target, path.basename.as_ref())
+    }
+
+    fn remove_symlink_if_same(
+        &self,
+        link_name: &str,
+        expected: &Arc<LockedDevFSInode>,
+    ) -> Result<(), SystemError> {
+        let _guard = self.operation_lock.lock();
+        let path = DevNodePath::parse(link_name)?;
+        let Some(parent) = self.root_inode.find_parent_dir_if_exists(&path)? else {
+            return Ok(());
+        };
+
+        if parent.unlink_if_same(path.basename.as_ref(), expected)? {
+            self.root_inode.prune_kernel_dirs(&path)?;
+        }
+        Ok(())
+    }
+
     /// @brief 在devfs内注册设备
     ///
     /// @param name 设备名称
@@ -625,15 +653,23 @@ impl LockedDevFSInode {
     /// - `path`: 符号链接指向的路径
     /// - `symlink_name`: 符号链接的名称
     pub fn add_dev_symlink(&self, path: &str, symlink_name: &str) -> Result<(), SystemError> {
-        let new_inode =
-            self.create_with_data(symlink_name, FileType::SymLink, InodeMode::S_IRWXUGO, 0)?;
-
-        let buf = path.as_bytes();
-        let len = buf.len();
-        let devfs_inode = new_inode.downcast_ref::<LockedDevFSInode>().unwrap();
-        devfs_inode.write_at(0, len, buf, Mutex::new(FilePrivateData::Unused).lock())?;
-        devfs_inode.0.lock().kernel_managed = true;
+        self.create_dev_symlink(path, symlink_name)?;
         Ok(())
+    }
+
+    fn create_dev_symlink(
+        &self,
+        path: &str,
+        symlink_name: &str,
+    ) -> Result<Arc<LockedDevFSInode>, SystemError> {
+        self.do_create_with_data(
+            symlink_name,
+            FileType::SymLink,
+            InodeMode::S_IRWXUGO,
+            0,
+            path.as_bytes().to_vec(),
+            true,
+        )
     }
 
     fn remove_if_same(&self, name: &str, expected: &Arc<dyn IndexNode>) -> Result<(), SystemError> {
@@ -651,14 +687,55 @@ impl LockedDevFSInode {
         Ok(())
     }
 
+    fn unlink_if_same(
+        &self,
+        name: &str,
+        expected: &Arc<LockedDevFSInode>,
+    ) -> Result<bool, SystemError> {
+        let mut inode = self.0.lock();
+        if inode.metadata.file_type != FileType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+
+        let dname = DName::from(name);
+        let Some(child) = inode.children.get(&dname).cloned() else {
+            return Ok(false);
+        };
+        let expected_node: Arc<dyn IndexNode> = expected.clone();
+        if !Arc::ptr_eq(&child, &expected_node) {
+            return Ok(false);
+        }
+
+        let mut child_inode = expected.0.lock();
+        if child_inode.metadata.file_type == FileType::Dir {
+            return Err(SystemError::EISDIR);
+        }
+
+        child_inode.metadata.nlinks = child_inode
+            .metadata
+            .nlinks
+            .checked_sub(1)
+            .ok_or(SystemError::EINVAL)?;
+        let now = PosixTimeSpec::now();
+        child_inode.metadata.ctime = now;
+        drop(child_inode);
+
+        inode.children.remove(&dname);
+        inode.metadata.mtime = now;
+        inode.metadata.ctime = now;
+        Ok(true)
+    }
+
     fn do_create_with_data(
         &self,
-        mut guard: MutexGuard<DevFSInode>,
         name: &str,
         file_type: FileType,
         mode: InodeMode,
         dev: usize,
-    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        initial_data: Vec<u8>,
+        kernel_managed: bool,
+    ) -> Result<Arc<LockedDevFSInode>, SystemError> {
+        let mut guard = self.0.lock();
         if guard.metadata.file_type != FileType::Dir {
             return Err(SystemError::ENOTDIR);
         }
@@ -673,11 +750,11 @@ impl LockedDevFSInode {
             parent: guard.self_ref.clone(),
             self_ref: Weak::default(),
             children: BTreeMap::new(),
-            kernel_managed: false,
+            kernel_managed,
             metadata: Metadata {
                 dev_id: 0,
                 inode_id: generate_inode_id(),
-                size: 0,
+                size: initial_data.len() as i64,
                 blk_size: 0,
                 blocks: 0,
                 atime: PosixTimeSpec::default(),
@@ -694,7 +771,7 @@ impl LockedDevFSInode {
             },
             fs: guard.fs.clone(),
             dname: name.clone(),
-            data: Vec::new(),
+            data: initial_data,
         })));
 
         // 初始化inode的自引用的weak指针
@@ -730,10 +807,7 @@ impl IndexNode for LockedDevFSInode {
         mode: InodeMode,
         data: usize,
     ) -> Result<Arc<dyn IndexNode>, SystemError> {
-        // 获取当前inode
-        let guard: MutexGuard<DevFSInode> = self.0.lock();
-        // 如果当前inode不是文件夹，则返回
-        return self.do_create_with_data(guard, name, file_type, mode, data);
+        return Ok(self.do_create_with_data(name, file_type, mode, data, Vec::new(), false)?);
     }
 
     fn find(&self, name: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
@@ -1081,11 +1155,18 @@ pub fn devfs_create_node_dyn(
 }
 
 /// 在 /dev 下创建符号链接
-#[allow(dead_code)]
-pub fn devfs_add_symlink(link_name: &str, target: &str) -> Result<(), SystemError> {
-    devfs_global_instance()
-        .root_inode
-        .add_dev_symlink(target, link_name)
+pub fn devfs_add_symlink(
+    link_name: &str,
+    target: &str,
+) -> Result<Arc<LockedDevFSInode>, SystemError> {
+    devfs_global_instance().create_symlink(link_name, target)
+}
+
+pub fn devfs_remove_symlink_if_same(
+    link_name: &str,
+    expected: &Arc<LockedDevFSInode>,
+) -> Result<(), SystemError> {
+    devfs_global_instance().remove_symlink_if_same(link_name, expected)
 }
 
 /// @brief devfs的设备卸载函数

--- a/user/apps/tests/dunitest/suites/normal/tty_console_device.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_console_device.cc
@@ -1,0 +1,77 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <termios.h>
+#include <unistd.h>
+
+namespace {
+
+class UniqueFd {
+public:
+    explicit UniqueFd(int fd = -1) : fd_(fd) {}
+    UniqueFd(const UniqueFd&) = delete;
+    UniqueFd& operator=(const UniqueFd&) = delete;
+
+    ~UniqueFd() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int get() const { return fd_; }
+
+private:
+    int fd_;
+};
+
+void ExpectConsoleDevice(const char* path) {
+    struct stat st = {};
+    ASSERT_EQ(0, stat(path, &st)) << "stat(" << path << ") failed: errno=" << errno << " ("
+                                 << strerror(errno) << ")";
+    EXPECT_TRUE(S_ISCHR(st.st_mode)) << path << " is not a character device";
+    EXPECT_EQ(4u, major(st.st_rdev)) << path << " major mismatch";
+    EXPECT_EQ(0u, minor(st.st_rdev)) << path << " minor mismatch";
+}
+
+} // namespace
+
+TEST(TtyConsoleDevice, Tty0AndVc0AreUsableWithoutFramebuffer) {
+    ExpectConsoleDevice("/dev/tty0");
+
+    struct stat alias_stat = {};
+    ASSERT_EQ(0, lstat("/dev/vc0", &alias_stat))
+        << "lstat(/dev/vc0) failed: errno=" << errno << " (" << strerror(errno) << ")";
+    ASSERT_TRUE(S_ISLNK(alias_stat.st_mode)) << "/dev/vc0 is not a symbolic link";
+
+    char target[16] = {};
+    ssize_t target_len = readlink("/dev/vc0", target, sizeof(target));
+    ASSERT_EQ(4, target_len) << "readlink(/dev/vc0) failed: errno=" << errno << " ("
+                             << strerror(errno) << ")";
+    EXPECT_EQ(0, memcmp(target, "tty0", 4));
+
+    ExpectConsoleDevice("/dev/vc0");
+
+    UniqueFd tty(open("/dev/tty0", O_RDWR | O_NOCTTY));
+    ASSERT_GE(tty.get(), 0) << "open(/dev/tty0) failed: errno=" << errno << " ("
+                            << strerror(errno) << ")";
+
+    struct termios term = {};
+    ASSERT_EQ(0, tcgetattr(tty.get(), &term))
+        << "tcgetattr(/dev/tty0) failed: errno=" << errno << " (" << strerror(errno) << ")";
+
+    struct winsize winsize = {};
+    ASSERT_EQ(0, ioctl(tty.get(), TIOCGWINSZ, &winsize))
+        << "TIOCGWINSZ failed: errno=" << errno << " (" << strerror(errno) << ")";
+    EXPECT_GT(winsize.ws_row, 0u);
+    EXPECT_GT(winsize.ws_col, 0u);
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -62,6 +62,7 @@ normal/proc_self_exec_cmdline
 normal/proc_thread_accounting
 normal/user_namespace_id_map
 normal/tty_tcflush
+normal/tty_console_device
 normal/hvc_console_backpressure
 normal/signal_fpstate_sigreturn
 normal/general_protection_signal


### PR DESCRIPTION
## Summary

- select and cache a shared virtual-terminal backend on first VT installation
- use the framebuffer console when fb0 exists and the dummy console on headless systems
- expose vcN as an atomic, identity-protected devfs symlink to ttyN instead of registering a duplicate device
- roll back automatically allocated TTY indexes when driver installation fails
- add dunitest coverage for tty0 and vc0 semantics without a framebuffer

## Root cause

The x86 virtual-terminal driver always constructed a framebuffer console. Headless boots do not register fb0, so framebuffer console initialization returned ENODEV and tty0 installation failed.

## Design

The TTY console driver now chooses its backend when the first VT is installed and retains one shared backend for all VTs. Framebuffer-backed boots keep the existing shared rendering state and serialization, while framebuffer-less boots use the dummy console. Devfs console aliases are created and removed under the devfs operation lock with inode identity checks and complete link metadata updates.

## Validation

- `make fmt`
- `make kernel`
- QEMU nographic boot: tty0 error removed, hvc0 remains active, `/dev/tty0` is 4:0, and `/dev/vc0 -> tty0`
- `normal/tty_console_device`: passed
- `normal/hvc_console_backpressure`: 1/1 passed
- `normal/tty_pty_hangup`: 36/36 passed
- `normal/tty_tcflush`: 6/6 passed
- `normal/tty_termios`: 14/14 passed
- full dunitest run: 889 passed, 27 skipped, with one unrelated existing OverlayFS failure

## Compatibility notes

This change preserves the existing framebuffer path and does not implement dynamic framebuffer takeover. End-to-end legacy graphical boot remains blocked before TTY initialization by an independent early serial lock stall; the framebuffer path was reviewed for ownership, locking, and shared-state regressions.