### PR TITLE
feat(mm): account page faults through Linux-compatible APIs

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -538,11 +538,13 @@ impl X86_64MMArch {
                             }
                             Err(SystemError::ENOMEM) => {
                                 fault = VmFaultReason::VM_FAULT_OOM;
+                                crate::mm::fault::account_fault_result(flags, fault);
                                 space_guard = current_address_space.write();
                                 break;
                             }
                             Err(_) => {
                                 fault = VmFaultReason::VM_FAULT_SIGBUS;
+                                crate::mm::fault::account_fault_result(flags, fault);
                                 space_guard = current_address_space.write();
                                 break;
                             }
@@ -587,7 +589,6 @@ impl X86_64MMArch {
                         crate::mm::page::PageReclaimer::shrink_list(
                             <crate::mm::allocator::page_frame::PageFrameCount>::new(64),
                         );
-                        flags |= FaultFlags::FAULT_FLAG_TRIED;
                         continue;
                     }
 
@@ -608,7 +609,6 @@ impl X86_64MMArch {
                     };
                     match crate::mm::oom::pagefault_out_of_memory(ctx) {
                         OomOutcome::Retry => {
-                            flags |= FaultFlags::FAULT_FLAG_TRIED;
                             continue;
                         }
                         OomOutcome::CurrentTaskKilled => {

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -785,6 +785,7 @@ impl FileSystem for FuseFS {
             .unwrap_or(true);
 
         if major {
+            crate::mm::fault::account_major_fault_event();
             let can_retry = pfm.flags().contains(FaultFlags::FAULT_FLAG_ALLOW_RETRY)
                 && !pfm.flags().contains(FaultFlags::FAULT_FLAG_RETRY_NOWAIT);
             if can_retry {

--- a/kernel/src/filesystem/procfs/pid/mod.rs
+++ b/kernel/src/filesystem/procfs/pid/mod.rs
@@ -191,7 +191,7 @@ impl PidDirOps {
             NsDirOps::new_inode(ops.target.clone(), parent)
         }),
         ("stat", |ops, parent| {
-            StatFileOps::new_inode(ops.target.clone(), parent)
+            StatFileOps::new_inode(ops.target.clone(), stat::StatScope::ThreadGroup, parent)
         }),
         ("statm", |ops, parent| {
             StatmFileOps::new_inode(ops.target.clone(), parent)

--- a/kernel/src/filesystem/procfs/pid/stat.rs
+++ b/kernel/src/filesystem/procfs/pid/stat.rs
@@ -14,7 +14,7 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    process::{pid::PidType, ProcessState, RawPid},
+    process::{pid::PidType, resource::RUsageWho, ProcessState, RawPid},
     sched::{cputime::ns_to_clock_t, prio::PrioUtil},
 };
 use alloc::{
@@ -28,11 +28,22 @@ use system_error::SystemError;
 #[derive(Debug)]
 pub struct StatFileOps {
     target: ProcPidTarget,
+    scope: StatScope,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum StatScope {
+    ThreadGroup,
+    Thread,
 }
 
 impl StatFileOps {
-    pub fn new_inode(target: ProcPidTarget, parent: Weak<dyn IndexNode>) -> Arc<dyn IndexNode> {
-        ProcFileBuilder::new(Self { target }, InodeMode::S_IRUGO)
+    pub fn new_inode(
+        target: ProcPidTarget,
+        scope: StatScope,
+        parent: Weak<dyn IndexNode>,
+    ) -> Arc<dyn IndexNode> {
+        ProcFileBuilder::new(Self { target, scope }, InodeMode::S_IRUGO)
             .parent(parent)
             .build()
             .unwrap()
@@ -76,6 +87,10 @@ struct ProcStatSnapshot {
     processor: i32,
     utime: u64,
     stime: u64,
+    minflt: usize,
+    cminflt: usize,
+    majflt: usize,
+    cmajflt: usize,
 }
 
 /// 生成 Linux 风格的 /proc/[pid]/stat 行
@@ -88,11 +103,6 @@ fn generate_linux_proc_stat_line(snapshot: ProcStatSnapshot) -> String {
     let session: usize = 0;
     let tpgid: i32 = 0;
     let flags: u64 = 0;
-    let minflt: u64 = 0;
-    let cminflt: u64 = 0;
-    let majflt: u64 = 0;
-    let cmajflt: u64 = 0;
-
     let cutime: i64 = 0;
     let cstime: i64 = 0;
 
@@ -110,6 +120,10 @@ fn generate_linux_proc_stat_line(snapshot: ProcStatSnapshot) -> String {
         tty_nr = snapshot.tty_nr,
         utime = snapshot.utime,
         stime = snapshot.stime,
+        minflt = snapshot.minflt,
+        cminflt = snapshot.cminflt,
+        majflt = snapshot.majflt,
+        cmajflt = snapshot.cmajflt,
         priority = snapshot.priority,
         nice = snapshot.nice,
         num_threads = snapshot.num_threads,
@@ -143,6 +157,14 @@ impl FileOps for StatFileOps {
         let cpu_time = pcb.cputime();
         let utime = ns_to_clock_t(cpu_time.utime.load(Ordering::Relaxed));
         let stime = ns_to_clock_t(cpu_time.stime.load(Ordering::Relaxed));
+        let fault_usage = match self.scope {
+            StatScope::ThreadGroup => pcb.get_rusage(RUsageWho::RUsageSelf),
+            StatScope::Thread => pcb.get_rusage(RUsageWho::RusageThread),
+        }
+        .unwrap_or_default();
+        let child_usage = pcb
+            .get_rusage(RUsageWho::RUsageChildren)
+            .unwrap_or_default();
         let priority = pcb.sched_info().prio() as i64;
         let nice = PrioUtil::prio_to_nice(pcb.sched_info().static_prio()) as i64;
         let num_threads = pcb
@@ -183,6 +205,10 @@ impl FileOps for StatFileOps {
             processor,
             utime,
             stime,
+            minflt: fault_usage.ru_minflt,
+            cminflt: child_usage.ru_minflt,
+            majflt: fault_usage.ru_majflt,
+            cmajflt: child_usage.ru_majflt,
         });
         proc_read(offset, len, buf, content.as_bytes())
     }

--- a/kernel/src/filesystem/procfs/pid/task.rs
+++ b/kernel/src/filesystem/procfs/pid/task.rs
@@ -205,7 +205,7 @@ impl TidDirOps {
         fn(&TidDirOps, Weak<dyn IndexNode>) -> Arc<dyn IndexNode>,
     )] = &[
         ("stat", |ops, parent| {
-            StatFileOps::new_inode(ops.target.clone(), parent)
+            StatFileOps::new_inode(ops.target.clone(), super::stat::StatScope::Thread, parent)
         }),
         ("ns", |ops, parent| {
             NsDirOps::new_inode(ops.target.clone(), parent)

--- a/kernel/src/filesystem/procfs/vmstat.rs
+++ b/kernel/src/filesystem/procfs/vmstat.rs
@@ -9,7 +9,7 @@ use crate::{
         },
         vfs::{FilePrivateData, IndexNode, InodeMode},
     },
-    mm::{oom, page_cache_stats},
+    mm::{fault, oom, page_cache_stats},
 };
 use alloc::{borrow::ToOwned, format, sync::Arc, sync::Weak, vec::Vec};
 use system_error::SystemError;
@@ -25,6 +25,8 @@ enum VmstatSource {
     Unevictable,
     DropPagecache,
     OomKill,
+    PageFaults,
+    PageMajorFaults,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -301,11 +303,11 @@ const VMSTAT_FIELDS: &[VmstatField] = &[
     },
     VmstatField {
         name: "pgfault",
-        source: VmstatSource::Zero,
+        source: VmstatSource::PageFaults,
     },
     VmstatField {
         name: "pgmajfault",
-        source: VmstatSource::Zero,
+        source: VmstatSource::PageMajorFaults,
     },
     VmstatField {
         name: "pglazyfreed",
@@ -472,6 +474,8 @@ impl VmstatFileOps {
                 VmstatSource::Unevictable => stats.unevictable,
                 VmstatSource::DropPagecache => stats.drop_pagecache,
                 VmstatSource::OomKill => oom::oom_kill_count(),
+                VmstatSource::PageFaults => fault::page_fault_count(),
+                VmstatSource::PageMajorFaults => fault::page_major_fault_count(),
             };
             data.append(&mut format!("{} {}\n", field.name, value).as_bytes().to_owned());
         }

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -307,7 +307,15 @@ impl Futex {
                 let wait = fault.retry_wait;
                 drop(space_guard);
                 if let Some(wait) = wait {
-                    wait.wait().map_err(|_| SystemError::EFAULT)?;
+                    if let Err(error) = wait.wait() {
+                        if !matches!(error, SystemError::EINTR | SystemError::ERESTARTSYS) {
+                            crate::mm::fault::account_fault_result(
+                                flags,
+                                VmFaultReason::VM_FAULT_SIGBUS,
+                            );
+                        }
+                        return Err(SystemError::EFAULT);
+                    }
                 }
                 continue;
             }

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -3,6 +3,7 @@ use core::{
     cmp::{max, min},
     intrinsics::unlikely,
     panic,
+    sync::atomic::{AtomicU64, Ordering},
 };
 
 use alloc::sync::Arc;
@@ -14,6 +15,7 @@ use crate::{
     libs::align::align_down,
     mm::{
         page::{page_manager_lock, EntryFlags},
+        percpu::PerCpu,
         ucontext::{AddressSpace, InnerAddressSpace, LockedVMA},
         PhysAddr, VirtAddr, VmFaultReason, VmFlags,
     },
@@ -23,6 +25,85 @@ use crate::{
 use crate::mm::MemoryManagementArch;
 
 use super::page::{Page, PageFlags, PageType};
+
+#[repr(align(64))]
+struct FaultEventShard {
+    faults: AtomicU64,
+    major_faults: AtomicU64,
+}
+
+impl FaultEventShard {
+    const fn new() -> Self {
+        Self {
+            faults: AtomicU64::new(0),
+            major_faults: AtomicU64::new(0),
+        }
+    }
+}
+
+static FAULT_EVENTS: [FaultEventShard; PerCpu::MAX_CPU_NUM as usize] =
+    [const { FaultEventShard::new() }; PerCpu::MAX_CPU_NUM as usize];
+
+#[inline]
+fn fault_event_shard_for(pcb: &crate::process::ProcessControlBlock) -> &'static FaultEventShard {
+    let index = pcb
+        .sched_info()
+        .statistics_cpu_hint()
+        .map(|cpu| cpu.data() as usize)
+        .filter(|index| *index < FAULT_EVENTS.len())
+        .unwrap_or(0);
+    &FAULT_EVENTS[index]
+}
+
+/// Record a major-fault event at the point where backing I/O is required.
+#[inline]
+pub(crate) fn account_major_fault_event() {
+    let pcb = ProcessManager::current_pcb();
+    fault_event_shard_for(&pcb)
+        .major_faults
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+/// Apply Linux mm_account_fault() semantics to one final MM fault outcome.
+#[inline]
+pub(crate) fn account_fault_result(flags: FaultFlags, reason: VmFaultReason) {
+    let pcb = ProcessManager::current_pcb();
+    account_fault_result_for(&pcb, flags, reason);
+}
+
+#[inline]
+fn account_fault_result_for(
+    pcb: &crate::process::ProcessControlBlock,
+    flags: FaultFlags,
+    reason: VmFaultReason,
+) {
+    if reason.contains(VmFaultReason::VM_FAULT_RETRY) {
+        return;
+    }
+
+    fault_event_shard_for(pcb)
+        .faults
+        .fetch_add(1, Ordering::Relaxed);
+    if reason.intersects(VmFaultReason::VM_FAULT_ERROR) {
+        return;
+    }
+
+    let major = reason.contains(VmFaultReason::VM_FAULT_MAJOR)
+        || flags.contains(FaultFlags::FAULT_FLAG_TRIED);
+    pcb.account_page_fault(major);
+}
+
+pub fn page_fault_count() -> u64 {
+    FAULT_EVENTS.iter().fold(0u64, |total, shard| {
+        total.wrapping_add(shard.faults.load(Ordering::Relaxed))
+    })
+}
+
+pub fn page_major_fault_count() -> u64 {
+    FAULT_EVENTS.iter().fold(0u64, |total, shard| {
+        total.wrapping_add(shard.major_faults.load(Ordering::Relaxed))
+    })
+}
 
 pub trait FaultRetryWait: core::fmt::Debug + Send + Sync {
     fn wait(&self) -> Result<(), SystemError>;
@@ -395,33 +476,29 @@ impl PageFaultHandler {
             current_pcb.sched_info().set_state(ProcessState::Runnable);
         }
 
-        if !MMArch::vma_access_permitted(
+        let reason = if !MMArch::vma_access_permitted(
             vma.clone(),
             flags.contains(FaultFlags::FAULT_FLAG_WRITE),
             flags.contains(FaultFlags::FAULT_FLAG_INSTRUCTION),
             flags.contains(FaultFlags::FAULT_FLAG_REMOTE),
         ) {
-            return VmFaultOutcome {
-                reason: VmFaultReason::VM_FAULT_SIGSEGV,
-                retry_wait: None,
-            };
-        }
-
-        let guard = vma.lock();
-        let vm_flags = *guard.vm_flags();
-        drop(guard);
-        if unlikely(vm_flags.contains(VmFlags::VM_HUGETLB)) {
-            //TODO: 添加handle_hugetlb_fault处理大页缺页异常
+            VmFaultReason::VM_FAULT_SIGSEGV
         } else {
-            let reason = Self::handle_normal_fault(&mut pfm);
-            return VmFaultOutcome {
-                reason,
-                retry_wait: pfm.retry_wait.take(),
-            };
-        }
+            let guard = vma.lock();
+            let vm_flags = *guard.vm_flags();
+            drop(guard);
+            if unlikely(vm_flags.contains(VmFlags::VM_HUGETLB)) {
+                // TODO: 添加 handle_hugetlb_fault 处理大页缺页异常。
+                VmFaultReason::VM_FAULT_COMPLETED
+            } else {
+                Self::handle_normal_fault(&mut pfm)
+            }
+        };
+
+        account_fault_result_for(&current_pcb, flags, reason);
 
         VmFaultOutcome {
-            reason: VmFaultReason::VM_FAULT_COMPLETED,
+            reason,
             retry_wait: pfm.retry_wait.take(),
         }
     }
@@ -1207,6 +1284,7 @@ impl PageFaultHandler {
         }
 
         if !page_cache.is_page_ready(backing_pgoff) {
+            account_major_fault_event();
             ret = VmFaultReason::VM_FAULT_MAJOR;
         }
 

--- a/kernel/src/mm/ucontext/address_space.rs
+++ b/kernel/src/mm/ucontext/address_space.rs
@@ -86,7 +86,7 @@ impl AddressSpace {
         let mut addr = start;
         let mut retried = false;
         while addr.data() < end {
-            let retry_wait = {
+            let (retry_wait, retry_flags) = {
                 let mut guard = self.write();
                 let Some(vma) = guard.mappings.contains(addr) else {
                     addr = VirtAddr::new(addr.data() + MMArch::PAGE_SIZE);
@@ -152,7 +152,7 @@ impl AddressSpace {
                     continue;
                 }
                 if outcome.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
-                    outcome.retry_wait
+                    (outcome.retry_wait, fault_flags)
                 } else if outcome.reason.contains(VmFaultReason::VM_FAULT_OOM) {
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
                 } else {
@@ -165,7 +165,15 @@ impl AddressSpace {
             // PageCache invalidation read guard may now acquire the mm read
             // side and complete before this population retry blocks.
             if let Some(wait) = retry_wait {
-                wait.wait()?;
+                if let Err(error) = wait.wait() {
+                    if !matches!(error, SystemError::EINTR | SystemError::ERESTARTSYS) {
+                        crate::mm::fault::account_fault_result(
+                            retry_flags,
+                            VmFaultReason::VM_FAULT_SIGBUS,
+                        );
+                    }
+                    return Err(error);
+                }
             } else {
                 // A legacy retry (for example, a changed backing index) has
                 // no blocking predicate.  The guard is still released, and

--- a/kernel/src/process/resource.rs
+++ b/kernel/src/process/resource.rs
@@ -193,6 +193,13 @@ impl TryFrom<usize> for RLimitID {
 }
 
 impl ProcessControlBlock {
+    /// Account one successfully completed page fault to this task.
+    #[inline]
+    pub(crate) fn account_page_fault(&self, major: bool) {
+        let counter = if major { &self.maj_flt } else { &self.min_flt };
+        counter.fetch_add(1, Ordering::Relaxed);
+    }
+
     fn leader_for_rusage(&self) -> Arc<ProcessControlBlock> {
         if self.is_thread_group_leader() {
             return self
@@ -212,6 +219,8 @@ impl ProcessControlBlock {
         RUsage {
             ru_utime: RUsageTimeval::from_ns(ct.utime.load(Ordering::Relaxed)),
             ru_stime: RUsageTimeval::from_ns(ct.stime.load(Ordering::Relaxed)),
+            ru_minflt: self.min_flt.load(Ordering::Relaxed) as usize,
+            ru_majflt: self.maj_flt.load(Ordering::Relaxed) as usize,
             ..RUsage::default()
         }
     }

--- a/kernel/src/process/sched_info.rs
+++ b/kernel/src/process/sched_info.rs
@@ -146,6 +146,14 @@ impl ProcessSchedulerInfo {
         }
     }
 
+    /// Best-effort task CPU hint for sharding statistics only.
+    ///
+    /// This must not be used for scheduling or task ownership decisions.
+    pub(crate) fn statistics_cpu_hint(&self) -> Option<ProcessorId> {
+        let on_cpu = self.on_cpu.load(Ordering::Relaxed);
+        (on_cpu != ProcessorId::INVALID).then_some(on_cpu)
+    }
+
     pub fn set_on_cpu(&self, on_cpu: Option<ProcessorId>) {
         if let Some(cpu_id) = on_cpu {
             self.on_cpu.store(cpu_id, Ordering::SeqCst);

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -193,6 +193,10 @@ pub struct ProcessControlBlock {
 
     /// CPU time accounting.
     pub(super) cpu_time: Arc<ProcessCpuTime>,
+    /// Minor page faults completed by this task.
+    pub(super) min_flt: AtomicU64,
+    /// Major page faults completed by this task.
+    pub(super) maj_flt: AtomicU64,
     /// Raw CPU time accumulated from threads that have left this thread group.
     ///
     /// This remains in nanoseconds for CLOCK_PROCESS_CPUTIME_ID.  The separate
@@ -369,6 +373,8 @@ impl ProcessControlBlock {
                 itimers: SpinLock::new(ProcessItimers::default()),
                 posix_timers: SpinLock::new(posix_timer::ProcessPosixTimers::default()),
                 cpu_time: Arc::new(ProcessCpuTime::default()),
+                min_flt: AtomicU64::new(0),
+                maj_flt: AtomicU64::new(0),
                 exited_thread_group_cputime_ns: SpinLock::new(0),
                 exited_thread_group_rusage: SpinLock::new(RUsage::default()),
                 children_rusage: SpinLock::new(RUsage::default()),

--- a/kernel/src/syscall/user_access.rs
+++ b/kernel/src/syscall/user_access.rs
@@ -90,6 +90,7 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
 
         let mm = AddressSpace::current()?;
         let mut current = start_page;
+        let mut retried = false;
         'retry: loop {
             let mut space_guard = mm.write_guard_no_reservation_conflict(region);
             loop {
@@ -107,11 +108,14 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
                     return Err(SystemError::EFAULT);
                 }
 
-                let fault_flags = if write {
+                let mut fault_flags = if write {
                     FaultFlags::FAULT_FLAG_WRITE
                 } else {
                     FaultFlags::empty()
                 };
+                if retried {
+                    fault_flags |= FaultFlags::FAULT_FLAG_TRIED;
+                }
                 let fault = unsafe {
                     let message = PageFaultMessage::new(
                         vma,
@@ -126,10 +130,19 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
                     return Err(SystemError::ENOMEM);
                 }
                 if fault.reason.contains(VmFaultReason::VM_FAULT_RETRY) {
+                    retried = true;
                     let wait = fault.retry_wait;
                     drop(space_guard);
                     if let Some(wait) = wait {
-                        wait.wait().map_err(|_| SystemError::EFAULT)?;
+                        if let Err(error) = wait.wait() {
+                            if !matches!(error, SystemError::EINTR | SystemError::ERESTARTSYS) {
+                                crate::mm::fault::account_fault_result(
+                                    fault_flags,
+                                    VmFaultReason::VM_FAULT_SIGBUS,
+                                );
+                            }
+                            return Err(SystemError::EFAULT);
+                        }
                     }
                     continue 'retry;
                 }
@@ -146,6 +159,7 @@ fn prefault_user_range(addr: VirtAddr, len: usize, write: bool) -> Result<(), Sy
                 if current == end_page {
                     return Ok(());
                 }
+                retried = false;
                 current = VirtAddr::new(
                     current
                         .data()

--- a/user/apps/tests/dunitest/suites/normal/page_fault_accounting.cc
+++ b/user/apps/tests/dunitest/suites/normal/page_fault_accounting.cc
@@ -1,0 +1,258 @@
+#include <gtest/gtest.h>
+
+#include <fcntl.h>
+#include <pthread.h>
+#include <sys/mman.h>
+#include <sys/resource.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <cerrno>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr size_t kPageSize = 4096;
+constexpr size_t kFaultPages = 128;
+
+struct FaultStat {
+  uint64_t minflt;
+  uint64_t cminflt;
+  uint64_t majflt;
+  uint64_t cmajflt;
+};
+
+bool ReadProcStat(const std::string& path, FaultStat* out) {
+  std::ifstream input(path);
+  std::string line;
+  if (!std::getline(input, line)) return false;
+
+  const size_t comm_end = line.rfind(')');
+  if (comm_end == std::string::npos || comm_end + 2 >= line.size()) return false;
+
+  std::istringstream fields(line.substr(comm_end + 2));
+  std::vector<std::string> values;
+  for (std::string value; fields >> value;) values.push_back(value);
+  if (values.size() <= 10) return false;
+
+  try {
+    out->minflt = std::stoull(values[7]);
+    out->cminflt = std::stoull(values[8]);
+    out->majflt = std::stoull(values[9]);
+    out->cmajflt = std::stoull(values[10]);
+  } catch (...) {
+    return false;
+  }
+  return true;
+}
+
+bool ReadVmstat(const char* name, uint64_t* out) {
+  std::ifstream input("/proc/vmstat");
+  std::string key;
+  uint64_t value;
+  while (input >> key >> value) {
+    if (key == name) {
+      *out = value;
+      return true;
+    }
+  }
+  return false;
+}
+
+void* MapAndTouch(size_t pages) {
+  const size_t length = pages * kPageSize;
+  void* mapping = mmap(nullptr, length, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  if (mapping == MAP_FAILED) return MAP_FAILED;
+
+  volatile uint8_t* bytes = static_cast<volatile uint8_t*>(mapping);
+  for (size_t page = 0; page < pages; ++page) bytes[page * kPageSize] = 0x5a;
+  return mapping;
+}
+
+bool WriteByte(int fd) {
+  const char byte = 'x';
+  return write(fd, &byte, 1) == 1;
+}
+
+bool ReadByte(int fd) {
+  char byte;
+  return read(fd, &byte, 1) == 1;
+}
+
+bool WriteExact(int fd, const void* data, size_t length) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  while (length != 0) {
+    const ssize_t written = write(fd, bytes, length);
+    if (written <= 0) return false;
+    bytes += written;
+    length -= static_cast<size_t>(written);
+  }
+  return true;
+}
+
+bool ReadExact(int fd, void* data, size_t length) {
+  auto* bytes = static_cast<uint8_t*>(data);
+  while (length != 0) {
+    const ssize_t nread = read(fd, bytes, length);
+    if (nread <= 0) return false;
+    bytes += nread;
+    length -= static_cast<size_t>(nread);
+  }
+  return true;
+}
+
+struct WorkerContext {
+  int ready_write;
+  int start_read;
+  int done_write;
+  int finish_read;
+  void* mapping;
+};
+
+void* FaultWorker(void* arg) {
+  auto* context = static_cast<WorkerContext*>(arg);
+  const pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+  if (!WriteExact(context->ready_write, &tid, sizeof(tid)) ||
+      !ReadByte(context->start_read))
+    return nullptr;
+  context->mapping = MapAndTouch(kFaultPages);
+  const char status = context->mapping == MAP_FAILED ? 'e' : 'x';
+  if (!WriteExact(context->done_write, &status, sizeof(status))) return nullptr;
+  (void)ReadByte(context->finish_read);
+  return nullptr;
+}
+
+TEST(PageFaultAccounting, AnonymousWriteUpdatesTaskAndVmstat) {
+  struct rusage before_usage {};
+  struct rusage after_usage {};
+  FaultStat before_stat {};
+  FaultStat after_stat {};
+  uint64_t before_vmstat = 0;
+  uint64_t after_vmstat = 0;
+
+  ASSERT_EQ(0, getrusage(RUSAGE_THREAD, &before_usage)) << strerror(errno);
+  ASSERT_TRUE(ReadProcStat("/proc/self/task/" + std::to_string(getpid()) + "/stat",
+                           &before_stat));
+  ASSERT_TRUE(ReadVmstat("pgfault", &before_vmstat));
+
+  void* mapping = MapAndTouch(kFaultPages);
+  ASSERT_NE(MAP_FAILED, mapping) << strerror(errno);
+
+  ASSERT_EQ(0, getrusage(RUSAGE_THREAD, &after_usage)) << strerror(errno);
+  ASSERT_TRUE(ReadProcStat("/proc/self/task/" + std::to_string(getpid()) + "/stat",
+                           &after_stat));
+  ASSERT_TRUE(ReadVmstat("pgfault", &after_vmstat));
+
+  ASSERT_GE(after_usage.ru_minflt, before_usage.ru_minflt);
+  ASSERT_GE(after_stat.minflt, before_stat.minflt);
+  ASSERT_GE(after_vmstat, before_vmstat);
+  EXPECT_GE(static_cast<uint64_t>(after_usage.ru_minflt - before_usage.ru_minflt), kFaultPages);
+  EXPECT_GE(after_stat.minflt - before_stat.minflt, kFaultPages);
+  EXPECT_GE(after_vmstat - before_vmstat, kFaultPages);
+  EXPECT_EQ(0, munmap(mapping, kFaultPages * kPageSize));
+}
+
+TEST(PageFaultAccounting, ProcStatDistinguishesThreadAndThreadGroup) {
+  int ready[2], start[2], done[2], finish[2];
+  ASSERT_EQ(0, pipe(ready));
+  ASSERT_EQ(0, pipe(start));
+  ASSERT_EQ(0, pipe(done));
+  ASSERT_EQ(0, pipe(finish));
+
+  WorkerContext context{ready[1], start[0], done[1], finish[0], MAP_FAILED};
+  pthread_t worker;
+  ASSERT_EQ(0, pthread_create(&worker, nullptr, FaultWorker, &context));
+  pid_t worker_tid = 0;
+  const bool got_tid = ReadExact(ready[0], &worker_tid, sizeof(worker_tid));
+
+  const std::string worker_path =
+      "/proc/self/task/" + std::to_string(worker_tid) + "/stat";
+  const std::string main_path = "/proc/self/task/" +
+                                std::to_string(static_cast<pid_t>(syscall(SYS_gettid))) +
+                                "/stat";
+  FaultStat worker_before {}, worker_after {}, main_before {}, main_after {}, group_before {},
+      group_after {};
+  const bool baseline_ok = got_tid && ReadProcStat(worker_path, &worker_before) &&
+                           ReadProcStat(main_path, &main_before) &&
+                           ReadProcStat("/proc/self/stat", &group_before);
+
+  const bool started = WriteByte(start[1]);
+  char worker_status = 'e';
+  const bool completed = started && ReadExact(done[0], &worker_status, sizeof(worker_status));
+  const bool after_ok = completed && ReadProcStat(worker_path, &worker_after) &&
+                        ReadProcStat(main_path, &main_after) &&
+                        ReadProcStat("/proc/self/stat", &group_after);
+
+  const bool finish_sent = WriteByte(finish[1]);
+  const int join_result = pthread_join(worker, nullptr);
+  for (int fd : {ready[0], ready[1], start[0], start[1], done[0], done[1],
+                 finish[0], finish[1]})
+    close(fd);
+
+  ASSERT_TRUE(got_tid);
+  ASSERT_TRUE(baseline_ok);
+  ASSERT_TRUE(completed);
+  ASSERT_EQ('x', worker_status);
+  ASSERT_TRUE(after_ok);
+  ASSERT_TRUE(finish_sent);
+  ASSERT_EQ(0, join_result);
+  ASSERT_NE(MAP_FAILED, context.mapping);
+  ASSERT_GE(worker_after.minflt, worker_before.minflt);
+  ASSERT_GE(main_after.minflt, main_before.minflt);
+  ASSERT_GE(group_after.minflt, group_before.minflt);
+  const uint64_t worker_delta = worker_after.minflt - worker_before.minflt;
+  const uint64_t main_delta = main_after.minflt - main_before.minflt;
+  const uint64_t group_delta = group_after.minflt - group_before.minflt;
+  EXPECT_GE(worker_delta, kFaultPages);
+  EXPECT_GE(group_delta, worker_delta);
+  EXPECT_LT(main_delta, worker_delta);
+
+  EXPECT_EQ(0, munmap(context.mapping, kFaultPages * kPageSize));
+}
+
+TEST(PageFaultAccounting, ReapedChildUpdatesChildrenUsage) {
+  struct rusage before_children {};
+  struct rusage after_children {};
+  struct rusage waited {};
+  FaultStat before_stat {};
+  FaultStat after_stat {};
+  ASSERT_EQ(0, getrusage(RUSAGE_CHILDREN, &before_children)) << strerror(errno);
+  ASSERT_TRUE(ReadProcStat("/proc/self/stat", &before_stat));
+
+  pid_t child = fork();
+  ASSERT_GE(child, 0) << strerror(errno);
+  if (child == 0) {
+    void* mapping = MapAndTouch(kFaultPages);
+    _exit(mapping == MAP_FAILED ? 2 : 0);
+  }
+
+  int status = 0;
+  ASSERT_EQ(child, wait4(child, &status, 0, &waited)) << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(0, WEXITSTATUS(status));
+  ASSERT_EQ(0, getrusage(RUSAGE_CHILDREN, &after_children)) << strerror(errno);
+  ASSERT_TRUE(ReadProcStat("/proc/self/stat", &after_stat));
+
+  ASSERT_GE(after_children.ru_minflt, before_children.ru_minflt);
+  ASSERT_GE(after_stat.cminflt, before_stat.cminflt);
+  EXPECT_GE(static_cast<uint64_t>(waited.ru_minflt), kFaultPages);
+  EXPECT_GE(static_cast<uint64_t>(after_children.ru_minflt - before_children.ru_minflt),
+            static_cast<uint64_t>(waited.ru_minflt));
+  EXPECT_GE(after_stat.cminflt - before_stat.cminflt,
+            static_cast<uint64_t>(waited.ru_minflt));
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -78,6 +78,7 @@ normal/dma_allocator_selftest
 normal/mknod_socket
 normal/pmem_block
 normal/page_cache_accounting
+normal/page_fault_accounting
 normal/pipe_release_wakeup
 normal/pipe_waitqueue_wakeup
 normal/oom_killer_semantics


### PR DESCRIPTION
## Summary

- account completed minor and major page faults per task using Linux-compatible retry and error semantics
- expose `pgfault`/`pgmajfault` through `/proc/vmstat` and task, thread-group, and child fault totals through procfs and `getrusage`
- shard system counters by task CPU to avoid a shared hot-path cache line
- add dunitest coverage for anonymous faults, thread versus thread-group views, and reaped-child aggregation

## Motivation

DragonOS currently exports page-fault fields through procfs and `rusage`, but those fields remain zero. This prevents standard tooling from observing anonymous-fault-heavy workloads and makes performance diagnosis depend on ad-hoc instrumentation.

The implementation follows Linux 6.6 accounting boundaries: retries are counted only when they reach a final result, failed faults update the system fault total but not per-task minor/major totals, and major system events are recorded where backing I/O is required.

## Implementation notes

- system counters use private cache-line-aligned shards and relaxed atomics
- the ordinary fault path adds no locks, allocations, logging, timestamps, or CPU-ID probing
- existing `RUsage` aggregation is reused for live threads, exited siblings, `exec`, `wait4`, and reaped children
- `/proc/<pid>/stat` and `/proc/<pid>/task/<tid>/stat` explicitly select thread-group and thread scopes
- interrupted retry waiters remain unaccounted until completion; terminal waiter errors contribute one failed `pgfault`

## Validation

- `make kernel`
- `cargo +nightly-2026-02-24 fmt --manifest-path kernel/Cargo.toml -- --check`
- page-fault accounting dunitest: 3/3 passed on Linux
- page-fault accounting dunitest: 3/3 passed on DragonOS QEMU
- existing `wait_rusage` dunitest: 34/34 passed on DragonOS QEMU
- `git diff --check`
