### PR TITLE
perf(mm): compact page-level reverse mappings

### DIFF
--- a/kernel/src/mm/page.rs
+++ b/kernel/src/mm/page.rs
@@ -790,10 +790,113 @@ impl Page {
 }
 
 #[derive(Debug)]
+enum PageVmaSet {
+    Empty,
+    One(Arc<LockedVMA>),
+    Two(Arc<LockedVMA>, Arc<LockedVMA>),
+    Many(HashSet<Arc<LockedVMA>>),
+}
+
+impl PageVmaSet {
+    fn new() -> Self {
+        Self::Empty
+    }
+
+    fn len(&self) -> usize {
+        match self {
+            Self::Empty => 0,
+            Self::One(_) => 1,
+            Self::Two(_, _) => 2,
+            Self::Many(vmas) => vmas.len(),
+        }
+    }
+
+    fn contains(&self, vma: &LockedVMA) -> bool {
+        match self {
+            Self::Empty => false,
+            Self::One(existing) => existing.as_ref() == vma,
+            Self::Two(first, second) => first.as_ref() == vma || second.as_ref() == vma,
+            Self::Many(vmas) => vmas.contains(vma),
+        }
+    }
+
+    fn insert(&mut self, vma: Arc<LockedVMA>) -> bool {
+        match self {
+            Self::Empty => {
+                *self = Self::One(vma);
+                true
+            }
+            Self::One(existing) => {
+                if existing.as_ref() == vma.as_ref() {
+                    false
+                } else {
+                    let Self::One(existing) = mem::replace(self, Self::Empty) else {
+                        unreachable!();
+                    };
+                    *self = Self::Two(existing, vma);
+                    true
+                }
+            }
+            Self::Two(first, second) => {
+                if first.as_ref() == vma.as_ref() || second.as_ref() == vma.as_ref() {
+                    return false;
+                }
+
+                // Allocate before taking the inline state so allocation failure cannot discard
+                // either existing reverse mapping.
+                let mut vmas = HashSet::with_capacity(3);
+                let Self::Two(first, second) = mem::replace(self, Self::Empty) else {
+                    unreachable!();
+                };
+                vmas.insert(first);
+                vmas.insert(second);
+                vmas.insert(vma);
+                *self = Self::Many(vmas);
+                true
+            }
+            Self::Many(vmas) => vmas.insert(vma),
+        }
+    }
+
+    fn remove(&mut self, vma: &LockedVMA) -> bool {
+        match self {
+            Self::Empty => false,
+            Self::One(existing) => {
+                if existing.as_ref() != vma {
+                    return false;
+                }
+                *self = Self::Empty;
+                true
+            }
+            Self::Two(first, second) => {
+                let remove_first = first.as_ref() == vma;
+                let remove_second = second.as_ref() == vma;
+                if !remove_first && !remove_second {
+                    return false;
+                }
+
+                let Self::Two(first, second) = mem::replace(self, Self::Empty) else {
+                    unreachable!();
+                };
+                *self = Self::One(if remove_first { second } else { first });
+                true
+            }
+            Self::Many(vmas) => {
+                let removed = vmas.remove(vma);
+                if removed && vmas.is_empty() {
+                    *self = Self::Empty;
+                }
+                removed
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
 /// 物理页面信息
 pub struct InnerPage {
     /// 映射到当前page的VMA
-    vma_set: HashSet<Arc<LockedVMA>>,
+    vma_set: PageVmaSet,
     /// 当前对该页贡献 mlock/unevictable 原因的 VMA 子集。
     ///
     /// 该集合必须始终是 `vma_set` 的子集。它让 page-cache reclassify
@@ -820,7 +923,7 @@ impl InnerPage {
         let intrinsic_unevictable =
             flags.contains(PageFlags::PG_UNEVICTABLE) && !matches!(page_type, PageType::File(_));
         Self {
-            vma_set: HashSet::new(),
+            vma_set: PageVmaSet::new(),
             mlocked_vmas: HashSet::new(),
             intrinsic_unevictable,
             backing_lifetime_pins: 0,
@@ -884,7 +987,7 @@ impl InnerPage {
     }
 
     pub fn add_mlocked_vma_ref(&mut self, vma: &Arc<LockedVMA>) {
-        if self.vma_set.contains(vma) && self.mlocked_vmas.insert(vma.clone()) {
+        if self.vma_set.contains(vma.as_ref()) && self.mlocked_vmas.insert(vma.clone()) {
             self.flags.insert(PageFlags::PG_UNEVICTABLE);
         }
     }
@@ -950,11 +1053,6 @@ impl InnerPage {
 
     pub fn set_page_type(&mut self, page_type: PageType) {
         self.page_type = page_type;
-    }
-
-    #[inline(always)]
-    pub fn vma_set(&self) -> &HashSet<Arc<LockedVMA>> {
-        &self.vma_set
     }
 
     #[inline(always)]

--- a/user/apps/tests/dunitest/suites/normal/sysv_shm_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sysv_shm_semantics.cc
@@ -610,6 +610,68 @@ TEST(SysvShmSemantics, ShmNattchTracksAttachDetach) {
     EXPECT_EQ(0, ShmNattch(shm.id()));
 }
 
+TEST(SysvShmSemantics, ThreeAliasesRemainCoherentWhileDetachedIndividually) {
+    ShmSegment shm(SegmentSize());
+    ASSERT_TRUE(shm.valid()) << "shmget failed: errno=" << errno << " (" << strerror(errno)
+                             << ")";
+
+    char* aliases[3] = {nullptr, nullptr, nullptr};
+    size_t attached = 0;
+    for (; attached < 3; ++attached) {
+        aliases[attached] = static_cast<char*>(Attach(shm.id()));
+        if (aliases[attached] == MAP_FAILED) {
+            break;
+        }
+    }
+    if (attached != 3) {
+        const int attach_errno = errno;
+        while (attached > 0) {
+            --attached;
+            (void)shmdt(aliases[attached]);
+        }
+        ADD_FAILURE() << "shmat failed: errno=" << attach_errno << " ("
+                      << strerror(attach_errno) << ")";
+        return;
+    }
+
+    const size_t ps = PageSize();
+    for (size_t page = 0; page < SegmentSize() / ps; ++page) {
+        aliases[0][page * ps] = static_cast<char>('a' + page);
+        EXPECT_EQ(aliases[0][page * ps], aliases[1][page * ps]);
+        EXPECT_EQ(aliases[0][page * ps], aliases[2][page * ps]);
+    }
+
+    if (shmdt(aliases[0]) == 0) {
+        aliases[0] = nullptr;
+    } else {
+        ADD_FAILURE() << "shmdt(first alias) failed: errno=" << errno << " (" << strerror(errno)
+                      << ")";
+    }
+    aliases[1][ps] = 'x';
+    EXPECT_EQ('x', aliases[2][ps]);
+
+    if (shmdt(aliases[1]) == 0) {
+        aliases[1] = nullptr;
+    } else {
+        ADD_FAILURE() << "shmdt(second alias) failed: errno=" << errno << " (" << strerror(errno)
+                      << ")";
+    }
+    EXPECT_EQ('x', aliases[2][ps]);
+
+    if (shmdt(aliases[2]) == 0) {
+        aliases[2] = nullptr;
+    } else {
+        ADD_FAILURE() << "shmdt(third alias) failed: errno=" << errno << " (" << strerror(errno)
+                      << ")";
+    }
+
+    for (char* alias : aliases) {
+        if (alias != nullptr) {
+            (void)shmdt(alias);
+        }
+    }
+}
+
 TEST(SysvShmSemantics, DetachedSegmentPersists) {
     ShmSegment shm(SegmentSize());
     ASSERT_TRUE(shm.valid());


### PR DESCRIPTION
## Summary

- replace the per-page reverse-mapping `HashSet` with a private `Empty`/`One`/`Two`/`Many` representation
- keep the first two VMA references inline and retain a sticky `HashSet` after a page reaches three mappings
- move existing `Arc<LockedVMA>` values between states without extra reference-count operations
- add a SysV shared-memory test that faults three aliases and detaches them independently

## Motivation

Most anonymous pages have one VMA owner, while fork and VMA identity replacement commonly require exactly two reverse mappings. Allocating a hash table for the first mapping adds a separate bucket allocation, allocator lock traffic, and zeroing to every anonymous page fault.

The compact representation removes that allocation from the common one- and two-mapping cases while preserving average constant-time lookup for pages with three or more mappings. The allocated state remains sticky until the last mapping is removed, avoiding allocator churn around the two-to-three mapping boundary.

## Correctness and scope

- duplicate insertion and missing removal retain the existing `HashSet` semantics
- map counts, shared-page detection, mlock tracking, and final page reclamation continue to use the same public `InnerPage` operations
- promotion allocates capacity before taking the inline state, so allocation failure cannot discard existing reverse mappings
- state transitions move existing `Arc` ownership instead of cloning surviving members
- no page-fault API, page-table, TLB, allocator, or implicit-zeroing behavior is changed

## Validation

- x86_64 kernel build
- RISC-V and LoongArch64 kernel checks
- full SysV shared-memory suite: 62 passed, 3 existing environment-dependent skips
- page-fault accounting, TLB shootdown, mlock, and OOM regression suites
- three-alias SysV shared-memory regression test
- repeated fork and VMA-split before/after probes, with no performance regression
- Rust formatting and `git diff --check`
