### PR TITLE
fix(vfs): implement SEEK_DATA and SEEK_HOLE

### DIFF
--- a/kernel/src/driver/base/block/mod.rs
+++ b/kernel/src/driver/base/block/mod.rs
@@ -11,5 +11,7 @@ pub enum SeekFrom {
     SeekSet(i64),
     SeekCurrent(i64),
     SeekEnd(i64),
+    SeekData(i64),
+    SeekHole(i64),
     Invalid,
 }

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1835,14 +1835,18 @@ impl File {
             return Err(SystemError::ESPIPE);
         }
 
-        let file_type = self.inode.metadata()?.file_type;
+        let metadata = self.inode.metadata()?;
+        let file_type = metadata.file_type;
         // Check for procfs private data. If this is a procfs pseudo-file, disallow SEEK_END
         // and other unsupported seek modes.
         {
             let pdata = self.private_data.lock();
             if let FilePrivateData::Procfs(_) = &*pdata {
                 match origin {
-                    SeekFrom::SeekEnd(_) | SeekFrom::Invalid => {
+                    SeekFrom::SeekEnd(_)
+                    | SeekFrom::SeekData(_)
+                    | SeekFrom::SeekHole(_)
+                    | SeekFrom::Invalid => {
                         return Err(SystemError::EINVAL);
                     }
                     _ => {}
@@ -1858,6 +1862,9 @@ impl File {
                 SeekFrom::SeekEnd(_) => {
                     // Preserve the existing directory SEEK_END behavior.
                     return Ok(MAX_LFS_FILESIZE as usize);
+                }
+                SeekFrom::SeekData(_) | SeekFrom::SeekHole(_) => {
+                    return Err(SystemError::EINVAL);
                 }
                 SeekFrom::Invalid => return Err(SystemError::EINVAL),
             };
@@ -1877,9 +1884,24 @@ impl File {
         let pos: i64 = match origin {
             SeekFrom::SeekSet(offset) => offset,
             SeekFrom::SeekCurrent(offset) => self.offset.load(Ordering::SeqCst) as i64 + offset,
-            SeekFrom::SeekEnd(offset) => {
-                let metadata = self.metadata()?;
-                metadata.size + offset
+            SeekFrom::SeekEnd(offset) => metadata.size + offset,
+            SeekFrom::SeekData(offset) => {
+                if file_type != FileType::File {
+                    return Err(SystemError::EINVAL);
+                }
+                if offset < 0 || offset >= metadata.size {
+                    return Err(SystemError::ENXIO);
+                }
+                offset
+            }
+            SeekFrom::SeekHole(offset) => {
+                if file_type != FileType::File {
+                    return Err(SystemError::EINVAL);
+                }
+                if offset < 0 || offset >= metadata.size {
+                    return Err(SystemError::ENXIO);
+                }
+                metadata.size
             }
             SeekFrom::Invalid => {
                 return Err(SystemError::EINVAL);

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -146,7 +146,9 @@ mod xattr_utils;
 pub const SEEK_SET: u32 = 0;
 pub const SEEK_CUR: u32 = 1;
 pub const SEEK_END: u32 = 2;
-pub const SEEK_MAX: u32 = 3;
+pub const SEEK_DATA: u32 = 3;
+pub const SEEK_HOLE: u32 = 4;
+pub const SEEK_MAX: u32 = SEEK_HOLE;
 
 bitflags! {
     /// Flags used in the `renameat2` system call.

--- a/kernel/src/filesystem/vfs/syscall/sys_lseek.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_lseek.rs
@@ -2,8 +2,7 @@
 
 use system_error::SystemError;
 
-use super::SEEK_MAX;
-use super::{SEEK_CUR, SEEK_END, SEEK_SET};
+use super::{SEEK_CUR, SEEK_DATA, SEEK_END, SEEK_HOLE, SEEK_MAX, SEEK_SET};
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_LSEEK;
 use crate::driver::base::block::SeekFrom;
@@ -37,15 +36,6 @@ impl Syscall for SysLseekHandle {
         let offset = Self::offset(args);
         let whence = Self::whence(args);
 
-        // Convert seek type to SeekFrom enum
-        let seek = match whence {
-            SEEK_SET => Ok(SeekFrom::SeekSet(offset)),
-            SEEK_CUR => Ok(SeekFrom::SeekCurrent(offset)),
-            SEEK_END => Ok(SeekFrom::SeekEnd(offset)),
-            SEEK_MAX => Ok(SeekFrom::SeekEnd(0)),
-            _ => Err(SystemError::EINVAL),
-        }?;
-
         // Get file from file descriptor table
         let binding = ProcessManager::current_pcb().fd_table();
         let fd_table_guard = binding.read();
@@ -55,6 +45,21 @@ impl Syscall for SysLseekHandle {
 
         // Drop guard to avoid scheduling issues
         drop(fd_table_guard);
+
+        // Decode whence after the file descriptor lookup. Linux gives EBADF
+        // precedence when both the descriptor and whence are invalid.
+        if whence > SEEK_MAX {
+            return Err(SystemError::EINVAL);
+        }
+        let seek = match whence {
+            SEEK_SET => Ok(SeekFrom::SeekSet(offset)),
+            SEEK_CUR => Ok(SeekFrom::SeekCurrent(offset)),
+            SEEK_END => Ok(SeekFrom::SeekEnd(offset)),
+            SEEK_DATA => Ok(SeekFrom::SeekData(offset)),
+            SEEK_HOLE => Ok(SeekFrom::SeekHole(offset)),
+            _ => Err(SystemError::EINVAL),
+        }?;
+
         // Perform the seek operation
         return file.lseek(seek);
     }
@@ -121,7 +126,8 @@ impl SysLseekHandle {
             SEEK_SET => "SEEK_SET".to_string(),
             SEEK_CUR => "SEEK_CUR".to_string(),
             SEEK_END => "SEEK_END".to_string(),
-            SEEK_MAX => "SEEK_MAX".to_string(),
+            SEEK_DATA => "SEEK_DATA".to_string(),
+            SEEK_HOLE => "SEEK_HOLE".to_string(),
             _ => format!("UNKNOWN({})", whence),
         }
     }

--- a/kernel/src/libs/vec_cursor.rs
+++ b/kernel/src/libs/vec_cursor.rs
@@ -135,7 +135,7 @@ impl VecCursor {
             SeekFrom::SeekCurrent(offset) => self.pos as i64 + offset,
             // 请注意，此处的offset应小于等于0，否则肯定是不合法的
             SeekFrom::SeekEnd(offset) => self.data.len() as i64 + offset,
-            SeekFrom::Invalid => {
+            SeekFrom::SeekData(_) | SeekFrom::SeekHole(_) | SeekFrom::Invalid => {
                 return Err(SystemError::EINVAL);
             }
         };

--- a/user/apps/tests/dunitest/suites/normal/lseek_seek_data_hole.cc
+++ b/user/apps/tests/dunitest/suites/normal/lseek_seek_data_hole.cc
@@ -1,0 +1,129 @@
+#include <errno.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#ifndef SEEK_DATA
+#define SEEK_DATA 3
+#endif
+
+#ifndef SEEK_HOLE
+#define SEEK_HOLE 4
+#endif
+
+namespace {
+
+class TempFile {
+  public:
+    TempFile() {
+        char path[] = "/tmp/dragonos-lseek-XXXXXX";
+        fd_ = mkstemp(path);
+        if (fd_ >= 0) {
+            unlink(path);
+        }
+    }
+
+    ~TempFile() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    TempFile(const TempFile &) = delete;
+    TempFile &operator=(const TempFile &) = delete;
+
+    int fd() const { return fd_; }
+    bool valid() const { return fd_ >= 0; }
+
+  private:
+    int fd_ = -1;
+};
+
+void ExpectSeekFailureWithoutOffsetChange(int fd, off_t offset, int whence,
+                                          int expected_errno, off_t original_offset) {
+    errno = 0;
+    EXPECT_EQ(-1, lseek(fd, offset, whence));
+    EXPECT_EQ(expected_errno, errno);
+    EXPECT_EQ(original_offset, lseek(fd, 0, SEEK_CUR));
+}
+
+TEST(LseekSeekDataHole, DenseRegularFileUsesGenericLinuxFallback) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    constexpr char kContents[] = "DEADBEEF";
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(kContents) - 1),
+              write(file.fd(), kContents, sizeof(kContents) - 1));
+
+    int duplicate = dup(file.fd());
+    ASSERT_GE(duplicate, 0) << "dup failed: " << strerror(errno);
+
+    EXPECT_EQ(0, lseek(file.fd(), 0, SEEK_DATA));
+    EXPECT_EQ(0, lseek(duplicate, 0, SEEK_CUR));
+
+    EXPECT_EQ(4, lseek(file.fd(), 4, SEEK_DATA));
+    EXPECT_EQ(4, lseek(duplicate, 0, SEEK_CUR));
+
+    EXPECT_EQ(8, lseek(file.fd(), 4, SEEK_HOLE));
+    EXPECT_EQ(8, lseek(duplicate, 0, SEEK_CUR));
+
+    ASSERT_EQ(2, lseek(file.fd(), 2, SEEK_SET));
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), -1, SEEK_DATA, ENXIO, 2);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), -1, SEEK_HOLE, ENXIO, 2);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 8, SEEK_DATA, ENXIO, 2);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 8, SEEK_HOLE, ENXIO, 2);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 9, SEEK_DATA, ENXIO, 2);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 9, SEEK_HOLE, ENXIO, 2);
+
+    EXPECT_EQ(0, close(duplicate));
+}
+
+TEST(LseekSeekDataHole, EmptyFileHasNeitherDataNorHoleAtEof) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 0, SEEK_DATA, ENXIO, 0);
+    ExpectSeekFailureWithoutOffsetChange(file.fd(), 0, SEEK_HOLE, ENXIO, 0);
+}
+
+TEST(LseekSeekDataHole, PreservesLinuxErrorPrecedence) {
+    TempFile file;
+    ASSERT_TRUE(file.valid()) << "mkstemp failed: " << strerror(errno);
+
+    constexpr int kInvalidWhence = 99;
+    errno = 0;
+    EXPECT_EQ(-1, lseek(file.fd(), 0, kInvalidWhence));
+    EXPECT_EQ(EINVAL, errno);
+
+    int invalid_fd = dup(file.fd());
+    ASSERT_GE(invalid_fd, 0) << "dup failed: " << strerror(errno);
+    ASSERT_EQ(0, close(invalid_fd));
+
+    errno = 0;
+    EXPECT_EQ(-1, lseek(invalid_fd, 0, kInvalidWhence));
+    EXPECT_EQ(EBADF, errno);
+}
+
+TEST(LseekSeekDataHole, DirectoryDoesNotUseRegularFileFallback) {
+    int fd = open("/tmp", O_RDONLY | O_DIRECTORY);
+    ASSERT_GE(fd, 0) << "open /tmp failed: " << strerror(errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, lseek(fd, 0, SEEK_DATA));
+    EXPECT_EQ(EINVAL, errno);
+
+    errno = 0;
+    EXPECT_EQ(-1, lseek(fd, 0, SEEK_HOLE));
+    EXPECT_EQ(EINVAL, errno);
+
+    EXPECT_EQ(0, close(fd));
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary

- add the Linux `SEEK_DATA` and `SEEK_HOLE` ABI values to `lseek`
- implement the Linux generic regular-file fallback without incomplete extent scanning
- preserve Linux fd/whence error precedence and leave the OFD offset unchanged on failures
- add regression coverage for boundary conditions, `dup`-shared offsets, invalid descriptors, empty files, and directories

## Root cause

DragonOS treated whence value `3` as an end-of-file alias even though Linux defines it as `SEEK_DATA`, and it rejected `SEEK_HOLE` value `4`. Coreutils observed a successful data lookup and then failed its hole lookup, causing file copies used by package installation to abort.

## Implementation

Regular files now use Linux's conservative generic behavior: every byte before EOF is reported as data and EOF is the virtual hole. Negative offsets and offsets at or beyond EOF return `ENXIO`. Unsupported file types are rejected without applying regular-file semantics, and one metadata snapshot supplies both file type and size.

The syscall resolves the descriptor before validating whence, matching Linux's `EBADF` precedence. Successful operations continue to update the shared open-file-description offset.

## Validation

- `make kernel`
- new DragonOS dunitest: 4/4 passed
- gVisor `lseek_test`: 15/15 passed
- `LseekTest.SeekDataAndSeekHole`: passed
- coreutils copy of `/usr/share/readline/inputrc`: succeeded and matched byte-for-byte with `cmp`
