### PR TITLE
fix(mm): support shared /dev/zero mappings

### DIFF
--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -168,7 +168,11 @@ impl FileSystem for DevFS {
         if !is_zero_inode(pfm) {
             return VmFaultReason::VM_FAULT_SIGBUS;
         }
-        PageFaultHandler::zero_fault(pfm)
+        if pfm.vma().lock().shared_anon.is_some() {
+            PageFaultHandler::shared_anon_fault(pfm)
+        } else {
+            PageFaultHandler::zero_fault(pfm)
+        }
     }
 
     unsafe fn page_mkwrite(&self, pfm: &mut PageFaultMessage) -> VmFaultReason {
@@ -187,7 +191,11 @@ impl FileSystem for DevFS {
         if !is_zero_inode(pfm) {
             return VmFaultReason::VM_FAULT_SIGBUS;
         }
-        PageFaultHandler::zero_map_pages(pfm, start_pgoff, end_pgoff)
+        if pfm.vma().lock().shared_anon.is_some() {
+            PageFaultHandler::shared_anon_map_pages(pfm, start_pgoff, end_pgoff)
+        } else {
+            PageFaultHandler::zero_map_pages(pfm, start_pgoff, end_pgoff)
+        }
     }
 }
 

--- a/kernel/src/filesystem/devfs/zero_dev.rs
+++ b/kernel/src/filesystem/devfs/zero_dev.rs
@@ -7,6 +7,7 @@ use crate::filesystem::vfs::{
     InodeFlags, Metadata,
 };
 use crate::libs::mutex::MutexGuard;
