### PR TITLE
perf(mm): optimize anonymous page fault handling

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -244,13 +244,10 @@ impl X86_64MMArch {
             Self::page_fault_oops(regs, error_code, address);
         }
 
-        let feature = x86::cpuid::CpuId::new()
-            .get_extended_feature_info()
-            .unwrap();
         if unlikely(
-            feature.has_smap()
-                && !error_code.contains(X86PfErrorCode::X86_PF_USER)
-                && rflags.contains(RFlags::FLAGS_AC),
+            !error_code.contains(X86PfErrorCode::X86_PF_USER)
+                && unsafe { x86::controlregs::cr4().contains(Cr4::CR4_ENABLE_SMAP) }
+                && !rflags.contains(RFlags::FLAGS_AC),
         ) {
             Self::page_fault_oops(regs, error_code, address);
         }

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -608,70 +608,67 @@ impl PageFaultHandler {
             return VmFaultReason::VM_FAULT_OOM | VmFaultReason::VM_FAULT_OOM_INJECTED;
         }
         let address = pfm.address_aligned_down();
+        let vm_flags = pfm.vm_flags();
+        let backing_pgoff = pfm.backing_pgoff();
         let vma = pfm.vma.clone();
         let mm = pfm.mm().clone();
         let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
-        // If this is an anonymous shared mapping, use a shared backing so pages are visible across fork
-        {
-            let guard = vma.lock();
-            if guard.vm_flags().contains(VmFlags::VM_SHARED) {
-                let shared = guard.shared_anon.clone();
-                if let Some(shared) = shared {
-                    // Compute page index within the shared-anon backing object.
-                    // Base offset is stored in VMA.backing_pgoff.
-                    let base = guard.backing_page_offset().unwrap_or(0);
-                    let pgoff = base
-                        + ((address.data() - guard.region().start().data()) >> MMArch::PAGE_SHIFT);
+        // Shared anonymous mappings must always use their shared backing. A
+        // missing backing is a malformed shared VMA, not a private fallback.
+        if vm_flags.contains(VmFlags::VM_SHARED) {
+            let (shared, flags, mlocked) = {
+                let guard = vma.lock();
+                (
+                    guard.shared_anon.clone(),
+                    guard.flags(),
+                    guard.vm_flags().contains(VmFlags::VM_LOCKED),
+                )
+            };
+            let Some(shared) = shared else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
+            let Some(pgoff) = backing_pgoff else {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            };
 
-                    // Linux semantics: access beyond the backing size should SIGBUS.
-                    if pgoff >= shared.size_pages() {
-                        drop(guard);
-                        return VmFaultReason::VM_FAULT_SIGBUS;
-                    }
-                    drop(guard);
+            // Linux semantics: access beyond the backing size should SIGBUS.
+            if pgoff >= shared.size_pages() {
+                return VmFaultReason::VM_FAULT_SIGBUS;
+            }
 
-                    // Atomically get or create the shared page to avoid races
-                    let page = match shared.get_or_create_page(pgoff) {
-                        Ok(p) => p,
-                        Err(_) => return VmFaultReason::VM_FAULT_OOM,
-                    };
+            // Atomically get or create the shared page to avoid races.
+            let page = match shared.get_or_create_page(pgoff) {
+                Ok(p) => p,
+                Err(_) => return VmFaultReason::VM_FAULT_OOM,
+            };
 
-                    // Map the shared page into current process
-                    let flags = vma.lock().flags();
-                    let mlocked = vma.lock().vm_flags().contains(VmFlags::VM_LOCKED);
-                    if let Some(flush) = mapper.map_phys(address, page.phys_address(), flags) {
-                        flush.flush();
-                        Self::account_new_present_mapping(pfm.mm());
-                        Self::attach_fault_mapped_page(&page, &vma, mlocked);
-                        return VmFaultReason::VM_FAULT_COMPLETED;
-                    } else {
-                        return VmFaultReason::VM_FAULT_OOM;
-                    }
-                }
+            if let Some(flush) = mapper.map_phys(address, page.phys_address(), flags) {
+                flush.flush();
+                Self::account_new_present_mapping(pfm.mm());
+                Self::attach_fault_mapped_page(&page, &vma, mlocked);
+                return VmFaultReason::VM_FAULT_COMPLETED;
+            } else {
+                return VmFaultReason::VM_FAULT_OOM;
             }
         }
 
-        // Fallback: private anonymous page (MAP_PRIVATE or non-shared anon)
-        let guard = vma.lock();
-        let flags = guard.flags();
-        let mlocked = guard.vm_flags().contains(VmFlags::VM_LOCKED);
-        drop(guard);
-        if let Some(flush) = mapper.map(address, flags) {
+        // Private anonymous page.
+        let (flags, mlocked) = {
+            let guard = vma.lock();
+            (guard.flags(), guard.vm_flags().contains(VmFlags::VM_LOCKED))
+        };
+        if let Some((page, flush)) = mapper.map_new_page(address, flags) {
             flush.flush();
             crate::debug::klog::mm::mm_debug_log(
                 klog_types::AllocatorLogType::LazyAlloc(klog_types::AllocLogItem::new(
                     Layout::from_size_align(MMArch::PAGE_SIZE, MMArch::PAGE_SIZE).unwrap(),
                     Some(address.data()),
-                    Some(mapper.translate(address).unwrap().0.data()),
+                    Some(page.phys_address().data()),
                 )),
                 klog_types::LogSource::Buddy,
             );
-            let paddr = mapper.translate(address).unwrap().0;
-            let mut page_manager_guard = page_manager_lock();
-            let page = page_manager_guard.get_unwrap(&paddr);
-            drop(page_manager_guard);
             Self::account_new_present_mapping(pfm.mm());
             Self::attach_fault_mapped_page(&page, &vma, mlocked);
             VmFaultReason::VM_FAULT_COMPLETED
@@ -692,7 +689,7 @@ impl PageFaultHandler {
     pub unsafe fn do_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
         if !pfm.flags().contains(FaultFlags::FAULT_FLAG_WRITE) {
             Self::do_read_fault(pfm)
-        } else if !pfm.vma().lock().vm_flags().contains(VmFlags::VM_SHARED) {
+        } else if !pfm.vm_flags().contains(VmFlags::VM_SHARED) {
             Self::do_cow_fault(pfm)
         } else {
             Self::do_shared_fault(pfm)
@@ -1496,12 +1493,8 @@ impl PageFaultHandler {
         let _pt_edit = mm.page_table_edit();
         let mapper = &mut pfm.mapper;
 
-        if let Some(flush) = mapper.map(address, flags) {
+        if let Some((page, flush)) = mapper.map_new_page(address, flags) {
             flush.flush();
-            let mut pm = page_manager_lock();
-            let paddr = mapper.translate(address).unwrap().0;
-            let page = pm.get_unwrap(&paddr);
-            drop(pm);
             Self::account_new_present_mapping(pfm.mm());
             Self::attach_fault_mapped_page(&page, &vma, mlocked);
             VmFaultReason::VM_FAULT_COMPLETED
@@ -1535,12 +1528,11 @@ impl PageFaultHandler {
         let mapper = &mut pfm.mapper;
         for pgoff in start_pgoff..end_pgoff {
             let addr = VirtAddr::new(base.data() + ((pgoff - backing_pgoff) << MMArch::PAGE_SHIFT));
-            if let Some(flush) = mapper.map(addr, flags) {
+            if mapper.get_entry(addr, 0).is_some() {
+                continue;
+            }
+            if let Some((page, flush)) = mapper.map_new_page(addr, flags) {
                 flush.flush();
-                let mut pm = page_manager_lock();
-                let paddr = mapper.translate(addr).unwrap().0;
-                let page = pm.get_unwrap(&paddr);
-                drop(pm);
                 Self::account_new_present_mapping(&mm);
                 Self::attach_fault_mapped_page(&page, &vma, mlocked);
             } else {

--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -1797,12 +1797,38 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
         return &mut self.frame_allocator;
     }
 
-    /// 从当前PageMapper的页分配器中分配一个物理页，并将其映射到指定的虚拟地址
+    /// Allocate a physical page from this mapper's allocator and map it at the
+    /// specified virtual address.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the mapper's required page-table edit serialization
+    /// and ensure that the target leaf entry is empty.
     pub unsafe fn map(
         &mut self,
         virt: VirtAddr,
         flags: EntryFlags<Arch>,
     ) -> Option<PageFlush<Arch>> {
+        self.map_new_page(virt, flags).map(|(_, flush)| flush)
+    }
+
+    /// Allocate a managed normal page and map it into an empty leaf entry.
+    ///
+    /// The returned [`Arc<Page>`] is the same object registered in the global
+    /// page manager. Callers can use it directly for rmap/LRU accounting
+    /// instead of translating the new PTE and looking the page up again.
+    ///
+    /// # Safety
+    ///
+    /// The caller must hold the mapper's required page-table edit serialization
+    /// and must have established that the target leaf entry is empty. This
+    /// method deliberately does not repeat that lookup on the anonymous-fault
+    /// hot path.
+    pub(crate) unsafe fn map_new_page(
+        &mut self,
+        virt: VirtAddr,
+        flags: EntryFlags<Arch>,
+    ) -> Option<(Arc<Page>, PageFlush<Arch>)> {
         let mut page_manager_guard = page_manager_lock();
         let page = page_manager_guard
             .create_one_page(
@@ -1813,11 +1839,13 @@ impl<Arch: MemoryManagementArch, F: FrameAllocator> PageMapper<Arch, F> {
             .ok()?;
         drop(page_manager_guard);
         let phys = page.phys_address();
-        let mapped = self.map_phys(virt, phys, flags);
-        if mapped.is_none() {
-            let _ = page_manager_lock().remove_page(&phys);
+        match self.map_phys(virt, phys, flags) {
+            Some(flush) => Some((page, flush)),
+            None => {
+                let _ = page_manager_lock().remove_page(&phys);
+                None
+            }
         }
-        return mapped;
     }
 
     /// 映射一个物理页到指定的虚拟地址

--- a/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
@@ -5,12 +5,14 @@
 #include <stdio.h>
 #include <string.h>
 #include <sys/mount.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
 #include <sys/syscall.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
 
+#include <cstdint>
 #include <fstream>
 #include <sstream>
 #include <string>
@@ -137,6 +139,82 @@ TEST(DevtmpfsSemantics, BuiltinDeviceNumbersAndLinks) {
 
     EXPECT_EQ("/proc/self/fd", ReadLink("/dev/fd"));
     ExpectReadZeros("/dev/zero");
+}
+
+TEST(DevtmpfsSemantics, PrivateZeroMmapPreservesPagesAcrossFaultAroundWindows) {
+    constexpr size_t kPageSize = 4096;
+    constexpr size_t kPages = 33;
+    constexpr size_t kLength = kPages * kPageSize;
+    // 32 divides the 512-entry x86 PTE table. Offset 5 leaves enough room for
+    // two complete 16-page fault-around windows without crossing its end.
+    constexpr size_t kAlignmentPages = 32;
+    constexpr size_t kReservePages = kPages + kAlignmentPages - 1;
+    constexpr uintptr_t kDesiredPteOffset = 5;
+
+    int fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+
+    void* reservation = mmap(nullptr, kReservePages * kPageSize, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE, fd, 0);
+    if (reservation == MAP_FAILED) {
+        const int saved_errno = errno;
+        close(fd);
+        FAIL() << strerror(saved_errno);
+        return;
+    }
+    const uintptr_t first_page = reinterpret_cast<uintptr_t>(reservation) / kPageSize;
+    const size_t prefix_pages = (kDesiredPteOffset + kAlignmentPages -
+                                 (first_page & (kAlignmentPages - 1))) &
+                                (kAlignmentPages - 1);
+    const size_t suffix_pages = kReservePages - prefix_pages - kPages;
+    auto* raw_mapping = static_cast<unsigned char*>(reservation) + prefix_pages * kPageSize;
+    if (prefix_pages != 0 && munmap(reservation, prefix_pages * kPageSize) != 0) {
+        const int saved_errno = errno;
+        munmap(reservation, kReservePages * kPageSize);
+        close(fd);
+        FAIL() << strerror(saved_errno);
+        return;
+    }
+    if (suffix_pages != 0 && munmap(raw_mapping + kLength, suffix_pages * kPageSize) != 0) {
+        const int saved_errno = errno;
+        munmap(raw_mapping, (kPages + suffix_pages) * kPageSize);
+        close(fd);
+        FAIL() << strerror(saved_errno);
+        return;
+    }
+    EXPECT_EQ(kDesiredPteOffset,
+              (reinterpret_cast<uintptr_t>(raw_mapping) / kPageSize) & (kAlignmentPages - 1));
+    auto* mapping = static_cast<volatile unsigned char*>(raw_mapping);
+
+    // A deliberately unaligned VMA makes consecutive fault-around windows
+    // overlap. Later faults must preserve pages populated by an earlier window.
+    for (size_t page = 0; page < kPages; ++page) {
+        EXPECT_EQ(0, mapping[page * kPageSize]);
+        mapping[page * kPageSize] = static_cast<unsigned char>(page + 1);
+    }
+    for (size_t page = 0; page < kPages; ++page) {
+        EXPECT_EQ(static_cast<unsigned char>(page + 1), mapping[page * kPageSize]);
+    }
+    EXPECT_EQ(0, munmap(const_cast<unsigned char*>(mapping), kLength));
+
+    void* raw_populated =
+        mmap(nullptr, kLength, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_POPULATE, fd, 0);
+    if (raw_populated == MAP_FAILED) {
+        const int saved_errno = errno;
+        close(fd);
+        FAIL() << strerror(saved_errno);
+        return;
+    }
+    auto* populated = static_cast<volatile unsigned char*>(raw_populated);
+    for (size_t page = 0; page < kPages; ++page) {
+        EXPECT_EQ(0, populated[page * kPageSize]);
+        populated[page * kPageSize] = static_cast<unsigned char>(0xa0 + page);
+    }
+    for (size_t page = 0; page < kPages; ++page) {
+        EXPECT_EQ(static_cast<unsigned char>(0xa0 + page), populated[page * kPageSize]);
+    }
+    EXPECT_EQ(0, munmap(const_cast<unsigned char*>(populated), kLength));
+    EXPECT_EQ(0, close(fd));
 }
 
 TEST(DevtmpfsSemantics, PublicMountReusesKernelInstance) {

--- a/user/apps/tests/dunitest/suites/normal/page_fault_accounting.cc
+++ b/user/apps/tests/dunitest/suites/normal/page_fault_accounting.cc
@@ -250,6 +250,87 @@ TEST(PageFaultAccounting, ReapedChildUpdatesChildrenUsage) {
             static_cast<uint64_t>(waited.ru_minflt));
 }
 
+TEST(PageFaultAccounting, SharedAnonymousDelayedFaultsRemainVisibleAcrossFork) {
+  constexpr size_t kLength = 2 * kPageSize;
+  void* raw_mapping =
+      mmap(nullptr, kLength, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(MAP_FAILED, raw_mapping) << strerror(errno);
+  auto* mapping = static_cast<volatile uint8_t*>(raw_mapping);
+
+  FaultStat before {};
+  FaultStat after {};
+  const std::string stat_path = "/proc/self/task/" + std::to_string(getpid()) + "/stat";
+  if (!ReadProcStat(stat_path, &before)) {
+    munmap(const_cast<uint8_t*>(mapping), kLength);
+    FAIL() << "failed to read parent task stat";
+    return;
+  }
+
+  int child_ready[2];
+  int parent_ready[2];
+  if (pipe(child_ready) != 0) {
+    const int saved_errno = errno;
+    munmap(const_cast<uint8_t*>(mapping), kLength);
+    FAIL() << strerror(saved_errno);
+    return;
+  }
+  if (pipe(parent_ready) != 0) {
+    const int saved_errno = errno;
+    close(child_ready[0]);
+    close(child_ready[1]);
+    munmap(const_cast<uint8_t*>(mapping), kLength);
+    FAIL() << strerror(saved_errno);
+    return;
+  }
+
+  pid_t child = fork();
+  if (child < 0) {
+    const int saved_errno = errno;
+    close(child_ready[0]);
+    close(child_ready[1]);
+    close(parent_ready[0]);
+    close(parent_ready[1]);
+    munmap(const_cast<uint8_t*>(mapping), kLength);
+    FAIL() << strerror(saved_errno);
+    return;
+  }
+  if (child == 0) {
+    close(child_ready[0]);
+    close(parent_ready[1]);
+    mapping[kPageSize] = 0x22;
+    if (!WriteByte(child_ready[1]) || !ReadByte(parent_ready[0])) _exit(2);
+    _exit(mapping[0] == 0x11 ? 0 : 3);
+  }
+
+  close(child_ready[1]);
+  close(parent_ready[0]);
+  const bool child_faulted = ReadByte(child_ready[0]);
+  const bool child_value_visible = child_faulted && mapping[kPageSize] == 0x22;
+  bool parent_faulted = false;
+  if (child_faulted) {
+    mapping[0] = 0x11;
+    parent_faulted = WriteByte(parent_ready[1]);
+  }
+  close(parent_ready[1]);
+
+  int status = 0;
+  const pid_t waited = waitpid(child, &status, 0);
+  close(child_ready[0]);
+  const bool stat_ok = ReadProcStat(stat_path, &after);
+  const int unmap_result = munmap(const_cast<uint8_t*>(mapping), kLength);
+
+  ASSERT_TRUE(child_faulted);
+  ASSERT_TRUE(child_value_visible);
+  ASSERT_TRUE(parent_faulted);
+  ASSERT_EQ(child, waited) << strerror(errno);
+  ASSERT_TRUE(WIFEXITED(status));
+  ASSERT_EQ(0, WEXITSTATUS(status));
+  ASSERT_TRUE(stat_ok);
+  ASSERT_GE(after.minflt, before.minflt);
+  EXPECT_GE(after.minflt - before.minflt, 2u);
+  EXPECT_EQ(0, unmap_result);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- remove the unconditional CPUID query from the x86 page-fault hot path and align the active SMAP check with Linux semantics
- return newly allocated managed pages to fault handlers to avoid redundant page-table translations and global page-manager lookups
- reuse VMA fault snapshots and preserve shared-anonymous and /dev/zero mapping invariants
- add regression coverage for overlapping /dev/zero fault-around windows, MAP_POPULATE, shared-anonymous fork visibility, and fault accounting

## Root cause

Anonymous minor faults performed avoidable architecture feature discovery, repeated page-table translation, and a global managed-page lookup after allocating and mapping each page. These costs accumulated in allocation-heavy workloads such as APT package-list parsing.

## User impact

The anonymous page-fault microbenchmark improved from a 1.48 s median to 1.14 s, while the measured APT simulation warm run improved from 5.86-5.87 s to 4.94 s under the same QEMU configuration.

## Validation

- `git diff --check`
- `make kernel`
- full `make all`
- page fault accounting dunitest: 4/4 passed
- devtmpfs semantics dunitest: 8/8 passed
- mlock semantics dunitest: 16 passed, 1 environment-dependent skip
- capability and EFAULT dunitest: 27/27 passed
- QEMU boot and repeated single-worker and two-worker anonymous-fault workloads