### PR TITLE
fix(epoll): prevent hardirq registration deadlocks

### DIFF
--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -13,7 +13,7 @@ use crate::{
     arch::ipc::signal::Signal,
     driver::base::device::device_number::DeviceNumber,
     filesystem::epoll::{
-        event_poll::{EventPoll, LockedEPItemLinkedList},
+        event_poll::{EPollItemList, EventPoll},
         EPollEventType, EPollItem,
     },
     filesystem::vfs::fasync::{FAsyncItem, FAsyncItems},
@@ -150,7 +150,7 @@ impl TtyCore {
             hangup_generation: AtomicUsize::new(0),
             flow: SpinLock::new(TtyFlowState::default()),
             link: RwLock::default(),
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: EPollItemList::default(),
             fasync_items: FAsyncItems::new(),
             device_number,
             privete_fields: SpinLock::new(None),
@@ -677,7 +677,7 @@ pub struct TtyCoreData {
     /// 链接tty
     link: RwLock<Weak<TtyCore>>,
     /// epitems
-    epitems: LockedEPItemLinkedList,
+    epitems: EPollItemList,
     /// Open file descriptions registered for asynchronous TTY notification.
     fasync_items: FAsyncItems,
     /// 设备号
@@ -954,20 +954,14 @@ impl TtyCoreData {
 
     #[inline]
     pub fn add_epitem(&self, epitem: Arc<EPollItem>) {
-        self.epitems.lock().push_back(epitem)
+        self.epitems.add(epitem)
     }
 
     pub fn remove_epitem(&self, epitem: &Arc<EPollItem>) -> Result<(), SystemError> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            return Ok(());
-        }
-        Err(SystemError::ENOENT)
+        self.epitems.remove(epitem)
     }
 
-    pub fn epitems(&self) -> &LockedEPItemLinkedList {
+    pub fn epitems(&self) -> &EPollItemList {
         &self.epitems
     }
 

--- a/kernel/src/filesystem/epoll/event_poll.rs
+++ b/kernel/src/filesystem/epoll/event_poll.rs
@@ -26,11 +26,13 @@ use system_error::SystemError;
 
 use super::{fs::EPollInode, EPollCtlOption, EPollEvent, EPollEventType, EPollItem};
 
-/// epoll 就绪状态，由独立的 irqsave SpinLock 保护。
+/// Epoll ready state protected by a dedicated irqsave spin lock.
 ///
-/// 对标 Linux 6.6 中由 `ep->lock`（rwlock_t）保护的 `rdllist` + `ovflist` + `wq`。
-/// 回调路径（`wakeup_epoll`，等价于 Linux `ep_poll_callback`）仅获取此 SpinLock，
-/// 不碰外层 Mutex，因此完全 hardirq-safe。
+/// This corresponds to Linux 6.6's `ep->lock`, which protects `rdllist`,
+/// `ovflist`, and the wait queue. The callback path does not acquire the outer
+/// sleeping mutex. The source registration snapshot still allocates and scans
+/// entries in hardirq context; that existing latency concern is separate from
+/// this lock-discipline guarantee.
 pub(crate) struct ReadyState {
     /// 就绪列表（正常路径）
     ready_list: LinkedList<Arc<EPollItem>>,
@@ -44,6 +46,21 @@ pub(crate) struct ReadyState {
     ovflist: Option<Vec<Arc<EPollItem>>>,
     /// epoll_wait 等待者
     epoll_wq: WaitQueue,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub(crate) struct EPollKey {
+    open_file_id: usize,
+    fd: i32,
+}
+
+impl EPollKey {
+    pub(super) fn new(file: &File, fd: i32) -> Self {
+        Self {
+            open_file_id: file.open_file_id(),
+            fd,
+        }
+    }
 }
 
 impl Debug for ReadyState {
@@ -69,11 +86,11 @@ impl Debug for ReadyState {
 #[derive(Debug)]
 pub struct EventPoll {
     /// 维护所有添加进来的socket的红黑树（由外层 Mutex 保护）
-    ep_items: RBTree<i32, Arc<EPollItem>>,
+    ep_items: RBTree<EPollKey, Arc<EPollItem>>,
     /// 就绪状态（由内层 irqsave SpinLock 保护）
     ready_state: Arc<SpinLock<ReadyState>>,
     /// 监听本 epollfd 的 epitems（用于支持 epoll 嵌套：epollfd 被加入另一个 epoll）
-    pub(super) poll_epitems: Arc<LockedEPItemLinkedList>,
+    pub(super) poll_epitems: Arc<EPollItemList>,
     self_ref: Option<Weak<Mutex<EventPoll>>>,
 }
 
@@ -90,25 +107,23 @@ impl EventPoll {
                 ovflist: None,
                 epoll_wq: WaitQueue::default(),
             })),
-            poll_epitems: Arc::new(LockedEPItemLinkedList::default()),
+            poll_epitems: Arc::new(EPollItemList::default()),
             self_ref: None,
         }
     }
 
     /// 关闭epoll时，执行的逻辑
     pub(super) fn close(&mut self) -> Result<(), SystemError> {
-        let fds: Vec<i32> = self.ep_items.keys().cloned().collect::<Vec<_>>();
-        // 清理红黑树里面的epitems
-        for fd in fds {
-            let fdtable = ProcessManager::current_pcb().basic().try_fd_table().clone();
-            let file = fdtable.and_then(|fdtable| fdtable.read().get_file_by_fd(fd));
-
-            if let Some(file) = file {
-                let epitm = self.ep_items.get(&fd).unwrap();
-                // 尝试移除epitem，忽略错误（对于普通文件，我们没有添加epitem，所以会失败）
-                let _ = file.remove_epitem(epitm);
+        let keys: Vec<EPollKey> = self.ep_items.keys().copied().collect();
+        for key in keys {
+            let Some(epitem) = self.ep_items.get(&key).cloned() else {
+                continue;
+            };
+            if let Some(file) = epitem.file().upgrade() {
+                let _ = file.remove_epitem(&epitem);
             }
-            self.ep_items.remove(&fd);
+            Self::deactivate_and_remove_ready(self, &epitem);
+            self.ep_items.remove(&key);
         }
 
         Ok(())
@@ -252,7 +267,8 @@ impl EventPoll {
                 }
             };
 
-            let ep_item = epoll_guard.ep_items.get(&dstfd).cloned();
+            let key = EPollKey::new(&dst_file, dstfd);
+            let ep_item = epoll_guard.ep_items.get(&key).cloned();
             let notify_nested = match op {
                 EPollCtlOption::Add => {
                     // 如果已经存在，则返回错误
@@ -265,8 +281,8 @@ impl EventPoll {
                         Arc::downgrade(&epoll_data.epoll.0),
                         Arc::downgrade(&epoll_guard.ready_state),
                         Arc::downgrade(&epoll_guard.poll_epitems),
+                        key,
                         epds,
-                        dstfd,
                         Arc::downgrade(&dst_file),
                     ));
                     Self::ep_insert(&mut epoll_guard, dst_file, epitem)?
@@ -274,7 +290,7 @@ impl EventPoll {
                 EPollCtlOption::Del => match ep_item {
                     Some(ref ep_item) => {
                         // 删除
-                        Self::ep_remove(&mut epoll_guard, dstfd, Some(dst_file), ep_item)?;
+                        Self::ep_remove(&mut epoll_guard, key, Some(dst_file), ep_item)?;
                         false
                     }
                     None => {
@@ -700,13 +716,13 @@ impl EventPoll {
             return Err(SystemError::ENOSYS);
         }
 
-        epoll_guard.ep_items.insert(epitem.fd, epitem.clone());
+        epoll_guard.ep_items.insert(epitem.key(), epitem.clone());
 
         // 先将 epitem 添加到目标文件的 epoll_items 中，这样之后的 notify/wakeup_epoll
         // 才能找到并唤醒这个 epitem。
         if let Err(e) = dst_file.add_epitem(epitem.clone()) {
             // 如果添加失败，需要清理 ep_items 中已插入的项
-            epoll_guard.ep_items.remove(&epitem.fd);
+            epoll_guard.ep_items.remove(&epitem.key());
             return Err(e);
         }
 
@@ -726,18 +742,16 @@ impl EventPoll {
         Ok(notify_nested)
     }
 
-    pub fn ep_remove(
+    fn ep_remove(
         epoll: &mut MutexGuard<EventPoll>,
-        fd: i32,
+        key: EPollKey,
         dst_file: Option<Arc<File>>,
         epitem: &Arc<EPollItem>,
     ) -> Result<(), SystemError> {
+        let removed = epoll.ep_items.remove(&key).ok_or(SystemError::ENOENT)?;
+        Self::deactivate_and_remove_ready(epoll, &removed);
         if let Some(dst_file) = dst_file {
-            dst_file.remove_epitem(epitem)?;
-        }
-
-        if let Some(removed) = epoll.ep_items.remove(&fd) {
-            Self::remove_ready_item(epoll, &removed);
+            let _ = dst_file.remove_epitem(epitem);
         }
 
         Ok(())
@@ -752,20 +766,21 @@ impl EventPoll {
             return;
         };
         let mut epoll = epoll.lock();
-        let fd = epitem.fd();
-        let Some(current) = epoll.ep_items.get(&fd).cloned() else {
+        let key = epitem.key();
+        let Some(current) = epoll.ep_items.get(&key).cloned() else {
             return;
         };
         if !Arc::ptr_eq(&current, epitem) {
             return;
         }
 
-        epoll.ep_items.remove(&fd);
-        Self::remove_ready_item(&mut epoll, &current);
+        epoll.ep_items.remove(&key);
+        Self::deactivate_and_remove_ready(&epoll, &current);
     }
 
-    fn remove_ready_item(epoll: &mut MutexGuard<EventPoll>, epitem: &Arc<EPollItem>) {
+    fn deactivate_and_remove_ready(epoll: &EventPoll, epitem: &Arc<EPollItem>) {
         let mut rs = epoll.ready_state.lock_irqsave();
+        epitem.deactivate();
         rs.ready_list.retain(|item| !Arc::ptr_eq(item, epitem));
         if let Some(ovflist) = rs.ovflist.as_mut() {
             ovflist.retain(|item| !Arc::ptr_eq(item, epitem));
@@ -859,23 +874,19 @@ impl EventPoll {
         Ok(())
     }
 
-    /// ### epoll的回调，支持epoll的文件有事件到来时直接调用该方法即可
+    /// Processes notifications from files that support epoll.
     ///
-    /// 对标 Linux `ep_poll_callback()`。仅获取内层 SpinLock（irqsave），
-    /// **不获取外层 Mutex**，因此完全 hardirq-safe。
-    ///
-    /// 回调路径通过 `EPollItem::ready_state()` 直接访问 `ReadyState`，
-    /// 绕过 `Mutex<EventPoll>`。
+    /// Like Linux `ep_poll_callback()`, this path never acquires the outer
+    /// sleeping `Mutex<EventPoll>`. Registration and ready-state locks use
+    /// irqsave discipline. The registration snapshot's existing allocation and
+    /// O(N) scan remain a separately documented hardirq latency risk.
     pub fn wakeup_epoll(
-        epitems: &LockedEPItemLinkedList,
+        epitems: &EPollItemList,
         pollflags: EPollEventType,
     ) -> Result<(), SystemError> {
         // 在 epitems 锁下复制一份快照，然后释放锁，再逐个处理。
         // 避免持有 epitems 锁时再去获取其他锁导致 ABBA 死锁。
-        let epitems_snapshot: Vec<Arc<EPollItem>> = {
-            let epitems_guard = epitems.lock_irqsave();
-            epitems_guard.iter().cloned().collect()
-        };
+        let epitems_snapshot = epitems.snapshot();
 
         for epitem in epitems_snapshot.iter() {
             // 通过 EPollItem 的 ready_state Weak 直接访问 ReadyState — 不需要 Mutex
@@ -907,6 +918,9 @@ impl EventPoll {
             {
                 // 仅获取 SpinLock（irqsave）— hardirq-safe
                 let mut rs = rs_arc.lock_irqsave();
+                if !epitem.is_active() {
+                    continue;
+                }
 
                 if let Some(ref mut ovflist) = rs.ovflist {
                     // 扫描进行中 — 推入溢出列表
@@ -941,16 +955,45 @@ impl EventPoll {
     }
 }
 
-/// LockedEPItemLinkedList — 使用 irqsave SpinLock 保护的 epitem 链表。
+/// An IRQ-safe list of epoll registrations attached to a pollable source.
 ///
-/// 从 Mutex 改为 SpinLock 使得 `wakeup_epoll` 中的快照操作在 hardirq
-/// 上下文中也是安全的。链表操作（push_back、retain、snapshot clone）
-/// 临界区都很短，适合 SpinLock。
-pub type LockedEPItemLinkedList = SpinLock<LinkedList<Arc<EPollItem>>>;
+/// The inner lock is deliberately private: wakeups can run in hardirq context,
+/// so task-context registration updates must use the same irqsave discipline.
+#[derive(Debug)]
+pub struct EPollItemList {
+    items: SpinLock<LinkedList<Arc<EPollItem>>>,
+}
 
-impl Default for LockedEPItemLinkedList {
+impl EPollItemList {
+    pub fn add(&self, epitem: Arc<EPollItem>) {
+        self.items.lock_irqsave().push_back(epitem);
+    }
+
+    pub fn remove(&self, epitem: &Arc<EPollItem>) -> Result<(), SystemError> {
+        let mut items = self.items.lock_irqsave();
+        let old_len = items.len();
+        items.retain(|item| !Arc::ptr_eq(item, epitem));
+        if items.len() != old_len {
+            Ok(())
+        } else {
+            Err(SystemError::ENOENT)
+        }
+    }
+
+    fn snapshot(&self) -> Vec<Arc<EPollItem>> {
+        self.items.lock_irqsave().iter().cloned().collect()
+    }
+
+    pub fn take_all(&self) -> LinkedList<Arc<EPollItem>> {
+        core::mem::take(&mut *self.items.lock_irqsave())
+    }
+}
+
+impl Default for EPollItemList {
     fn default() -> Self {
-        SpinLock::new(LinkedList::new())
+        Self {
+            items: SpinLock::new(LinkedList::new()),
+        }
     }
 }
 

--- a/kernel/src/filesystem/epoll/fs.rs
+++ b/kernel/src/filesystem/epoll/fs.rs
@@ -117,7 +117,7 @@ impl PollableInode for EPollInode {
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
         let poll_epitems = { self.epoll.0.lock().poll_epitems.clone() };
-        poll_epitems.lock_irqsave().push_back(epitem);
+        poll_epitems.add(epitem);
         Ok(())
     }
 
@@ -127,13 +127,6 @@ impl PollableInode for EPollInode {
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
         let poll_epitems = { self.epoll.0.lock().poll_epitems.clone() };
-        let mut guard = poll_epitems.lock_irqsave();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if guard.len() != len {
-            Ok(())
-        } else {
-            Err(SystemError::ENOENT)
-        }
+        poll_epitems.remove(epitem)
     }
 }

--- a/kernel/src/filesystem/epoll/mod.rs
+++ b/kernel/src/filesystem/epoll/mod.rs
@@ -2,7 +2,8 @@ use super::{poll::PollFlags, vfs::file::File};
 use crate::libs::{mutex::Mutex, spinlock::SpinLock};
 use alloc::sync::Weak;
 use core::fmt::Debug;
-use event_poll::{EventPoll, LockedEPItemLinkedList, ReadyState};
+use core::sync::atomic::{AtomicBool, Ordering};
+use event_poll::{EPollItemList, EPollKey, EventPoll, ReadyState};
 use system_error::SystemError;
 
 pub mod event_poll;
@@ -58,17 +59,18 @@ pub struct EPollItem {
     /// 对标 Linux 中 ep_poll_callback 仅获取 ep->lock 而不获取 ep->mtx 的设计。
     ready_state: Weak<SpinLock<ReadyState>>,
     /// 直接引用 EventPoll 的 poll_epitems，使嵌套 epoll 的向上传播无需获取外层 Mutex。
-    poll_epitems: Weak<LockedEPItemLinkedList>,
+    poll_epitems: Weak<EPollItemList>,
     /// 用户注册的事件
     /// 使用 irqsave SpinLock 而非 RwSem，因为 wakeup_epoll 回调路径可能在
     /// hardirq 上下文中执行（例如 timer IRQ → signal → signalfd → epoll），
     /// RwSem 是可睡眠锁，在 hardirq 中使用会导致死锁。
     /// 对标 Linux 中 epitem.event 由 ep->lock (spin_lock_irqsave) 保护的设计。
     event: SpinLock<EPollEvent>,
-    /// 监听的描述符
-    fd: i32,
     /// 对应的文件
     file: Weak<File>,
+    key: EPollKey,
+    /// Whether callbacks may still publish this registration to the ready list.
+    active: AtomicBool,
 }
 
 impl EPollItem {
@@ -76,18 +78,19 @@ impl EPollItem {
     pub(super) fn new(
         epoll: Weak<Mutex<EventPoll>>,
         ready_state: Weak<SpinLock<ReadyState>>,
-        poll_epitems: Weak<LockedEPItemLinkedList>,
+        poll_epitems: Weak<EPollItemList>,
+        key: EPollKey,
         events: EPollEvent,
-        fd: i32,
         file: Weak<File>,
     ) -> Self {
         Self {
             epoll,
             ready_state,
             poll_epitems,
+            key,
             event: SpinLock::new(events),
-            fd,
             file,
+            active: AtomicBool::new(true),
         }
     }
 
@@ -103,8 +106,16 @@ impl EPollItem {
 
     /// 获取 poll_epitems 的 Weak 引用，用于嵌套 epoll 的向上传播。
     #[allow(dead_code)]
-    pub(crate) fn poll_epitems(&self) -> Weak<LockedEPItemLinkedList> {
+    pub(crate) fn poll_epitems(&self) -> Weak<EPollItemList> {
         self.poll_epitems.clone()
+    }
+
+    pub(crate) fn is_active(&self) -> bool {
+        self.active.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn deactivate(&self) {
+        self.active.store(false, Ordering::Relaxed);
     }
 
     pub fn event(&self) -> &SpinLock<EPollEvent> {
@@ -115,8 +126,8 @@ impl EPollItem {
         self.file.clone()
     }
 
-    pub fn fd(&self) -> i32 {
-        self.fd
+    pub(crate) fn key(&self) -> EPollKey {
+        self.key
     }
 
     /// ## 通过epoll_item来执行绑定文件的poll方法，并获取到感兴趣的事件

--- a/kernel/src/filesystem/eventfd.rs
+++ b/kernel/src/filesystem/eventfd.rs
@@ -1,6 +1,6 @@
 use super::vfs::PollableInode;
 use crate::arch::MMArch;
-use crate::filesystem::epoll::event_poll::LockedEPItemLinkedList;
+use crate::filesystem::epoll::event_poll::EPollItemList;
 use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::{InodeMode, OpenFileBehavior, PostWriteSyncPolicy};
 use crate::filesystem::{
@@ -101,7 +101,7 @@ impl EventFd {
 pub struct EventFdInode {
     eventfd: Mutex<EventFd>,
     wait_queue: WaitQueue,
-    epitems: LockedEPItemLinkedList,
+    epitems: EPollItemList,
 }
 
 impl EventFdInode {
@@ -109,7 +109,7 @@ impl EventFdInode {
         EventFdInode {
             eventfd: Mutex::new(eventfd),
             wait_queue: WaitQueue::default(),
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: EPollItemList::default(),
         }
     }
     fn readable(&self) -> bool {
@@ -147,7 +147,7 @@ impl PollableInode for EventFdInode {
         epitem: Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        self.epitems.lock().push_back(epitem);
+        self.epitems.add(epitem);
         Ok(())
     }
 
@@ -156,13 +156,7 @@ impl PollableInode for EventFdInode {
         epitem: &Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            return Ok(());
-        }
-        Err(SystemError::ENOENT)
+        self.epitems.remove(epitem)
     }
 }
 

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -14,9 +14,7 @@ use system_error::SystemError;
 use crate::filesystem::page_cache::PageCacheReadDmaReservation;
 use crate::{
     arch::MMArch,
-    filesystem::epoll::{
-        event_poll::EventPoll, event_poll::LockedEPItemLinkedList, EPollEventType,
-    },
+    filesystem::epoll::{event_poll::EPollItemList, event_poll::EventPoll, EPollEventType},
     libs::{
         mutex::Mutex,
         wait_queue::{WaitQueue, Waiter},
@@ -778,7 +776,7 @@ pub struct FuseConn {
     read_wait: WaitQueue,
     init_wait: WaitQueue,
     bridge_wake: FuseBridgeWake,
-    epitems: LockedEPItemLinkedList,
+    epitems: EPollItemList,
     backend_reply_limit: Option<usize>,
     reply_layout_minor: AtomicU32,
     background: Arc<FuseBackgroundState>,
@@ -920,7 +918,7 @@ impl FuseConn {
             read_wait: WaitQueue::default(),
             init_wait: WaitQueue::default(),
             bridge_wake: FuseBridgeWake::new(),
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: EPollItemList::default(),
             backend_reply_limit,
             reply_layout_minor: AtomicU32::new(0),
             background: FuseBackgroundState::new(),

--- a/kernel/src/filesystem/fuse/conn/daemon.rs
+++ b/kernel/src/filesystem/fuse/conn/daemon.rs
@@ -107,18 +107,12 @@ impl FuseConn {
     }
 
     pub fn add_epitem(&self, epitem: Arc<EPollItem>) -> Result<(), SystemError> {
-        self.epitems.lock().push_back(epitem);
+        self.epitems.add(epitem);
         Ok(())
     }
 
     pub fn remove_epitem(&self, epitem: &Arc<EPollItem>) -> Result<(), SystemError> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            return Ok(());
-        }
-        Err(SystemError::ENOENT)
+        self.epitems.remove(epitem)
     }
 
     fn calc_min_read_buffer(max_write: usize) -> usize {

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -26,7 +26,7 @@ use crate::{
     filesystem::{
         devfs::{devfs_lookup_device_by_devnum, LockedDevFSInode},
         epoll::{
-            event_poll::{EPollPrivateData, EventPoll, LockedEPItemLinkedList},
+            event_poll::{EPollItemList, EPollPrivateData, EventPoll},
             EPollItem,
         },
         ext4::inode::LockedExt4Inode,
@@ -675,7 +675,7 @@ pub struct File {
     /// Linux removes these from their owning epoll instances during `__fput()`
     /// via `eventpoll_release(file)`.  DragonOS keeps the same lifetime edge
     /// here so fd numbers can be safely reused after close.
-    epitems: Arc<LockedEPItemLinkedList>,
+    epitems: Arc<EPollItemList>,
     /// One semantic inode pin per open file description. Duplicated file
     /// descriptors and VMAs share this `File`, while `O_PATH` still owns it.
     /// Declared last so the explicit `Drop` body runs `close()` before release.
@@ -1275,7 +1275,7 @@ impl File {
             ra_state: Mutex::new(FileReadaheadState::new()),
             wb_error_seq: Mutex::new(wb_error_seq),
             sb_error_seq: Mutex::new(sb_error_seq),
-            epitems: Arc::new(LockedEPItemLinkedList::default()),
+            epitems: Arc::new(EPollItemList::default()),
             _inode_retention: inode_retention,
             _mount_guard: mount_guard,
         };
@@ -2139,7 +2139,7 @@ impl File {
             ra_state: Mutex::new(self.ra_state.lock().clone()),
             wb_error_seq: Mutex::new(*self.wb_error_seq.lock()),
             sb_error_seq: Mutex::new(*self.sb_error_seq.lock()),
-            epitems: Arc::new(LockedEPItemLinkedList::default()),
+            epitems: Arc::new(EPollItemList::default()),
             _inode_retention: inode_retention,
             _mount_guard: mount_guard,
         };
@@ -2325,7 +2325,7 @@ impl File {
         self.inode
             .as_pollable_inode()?
             .add_epitem(epitem.clone(), &private_data)?;
-        self.epitems.lock_irqsave().push_back(epitem);
+        self.epitems.add(epitem);
         Ok(())
     }
 
@@ -2336,9 +2336,7 @@ impl File {
             .inode
             .as_pollable_inode()?
             .remove_epitem(epitem, &private_data);
-        self.epitems
-            .lock_irqsave()
-            .retain(|x| !Arc::ptr_eq(x, epitem));
+        let _ = self.epitems.remove(epitem);
         result
     }
 
@@ -2421,12 +2419,7 @@ impl File {
 
 impl Drop for File {
     fn drop(&mut self) {
-        let epitems = {
-            let mut guard = self.epitems.lock_irqsave();
-            let snapshot = guard.iter().cloned().collect::<Vec<_>>();
-            guard.clear();
-            snapshot
-        };
+        let epitems = self.epitems.take_all();
         for epitem in epitems {
             EventPoll::release_file_epitem(&epitem);
             let _ = self.remove_epitem(&epitem);

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -4,7 +4,7 @@ use crate::{
     arch::{ipc::signal::Signal, MMArch},
     filesystem::{
         epoll::{
-            event_poll::{EventPoll, LockedEPItemLinkedList},
+            event_poll::{EPollItemList, EventPoll},
             EPollEventType, EPollItem,
         },
         vfs::{
@@ -239,7 +239,7 @@ pub struct LockedPipeInode {
     write_wait_queue: WaitQueue,
     /// 用于 FIFO 打开时的阻塞等待（等待另一端打开）
     open_wait_queue: WaitQueue,
-    epitems: LockedEPItemLinkedList,
+    epitems: EPollItemList,
     read_fasync_items: FAsyncItems,
     write_fasync_items: FAsyncItems,
 }
@@ -617,7 +617,7 @@ impl LockedPipeInode {
             read_wait_queue: WaitQueue::default(),
             write_wait_queue: WaitQueue::default(),
             open_wait_queue: WaitQueue::default(),
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: EPollItemList::default(),
             read_fasync_items: FAsyncItems::default(),
             write_fasync_items: FAsyncItems::default(),
         });
@@ -1773,7 +1773,7 @@ impl PollableInode for LockedPipeInode {
         epitem: Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        self.epitems.lock().push_back(epitem);
+        self.epitems.add(epitem);
         Ok(())
     }
 
@@ -1782,13 +1782,7 @@ impl PollableInode for LockedPipeInode {
         epitem: &Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            return Ok(());
-        }
-        Err(SystemError::ENOENT)
+        self.epitems.remove(epitem)
     }
 
     fn add_fasync(

--- a/kernel/src/ipc/sighand.rs
+++ b/kernel/src/ipc/sighand.rs
@@ -7,7 +7,7 @@ use system_error::SystemError;
 
 use crate::{
     arch::ipc::signal::{SigFlags, SigSet, Signal, MAX_SIG_NUM},
-    filesystem::epoll::event_poll::LockedEPItemLinkedList,
+    filesystem::epoll::event_poll::EPollItemList,
     ipc::signal_types::{SaHandlerType, SigCode, SigInfo, SigPending, SigactionType, SignalFlags},
     libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard},
     libs::wait_queue::WaitQueue,
@@ -73,7 +73,7 @@ pub struct SigHand {
     /// 信号投递路径（包括 hardirq）直接对此列表调用 `wakeup_epoll`，
     /// 避免遍历 fd_table（涉及 RwLock/RwSem，在 hardirq 中不安全）。
     /// 使用 irqsave SpinLock，hardirq 安全。
-    signalfd_epitems: LockedEPItemLinkedList,
+    signalfd_epitems: EPollItemList,
 }
 
 impl Debug for SigHand {
@@ -123,7 +123,7 @@ impl SigHand {
             inner: RwLock::new(InnerSigHand::default()),
             group_exec_wait_queue: WaitQueue::default(),
             signalfd_wqh: WaitQueue::default(),
-            signalfd_epitems: LockedEPItemLinkedList::default(),
+            signalfd_epitems: EPollItemList::default(),
         })
     }
 
@@ -156,7 +156,7 @@ impl SigHand {
     /// signalfd 的 `add_epitem` 将 EPollItem 同时注册到此列表中，
     /// 信号投递路径通过 `wakeup_epoll(&signalfd_epitems, ...)` 直接通知 epoll，
     /// 避免在 hardirq 中遍历 fd_table。
-    pub fn signalfd_epitems(&self) -> &LockedEPItemLinkedList {
+    pub fn signalfd_epitems(&self) -> &EPollItemList {
         &self.signalfd_epitems
     }
 

--- a/kernel/src/ipc/signalfd.rs
+++ b/kernel/src/ipc/signalfd.rs
@@ -1,5 +1,6 @@
+use alloc::collections::LinkedList;
 use alloc::string::String;
-use alloc::sync::Arc;
+use alloc::sync::{Arc, Weak};
 use alloc::vec::Vec;
 use core::any::Any;
 use core::mem::size_of;
@@ -8,13 +9,14 @@ use bitflags::bitflags;
 
 use crate::arch::ipc::signal::{SigSet, Signal};
 use crate::arch::MMArch;
-use crate::filesystem::epoll::event_poll::{EventPoll, LockedEPItemLinkedList};
+use crate::filesystem::epoll::event_poll::EventPoll;
 use crate::filesystem::epoll::{EPollEventType, EPollItem};
 use crate::filesystem::vfs::file::FileFlags;
 use crate::filesystem::vfs::{
     vcore::generate_inode_id, FilePrivateData, FileSystem, FileType, FsInfo, IndexNode, InodeFlags,
     InodeMode, Magic, Metadata, PollableInode, SuperBlock,
 };
+use crate::ipc::sighand::SigHand;
 use crate::libs::mutex::MutexGuard;
 use crate::libs::spinlock::{SpinLock, SpinLockGuard};
 use crate::mm::MemoryManagementArch;
@@ -99,7 +101,13 @@ struct SignalFdState {
 #[derive(Debug)]
 pub struct SignalFdInode {
     state: SpinLock<SignalFdState>,
-    epitems: LockedEPItemLinkedList,
+    epitems: SpinLock<LinkedList<SignalFdEPollRegistration>>,
+}
+
+#[derive(Debug)]
+struct SignalFdEPollRegistration {
+    epitem: Arc<EPollItem>,
+    sighand: Weak<SigHand>,
 }
 
 impl SignalFdInode {
@@ -128,7 +136,7 @@ impl SignalFdInode {
                 flags,
                 metadata,
             }),
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: SpinLock::new(LinkedList::new()),
         }
     }
 
@@ -184,14 +192,14 @@ impl PollableInode for SignalFdInode {
         epitem: Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        self.epitems.lock().push_back(epitem.clone());
-        // 同时注册到 sighand 的 signalfd_epitems，使信号投递路径
-        // 可以在 hardirq 中直接 wakeup_epoll 而无需遍历 fd_table。
-        let pcb = ProcessManager::current_pcb();
-        pcb.sighand()
-            .signalfd_epitems()
+        let sighand = ProcessManager::current_pcb().sighand();
+        self.epitems
             .lock_irqsave()
-            .push_back(epitem);
+            .push_back(SignalFdEPollRegistration {
+                epitem: epitem.clone(),
+                sighand: Arc::downgrade(&sighand),
+            });
+        sighand.signalfd_epitems().add(epitem);
         Ok(())
     }
 
@@ -200,21 +208,26 @@ impl PollableInode for SignalFdInode {
         epitem: &Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if guard.len() != len {
-            drop(guard);
-            // 同时从 sighand 的 signalfd_epitems 中移除
-            let pcb = ProcessManager::current_pcb();
-            pcb.sighand()
-                .signalfd_epitems()
-                .lock_irqsave()
-                .retain(|x| !Arc::ptr_eq(x, epitem));
-            Ok(())
-        } else {
-            Err(SystemError::ENOENT)
+        let owner = {
+            let mut registrations = self.epitems.lock_irqsave();
+            let mut owner = None;
+            registrations.retain(|registration| {
+                if Arc::ptr_eq(&registration.epitem, epitem) {
+                    owner = Some(registration.sighand.clone());
+                    false
+                } else {
+                    true
+                }
+            });
+            owner
+        };
+        let Some(owner) = owner else {
+            return Err(SystemError::ENOENT);
+        };
+        if let Some(sighand) = owner.upgrade() {
+            let _ = sighand.signalfd_epitems().remove(epitem);
         }
+        Ok(())
     }
 }
 

--- a/kernel/src/net/socket/common/epoll_items.rs
+++ b/kernel/src/net/socket/common/epoll_items.rs
@@ -1,62 +1,25 @@
-use alloc::{
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::sync::Arc;
 use system_error::SystemError;
 
-use crate::{
-    filesystem::epoll::{
-        event_poll::{EventPoll, LockedEPItemLinkedList},
-        EPollItem,
-    },
-    libs::mutex::Mutex,
-};
+use crate::filesystem::epoll::{event_poll::EPollItemList, EPollItem};
 
 #[derive(Debug, Default)]
 pub struct EPollItems {
-    items: LockedEPItemLinkedList,
+    items: EPollItemList,
 }
 
-impl AsRef<LockedEPItemLinkedList> for EPollItems {
-    fn as_ref(&self) -> &LockedEPItemLinkedList {
+impl AsRef<EPollItemList> for EPollItems {
+    fn as_ref(&self) -> &EPollItemList {
         &self.items
     }
 }
 
 impl EPollItems {
     pub fn add(&self, item: Arc<EPollItem>) {
-        self.items.lock().push_back(item);
+        self.items.add(item);
     }
 
-    pub fn remove(&self, item: &Weak<Mutex<EventPoll>>) -> Result<(), SystemError> {
-        let to_remove = self
-            .items
-            .lock()
-            .extract_if(|x| Weak::ptr_eq(&x.epoll(), item))
-            .collect::<Vec<_>>();
-
-        let result = if !to_remove.is_empty() {
-            Ok(())
-        } else {
-            Err(SystemError::ENOENT)
-        };
-
-        drop(to_remove);
-        return result;
-    }
-
-    pub fn clear(&self) -> Result<(), SystemError> {
-        let mut guard = self.items.lock();
-        let mut result = Ok(());
-        guard.iter().for_each(|item| {
-            if let Some(epoll) = item.epoll().upgrade() {
-                let _ =
-                    EventPoll::ep_remove(&mut epoll.lock(), item.fd(), None, item).map_err(|e| {
-                        result = Err(e);
-                    });
-            }
-        });
-        guard.clear();
-        return result;
+    pub fn remove(&self, item: &Arc<EPollItem>) -> Result<(), SystemError> {
+        self.items.remove(item)
     }
 }

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -460,7 +460,7 @@ impl<T: Socket + 'static> PollableInode for T {
         epitm: &Arc<crate::filesystem::epoll::EPollItem>,
         _: &FilePrivateData,
     ) -> Result<(), SystemError> {
-        let _ = self.epoll_items().remove(&epitm.epoll());
+        let _ = self.epoll_items().remove(epitm);
         return Ok(());
     }
 

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -6,7 +6,7 @@ mod util;
 
 use crate::arch::MMArch;
 use crate::bpf::prog::BpfProg;
-use crate::filesystem::epoll::event_poll::LockedEPItemLinkedList;
+use crate::filesystem::epoll::event_poll::EPollItemList;
 use crate::filesystem::epoll::{event_poll::EventPoll, EPollEventType, EPollItem};
 use crate::filesystem::page_cache::PageCache;
 use crate::filesystem::vfs::file::{File, FileFlags};
@@ -168,14 +168,14 @@ impl Drop for BasicPerfEbpfCallBack {
 #[derive(Debug)]
 pub struct PerfEventInode {
     event: Box<dyn PerfEventOps>,
-    epitems: LockedEPItemLinkedList,
+    epitems: EPollItemList,
 }
 
 impl PerfEventInode {
     pub fn new(event: Box<dyn PerfEventOps>) -> Self {
         Self {
             event,
-            epitems: LockedEPItemLinkedList::default(),
+            epitems: EPollItemList::default(),
         }
     }
     fn do_poll(&self) -> Result<usize> {
@@ -310,7 +310,7 @@ impl PollableInode for PerfEventInode {
     }
 
     fn add_epitem(&self, epitem: Arc<EPollItem>, _private_data: &FilePrivateData) -> Result<()> {
-        self.epitems.lock().push_back(epitem);
+        self.epitems.add(epitem);
         Ok(())
     }
 
@@ -319,13 +319,7 @@ impl PollableInode for PerfEventInode {
         epitem: &Arc<EPollItem>,
         _private_data: &FilePrivateData,
     ) -> Result<()> {
-        let mut guard = self.epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            return Ok(());
-        }
-        Err(SystemError::ENOENT)
+        self.epitems.remove(epitem)
     }
 }
 

--- a/kernel/src/process/pid.rs
+++ b/kernel/src/process/pid.rs
@@ -2,7 +2,7 @@ use core::fmt::Debug;
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use crate::filesystem::epoll::{
-    event_poll::{EventPoll, LockedEPItemLinkedList},
+    event_poll::{EPollItemList, EventPoll},
     EPollEventType, EPollItem,
 };
 use crate::libs::rwlock::RwLock;
@@ -77,7 +77,7 @@ pub struct Pid {
     /// 在各个namespace中的PID值
     numbers: SpinLock<Vec<Option<UPid>>>,
     /// pidfd poll/epoll waiters. Linux keeps this wakeup edge on struct pid.
-    pidfd_epitems: LockedEPItemLinkedList,
+    pidfd_epitems: EPollItemList,
 }
 
 impl Debug for Pid {
@@ -94,7 +94,7 @@ impl Pid {
             level,
             tasks: core::array::from_fn(|_| SpinLock::new(Vec::new())),
             numbers: SpinLock::new(vec![None; level as usize + 1]),
-            pidfd_epitems: LockedEPItemLinkedList::default(),
+            pidfd_epitems: EPollItemList::default(),
         });
 
         pid
@@ -109,18 +109,11 @@ impl Pid {
     }
 
     pub(crate) fn add_pidfd_epitem(&self, epitem: Arc<EPollItem>) {
-        self.pidfd_epitems.lock().push_back(epitem);
+        self.pidfd_epitems.add(epitem);
     }
 
     pub(crate) fn remove_pidfd_epitem(&self, epitem: &Arc<EPollItem>) -> Result<(), SystemError> {
-        let mut guard = self.pidfd_epitems.lock();
-        let len = guard.len();
-        guard.retain(|x| !Arc::ptr_eq(x, epitem));
-        if len != guard.len() {
-            Ok(())
-        } else {
-            Err(SystemError::ENOENT)
-        }
+        self.pidfd_epitems.remove(epitem)
     }
 
     pub(crate) fn wake_pidfd_pollers(&self) {

--- a/user/apps/tests/dunitest/suites/normal/epoll_ctl_wait_concurrency.cc
+++ b/user/apps/tests/dunitest/suites/normal/epoll_ctl_wait_concurrency.cc
@@ -4,6 +4,8 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/epoll.h>
+#include <sys/eventfd.h>
+#include <sys/socket.h>
 #include <unistd.h>
 
 #include <atomic>
@@ -132,6 +134,160 @@ TEST(EpollCtlWaitConcurrency, StableSourceSurvivesConcurrentCtlUpdates) {
     close(stable_pipe[1]);
     close(ctl_pipe[0]);
     close(ctl_pipe[1]);
+}
+
+TEST(EpollCtlWaitConcurrency, DeletedItemCannotBeRequeuedByConcurrentWakeup) {
+    constexpr int kRounds = 500;
+    constexpr int kRunning = 1;
+    constexpr int kPaused = 2;
+    constexpr int kStopped = 3;
+
+    const int source = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    ASSERT_GE(source, 0) << strerror(errno);
+    const int epfd = epoll_create1(EPOLL_CLOEXEC);
+    ASSERT_GE(epfd, 0) << strerror(errno);
+
+    std::atomic<int> state{kPaused};
+    std::atomic<bool> paused{true};
+    std::atomic<int> first_error{0};
+    std::thread producer([&]() {
+        const uint64_t one = 1;
+        for (;;) {
+            const int current = state.load(std::memory_order_acquire);
+            if (current == kStopped) {
+                return;
+            }
+            if (current == kPaused) {
+                paused.store(true, std::memory_order_release);
+                std::this_thread::yield();
+                continue;
+            }
+            paused.store(false, std::memory_order_release);
+            if (write(source, &one, sizeof(one)) != static_cast<ssize_t>(sizeof(one)) &&
+                errno != EAGAIN &&
+                errno != EWOULDBLOCK && errno != EINTR) {
+                record_first_error(&first_error, errno != 0 ? errno : EIO);
+                paused.store(true, std::memory_order_release);
+                return;
+            }
+        }
+    });
+
+    for (int round = 0; round < kRounds && first_error.load() == 0; ++round) {
+        epoll_event registration = {};
+        registration.events = EPOLLIN;
+        registration.data.u64 = kCtlSource;
+        if (epoll_ctl(epfd, EPOLL_CTL_ADD, source, &registration) != 0) {
+            record_first_error(&first_error, errno != 0 ? errno : EIO);
+            break;
+        }
+
+        state.store(kRunning, std::memory_order_release);
+        while (paused.load(std::memory_order_acquire) && first_error.load() == 0) {
+            std::this_thread::yield();
+        }
+        if (first_error.load() != 0) {
+            break;
+        }
+        if (epoll_ctl(epfd, EPOLL_CTL_DEL, source, nullptr) != 0) {
+            record_first_error(&first_error, errno != 0 ? errno : EIO);
+            break;
+        }
+        state.store(kPaused, std::memory_order_release);
+        while (!paused.load(std::memory_order_acquire) && first_error.load() == 0) {
+            std::this_thread::yield();
+        }
+        if (first_error.load() != 0) {
+            break;
+        }
+
+        epoll_event observed = {};
+        const int ready = epoll_wait(epfd, &observed, 1, 0);
+        if (ready != 0) {
+            record_first_error(&first_error, ready < 0 && errno != 0 ? errno : EIO);
+            break;
+        }
+
+        uint64_t count = 0;
+        while (read(source, &count, sizeof(count)) == sizeof(count)) {
+        }
+        if (errno != EAGAIN && errno != EWOULDBLOCK) {
+            record_first_error(&first_error, errno != 0 ? errno : EIO);
+            break;
+        }
+    }
+
+    state.store(kStopped, std::memory_order_release);
+    producer.join();
+    EXPECT_EQ(0, first_error.load()) << strerror(first_error.load());
+    close(epfd);
+    close(source);
+}
+
+TEST(EpollCtlWaitConcurrency, DeletingOneDuplicatedSocketRegistrationKeepsTheOther) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
+    const int duplicate = dup(sockets[0]);
+    ASSERT_GE(duplicate, 0) << strerror(errno);
+    const int epfd = epoll_create1(EPOLL_CLOEXEC);
+    ASSERT_GE(epfd, 0) << strerror(errno);
+
+    epoll_event original_event = {};
+    original_event.events = EPOLLIN;
+    original_event.data.u64 = 1;
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, sockets[0], &original_event)) << strerror(errno);
+
+    epoll_event duplicate_event = {};
+    duplicate_event.events = EPOLLIN;
+    duplicate_event.data.u64 = 2;
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, duplicate, &duplicate_event)) << strerror(errno);
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_DEL, sockets[0], nullptr)) << strerror(errno);
+
+    const char byte = 'x';
+    ASSERT_EQ(1, write(sockets[1], &byte, sizeof(byte))) << strerror(errno);
+    epoll_event observed = {};
+    ASSERT_EQ(1, epoll_wait(epfd, &observed, 1, 1000)) << strerror(errno);
+    EXPECT_EQ(2u, observed.data.u64);
+
+    close(epfd);
+    close(duplicate);
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(EpollCtlWaitConcurrency, ReusedFdNumberKeepsRegistrationsSeparatedByOpenFile) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
+    const int original_fd = sockets[0];
+    const int keepalive = dup(original_fd);
+    ASSERT_GE(keepalive, 0) << strerror(errno);
+    const int epfd = epoll_create1(EPOLL_CLOEXEC);
+    ASSERT_GE(epfd, 0) << strerror(errno);
+
+    epoll_event old_event = {};
+    old_event.events = EPOLLIN;
+    old_event.data.u64 = 11;
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, original_fd, &old_event)) << strerror(errno);
+    ASSERT_EQ(0, close(original_fd)) << strerror(errno);
+
+    const int replacement = eventfd(0, EFD_NONBLOCK | EFD_CLOEXEC);
+    ASSERT_EQ(original_fd, replacement) << "the replacement must reuse the registered fd number";
+    epoll_event new_event = {};
+    new_event.events = EPOLLIN;
+    new_event.data.u64 = 22;
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_ADD, replacement, &new_event)) << strerror(errno);
+    ASSERT_EQ(0, epoll_ctl(epfd, EPOLL_CTL_DEL, replacement, nullptr)) << strerror(errno);
+
+    const char byte = 'x';
+    ASSERT_EQ(1, write(sockets[1], &byte, sizeof(byte))) << strerror(errno);
+    epoll_event observed = {};
+    ASSERT_EQ(1, epoll_wait(epfd, &observed, 1, 1000)) << strerror(errno);
+    EXPECT_EQ(11u, observed.data.u64);
+
+    close(replacement);
+    close(epfd);
+    close(keepalive);
+    close(sockets[1]);
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/hvc_console_backpressure.cc
+++ b/user/apps/tests/dunitest/suites/normal/hvc_console_backpressure.cc
@@ -4,9 +4,12 @@
 #include <fcntl.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <poll.h>
 #include <unistd.h>
 
 #include <array>
+#include <atomic>
+#include <thread>
 
 namespace {
 
@@ -56,6 +59,59 @@ TEST(HvcConsoleBackpressureTest, LargeNonblockingWriteReportsProgressOrAgain) {
     ASSERT_EQ(0, ioctl(fd.get(), TIOCOUTQ, &pending))
         << "TIOCOUTQ failed: errno=" << errno << " (" << strerror(errno) << ")";
     EXPECT_GE(pending, 0);
+}
+
+TEST(HvcConsoleBackpressureTest, PollRegistrationSurvivesConcurrentTxCompletions) {
+    UniqueFd fd(open("/dev/hvc0", O_WRONLY | O_NONBLOCK));
+    if (fd.get() < 0 && errno == ENOENT) {
+        GTEST_SKIP() << "/dev/hvc0 is not available on this platform";
+    }
+    ASSERT_GE(fd.get(), 0) << "open(/dev/hvc0) failed: errno=" << errno << " ("
+                           << strerror(errno) << ")";
+
+    constexpr int kPollRounds = 20000;
+    constexpr int kWriteRounds = 256;
+    std::atomic<bool> start{false};
+    std::atomic<int> poll_error{0};
+    std::atomic<int> write_error{0};
+
+    std::thread poller([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        pollfd pfd = {fd.get(), POLLOUT, 0};
+        for (int i = 0; i < kPollRounds; ++i) {
+            pfd.revents = 0;
+            const int ret = poll(&pfd, 1, 0);
+            if (ret < 0 && errno != EINTR) {
+                poll_error.store(errno != 0 ? errno : EIO, std::memory_order_release);
+                return;
+            }
+        }
+    });
+
+    std::thread writer([&]() {
+        while (!start.load(std::memory_order_acquire)) {
+            std::this_thread::yield();
+        }
+        std::array<char, 64> data{};
+        data.fill('x');
+        for (int i = 0; i < kWriteRounds; ++i) {
+            const ssize_t ret = write(fd.get(), data.data(), data.size());
+            if (ret < 0 && errno != EAGAIN && errno != EWOULDBLOCK && errno != EINTR) {
+                write_error.store(errno != 0 ? errno : EIO, std::memory_order_release);
+                return;
+            }
+            std::this_thread::yield();
+        }
+    });
+
+    start.store(true, std::memory_order_release);
+    poller.join();
+    writer.join();
+
+    EXPECT_EQ(0, poll_error.load()) << strerror(poll_error.load());
+    EXPECT_EQ(0, write_error.load()) << strerror(write_error.load());
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- replace the exposed epoll registration-list spin lock with a narrow IRQ-safe container API
- linearize callback publication with `EPOLL_CTL_DEL`, file release, and epoll close
- distinguish registrations by open-file identity and descriptor, and preserve the original signalfd owner
- add regressions for HVC interrupt re-entry, stale callback requeue, duplicated sockets, and descriptor reuse

## Root cause

Task-context poll registration could hold a source's epoll-item spin lock with local interrupts enabled. A virtio-console TX interrupt could then re-enter the same source through TTY wakeup and spin forever on that lock on the same CPU. The public lock alias also allowed the same inconsistent lock discipline across other pollable sources.

## Design

The registration list now exposes only IRQ-safe add, exact remove, snapshot, and take-all operations. An active flag, ordered by the event poll ready-state lock, prevents an in-flight callback snapshot from publishing an item after definitive removal. Event-poll registrations use `(open_file_id, fd)` keys to match Linux open-file-description semantics, while source-specific cleanup retains exact item and owner identity.

## Validation

- `cargo fmt --manifest-path kernel/Cargo.toml --all --check`
- `git diff --check`
- x86_64 `make kernel`
- RISC-V release Rust build and kernel ELF link; the environment lacks the final DragonStub directory
- DragonOS guest: epoll concurrency 4/4
- DragonOS guest: HVC backpressure and concurrent TX completion 2/2
- DragonOS guest: epoll timeout 1/1
- DragonOS guest: pipe release 8/8
- DragonOS guest: TTY/PTTY hangup 36/36
- DragonOS guest: install and purge `ca-certificates`; both dpkg database scans completed through 100%
- final three-role adversarial review: no remaining findings
