### PR TITLE
fix(ext4): implement atomic symbolic link creation

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -1594,23 +1594,33 @@ impl Ext4 {
         Ok(root)
     }
 
-    /// Free an allocated inode and all data blocks allocated for it
+    /// Roll back an allocated inode that has not been published in a directory.
+    ///
+    /// The validated in-memory extent tree is authoritative here: an inode
+    /// write may fail after the tree was updated but before `i_blocks` was
+    /// recomputed, so the transient on-disk count is not a rollback precondition.
     pub(super) fn free_inode(&self, inode: &mut InodeRef) -> Result<()> {
         let inode_id = inode.id;
-        // Free the data blocks allocated for the inode
-        let pblocks = self.extent_all_data_blocks(inode)?;
-        for pblock in pblocks {
-            self.dealloc_block(inode, pblock)?;
-        }
-        // Free extent tree
-        let pblocks = self.extent_all_tree_blocks(inode)?;
-        for pblock in pblocks {
-            self.dealloc_block(inode, pblock)?;
+        if inode.inode.uses_extents() {
+            let data_blocks = self.extent_all_data_blocks(inode)?;
+            let tree_blocks = self.extent_all_tree_blocks(inode)?;
+            for pblock in data_blocks {
+                self.dealloc_block(inode, pblock)?;
+            }
+            for pblock in tree_blocks {
+                self.dealloc_block(inode, pblock)?;
+            }
+            // dealloc_block updates allocation metadata, not the in-memory
+            // inode that is about to be released.
+            inode.inode.set_fs_block_count(0);
+        } else if inode.inode.fs_block_count() != 0 {
+            return_error!(ErrCode::EIO, "Inline inode owns unexplained blocks");
         }
         // Free xattr block
         let xattr_block = inode.inode.xattr_block();
         if xattr_block != 0 {
             self.dealloc_block(inode, xattr_block)?;
+            inode.inode.set_xattr_block(0);
         }
         // Deallocate the inode
         self.dealloc_inode(inode)?;

--- a/kernel/crates/another_ext4/src/ext4/link.rs
+++ b/kernel/crates/another_ext4/src/ext4/link.rs
@@ -3,6 +3,19 @@ use super::Ext4;
 use crate::ext4_defs::*;
 use crate::prelude::*;
 
+pub(super) enum LinkFailure {
+    Unmodified(Ext4Error),
+    Indeterminate(Ext4Error),
+}
+
+impl LinkFailure {
+    pub(super) fn into_error(self) -> Ext4Error {
+        match self {
+            Self::Unmodified(error) | Self::Indeterminate(error) => error,
+        }
+    }
+}
+
 /// Whether removing one published namespace entry makes the inode an orphan.
 /// Directories cannot have hard-link aliases: once rmdir/rename has verified
 /// that the directory is empty, Linux clears even an unexpectedly high nlink.
@@ -19,35 +32,55 @@ impl Ext4 {
         name: &str,
         allow_orphan_relink: bool,
     ) -> Result<()> {
-        self.ensure_mutable()?;
+        self.link_inode_classified(parent, child, name, allow_orphan_relink)
+            .map_err(LinkFailure::into_error)
+    }
+
+    pub(super) fn link_inode_classified(
+        &self,
+        parent: &mut InodeRef,
+        child: &mut InodeRef,
+        name: &str,
+        allow_orphan_relink: bool,
+    ) -> core::result::Result<(), LinkFailure> {
+        self.ensure_mutable().map_err(LinkFailure::Unmodified)?;
         let child_link_count = child.inode.link_count();
         let parent_link_count = parent.inode.link_count();
         if child_link_count == 0 && allow_orphan_relink {
-            if self.legacy_orphan_membership(child)?
+            if self
+                .legacy_orphan_membership(child)
+                .map_err(LinkFailure::Unmodified)?
                 != super::orphan::LegacyOrphanMembership::ZeroLink
             {
-                return Err(Ext4Error::new(ErrCode::EINVAL));
+                return Err(LinkFailure::Unmodified(Ext4Error::new(ErrCode::EINVAL)));
             }
             if child.inode.is_dir() {
-                return Err(Ext4Error::new(ErrCode::EPERM));
+                return Err(LinkFailure::Unmodified(Ext4Error::new(ErrCode::EPERM)));
             }
-            if !self.dir_has_insert_space(parent, child, name)? {
-                self.prepare_empty_dir_slot(parent)?;
+            if !self
+                .dir_has_insert_space(parent, child, name)
+                .map_err(LinkFailure::Unmodified)?
+            {
+                self.prepare_empty_dir_slot(parent)
+                    .map_err(LinkFailure::Indeterminate)?;
             }
             // A zero-link inode is discoverable through the durable orphan
             // chain.  Linux removes it from that chain in the same handle that
             // publishes the new name and link count; otherwise a crash could
             // reclaim a newly reachable inode.
-            let mut transaction = self.transaction_start(3)?;
+            let mut transaction = self.transaction_start(3).map_err(LinkFailure::Unmodified)?;
             let mut sb = self.read_super_block_cached();
-            self.transaction_orphan_del(&mut transaction, child, &mut sb)?;
-            self.transaction_dir_add_existing(&mut transaction, parent, child, name)?;
+            self.transaction_orphan_del(&mut transaction, child, &mut sb)
+                .map_err(LinkFailure::Unmodified)?;
+            self.transaction_dir_add_existing(&mut transaction, parent, child, name)
+                .map_err(LinkFailure::Unmodified)?;
             child.inode.set_link_count(1);
             child.inode.set_next_orphan(0);
-            self.transaction_stage_inode_with_csum(&mut transaction, child)?;
+            self.transaction_stage_inode_with_csum(&mut transaction, child)
+                .map_err(LinkFailure::Unmodified)?;
             if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
                 self.poison(ErrCode::EIO);
-                return Err(error.error);
+                return Err(LinkFailure::Indeterminate(error.error));
             }
             return Ok(());
         }
@@ -55,25 +88,50 @@ impl Ext4 {
             // Prepare all inode metadata before publishing parent/name.  A
             // failure before the final dir_add_entry cannot leave a namespace
             // entry pointing at an inode that cleanup may release.
-            self.dir_add_entry(child, parent, "..")?;
+            match self.dir_add_entry_classified(child, parent, "..") {
+                Ok(()) => {}
+                Err(super::dir::DirAddFailure::Unmodified(error)) => {
+                    return Err(LinkFailure::Unmodified(error));
+                }
+                Err(super::dir::DirAddFailure::Indeterminate(error)) => {
+                    self.poison(ErrCode::EIO);
+                    return Err(LinkFailure::Indeterminate(error));
+                }
+            }
             parent.inode.set_link_count(parent_link_count + 1);
-            self.write_inode_with_csum(parent)?;
+            if let Err(error) = self.write_inode_with_csum(parent) {
+                self.poison(ErrCode::EIO);
+                return Err(LinkFailure::Indeterminate(error));
+            }
         }
         child.inode.set_link_count(child_link_count + 1);
-        self.write_inode_with_csum(child)?;
-        if let Err(error) = self.dir_add_entry(parent, child, name) {
-            child.inode.set_link_count(child_link_count);
-            let mut rollback_ok = self.write_inode_with_csum(child).is_ok();
+        if let Err(error) = self.write_inode_with_csum(child) {
             if child.inode.is_dir() {
-                parent.inode.set_link_count(parent_link_count);
-                rollback_ok &= self.write_inode_with_csum(parent).is_ok();
-            }
-            if !rollback_ok {
                 self.poison(ErrCode::EIO);
+                return Err(LinkFailure::Indeterminate(error));
             }
-            return Err(error);
+            return Err(LinkFailure::Unmodified(error));
         }
-        Ok(())
+        match self.dir_add_entry_classified(parent, child, name) {
+            Ok(()) => Ok(()),
+            Err(super::dir::DirAddFailure::Indeterminate(error)) => {
+                self.poison(ErrCode::EIO);
+                Err(LinkFailure::Indeterminate(error))
+            }
+            Err(super::dir::DirAddFailure::Unmodified(error)) => {
+                child.inode.set_link_count(child_link_count);
+                let mut rollback_ok = self.write_inode_with_csum(child).is_ok();
+                if child.inode.is_dir() {
+                    parent.inode.set_link_count(parent_link_count);
+                    rollback_ok &= self.write_inode_with_csum(parent).is_ok();
+                }
+                if !rollback_ok {
+                    self.poison(ErrCode::EIO);
+                    return Err(LinkFailure::Indeterminate(error));
+                }
+                Err(LinkFailure::Unmodified(error))
+            }
+        }
     }
 
     /// Unlink a child inode from a parent directory.

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -2944,20 +2944,27 @@ impl Ext4 {
         child: &mut InodeRef,
         name: &str,
     ) -> Result<()> {
-        if let Err(link_err) = self.link_inode(parent, child, name, false) {
-            if let Err(cleanup_err) = self.free_inode(child) {
-                trace!(
-                    "link failed for new inode {} (name {}), cleanup failed: {:?}; original link error: {:?}",
-                    child.id,
-                    name,
-                    cleanup_err,
-                    link_err
-                );
-                return Err(cleanup_err);
+        match self.link_inode_classified(parent, child, name, false) {
+            Ok(()) => Ok(()),
+            Err(super::link::LinkFailure::Indeterminate(link_err)) => {
+                self.poison(ErrCode::EIO);
+                Err(link_err)
             }
-            return Err(link_err);
+            Err(super::link::LinkFailure::Unmodified(link_err)) => {
+                if let Err(cleanup_err) = self.free_inode(child) {
+                    trace!(
+                        "link failed for new inode {} (name {}), cleanup failed: {:?}; original link error: {:?}",
+                        child.id,
+                        name,
+                        cleanup_err,
+                        link_err
+                    );
+                    self.poison(ErrCode::EIO);
+                    return Err(cleanup_err);
+                }
+                Err(link_err)
+            }
         }
-        Ok(())
     }
 
     /// Create a file. This function will not check the existence of
@@ -3014,6 +3021,60 @@ impl Ext4 {
         }
         // Create child inode and link it to parent directory
         let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
+        self.link_new_inode_or_free(&mut parent, &mut child, name)?;
+        Ok(Self::file_attr(&child))
+    }
+
+    /// Create a symbolic link whose target is initialized before its name is
+    /// published in the parent directory.
+    pub fn symlink_with_owner_and_attr(
+        &self,
+        parent: InodeId,
+        name: &str,
+        target: &str,
+        owner: InodeOwner,
+    ) -> Result<FileAttr> {
+        self.ensure_mutable()?;
+        if target.is_empty() {
+            return_error!(ErrCode::ENOENT, "Symbolic link target is empty");
+        }
+        if target.len() >= PATH_MAX {
+            return_error!(ErrCode::ENAMETOOLONG, "Symbolic link target is too long");
+        }
+
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _namespace_guard = self.namespace_lock.lock();
+        let _mutation_guards = self.lock_inode_mutations(&[parent]);
+        let mut parent = self.read_inode(parent)?;
+        if !parent.inode.is_dir() {
+            return_error!(ErrCode::ENOTDIR, "Inode {} is not a directory", parent.id);
+        }
+
+        let mode = InodeMode::SOFTLINK | InodeMode::ALL_RWX;
+        let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
+        let initialized = if target.len() + 1 <= child.inode.inline_block().len() {
+            child
+                .inode
+                .set_fast_symlink(target.as_bytes())
+                .and_then(|_| self.write_inode_with_csum(&mut child))
+        } else {
+            let mut image = Box::new([0; BLOCK_SIZE]);
+            image[..target.len()].copy_from_slice(target.as_bytes());
+            self.extent_query_or_create_initialized(&mut child, 0, 1, Some(image))
+                .and_then(|_| self.recompute_inode_block_count(&mut child))
+                .and_then(|_| {
+                    child.inode.set_size(target.len() as u64);
+                    self.write_inode_with_csum(&mut child)
+                })
+        };
+        if let Err(init_error) = initialized {
+            if let Err(cleanup_error) = self.free_inode(&mut child) {
+                self.poison(ErrCode::EIO);
+                return Err(cleanup_error);
+            }
+            return Err(init_error);
+        }
+
         self.link_new_inode_or_free(&mut parent, &mut child, name)?;
         Ok(Self::file_attr(&child))
     }
@@ -5033,6 +5094,7 @@ mod tests {
                 BASE_OFFSET + 12,
                 TEST_INITIAL_FREE_BLOCKS as u32,
             );
+            Self::write_u32(&mut sb_block, BASE_OFFSET + 16, 15);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 20, 0);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 24, 2);
             Self::write_u32(&mut sb_block, BASE_OFFSET + 28, 2);
@@ -5050,11 +5112,16 @@ mod tests {
             Self::write_u32(&mut bgdt, 4, TEST_INODE_BITMAP as u32);
             Self::write_u32(&mut bgdt, 8, TEST_INODE_TABLE as u32);
             Self::write_u16(&mut bgdt, 12, TEST_INITIAL_FREE_BLOCKS as u16);
+            Self::write_u16(&mut bgdt, 14, 15);
             blocks.insert(1, bgdt);
 
             let mut bitmap = blocks.remove(&TEST_BLOCK_BITMAP).unwrap();
             bitmap.data[0] = 0b0001_1111;
             blocks.insert(TEST_BLOCK_BITMAP, bitmap);
+
+            let mut inode_bitmap = blocks.remove(&TEST_INODE_BITMAP).unwrap();
+            inode_bitmap.data[0] = 0b0000_0010;
+            blocks.insert(TEST_INODE_BITMAP, inode_bitmap);
 
             let mut inode_table = blocks.remove(&TEST_INODE_TABLE).unwrap();
             let mut inode = Inode::default();
@@ -5362,6 +5429,48 @@ mod tests {
         assert_eq!(err.code(), ErrCode::EIO);
         assert_allocation_state(&fs, &block_device, false, TEST_INITIAL_FREE_BLOCKS);
         assert!(!block_device.block_is_zero(TEST_XATTR_BLOCK));
+    }
+
+    #[test]
+    fn unpublished_extent_rollback_uses_the_tree_before_i_blocks_is_recomputed() {
+        let (block_device, fs) = load_failing_test_fs();
+        let initial_sb_free_inodes = fs.read_super_block_cached().free_inodes_count();
+        let initial_bg_free_inodes = fs.read_block_group(0).unwrap().desc.free_inodes_count();
+        let mut inode = fs
+            .create_inode_with_owner(
+                InodeMode::SOFTLINK | InodeMode::ALL_RWX,
+                0,
+                0,
+            )
+            .unwrap();
+        assert!(fs.inode_is_allocated(inode.id).unwrap());
+        block_device.fail_once_on_write(TEST_INODE_TABLE);
+
+        let err = fs
+            .extent_query_or_create_initialized(
+                &mut inode,
+                0,
+                1,
+                Some(Box::new([0x5a; BLOCK_SIZE])),
+            )
+            .unwrap_err();
+
+        assert_eq!(err.code(), ErrCode::EIO);
+        assert_eq!(inode.inode.fs_block_count(), 0);
+        assert_eq!(fs.extent_all_data_blocks(&inode).unwrap(), vec![TEST_XATTR_BLOCK]);
+        assert_allocation_state(&fs, &block_device, true, TEST_INITIAL_FREE_BLOCKS - 1);
+
+        fs.free_inode(&mut inode).unwrap();
+        assert_allocation_state(&fs, &block_device, false, TEST_INITIAL_FREE_BLOCKS);
+        assert!(!fs.inode_is_allocated(inode.id).unwrap());
+        assert_eq!(
+            fs.read_super_block_cached().free_inodes_count(),
+            initial_sb_free_inodes
+        );
+        assert_eq!(
+            fs.read_block_group(0).unwrap().desc.free_inodes_count(),
+            initial_bg_free_inodes
+        );
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -3052,7 +3052,7 @@ impl Ext4 {
 
         let mode = InodeMode::SOFTLINK | InodeMode::ALL_RWX;
         let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
-        let initialized = if target.len() + 1 <= child.inode.inline_block().len() {
+        let initialized = if target.len() < child.inode.inline_block().len() {
             child
                 .inode
                 .set_fast_symlink(target.as_bytes())
@@ -5437,11 +5437,7 @@ mod tests {
         let initial_sb_free_inodes = fs.read_super_block_cached().free_inodes_count();
         let initial_bg_free_inodes = fs.read_block_group(0).unwrap().desc.free_inodes_count();
         let mut inode = fs
-            .create_inode_with_owner(
-                InodeMode::SOFTLINK | InodeMode::ALL_RWX,
-                0,
-                0,
-            )
+            .create_inode_with_owner(InodeMode::SOFTLINK | InodeMode::ALL_RWX, 0, 0)
             .unwrap();
         assert!(fs.inode_is_allocated(inode.id).unwrap());
         block_device.fail_once_on_write(TEST_INODE_TABLE);
@@ -5457,7 +5453,10 @@ mod tests {
 
         assert_eq!(err.code(), ErrCode::EIO);
         assert_eq!(inode.inode.fs_block_count(), 0);
-        assert_eq!(fs.extent_all_data_blocks(&inode).unwrap(), vec![TEST_XATTR_BLOCK]);
+        assert_eq!(
+            fs.extent_all_data_blocks(&inode).unwrap(),
+            vec![TEST_XATTR_BLOCK]
+        );
         assert_allocation_state(&fs, &block_device, true, TEST_INITIAL_FREE_BLOCKS - 1);
 
         fs.free_inode(&mut inode).unwrap();

--- a/kernel/crates/another_ext4/src/ext4_defs/inode.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/inode.rs
@@ -424,6 +424,26 @@ impl Inode {
         self.extent_root_mut().init(0, 0);
     }
 
+    /// Initialize the inline representation of a fast symbolic link.
+    ///
+    /// The trailing NUL is stored on disk but is not included in `i_size`.
+    pub(crate) fn set_fast_symlink(&mut self, target: &[u8]) -> Result<()> {
+        let disk_len = target
+            .len()
+            .checked_add(1)
+            .ok_or_else(|| Ext4Error::new(ErrCode::ENAMETOOLONG))?;
+        if !self.is_softlink() || disk_len > self.block.len() {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+
+        self.block.fill(0);
+        self.block[..target.len()].copy_from_slice(target);
+        self.flags &= !Self::FLAG_EXTENTS;
+        self.set_size(target.len() as u64);
+        self.set_fs_block_count(0);
+        Ok(())
+    }
+
     /// Check if this inode is a device node (character or block device).
     pub fn is_device(&self) -> bool {
         matches!(
@@ -648,6 +668,29 @@ mod tests {
 
         inode.set_dtime(456);
         assert_eq!(inode.next_orphan(), 456);
+    }
+
+    #[test]
+    fn fast_symlink_reserves_one_byte_for_the_trailing_nul() {
+        let mut inode = Inode::default();
+        inode.set_mode(InodeMode::SOFTLINK | InodeMode::ALL_RWX);
+        inode.extent_init();
+
+        let fast = [b'a'; 59];
+        inode.set_fast_symlink(&fast).unwrap();
+        assert_eq!(inode.size(), 59);
+        assert_eq!(inode.fs_block_count(), 0);
+        assert!(!inode.uses_extents());
+        assert_eq!(&inode.inline_block()[..59], &fast);
+        assert_eq!(inode.inline_block()[59], 0);
+
+        let mut boundary = Inode::default();
+        boundary.set_mode(InodeMode::SOFTLINK | InodeMode::ALL_RWX);
+        boundary.extent_init();
+        assert_eq!(
+            boundary.set_fast_symlink(&[b'b'; 60]).unwrap_err().code(),
+            ErrCode::EINVAL
+        );
     }
 
     #[test]

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1414,6 +1414,46 @@ impl IndexNode for LockedExt4Inode {
         Err(SystemError::ENOSYS)
     }
 
+    fn symlink(&self, name: &str, target: &str) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let _operation = self.begin_operation()?;
+        let _io = self.io_lock.lock();
+        let _namespace = self.namespace_lock.lock();
+        let parent_metadata = self.metadata()?;
+        let init = vfs::permission::child_inode_init(
+            &parent_metadata,
+            vfs::FileType::SymLink,
+            InodeMode::S_IRWXUGO,
+        );
+        let mut guard = self.inner.lock();
+        let fs = guard.concret_fs();
+        let _reuse = fs.begin_allocation()?;
+        let ext4 = &fs.fs;
+        let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
+
+        let attr = fs.retry_metadata_contention(|| {
+            ext4.symlink_with_owner_and_attr(
+                guard.inner_inode_num,
+                name,
+                target,
+                another_ext4::InodeOwner {
+                    uid: init.uid as u32,
+                    gid: init.gid as u32,
+                },
+            )
+        })?;
+
+        let dname = DName::from(name);
+        let inode = fs.publish_allocated_inode(
+            attr,
+            dname.clone(),
+            Some(Arc::downgrade(&self_arc)),
+            &_reuse,
+        )?;
+        guard.children.insert(dname, inode.clone());
+        drop(guard);
+        Ok(inode as Arc<dyn IndexNode>)
+    }
+
     fn read_at(
         &self,
         offset: usize,

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -22,6 +22,7 @@
 #include <chrono>
 #include <string>
 #include <thread>
+#include <vector>
 
 #ifndef __NR_syncfs
 #if defined(__x86_64__)
@@ -1287,6 +1288,87 @@ TEST(Ext4InodeIdentity, BufferedPartialTailWritebackSerializesWithTruncate) {
     ASSERT_EQ(0, close(sync_fd)) << strerror(errno);
     ASSERT_EQ(0, close(writer_fd)) << strerror(errno);
     ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, SymbolicLinksPersistAcrossRemountAndReclaimResources) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+
+    struct statvfs before = {};
+    ASSERT_EQ(0, statvfs(fs.mount_point().c_str(), &before)) << strerror(errno);
+
+    const std::string target_59(59, 'a');
+    const std::string target_60(60, 'b');
+    const std::vector<std::pair<std::string, std::string>> links = {
+        {"short_relative", "x"},
+        {"certificate", "/etc/ssl/certs/ca-certificates.crt"},
+        {"fast_boundary", target_59},
+        {"long_boundary", target_60},
+    };
+
+    for (const auto& [name, target] : links) {
+        const std::string path = fs.mount_point() + "/" + name;
+        ASSERT_EQ(0, symlink(target.c_str(), path.c_str())) << name << ": " << strerror(errno);
+    }
+
+    auto expect_link = [&](const std::string& name, const std::string& target) {
+        const std::string path = fs.mount_point() + "/" + name;
+        struct stat st = {};
+        ASSERT_EQ(0, lstat(path.c_str(), &st)) << name << ": " << strerror(errno);
+        EXPECT_TRUE(S_ISLNK(st.st_mode));
+        EXPECT_EQ(static_cast<off_t>(target.size()), st.st_size);
+        char observed[4096] = {};
+        ASSERT_LT(target.size(), sizeof(observed));
+        ssize_t count = readlink(path.c_str(), observed, sizeof(observed));
+        ASSERT_EQ(static_cast<ssize_t>(target.size()), count) << name << ": " << strerror(errno);
+        EXPECT_EQ(target, std::string(observed, static_cast<size_t>(count)));
+    };
+
+    for (const auto& [name, target] : links) {
+        expect_link(name, target);
+    }
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    for (const auto& [name, target] : links) {
+        expect_link(name, target);
+    }
+
+    int sync_fd = open(fs.mount_point().c_str(), O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(sync_fd, 0) << strerror(errno);
+    for (const auto& [name, target] : links) {
+        (void)target;
+        const std::string path = fs.mount_point() + "/" + name;
+        ASSERT_EQ(0, unlink(path.c_str())) << name << ": " << strerror(errno);
+    }
+    ASSERT_EQ(0, syscall(__NR_syncfs, sync_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(sync_fd)) << strerror(errno);
+
+    struct statvfs after = {};
+    bool reclaimed = false;
+    for (int attempt = 0; attempt < 20; ++attempt) {
+        ASSERT_EQ(0, statvfs(fs.mount_point().c_str(), &after)) << strerror(errno);
+        if (after.f_ffree >= before.f_ffree && after.f_bfree >= before.f_bfree) {
+            reclaimed = true;
+            break;
+        }
+        usleep(5 * 1000);
+    }
+    EXPECT_TRUE(reclaimed) << "free inodes before=" << before.f_ffree
+                           << " after=" << after.f_ffree
+                           << " free blocks before=" << before.f_bfree
+                           << " after=" << after.f_bfree;
+
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    for (const auto& [name, target] : links) {
+        (void)target;
+        const std::string path = fs.mount_point() + "/" + name;
+        struct stat st = {};
+        EXPECT_EQ(-1, lstat(path.c_str(), &st));
+        EXPECT_EQ(ENOENT, errno);
+    }
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }
 


### PR DESCRIPTION
## Summary

- add an ext4-specific symbolic link creation path for inline and extent-backed targets
- initialize the target before publishing the directory entry
- preserve publication failure classification and safely reclaim only unpublished inodes
- add boundary, persistence, resource-reclamation, and fault-injection coverage

## Root cause

The generic VFS fallback created and published a symlink inode before writing its target through the regular file path. ext4 rejected that write with `EINVAL`, leaving an empty visible symlink and causing packages such as OpenSSL to fail during unpack.

## Implementation

Fast targets are stored in the inode inline area with the extent flag cleared. Longer targets are initialized in an extent-backed data block before the inode is linked into the parent directory. Directory insertion failures retain their existing modified-versus-indeterminate classification so rollback cannot recycle an inode that might already be reachable.

The unpublished-inode cleanup path now handles inline representations and the transient state where an in-memory extent exists before `i_blocks` is recomputed. Indeterminate metadata failures fail-stop the mount instead of attempting unsafe reuse.

## Validation

- `make kernel`
- `cargo +nightly-2026-02-24 test --manifest-path kernel/crates/another_ext4/Cargo.toml` (163 passed)
- `make -C kernel check ARCH=riscv64 ROOT_PATH=/root/code/DragonOS`
- `make -C kernel check ARCH=loongarch64 ROOT_PATH=/root/code/DragonOS`
- `make test-dunit DUNITEST_PATTERN=normal/ext4_inode_identity` (34 passed)
- Ubuntu 24.04 `apt --fix-broken install -y`, `readlink /usr/lib/ssl/cert.pem`, and `dpkg --audit` end-to-end verification
- `git diff --check`