+use crate::mm::VmFlags;
 use crate::{libs::mutex::Mutex, time::PosixTimeSpec};
 use alloc::{
     string::String,
@@ -162,6 +163,10 @@ impl IndexNode for LockedZeroInode {
     fn mmap(&self, _start: usize, _len: usize, _offset: usize) -> Result<(), SystemError> {
         // /dev/zero 支持 mmap，语义等同匿名零页映射
         Ok(())
+    }
+
+    fn mmap_uses_shared_anon(&self, vm_flags: VmFlags) -> bool {
+        vm_flags.contains(VmFlags::VM_SHARED)
     }
 
     fn parent(&self) -> Result<Arc<dyn IndexNode>, SystemError> {

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -571,6 +571,11 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         Ok(vm_flags)
     }
 
+    /// Whether this file mapping should use MM's per-mmap shared-anonymous backing.
+    fn mmap_uses_shared_anon(&self, _vm_flags: VmFlags) -> bool {
+        false
+    }
+
     fn mmap_effective_file(&self, file: &Arc<File>) -> Result<Arc<File>, SystemError> {
         Ok(file.clone())
     }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -3725,6 +3725,10 @@ impl IndexNode for MountFSInode {
         self.dentry.inode.mmap_vm_flags(file, vm_flags)
     }
 
+    fn mmap_uses_shared_anon(&self, vm_flags: VmFlags) -> bool {
+        self.dentry.inode.mmap_uses_shared_anon(vm_flags)
+    }
+
     fn mmap_effective_file(
         &self,
         file: &Arc<super::file::File>,

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -672,7 +672,20 @@ impl Futex {
         let page_index =
             ((uaddr.data() - vma_guard.region().start().data()) >> MMArch::PAGE_SHIFT) as u64;
 
-        if let Some(file) = vma_guard.vm_file() {
+        if let Some(shared_anon) = &vma_guard.shared_anon {
+            let base_pgoff = vma_guard.backing_page_offset().unwrap_or(0) as u64;
+            let shared = SharedKey {
+                kind: SharedKeyKind::SharedAnon { id: shared_anon.id },
+                page_offset: base_pgoff + page_index,
+            };
+            let key = FutexKey {
+                ptr: 0,
+                word: 0,
+                offset: offset as u32,
+                key: InnerFutexKey::Shared(shared),
+            };
+            return Ok(key);
+        } else if let Some(file) = vma_guard.vm_file() {
             // 共享文件映射：使用 inode 唯一标识 + 文件页偏移
             let md = file.metadata()?;
             let dev = md.dev_id as u64;
@@ -691,57 +704,42 @@ impl Futex {
             return Ok(key);
         } else {
             // 匿名映射（包括栈、堆、匿名mmap等）
-            if let Some(shared_anon) = &vma_guard.shared_anon {
-                // 显式共享的匿名映射（MAP_SHARED | MAP_ANONYMOUS）
-                let shared = SharedKey {
-                    kind: SharedKeyKind::SharedAnon { id: shared_anon.id },
-                    page_offset: page_index,
-                };
-                let key = FutexKey {
-                    ptr: 0,
-                    word: 0,
-                    offset: offset as u32,
-                    key: InnerFutexKey::Shared(shared),
-                };
-                return Ok(key);
-            } else {
-                // 私有匿名映射（栈、堆等）+ FUTEX_SHARED 标志
-                //
-                // 按照 Linux 内核的实际实现（kernel/futex/core.c: get_futex_key）：
-                // 对于匿名页的 FUTEX_SHARED，Linux 仍然使用 mm + 虚拟地址作为 key
-                // （只是添加了一个 FUT_OFF_MMSHARED 标记）
-                //
-                // 这种设计的原因：
-                // 1. 栈/堆这种私有匿名映射本质上不能跨进程共享
-                // 2. 只能在同一进程的线程间同步（它们共享地址空间）
-                // 3. 使用虚拟地址而非物理地址，与 swap 机制兼容
-                //
-                // DragonOS 的实现：
-                // 使用 AddressSpace 的全局唯一 ID + 虚拟页号作为 shared key
-                // - 同一进程的线程共享 AddressSpace，因此会生成相同的 key
-                // - 不同进程的 AddressSpace 有不同的 ID，即使虚拟地址相同也不会冲突
-                // - AddressSpace ID 是递增分配的，永不重复，避免了地址重用问题
+            // 私有匿名映射（栈、堆等）+ FUTEX_SHARED 标志
+            //
+            // 按照 Linux 内核的实际实现（kernel/futex/core.c: get_futex_key）：
+            // 对于匿名页的 FUTEX_SHARED，Linux 仍然使用 mm + 虚拟地址作为 key
+            // （只是添加了一个 FUT_OFF_MMSHARED 标记）
+            //
+            // 这种设计的原因：
+            // 1. 栈/堆这种私有匿名映射本质上不能跨进程共享
+            // 2. 只能在同一进程的线程间同步（它们共享地址空间）
+            // 3. 使用虚拟地址而非物理地址，与 swap 机制兼容
+            //
+            // DragonOS 的实现：
+            // 使用 AddressSpace 的全局唯一 ID + 虚拟页号作为 shared key
+            // - 同一进程的线程共享 AddressSpace，因此会生成相同的 key
+            // - 不同进程的 AddressSpace 有不同的 ID，即使虚拟地址相同也不会冲突
+            // - AddressSpace ID 是递增分配的，永不重复，避免了地址重用问题
 
-                let address_space = AddressSpace::current()?;
-                let as_id = address_space.id();
+            let address_space = AddressSpace::current()?;
+            let as_id = address_space.id();
 
-                drop(vma_guard);
-                drop(as_guard);
+            drop(vma_guard);
+            drop(as_guard);
 
-                let shared = SharedKey {
-                    kind: SharedKeyKind::PrivateAnonShared { as_id },
-                    // 使用虚拟页号（不是物理页号！）
-                    page_offset: (address >> MMArch::PAGE_SHIFT) as u64,
-                };
+            let shared = SharedKey {
+                kind: SharedKeyKind::PrivateAnonShared { as_id },
+                // 使用虚拟页号（不是物理页号！）
+                page_offset: (address >> MMArch::PAGE_SHIFT) as u64,
+            };
 
-                let key = FutexKey {
-                    ptr: 0,
-                    word: 0,
-                    offset: offset as u32,
-                    key: InnerFutexKey::Shared(shared),
-                };
-                return Ok(key);
-            }
+            let key = FutexKey {
+                ptr: 0,
+                word: 0,
+                offset: offset as u32,
+                key: InnerFutexKey::Shared(shared),
+            };
+            return Ok(key);
         }
     }
 

--- a/kernel/src/mm/fault.rs
+++ b/kernel/src/mm/fault.rs
@@ -604,57 +604,23 @@ impl PageFaultHandler {
     /// ## 返回值
     /// - VmFaultReason: 页面错误处理信息标志
     pub unsafe fn do_anonymous_page(pfm: &mut PageFaultMessage) -> VmFaultReason {
-        if crate::mm::oom::should_inject_fault_oom() {
-            return VmFaultReason::VM_FAULT_OOM | VmFaultReason::VM_FAULT_OOM_INJECTED;
-        }
         let address = pfm.address_aligned_down();
         let vm_flags = pfm.vm_flags();
-        let backing_pgoff = pfm.backing_pgoff();
         let vma = pfm.vma.clone();
-        let mm = pfm.mm().clone();
-        let _pt_edit = mm.page_table_edit();
-        let mapper = &mut pfm.mapper;
 
         // Shared anonymous mappings must always use their shared backing. A
         // missing backing is a malformed shared VMA, not a private fallback.
         if vm_flags.contains(VmFlags::VM_SHARED) {
-            let (shared, flags, mlocked) = {
-                let guard = vma.lock();
-                (
-                    guard.shared_anon.clone(),
-                    guard.flags(),
-                    guard.vm_flags().contains(VmFlags::VM_LOCKED),
-                )
-            };
-            let Some(shared) = shared else {
-                return VmFaultReason::VM_FAULT_SIGBUS;
-            };
-            let Some(pgoff) = backing_pgoff else {
-                return VmFaultReason::VM_FAULT_SIGBUS;
-            };
-
-            // Linux semantics: access beyond the backing size should SIGBUS.
-            if pgoff >= shared.size_pages() {
-                return VmFaultReason::VM_FAULT_SIGBUS;
-            }
-
-            // Atomically get or create the shared page to avoid races.
-            let page = match shared.get_or_create_page(pgoff) {
-                Ok(p) => p,
-                Err(_) => return VmFaultReason::VM_FAULT_OOM,
-            };
-
-            if let Some(flush) = mapper.map_phys(address, page.phys_address(), flags) {
-                flush.flush();
-                Self::account_new_present_mapping(pfm.mm());
-                Self::attach_fault_mapped_page(&page, &vma, mlocked);
-                return VmFaultReason::VM_FAULT_COMPLETED;
-            } else {
-                return VmFaultReason::VM_FAULT_OOM;
-            }
+            return Self::shared_anon_fault(pfm);
         }
 
         // Private anonymous page.
+        if crate::mm::oom::should_inject_fault_oom() {
+            return VmFaultReason::VM_FAULT_OOM | VmFaultReason::VM_FAULT_OOM_INJECTED;
+        }
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
+        let mapper = &mut pfm.mapper;
         let (flags, mlocked) = {
             let guard = vma.lock();
             (guard.flags(), guard.vm_flags().contains(VmFlags::VM_LOCKED))
@@ -675,6 +641,90 @@ impl PageFaultHandler {
         } else {
             VmFaultReason::VM_FAULT_OOM
         }
+    }
+
+    /// Fault one page from a VMA's shared-anonymous backing.
+    pub unsafe fn shared_anon_fault(pfm: &mut PageFaultMessage) -> VmFaultReason {
+        if crate::mm::oom::should_inject_fault_oom() {
+            return VmFaultReason::VM_FAULT_OOM | VmFaultReason::VM_FAULT_OOM_INJECTED;
+        }
+        let address = pfm.address_aligned_down();
+        let pgoff = match pfm.backing_pgoff() {
+            Some(pgoff) => pgoff,
+            None => return VmFaultReason::VM_FAULT_SIGBUS,
+        };
+        let vma = pfm.vma();
+        let (shared, flags, mlocked) = {
+            let guard = vma.lock();
+            (
+                guard.shared_anon.clone(),
+                guard.flags(),
+                guard.vm_flags().contains(VmFlags::VM_LOCKED),
+            )
+        };
+        let Some(shared) = shared else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        if pgoff >= shared.size_pages() {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        }
+        let page = match shared.get_or_create_page(pgoff) {
+            Ok(page) => page,
+            Err(_) => return VmFaultReason::VM_FAULT_OOM,
+        };
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
+        if let Some(flush) = pfm.mapper.map_phys(address, page.phys_address(), flags) {
+            flush.flush();
+            Self::account_new_present_mapping(&mm);
+            Self::attach_fault_mapped_page(&page, &vma, mlocked);
+            VmFaultReason::VM_FAULT_COMPLETED
+        } else {
+            VmFaultReason::VM_FAULT_OOM
+        }
+    }
+
+    /// Map resident neighbours from a shared-anonymous backing without
+    /// allocating cold pages.
+    pub unsafe fn shared_anon_map_pages(
+        pfm: &mut PageFaultMessage,
+        start_pgoff: usize,
+        end_pgoff: usize,
+    ) -> VmFaultReason {
+        let vma = pfm.vma();
+        let (shared, base_pgoff, base, flags, mlocked) = {
+            let guard = vma.lock();
+            (
+                guard.shared_anon.clone(),
+                guard.backing_page_offset(),
+                guard.region().start(),
+                guard.flags(),
+                guard.vm_flags().contains(VmFlags::VM_LOCKED),
+            )
+        };
+        let (Some(shared), Some(base_pgoff)) = (shared, base_pgoff) else {
+            return VmFaultReason::VM_FAULT_SIGBUS;
+        };
+        let mm = pfm.mm().clone();
+        let _pt_edit = mm.page_table_edit();
+        for pgoff in start_pgoff..end_pgoff {
+            if pgoff < base_pgoff || pgoff >= shared.size_pages() {
+                continue;
+            }
+            let addr = VirtAddr::new(base.data() + ((pgoff - base_pgoff) << MMArch::PAGE_SHIFT));
+            if pfm.mapper.get_entry(addr, 0).is_some() {
+                continue;
+            }
+            let Some(page) = shared.lookup_page(pgoff) else {
+                continue;
+            };
+            if let Some(flush) = pfm.mapper.map_phys(addr, page.phys_address(), flags) {
+                flush.flush();
+                Self::account_new_present_mapping(&mm);
+                Self::attach_fault_mapped_page(&page, &vma, mlocked);
+            }
+        }
+        VmFaultReason::empty()
     }
 
     /// 处理文件映射页的缺页异常

--- a/kernel/src/mm/mincore.rs
+++ b/kernel/src/mm/mincore.rs
@@ -88,6 +88,12 @@ impl LockedVMA {
             let guard = self.lock();
             let pgoff = ((start_addr.data() - guard.region().start().data()) >> MMArch::PAGE_SHIFT)
                 + guard.backing_page_offset().unwrap();
+            if let Some(shared) = guard.shared_anon.as_ref() {
+                for i in 0..nr {
+                    vec[vec_offset + i] = u8::from(shared.lookup_page(pgoff + i).is_some());
+                }
+                return nr;
+            }
             if guard.vm_file().is_none() {
                 vec[vec_offset..vec_offset + nr].fill(0);
                 return nr;

--- a/kernel/src/mm/syscall/sys_msync.rs
+++ b/kernel/src/mm/syscall/sys_msync.rs
@@ -69,7 +69,7 @@ impl Syscall for SysMsyncHandle {
         loop {
             if let Some(vma) = next_vma.clone() {
                 // 读取VMA信息，确保在调用find_nearest前释放锁
-                let (vm_start, vm_end, vm_flags, file, backing_pgoff);
+                let (vm_start, vm_end, vm_flags, file, backing_pgoff, has_shared_anon);
                 {
                     let guard = vma.lock();
                     vm_start = guard.region().start().data();
@@ -77,6 +77,7 @@ impl Syscall for SysMsyncHandle {
                     vm_flags = *guard.vm_flags();
                     file = guard.vm_file();
                     backing_pgoff = guard.backing_page_offset();
+                    has_shared_anon = guard.shared_anon.is_some();
 
                     if start < vm_start {
                         if flags == MsFlags::MS_ASYNC {
@@ -101,7 +102,10 @@ impl Syscall for SysMsyncHandle {
                 let sync_end = end.min(vm_end);
                 start = vm_end;
 
-                if flags.contains(MsFlags::MS_SYNC) && vm_flags.contains(VmFlags::VM_SHARED) {
+                if flags.contains(MsFlags::MS_SYNC)
+                    && vm_flags.contains(VmFlags::VM_SHARED)
+                    && !has_shared_anon
+                {
                     if let Some(file) = file {
                         if sync_start < sync_end {
                             let file_start = backing_pgoff

--- a/kernel/src/mm/ucontext/address_space.rs
+++ b/kernel/src/mm/ucontext/address_space.rs
@@ -759,6 +759,7 @@ impl AddressSpace {
         let may_write =
             !map_flags.contains(MapFlags::MAP_SHARED) || file_mode.contains(FileMode::FMODE_WRITE);
         let vma_file = file.inode().mmap_effective_file(&file)?;
+        let mut shared_anon = None;
 
         loop {
             let mut guard = self.write();
@@ -838,6 +839,9 @@ impl AddressSpace {
                 Ok(flags) => flags,
                 Err(err) => map_fail!(err),
             };
+            if vma_file.inode().mmap_uses_shared_anon(vm_flags) && shared_anon.is_none() {
+                shared_anon = Some(AnonSharedMapping::new(page_count.data()));
+            }
 
             if vm_flags.contains(VmFlags::VM_LOCKED) {
                 let error = if map_flags.contains(MapFlags::MAP_LOCKED)
@@ -913,6 +917,9 @@ impl AddressSpace {
                 ));
                 if let Some(sysv_shm) = sysv_shm.clone() {
                     vma.lock().set_sysv_shm(Some(sysv_shm));
+                }
+                if let Some(shared_anon) = shared_anon.clone() {
+                    vma.lock().shared_anon = Some(shared_anon);
                 }
                 Some(vma)
             } else {
@@ -994,6 +1001,9 @@ impl AddressSpace {
                     Ok(vma) => {
                         if let Some(sysv_shm) = sysv_shm.clone() {
                             vma.lock().set_sysv_shm(Some(sysv_shm));
+                        }
+                        if let Some(shared_anon) = shared_anon.clone() {
+                            vma.lock().shared_anon = Some(shared_anon);
                         }
                         vma
                     }

--- a/kernel/src/mm/ucontext/vma.rs
+++ b/kernel/src/mm/ucontext/vma.rs
@@ -665,8 +665,8 @@ pub struct AnonSharedMapping {
     /// Linux semantics: mremap() expanding a MAP_SHARED|MAP_ANONYMOUS mapping does not grow the
     /// underlying shmem object; access beyond this size should SIGBUS.
     size_pages: usize,
-    // Per-page cache keyed by page index within the backing object; store physical address.
-    pages: SpinLock<HashMap<usize, PhysAddr>>,
+    // Per-page cache keyed by page index within the backing object.
+    pages: SpinLock<HashMap<usize, Arc<Page>>>,
 }
 
 impl AnonSharedMapping {
@@ -691,39 +691,60 @@ impl AnonSharedMapping {
     /// Get or create a shared page for the given offset atomically.
     /// This prevents the double-allocation race when multiple processes fault the same page.
     pub fn get_or_create_page(&self, pgoff: usize) -> Result<Arc<Page>, SystemError> {
-        let mut guard = self.pages.lock_irqsave();
-        if let Some(paddr) = guard.get(&pgoff).copied() {
-            let mut pm = page_manager_lock();
-            return Ok(pm.get_unwrap(&paddr));
+        if let Some(page) = self.lookup_page(pgoff) {
+            return Ok(page);
         }
 
-        // Allocate while holding the map lock to avoid duplicate creations.
+        // Page allocation may sleep, so it must not run under the backing's
+        // irqsave spinlock. Publish under the spinlock afterwards; a racing
+        // loser discards its still-unmapped candidate.
         let mut pm = page_manager_lock();
         let mut allocator = LockedFrameAllocator;
-        let page = pm.create_one_page(PageType::Normal, PageFlags::empty(), &mut allocator)?;
-        page.write().add_backing_lifetime_pin();
-        guard.insert(pgoff, page.phys_address());
-        Ok(page)
+        let candidate = pm.create_one_page(PageType::Normal, PageFlags::empty(), &mut allocator)?;
+        candidate.write().add_backing_lifetime_pin();
+        drop(pm);
+
+        let existing = {
+            let mut guard = self.pages.lock_irqsave();
+            if let Some(existing) = guard.get(&pgoff) {
+                Some(existing.clone())
+            } else {
+                guard.insert(pgoff, candidate.clone());
+                None
+            }
+        };
+        if let Some(existing) = existing {
+            candidate.write().remove_backing_lifetime_pin();
+            page_manager_lock().remove_page(&candidate.phys_address());
+            Ok(existing)
+        } else {
+            Ok(candidate)
+        }
+    }
+
+    /// Look up an already instantiated backing page without allocating it.
+    pub fn lookup_page(&self, pgoff: usize) -> Option<Arc<Page>> {
+        let guard = self.pages.lock_irqsave();
+        guard.get(&pgoff).cloned()
     }
 }
 
 impl Drop for AnonSharedMapping {
     fn drop(&mut self) {
         // When the backing object is destroyed, allow cached pages to be freed.
-        let pages: alloc::vec::Vec<PhysAddr> = {
+        let pages: alloc::vec::Vec<Arc<Page>> = {
             let guard = self.pages.lock_irqsave();
-            guard.values().copied().collect()
+            guard.values().cloned().collect()
         };
 
         let mut pm = page_manager_lock();
-        for paddr in pages {
-            if let Some(page) = pm.get(&paddr) {
-                let mut pg = page.write();
-                pg.remove_backing_lifetime_pin();
-                if pg.can_deallocate() {
-                    drop(pg);
-                    pm.remove_page(&paddr);
-                }
+        for page in pages {
+            let paddr = page.phys_address();
+            let mut pg = page.write();
+            pg.remove_backing_lifetime_pin();
+            if pg.can_deallocate() {
+                drop(pg);
+                pm.remove_page(&paddr);
             }
         }
     }

--- a/kernel/src/mm/ucontext/vma.rs
+++ b/kernel/src/mm/ucontext/vma.rs
@@ -696,30 +696,20 @@ impl AnonSharedMapping {
         }
 
         // Page allocation may sleep, so it must not run under the backing's
-        // irqsave spinlock. Publish under the spinlock afterwards; a racing
-        // loser discards its still-unmapped candidate.
+        // irqsave spinlock. Keep the existing PageManager mutex until the
+        // candidate is published, and recheck after acquiring it: this closes
+        // the allocate-before-publish window without adding another sleeping
+        // lock or per-index in-flight state.
         let mut pm = page_manager_lock();
+        if let Some(page) = self.lookup_page(pgoff) {
+            return Ok(page);
+        }
+
         let mut allocator = LockedFrameAllocator;
         let candidate = pm.create_one_page(PageType::Normal, PageFlags::empty(), &mut allocator)?;
         candidate.write().add_backing_lifetime_pin();
-        drop(pm);
-
-        let existing = {
-            let mut guard = self.pages.lock_irqsave();
-            if let Some(existing) = guard.get(&pgoff) {
-                Some(existing.clone())
-            } else {
-                guard.insert(pgoff, candidate.clone());
-                None
-            }
-        };
-        if let Some(existing) = existing {
-            candidate.write().remove_backing_lifetime_pin();
-            page_manager_lock().remove_page(&candidate.phys_address());
-            Ok(existing)
-        } else {
-            Ok(candidate)
-        }
+        self.pages.lock_irqsave().insert(pgoff, candidate.clone());
+        Ok(candidate)
     }
 
     /// Look up an already instantiated backing page without allocating it.

--- a/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/devtmpfs_semantics.cc
@@ -2,12 +2,16 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <linux/futex.h>
+#include <sched.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/mount.h>
 #include <sys/mman.h>
 #include <sys/stat.h>
 #include <sys/statfs.h>
+#include <sys/wait.h>
 #include <sys/syscall.h>
 #include <sys/sysmacros.h>
 #include <unistd.h>
@@ -214,6 +218,158 @@ TEST(DevtmpfsSemantics, PrivateZeroMmapPreservesPagesAcrossFaultAroundWindows) {
         EXPECT_EQ(static_cast<unsigned char>(0xa0 + page), populated[page * kPageSize]);
     }
     EXPECT_EQ(0, munmap(const_cast<unsigned char*>(populated), kLength));
+    EXPECT_EQ(0, close(fd));
+}
+
+TEST(DevtmpfsSemantics, SharedZeroLazyFaultsRemainSharedAcrossFork) {
+    constexpr size_t kPageSize = 4096;
+    int fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    auto* mapping = static_cast<volatile unsigned char*>(
+        mmap(nullptr, 2 * kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    ASSERT_NE(MAP_FAILED, const_cast<unsigned char*>(mapping)) << strerror(errno);
+
+    int parent_to_child[2];
+    int child_to_parent[2];
+    ASSERT_EQ(0, pipe(parent_to_child)) << strerror(errno);
+    ASSERT_EQ(0, pipe(child_to_parent)) << strerror(errno);
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        close(parent_to_child[1]);
+        close(child_to_parent[0]);
+        unsigned char token = 0;
+        if (read(parent_to_child[0], &token, 1) != 1 || mapping[0] != 0x31) {
+            _exit(1);
+        }
+        mapping[kPageSize] = 0x52;
+        token = 1;
+        if (write(child_to_parent[1], &token, 1) != 1) {
+            _exit(2);
+        }
+        _exit(0);
+    }
+
+    close(parent_to_child[0]);
+    close(child_to_parent[1]);
+    mapping[0] = 0x31;
+    unsigned char token = 1;
+    ASSERT_EQ(1, write(parent_to_child[1], &token, 1));
+    ASSERT_EQ(1, read(child_to_parent[0], &token, 1));
+
+    // The child instantiated page 1. It must be resident in the common
+    // backing even though this VMA does not yet have a PTE for it.
+    unsigned char residency[2] = {};
+    ASSERT_EQ(0, mincore(const_cast<unsigned char*>(mapping), 2 * kPageSize, residency))
+        << strerror(errno);
+    EXPECT_NE(0, residency[1] & 1);
+    EXPECT_EQ(0x52, mapping[kPageSize]);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    EXPECT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    EXPECT_EQ(0, close(parent_to_child[1]));
+    EXPECT_EQ(0, close(child_to_parent[0]));
+    EXPECT_EQ(0, munmap(const_cast<unsigned char*>(mapping), 2 * kPageSize));
+    EXPECT_EQ(0, close(fd));
+}
+
+TEST(DevtmpfsSemantics, SharedZeroMappingsHavePerMmapIdentity) {
+    constexpr size_t kPageSize = 4096;
+    int first_fd = open("/dev/zero", O_RDWR);
+    int second_fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(first_fd, 0) << strerror(errno);
+    ASSERT_GE(second_fd, 0) << strerror(errno);
+    auto* first = static_cast<unsigned char*>(
+        mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, first_fd, 0));
+    auto* same_fd = static_cast<unsigned char*>(
+        mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, first_fd, 0));
+    auto* other_fd = static_cast<unsigned char*>(
+        mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, second_fd, 0));
+    ASSERT_NE(MAP_FAILED, first) << strerror(errno);
+    ASSERT_NE(MAP_FAILED, same_fd) << strerror(errno);
+    ASSERT_NE(MAP_FAILED, other_fd) << strerror(errno);
+
+    first[0] = 0xa5;
+    EXPECT_EQ(0, same_fd[0]);
+    EXPECT_EQ(0, other_fd[0]);
+    EXPECT_EQ(0, msync(first, kPageSize, MS_SYNC)) << strerror(errno);
+    EXPECT_EQ(0, msync(first, kPageSize, MS_ASYNC)) << strerror(errno);
+
+    EXPECT_EQ(0, munmap(first, kPageSize));
+    EXPECT_EQ(0, munmap(same_fd, kPageSize));
+    EXPECT_EQ(0, munmap(other_fd, kPageSize));
+    EXPECT_EQ(0, close(first_fd));
+    EXPECT_EQ(0, close(second_fd));
+}
+
+TEST(DevtmpfsSemantics, SharedZeroUsesBackingIdentityForFutex) {
+    constexpr size_t kPageSize = 4096;
+    int fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    auto* futex_word = static_cast<int*>(
+        mmap(nullptr, kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    ASSERT_NE(MAP_FAILED, futex_word) << strerror(errno);
+    *futex_word = 0;
+
+    int ready[2];
+    ASSERT_EQ(0, pipe(ready)) << strerror(errno);
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << strerror(errno);
+    if (child == 0) {
+        close(ready[0]);
+        unsigned char token = 1;
+        if (write(ready[1], &token, 1) != 1) {
+            _exit(1);
+        }
+        int ret = syscall(SYS_futex, futex_word, FUTEX_WAIT, 0, nullptr, nullptr, 0);
+        _exit(ret == 0 ? 0 : 2);
+    }
+
+    close(ready[1]);
+    unsigned char token = 0;
+    ASSERT_EQ(1, read(ready[0], &token, 1));
+    int wake_count = 0;
+    for (int attempt = 0; attempt < 10000 && wake_count == 0; ++attempt) {
+        wake_count = syscall(SYS_futex, futex_word, FUTEX_WAKE, 1, nullptr, nullptr, 0);
+        if (wake_count == 0) {
+            sched_yield();
+        }
+    }
+    if (wake_count != 1) {
+        kill(child, SIGKILL);
+    }
+    EXPECT_EQ(1, wake_count);
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0)) << strerror(errno);
+    EXPECT_TRUE(WIFEXITED(status));
+    if (WIFEXITED(status)) {
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+    EXPECT_EQ(0, close(ready[0]));
+    EXPECT_EQ(0, munmap(futex_word, kPageSize));
+    EXPECT_EQ(0, close(fd));
+}
+
+TEST(DevtmpfsSemantics, SharedZeroFaultAroundDoesNotAllocateColdPages) {
+    constexpr size_t kPageSize = 4096;
+    constexpr size_t kPages = 33;
+    int fd = open("/dev/zero", O_RDWR);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    auto* mapping = static_cast<volatile unsigned char*>(
+        mmap(nullptr, kPages * kPageSize, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0));
+    ASSERT_NE(MAP_FAILED, const_cast<unsigned char*>(mapping)) << strerror(errno);
+
+    EXPECT_EQ(0, mapping[16 * kPageSize]);
+    unsigned char residency[kPages] = {};
+    ASSERT_EQ(0, mincore(const_cast<unsigned char*>(mapping), kPages * kPageSize, residency))
+        << strerror(errno);
+    for (size_t page = 0; page < kPages; ++page) {
+        EXPECT_EQ(page == 16, (residency[page] & 1) != 0) << "page=" << page;
+    }
+
+    EXPECT_EQ(0, munmap(const_cast<unsigned char*>(mapping), kPages * kPageSize));
     EXPECT_EQ(0, close(fd));
 }
 


### PR DESCRIPTION
## Summary

- create an independent anonymous shared backing for each `MAP_SHARED` `/dev/zero` mapping and preserve it across fork and derived VMAs
- route page faults and fault-around through the backing with race-safe two-phase page publication
- make futex, mincore, and msync consistently recognize hybrid file/shared-anonymous VMAs
- add regression coverage for lazy faults, per-mmap isolation, futex wakeups, residency, msync, and sparse fault-around behavior

## Root cause

The `/dev/zero` fault path allocated pages directly in each address space. Shared PTEs that already existed at fork time were inherited, but pages first faulted independently after fork had no common backing identity and therefore diverged.

## Design

Reuse the existing `AnonSharedMapping` backing rather than adding an inode-global page cache or a new shmem subsystem. Each mmap call receives its own backing, while fork, split, and remap-derived VMAs retain the same identity. Neighbor fault-around only maps pages that already exist in the backing, preserving sparse allocation.

## Validation

- `make kernel`
- Rust formatting check and `git diff --check`
- DragonOS `devtmpfs_semantics_test`: 12/12 passed
- DragonOS `page_fault_accounting_test`: 4/4 passed
- DragonOS `mlock_semantics_test`: 16 passed, 1 environment-dependent skip
- gVisor `MMapTest.MapDevZero*`: 7/7 passed

Fixes #2181