### PR TITLE
fix(exec): clean robust futex state before mm replacement

### DIFF
--- a/kernel/src/arch/x86_64/mm/fault.rs
+++ b/kernel/src/arch/x86_64/mm/fault.rs
@@ -347,18 +347,18 @@ impl X86_64MMArch {
                             continue;
                         }
 
-                        log::error!(
-                        "pid:{}, can not find nearest vma, \n\terror_code: {:?}, address: {:#x}, rip: {:#x}",
-                        ProcessManager::current_pid().data(),
-                        error_code,
-                        address.data(),
-                        regs.rip,
-                    );
-
-                        // VMA不存在，检查是否需要异常表修复
+                        // No VMA exists, so try an exception-table fixup first.
                         if handle_kernel_access_failed(regs) {
-                            return; // 已通过异常表修复
+                            return;
                         }
+
+                        log::error!(
+                            "pid:{}, can not find nearest vma, \n\terror_code: {:?}, address: {:#x}, rip: {:#x}",
+                            ProcessManager::current_pid().data(),
+                            error_code,
+                            address.data(),
+                            regs.rip,
+                        );
 
                         send_segv_maperr();
                         return;
@@ -469,18 +469,19 @@ impl X86_64MMArch {
                         drop(space_guard);
                         continue 'fault_retry;
                     } else {
-                        log::error!(
-                        "pid: {} No mapped vma, error_code: {:?},rip:{:#x}, address: {:#x}, flags: {:?}",
-                        ProcessManager::current_pid().data(),
-                        error_code,
-                        regs.rip,
-                        address.data(),
-                        flags
-                    );
-                        // 地址不在VMA范围内，检查是否需要异常表修复
+                        // The address is outside every VMA; try an exception-table fixup first.
                         if handle_kernel_access_failed(regs) {
-                            return; // 已通过异常表修复
+                            return;
                         }
+
+                        log::error!(
+                            "pid: {} No mapped vma, error_code: {:?},rip:{:#x}, address: {:#x}, flags: {:?}",
+                            ProcessManager::current_pid().data(),
+                            error_code,
+                            regs.rip,
+                            address.data(),
+                            flags
+                        );
 
                         send_segv_maperr();
                         return;

--- a/kernel/src/libs/futex/futex.rs
+++ b/kernel/src/libs/futex/futex.rs
@@ -14,7 +14,6 @@ use core::{
     intrinsics::{likely, unlikely},
     mem,
     ops::{Deref, DerefMut},
-    sync::atomic::{AtomicU32, Ordering},
 };
 use log::warn;
 
@@ -813,6 +812,132 @@ impl Futex {
         unsafe { Self::arch_futex_atomic_op_inuser_nofault(op, oparg, uaddr.as_ptr::<u32>()) }
     }
 
+    fn futex_cmpxchg_user(uaddr: VirtAddr, expected: u32, new: u32) -> Result<u32, SystemError> {
+        if uaddr.data() & (core::mem::align_of::<u32>() - 1) != 0 {
+            return Err(SystemError::EINVAL);
+        }
+        access_ok(uaddr, core::mem::size_of::<u32>()).map_err(|_| SystemError::EFAULT)?;
+
+        let _pagefault_guard = PageFaultDisabledGuard::new();
+        unsafe { Self::arch_futex_cmpxchg_nofault(uaddr.as_ptr::<u32>(), expected, new) }
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    unsafe fn arch_futex_cmpxchg_nofault(
+        uaddr: *mut u32,
+        mut expected: u32,
+        new: u32,
+    ) -> Result<u32, SystemError> {
+        let mut fault = 0usize;
+        asm!(
+            "2:",
+            "lock cmpxchg dword ptr [{ptr}], {new:e}",
+            "jmp 3f",
+            "4:",
+            "mov {fault}, 1",
+            "3:",
+            ".pushsection __ex_table, \"a\"",
+            ".balign 8",
+            ".quad 2b - .",
+            ".quad 4b - . + 8",
+            ".popsection",
+            ptr = in(reg) uaddr,
+            new = in(reg) new,
+            inout("eax") expected,
+            fault = inout(reg) fault,
+            options(nostack)
+        );
+        if fault == 0 {
+            Ok(expected)
+        } else {
+            Err(SystemError::EFAULT)
+        }
+    }
+
+    #[cfg(target_arch = "riscv64")]
+    unsafe fn arch_futex_cmpxchg_nofault(
+        uaddr: *mut u32,
+        expected: u32,
+        new: u32,
+    ) -> Result<u32, SystemError> {
+        let mut observed: usize;
+        let mut fault = 0usize;
+        asm!(
+            "2:",
+            "lr.w.aq {observed}, ({ptr})",
+            "bne {observed}, {expected}, 5f",
+            "3:",
+            "sc.w.rl {status}, {new}, ({ptr})",
+            "bnez {status}, 2b",
+            "j 5f",
+            "4:",
+            "li {fault}, 1",
+            "5:",
+            ".pushsection __ex_table, \"a\"",
+            ".balign 8",
+            ".quad 2b - .",
+            ".quad 4b - . + 8",
+            ".quad 3b - .",
+            ".quad 4b - . + 8",
+            ".popsection",
+            ptr = in(reg) uaddr,
+            expected = in(reg) expected as i32 as isize as usize,
+            new = in(reg) new as usize,
+            observed = out(reg) observed,
+            status = out(reg) _,
+            fault = inout(reg) fault,
+            options(nostack)
+        );
+        if fault == 0 {
+            Ok(observed as u32)
+        } else {
+            Err(SystemError::EFAULT)
+        }
+    }
+
+    #[cfg(target_arch = "loongarch64")]
+    unsafe fn arch_futex_cmpxchg_nofault(
+        uaddr: *mut u32,
+        expected: u32,
+        new: u32,
+    ) -> Result<u32, SystemError> {
+        let mut observed: usize;
+        let mut fault = 0usize;
+        asm!(
+            "2:",
+            "ll.w {observed}, {ptr}, 0",
+            "bne {observed}, {expected}, 5f",
+            "or {status}, {new}, $zero",
+            "3:",
+            "sc.w {status}, {ptr}, 0",
+            "beqz {status}, 2b",
+            "b 5f",
+            "4:",
+            "ori {fault}, $zero, 1",
+            "5:",
+            "dbar 0x700",
+            ".pushsection __ex_table, \"a\"",
+            ".balign 8",
+            ".dword 2b - .",
+            ".dword 4b - . + 8",
+            ".dword 3b - .",
+            ".dword 4b - . + 8",
+            ".popsection",
+            ptr = in(reg) uaddr,
+            expected = in(reg) expected as i32 as isize as usize,
+            new = in(reg) new as usize,
+            observed = out(reg) observed,
+            status = out(reg) _,
+            fault = inout(reg) fault,
+            options(nostack)
+        );
+        if fault == 0 {
+            Ok(observed as u32)
+        } else {
+            Err(SystemError::EFAULT)
+        }
+    }
+
     #[cfg(target_arch = "x86_64")]
     unsafe fn arch_futex_atomic_op_inuser_nofault(
         op: FutexOP,
@@ -1458,20 +1583,6 @@ impl DerefMut for RobustListHead {
 }
 
 impl RobustListHead {
-    /// # 获得futex的用户空间地址
-    pub fn futex_uaddr(&self, entry: VirtAddr) -> VirtAddr {
-        return VirtAddr::new(entry.data() + self.futex_offset as usize);
-    }
-
-    /// #获得list_op_peding的用户空间地址
-    pub fn pending_uaddr(&self) -> Option<VirtAddr> {
-        if self.list_op_pending.is_null() {
-            return None;
-        } else {
-            return Some(self.futex_uaddr(self.list_op_pending));
-        }
-    }
-
     /// # 在内核注册robust list
     /// ## 参数
     /// - head_uaddr：robust list head用户空间地址
@@ -1569,19 +1680,17 @@ impl RobustListHead {
         return Ok(0);
     }
 
-    /// # 进程/线程退出时清理工作
-    /// ## 参数
-    /// - current：当前进程/线程的pcb
-    /// - pid：当前进程/线程的pid
-    pub fn exit_robust_list(pcb: Arc<ProcessControlBlock>) {
-        //指向当前进程的robust list头部的指针
-        let head_info = match *pcb.get_robust_list() {
-            Some(rl) => rl,
-            None => {
-                return;
-            }
+    pub fn cleanup_robust_list(pcb: &Arc<ProcessControlBlock>) {
+        let Some(head) = pcb.take_robust_list() else {
+            return;
         };
+        Self::cleanup_robust_list_head(pcb, head);
+    }
 
+    pub(crate) fn cleanup_robust_list_head(
+        pcb: &Arc<ProcessControlBlock>,
+        head_info: RobustListHead,
+    ) {
         // 重新从用户空间读取 robust list head 的最新内容
         // 因为用户态可能在锁定 mutex 后已经更新了链表
         let user_buffer_reader = match UserBufferReader::new(
@@ -1610,20 +1719,17 @@ impl RobustListHead {
             uaddr: head_info.uaddr,
         };
 
-        // 遍历当前进程/线程的robust list
-        for futex_uaddr in head.futexes() {
-            let pid = pcb.raw_pid().into() as u32;
-            match Self::handle_pi_futex_death(futex_uaddr, pid) {
-                Ok(true) => continue,
-                Ok(false) => {}
-                Err(_) => return,
-            }
-            let ret = Self::handle_futex_death(futex_uaddr, pid);
-            if ret.is_err() {
+        let pid = pcb.task_pid_vnr().data() as u32;
+        for entry in head.futexes() {
+            let result = if entry.pi {
+                Self::handle_pi_futex_death(entry.uaddr, pid).map(|_| ())
+            } else {
+                Self::handle_futex_death(entry.uaddr, pid, entry.pending).map(|_| ())
+            };
+            if result.is_err() {
                 return;
             }
         }
-        pcb.set_robust_list(None);
     }
 
     /// # 返回robust list的迭代器，将robust list list_op_pending 放到最后（如果存在）
@@ -1653,26 +1759,31 @@ impl RobustListHead {
     /// ## 参数
     /// - futex_uaddr：futex的用户空间地址
     /// - pid: 当前进程/线程的pid
-    fn handle_futex_death(futex_uaddr: VirtAddr, pid: u32) -> Result<usize, SystemError> {
+    fn handle_futex_death(
+        futex_uaddr: VirtAddr,
+        pid: u32,
+        pending: bool,
+    ) -> Result<usize, SystemError> {
         // 安全地读取futex值
         let futex_val = match Self::safe_read_u32(futex_uaddr) {
             Some(val) => val,
-            None => {
-                // 地址无效，跳过此futex
-                return Ok(0);
-            }
+            None => return Err(SystemError::EFAULT),
         };
 
         let mut uval = futex_val;
 
-        // 获取futex的原子操作指针
-        // 使用 AtomicU32::from_ptr() 从原始指针创建原子操作对象
-        // 注意：这里我们已经通过safe_read验证了地址的有效性
-        let atomic_futex = unsafe { AtomicU32::from_ptr(futex_uaddr.as_ptr::<u32>()) };
-
         loop {
             // 该futex可能被其他进程占有
             let owner = uval & FUTEX_TID_MASK;
+            if pending && owner == 0 {
+                let _ = Futex::futex_wake(
+                    futex_uaddr,
+                    FutexFlag::FLAGS_SHARED,
+                    1,
+                    FUTEX_BITSET_MATCH_ANY,
+                );
+                break;
+            }
             if owner != pid {
                 break;
             }
@@ -1681,8 +1792,8 @@ impl RobustListHead {
             let mval = (uval & FUTEX_WAITERS) | FUTEX_OWNER_DIED;
 
             // 使用真正的原子CAS操作
-            match atomic_futex.compare_exchange(uval, mval, Ordering::SeqCst, Ordering::SeqCst) {
-                Ok(_) => {
+            match Futex::futex_cmpxchg_user(futex_uaddr, uval, mval) {
+                Ok(observed) if observed == uval => {
                     // CAS成功，检查是否需要唤醒等待者
                     if mval & FUTEX_WAITERS != 0 {
                         let mut flags = FutexFlag::FLAGS_MATCH_NONE;
@@ -1692,11 +1803,11 @@ impl RobustListHead {
                     }
                     break;
                 }
-                Err(current) => {
-                    // CAS失败，说明值被其他线程修改了，更新uval并重试
-                    uval = current;
+                Ok(observed) => {
+                    uval = observed;
                     continue;
                 }
+                Err(err) => return Err(err),
             }
         }
 
@@ -1711,12 +1822,10 @@ impl RobustListHead {
     fn handle_pi_futex_death(futex_uaddr: VirtAddr, pid: u32) -> Result<bool, SystemError> {
         let futex_val = match Self::safe_read_u32(futex_uaddr) {
             Some(val) => val,
-            None => return Ok(false),
+            None => return Err(SystemError::EFAULT),
         };
 
         let mut uval = futex_val;
-        let atomic_futex = unsafe { AtomicU32::from_ptr(futex_uaddr.as_ptr::<u32>()) };
-
         let key_private = Futex::get_futex_key(futex_uaddr, false, FutexAccess::FutexWrite).ok();
         let key_shared = Futex::get_futex_key(futex_uaddr, true, FutexAccess::FutexWrite).ok();
 
@@ -1752,17 +1861,13 @@ impl RobustListHead {
                     None => {
                         drop(futex_map_guard);
                         let mval = FUTEX_OWNER_DIED;
-                        match atomic_futex.compare_exchange(
-                            uval,
-                            mval,
-                            Ordering::SeqCst,
-                            Ordering::SeqCst,
-                        ) {
-                            Ok(_) => return Ok(true),
-                            Err(current) => {
-                                uval = current;
+                        match Futex::futex_cmpxchg_user(futex_uaddr, uval, mval) {
+                            Ok(observed) if observed == uval => return Ok(true),
+                            Ok(observed) => {
+                                uval = observed;
                                 continue;
                             }
+                            Err(err) => return Err(err),
                         }
                     }
                 };
@@ -1774,22 +1879,18 @@ impl RobustListHead {
 
                 if bucket.pi_waiters.is_empty() {
                     let mval = FUTEX_OWNER_DIED;
-                    match atomic_futex.compare_exchange(
-                        uval,
-                        mval,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    ) {
-                        Ok(_) => {
+                    match Futex::futex_cmpxchg_user(futex_uaddr, uval, mval) {
+                        Ok(observed) if observed == uval => {
                             bucket.pi_owner = 0;
                             drop(futex_map_guard);
                             FutexData::try_remove(key);
                             return Ok(true);
                         }
-                        Err(current) => {
-                            uval = current;
+                        Ok(observed) => {
+                            uval = observed;
                             continue;
                         }
+                        Err(err) => return Err(err),
                     }
                 }
 
@@ -1799,23 +1900,22 @@ impl RobustListHead {
                     let new_val = next_waiter.tid
                         | FUTEX_OWNER_DIED
                         | if has_more { FUTEX_WAITERS } else { 0 };
-                    match atomic_futex.compare_exchange(
-                        uval,
-                        new_val,
-                        Ordering::SeqCst,
-                        Ordering::SeqCst,
-                    ) {
-                        Ok(_) => {
+                    match Futex::futex_cmpxchg_user(futex_uaddr, uval, new_val) {
+                        Ok(observed) if observed == uval => {
                             bucket.pi_owner = next_waiter.tid;
                             drop(futex_map_guard);
                             next_waiter.waker.wake();
                             return Ok(true);
                         }
-                        Err(current) => {
+                        Ok(observed) => {
                             bucket.pi_waiters.push_front(next_waiter);
                             drop(futex_map_guard);
-                            uval = current;
+                            uval = observed;
                             continue;
+                        }
+                        Err(err) => {
+                            bucket.pi_waiters.push_front(next_waiter);
+                            return Err(err);
                         }
                     }
                 }
@@ -1825,21 +1925,29 @@ impl RobustListHead {
             }
 
             let mval = FUTEX_OWNER_DIED;
-            match atomic_futex.compare_exchange(uval, mval, Ordering::SeqCst, Ordering::SeqCst) {
-                Ok(_) => return Ok(true),
-                Err(current) => {
-                    uval = current;
+            match Futex::futex_cmpxchg_user(futex_uaddr, uval, mval) {
+                Ok(observed) if observed == uval => return Ok(true),
+                Ok(observed) => {
+                    uval = observed;
                     continue;
                 }
+                Err(err) => return Err(err),
             }
         }
     }
 }
 
-pub struct FutexIterator<'a> {
+struct FutexIterator<'a> {
     robust_list_head: &'a RobustListHead,
     entry: VirtAddr,
     count: isize,
+    stop_after_current: bool,
+}
+
+struct RobustFutexEntry {
+    uaddr: VirtAddr,
+    pi: bool,
+    pending: bool,
 }
 
 impl<'a> FutexIterator<'a> {
@@ -1848,7 +1956,37 @@ impl<'a> FutexIterator<'a> {
             robust_list_head,
             entry: robust_list_head.list.next,
             count: 0,
+            stop_after_current: false,
         };
+    }
+
+    fn decode_entry(
+        &self,
+        encoded: VirtAddr,
+        pending: bool,
+    ) -> Result<RobustFutexEntry, SystemError> {
+        if encoded.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+        let pi = encoded.data() & 1 != 0;
+        let base = encoded.data() & !1;
+        let address = base
+            .checked_add_signed(self.robust_list_head.futex_offset)
+            .ok_or(SystemError::EFAULT)?;
+        if address & (core::mem::align_of::<u32>() - 1) != 0 {
+            return Err(SystemError::EINVAL);
+        }
+        let uaddr = VirtAddr::new(address);
+        access_ok(uaddr, core::mem::size_of::<u32>()).map_err(|_| SystemError::EFAULT)?;
+        Ok(RobustFutexEntry { uaddr, pi, pending })
+    }
+
+    fn pending_entry(&self) -> Option<RobustFutexEntry> {
+        if self.robust_list_head.list_op_pending.is_null() {
+            return None;
+        }
+        self.decode_entry(self.robust_list_head.list_op_pending, true)
+            .ok()
     }
 
     fn is_end(&mut self) -> bool {
@@ -1859,52 +1997,68 @@ impl<'a> FutexIterator<'a> {
     fn is_sentinel(&self) -> bool {
         // 链表的哨兵是 &head.list，其地址就是 head.uaddr
         // 因为 list 是 head 结构的第一个字段
-        self.entry.data() == self.robust_list_head.uaddr.data()
+        (self.entry.data() & !1) == self.robust_list_head.uaddr.data()
     }
 }
 
 impl Iterator for FutexIterator<'_> {
-    type Item = VirtAddr;
+    type Item = RobustFutexEntry;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if self.is_end() {
+        if self.is_end() || self.stop_after_current {
+            self.count = -1;
             return None;
         }
 
         // 如果初始 entry 就是哨兵，说明链表为空
         if self.count == 0 && self.is_sentinel() {
             self.count = -1;
-            return self.robust_list_head.pending_uaddr();
+            return self.pending_entry();
         }
 
         while !self.is_sentinel() {
             if self.count >= ROBUST_LIST_LIMIT {
                 break;
             }
-            if self.entry.is_null() {
+            let encoded_entry = self.entry;
+            if encoded_entry.is_null() {
                 return None;
             }
 
+            let entry_address = VirtAddr::new(encoded_entry.data() & !1);
+            let pending_address = self.robust_list_head.list_op_pending.data() & !1;
+
             //获取futex val地址
-            let futex_uaddr = if self.entry.data() != self.robust_list_head.list_op_pending.data() {
-                Some(self.robust_list_head.futex_uaddr(self.entry))
+            let futex_entry = if entry_address.data() != pending_address {
+                match self.decode_entry(encoded_entry, false) {
+                    Ok(entry) => Some(entry),
+                    Err(_) => {
+                        self.count = -1;
+                        return None;
+                    }
+                }
             } else {
                 None
             };
 
             // 安全地读取下一个entry
-            let next_entry = RobustListHead::safe_read::<PosixRobustList>(self.entry)
-                .and_then(|reader| reader.read_one_from_user::<PosixRobustList>(0).ok())?;
+            let next_entry = RobustListHead::safe_read::<PosixRobustList>(entry_address)
+                .and_then(|reader| reader.read_one_from_user::<PosixRobustList>(0).ok());
+
+            let Some(next_entry) = next_entry else {
+                self.stop_after_current = true;
+                return futex_entry;
+            };
 
             self.entry = next_entry.next;
             self.count += 1;
 
-            if futex_uaddr.is_some() {
-                return futex_uaddr;
+            if futex_entry.is_some() {
+                return futex_entry;
             }
         }
 
         self.count = -1;
-        self.robust_list_head.pending_uaddr()
+        self.pending_entry()
     }
 }

--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -2,6 +2,7 @@ use crate::arch::CurrentIrqArch;
 use crate::exception::InterruptArch;
 use crate::filesystem::vfs::fcntl::AtFlags;
 use crate::filesystem::vfs::open::{do_open_execat, do_open_execat_with_flags};
+use crate::libs::futex::futex::RobustListHead;
 use crate::libs::rwsem::RwSem;
 use crate::process::exec::{
     load_binary_file_with_context, ExecContext, ExecInterpFlags, ExecParam, ExecParamFlags,
@@ -155,6 +156,8 @@ fn do_execve_internal(
 
             let pcb = ProcessManager::current_pcb();
 
+            commit_exec_robust_list(&pcb, old_vm.as_ref(), &address_space);
+
             // unshare fd_table if it's shared (CLONE_FILES case)
             // 参考 Linux: https://elixir.bootlin.com/linux/v6.1.9/source/fs/exec.c#L1857
             // "Ensure the files table is not shared"
@@ -267,14 +270,9 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
     // 暂存原本的用户地址空间的引用(因为如果在切换页表之前释放了它，可能会造成内存use after free)
     let old_address_space = basic_info.user_vm();
 
-    // INV-1: when execve switches mm, first clear this CPU from the old mm's active_cpus,
-    // then switch the hardware page table, then add this CPU to the new mm's active_cpus,
-    // and finally update per-CPU TlbState.
-    // Note: on the execve path the old/new mm are always different (the new mm is a freshly
-    // created AddressSpace::new result).
-    if let Some(old_vm) = old_address_space.as_ref() {
-        old_vm.active_cpus_clear(cpu);
-    }
+    // Match the scheduler's address-space switch invariant. The temporary
+    // double membership can cause an extra shootdown, but cannot miss one.
+    new_vm.active_cpus_set(cpu);
 
     // 在pcb中原来的用户地址空间
     unsafe {
@@ -296,10 +294,38 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
     // 切换到新的用户地址空间
     unsafe { new_vm.make_current() };
 
-    new_vm.active_cpus_set(cpu);
+    core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    if let Some(old_vm) = old_address_space.as_ref() {
+        if !Arc::ptr_eq(old_vm, &new_vm) {
+            old_vm.active_cpus_clear(cpu);
+        }
+    }
     unsafe { crate::mm::tlb::tlb_state_set_loaded_mm(new_vm.clone()) };
 
     drop(irq_guard);
 
     old_address_space
+}
+
+fn commit_exec_robust_list(
+    pcb: &Arc<ProcessControlBlock>,
+    old_vm: Option<&Arc<AddressSpace>>,
+    new_vm: &Arc<AddressSpace>,
+) {
+    let Some(head) = pcb.take_robust_list() else {
+        return;
+    };
+    let Some(old_vm) = old_vm else {
+        return;
+    };
+
+    let replaced = do_execve_switch_user_vm(old_vm.clone())
+        .expect("successful user exec must replace the new address space");
+    assert!(Arc::ptr_eq(&replaced, new_vm));
+
+    RobustListHead::cleanup_robust_list_head(pcb, head);
+
+    let replaced = do_execve_switch_user_vm(new_vm.clone())
+        .expect("robust-list cleanup must leave the old address space installed");
+    assert!(Arc::ptr_eq(&replaced, old_vm));
 }

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -437,7 +437,7 @@ impl ProcessManager {
             }
             compiler_fence(Ordering::SeqCst);
 
-            RobustListHead::exit_robust_list(pcb.clone());
+            RobustListHead::cleanup_robust_list(&pcb);
             // If this process was created via vfork, complete the completion.
             if let Some(vd) = vfork_done {
                 vd.complete_all();

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -1347,6 +1347,11 @@ impl ProcessControlBlock {
     }
 
     #[inline(always)]
+    pub fn take_robust_list(&self) -> Option<RobustListHead> {
+        self.robust_list.write_irqsave().take()
+    }
+
+    #[inline(always)]
     pub fn alarm_timer_irqsave(&self) -> SpinLockGuard<'_, Option<AlarmTimer>> {
         return self.alarm_timer.lock_irqsave();
     }

--- a/user/apps/tests/dunitest/suites/normal/exec_abi.cc
+++ b/user/apps/tests/dunitest/suites/normal/exec_abi.cc
@@ -3,11 +3,15 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>
+#include <stddef.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/auxv.h>
+#include <sys/mman.h>
 #include <sys/stat.h>
+#include <sys/syscall.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -59,6 +63,43 @@ constexpr unsigned char kCheckRdxElf[] = {
     0x0f, 0x05,
 };
 
+constexpr unsigned char kCheckRobustListClearedElf[] = {
+    0x7f, 0x45, 0x4c, 0x46, 0x02, 0x01, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x3e, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x78, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x38, 0x00, 0x01, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00,
+
+    0x01, 0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00, 0xb6, 0x00, 0x00, 0x00,
+    0x00, 0x00, 0x00, 0x00, 0xb6, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+    0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+    // get_robust_list(0, rsp, rsp + 8); require a NULL head and sizeof(head).
+    0x48, 0x83, 0xec, 0x20, 0x31, 0xff, 0x48, 0x8d, 0x34, 0x24, 0x48, 0x8d,
+    0x54, 0x24, 0x08, 0xb8, 0x12, 0x01, 0x00, 0x00, 0x0f, 0x05, 0x85, 0xc0,
+    0x75, 0x18, 0x48, 0x83, 0x3c, 0x24, 0x00, 0x75, 0x11, 0x48, 0x83, 0x7c,
+    0x24, 0x08, 0x18, 0x75, 0x09, 0x31, 0xff, 0xb8, 0x3c, 0x00, 0x00, 0x00,
+    0x0f, 0x05, 0xbf, 0x2a, 0x00, 0x00, 0x00, 0xb8, 0x3c, 0x00, 0x00, 0x00,
+    0x0f, 0x05,
+};
+
+struct TestRobustListHead {
+    uintptr_t next;
+    intptr_t futex_offset;
+    uintptr_t list_op_pending;
+};
+
+struct TestRobustNode {
+    uintptr_t next;
+    uint32_t futex;
+};
+
+constexpr uint32_t kFutexTidMask = 0x3fffffffU;
+constexpr uint32_t kFutexOwnerDied = 0x40000000U;
+
 void write_all(int fd, const void* data, size_t size) {
     const char* p = static_cast<const char*>(data);
     while (size > 0) {
@@ -80,6 +121,25 @@ void write_check_rdx_elf(char* path, size_t path_size) {
                             << strerror(errno) << ")";
     ASSERT_EQ(0, chmod(path, 0755)) << "chmod(" << path << ") failed: errno=" << errno << " ("
                                     << strerror(errno) << ")";
+}
+
+void write_executable(const char* path, const void* data, size_t size) {
+    int fd = open(path, O_CREAT | O_TRUNC | O_WRONLY, 0755);
+    ASSERT_GE(fd, 0) << "open(" << path << ") failed: errno=" << errno << " ("
+                     << strerror(errno) << ")";
+    write_all(fd, data, size);
+    ASSERT_EQ(0, close(fd));
+    ASSERT_EQ(0, chmod(path, 0755));
+}
+
+int set_test_robust_list(TestRobustListHead* head, TestRobustNode* node) {
+    const pid_t tid = static_cast<pid_t>(syscall(SYS_gettid));
+    node->next = reinterpret_cast<uintptr_t>(head);
+    node->futex = static_cast<uint32_t>(tid);
+    head->next = reinterpret_cast<uintptr_t>(node);
+    head->futex_offset = offsetof(TestRobustNode, futex);
+    head->list_op_pending = 0;
+    return static_cast<int>(syscall(SYS_set_robust_list, head, sizeof(*head)));
 }
 
 #endif
@@ -128,6 +188,132 @@ TEST(ExecAbi, X86_64ExecClearsRdxWhenEnvpIsNonNull) {
     ASSERT_TRUE(WIFEXITED(status)) << "child did not exit normally, status=" << status;
     EXPECT_EQ(0, WEXITSTATUS(status))
         << "exec entry %rdx was not cleared; exit 42 means old envp leaked into %rdx";
+}
+
+TEST(ExecAbi, SuccessfulExecCleansOldRobustList) {
+    ensure_tmp_dir();
+    char path[128] = {};
+    snprintf(path, sizeof(path), "/tmp/exec_abi_robust_%d", getpid());
+    write_executable(path, kCheckRobustListClearedElf, sizeof(kCheckRobustListClearedElf));
+
+    auto* node = static_cast<TestRobustNode*>(
+        mmap(nullptr, sizeof(TestRobustNode), PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, node);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        TestRobustListHead head = {};
+        if (set_test_robust_list(&head, node) != 0) {
+            _exit(90);
+        }
+        char* const argv[] = {path, nullptr};
+        char* const envp[] = {nullptr};
+        execve(path, argv, envp);
+        _exit(91);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    const uint32_t futex = __atomic_load_n(&node->futex, __ATOMIC_SEQ_CST);
+    EXPECT_EQ(0U, futex & kFutexTidMask);
+    EXPECT_NE(0U, futex & kFutexOwnerDied);
+
+    EXPECT_EQ(0, munmap(node, sizeof(TestRobustNode)));
+    EXPECT_EQ(0, unlink(path));
+}
+
+TEST(ExecAbi, SuccessfulExecToleratesReadOnlyRobustFutex) {
+    ensure_tmp_dir();
+    char path[128] = {};
+    snprintf(path, sizeof(path), "/tmp/exec_abi_robust_ro_%d", getpid());
+    write_executable(path, kCheckRobustListClearedElf, sizeof(kCheckRobustListClearedElf));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    auto* node = static_cast<TestRobustNode*>(
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_READ | PROT_WRITE,
+             MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+    ASSERT_NE(MAP_FAILED, node);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        TestRobustListHead head = {};
+        if (set_test_robust_list(&head, node) != 0) {
+            _exit(96);
+        }
+        if (mprotect(node, static_cast<size_t>(page_size), PROT_READ) != 0) {
+            _exit(97);
+        }
+        char* const argv[] = {path, nullptr};
+        char* const envp[] = {nullptr};
+        execve(path, argv, envp);
+        _exit(98);
+    }
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status));
+    const uint32_t futex = __atomic_load_n(&node->futex, __ATOMIC_SEQ_CST);
+    EXPECT_NE(0U, futex & kFutexTidMask);
+    EXPECT_EQ(0U, futex & kFutexOwnerDied);
+
+    EXPECT_EQ(0, munmap(node, static_cast<size_t>(page_size)));
+    EXPECT_EQ(0, unlink(path));
+}
+
+TEST(ExecAbi, FailedExecPreservesRobustList) {
+    ensure_tmp_dir();
+    char early_path[128] = {};
+    char late_path[128] = {};
+    snprintf(early_path, sizeof(early_path), "/tmp/exec_abi_bad_early_%d", getpid());
+    snprintf(late_path, sizeof(late_path), "/tmp/exec_abi_bad_late_%d", getpid());
+    static constexpr char kNotElf[] = "not an executable";
+    write_executable(early_path, kNotElf, sizeof(kNotElf));
+
+    unsigned char malformed[sizeof(kCheckRdxElf)] = {};
+    memcpy(malformed, kCheckRdxElf, sizeof(malformed));
+    malformed[96] += 1;  // p_filesz > p_memsz, rejected after begin_new_exec().
+    write_executable(late_path, malformed, sizeof(malformed));
+
+    for (const char* path : {early_path, late_path}) {
+        pid_t child = fork();
+        ASSERT_GE(child, 0);
+        if (child == 0) {
+            TestRobustListHead head = {};
+            TestRobustNode node = {};
+            if (set_test_robust_list(&head, &node) != 0) {
+                _exit(92);
+            }
+            char* const argv[] = {const_cast<char*>(path), nullptr};
+            char* const envp[] = {nullptr};
+            if (execve(path, argv, envp) == 0) {
+                _exit(93);
+            }
+            TestRobustListHead* observed = nullptr;
+            size_t observed_size = 0;
+            if (syscall(SYS_get_robust_list, 0, &observed, &observed_size) != 0) {
+                _exit(94);
+            }
+            if (observed != &head || observed_size != sizeof(head) ||
+                (node.futex & kFutexOwnerDied) != 0) {
+                _exit(95);
+            }
+            _exit(0);
+        }
+        int status = 0;
+        ASSERT_EQ(child, waitpid(child, &status, 0));
+        ASSERT_TRUE(WIFEXITED(status));
+        EXPECT_EQ(0, WEXITSTATUS(status));
+    }
+
+    EXPECT_EQ(0, unlink(early_path));
+    EXPECT_EQ(0, unlink(late_path));
 }
 
 #endif


### PR DESCRIPTION
## Summary

- clean robust-futex state from the old address space during the successful exec commit
- share one take-once cleanup path between exec and task exit
- make robust owner-death updates safe against userspace faults on x86_64, RISC-V, and LoongArch
- align exec address-space switching with scheduler TLB shootdown invariants
- suppress misleading missing-VMA errors when exception-table recovery succeeds
- add exec ABI regressions for cleanup, registration reset, protected write faults, and failed exec preservation

## Root cause

Successful exec replaced the task's address space without releasing its robust-list registration. The registration continued to point into the old mm, so task exit later walked an unmapped userspace address. Besides producing misleading missing-VMA diagnostics, this skipped the Linux-compatible owner-death transition and waiter wakeup.

The existing robust cleanup also performed raw atomic operations on userspace pointers after a protected read. A shared-mm peer could invalidate the mapping between those operations, turning a best-effort cleanup into an unhandled kernel fault.

## Implementation

The exec commit now takes the robust-list registration exactly once, temporarily restores the old mm, performs the same best-effort cleanup used by task exit, and restores the new mm. Failed exec paths retain their original registration.

The userspace compare-exchange operation is protected by architecture exception tables and page-fault disabling. Robust entry decoding now handles PI metadata, signed offsets, alignment, malformed successors, namespace-visible owner TIDs, RISC-V and LoongArch 32-bit load extension, and LoongArch weak LL/SC ordering.

## Validation

- `make kernel ARCH=x86_64 ROOTFS_MANIFEST=ubuntu2404`
- LoongArch64 kernel compile and link
- RISC-V kernel compile and link; final packaging remains blocked by the existing missing DragonStub `install` target
- targeted `exec_abi` cleanup, read-only futex fault, and failed-exec tests repeated five times
- serial log check for missing-VMA errors, illegal userspace accesses, and kernel panics
- `git diff --check`
