### PR TITLE
test(procfs): fix TID reuse cache test semantics

### DIFF
--- a/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
+++ b/user/apps/tests/dunitest/suites/normal/proc_pid_reuse_cache.cc
@@ -7,7 +7,6 @@
 #include <string.h>
 #include <sys/syscall.h>
 #include <sys/types.h>
-#include <sys/utsname.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
@@ -77,15 +76,6 @@ void release_child(pid_t child, int release_fd) {
     int status = 0;
     while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
     }
-}
-
-bool is_dragonos() {
-    utsname uts = {};
-    if (uname(&uts) != 0) {
-        return false;
-    }
-    return strstr(uts.release, "dragonos") != nullptr ||
-           strstr(uts.nodename, "dragonos") != nullptr;
 }
 
 struct NamespaceThreadResult {
@@ -236,16 +226,6 @@ TEST(ProcPidReuseCache, ReusedTidRefreshesTaskNamespaceDirectory) {
         << strerror(first.open_errno) << ")";
     ASSERT_TRUE(first.link_read);
 
-    char stale_path[96] = {};
-    snprintf(stale_path, sizeof(stale_path), "/proc/%d/task/%d", getpid(), first.tid);
-    errno = 0;
-    const int stale_fd = open(stale_path, O_RDONLY | O_DIRECTORY);
-    EXPECT_EQ(-1, stale_fd);
-    EXPECT_EQ(ENOENT, errno);
-    if (stale_fd >= 0) {
-        close(stale_fd);
-    }
-
     constexpr int kMaxReuseAttempts = 128;
     bool observed_reuse = false;
     for (int attempt = 0; attempt < kMaxReuseAttempts; ++attempt) {
@@ -264,11 +244,9 @@ TEST(ProcPidReuseCache, ReusedTidRefreshesTaskNamespaceDirectory) {
         }
     }
 
-    if (!observed_reuse && !is_dragonos()) {
-        GTEST_SKIP() << "Linux does not guarantee TID reuse within a small fixed attempt budget";
+    if (!observed_reuse) {
+        GTEST_SKIP() << "TID reuse was not observed within the fixed attempt budget";
     }
-    EXPECT_TRUE(observed_reuse) << "DragonOS did not reuse the released TID within "
-                                << kMaxReuseAttempts << " attempts";
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- remove the assertion that requires `/proc/<tgid>/task/<tid>` to disappear immediately after `pthread_join`
- treat missing TID reuse within the fixed attempt budget as an unmet test precondition on every platform
- preserve the live replacement-thread namespace lookup that detects stale procfs cache entries after actual TID reuse

## Root cause

`pthread_join` waits for the kernel's `CLONE_CHILD_CLEARTID` clear-and-wake operation. Linux and DragonOS both perform that operation before the exiting thread is necessarily unhashed from the PID tables, so join completion does not establish that the procfs task directory must already return `ENOENT`.

The test also assumed that DragonOS must reuse a specific TID within 128 attempts. That finite reuse bound is not a userspace ABI guarantee. Runs that do not construct the reuse precondition now skip, while runs that observe reuse still execute all namespace open and readlink assertions.

## Validation

- `make -C user/apps/tests/dunitest bin/normal/proc_pid_reuse_cache_test`
- `make kernel`
- DragonOS guest full binary: 3 tests passed
- DragonOS guest target repeated 100 times: 97 passed after observing reuse, 3 skipped without reuse, 0 failed
- Linux host target repeated 300 times: no failure or hang

Fixes #2174
