### PR TITLE
fix(vfs): isolate page-cache writeback lifecycles

### DIFF
--- a/kernel/src/filesystem/cgroup2/mount.rs
+++ b/kernel/src/filesystem/cgroup2/mount.rs
@@ -52,6 +52,12 @@ impl Cgroup2Fs {
 }
 
 impl FileSystem for Cgroup2Fs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn crate::filesystem::vfs::IndexNode> {
         self.root_inode.clone()
     }

--- a/kernel/src/filesystem/debugfs.rs
+++ b/kernel/src/filesystem/debugfs.rs
@@ -29,6 +29,12 @@ impl DebugFs {
 }
 
 impl FileSystem for DebugFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root.clone()
     }

--- a/kernel/src/filesystem/devfs/mod.rs
+++ b/kernel/src/filesystem/devfs/mod.rs
@@ -141,6 +141,12 @@ fn is_zero_inode(pfm: &PageFaultMessage) -> bool {
 }
 
 impl FileSystem for DevFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }

--- a/kernel/src/filesystem/devpts/mod.rs
+++ b/kernel/src/filesystem/devpts/mod.rs
@@ -146,6 +146,12 @@ impl DevPtsFs {
 }
 
 impl FileSystem for DevPtsFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root_inode.clone()
     }

--- a/kernel/src/filesystem/eventfd.rs
+++ b/kernel/src/filesystem/eventfd.rs
@@ -41,6 +41,12 @@ impl EventFdFs {
 }
 
 impl FileSystem for EventFdFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         // EventFdFs 没有真正的根 inode，但我们需要实现这个方法
         // 返回一个空的 eventfd inode 作为占位符

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -8,6 +8,7 @@ use crate::{
         ext4::inode::{
             Ext4Inode, Ext4InodeLifecycle, Ext4InodeLifecycleState, Ext4InodeTimes, InodeDirtyState,
         },
+        page_cache::PageCacheWritebackDomain,
         vfs::{
             self,
             fcntl::AtFlags,
@@ -186,6 +187,7 @@ impl another_ext4::MetadataMutationWaker for Ext4MetadataMutationWait {
 }
 
 pub struct Ext4FileSystem {
+    pub(super) writeback_domain: Arc<PageCacheWritebackDomain>,
     /// 对应 another_ext4 中的实际文件系统
     pub(super) fs: another_ext4::Ext4,
     /// 当前文件系统对应的设备号
@@ -331,6 +333,22 @@ impl Ext4MountOptions {
 }
 
 impl FileSystem for Ext4FileSystem {
+    fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
+        Some(&self.writeback_domain)
+    }
+
+    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+        if self._mount_options.read_only {
+            return Ok(());
+        }
+        self.close_delalloc_admission();
+        if let Err(error) = self.drain_registered_delalloc() {
+            self.fail_stop_lifecycle();
+            self.terminalize_idle_delalloc_after_fail_stop();
+            return Err(error);
+        }
+        Ok(())
+    }
     fn reconfigure(&self, request: FsReconfigureRequest<'_>) -> Result<MountFlags, SystemError> {
         if request.raw_data.is_some_and(|raw| !raw.trim().is_empty()) {
             return Err(SystemError::EINVAL);
@@ -435,16 +453,6 @@ impl FileSystem for Ext4FileSystem {
 
     fn on_umount(&self) {
         if self._mount_options.read_only {
-            return;
-        }
-        self.close_delalloc_admission();
-        if let Err(error) = self.drain_registered_delalloc() {
-            log::error!(
-                "ext4: failed to drain delayed mappings on unmount: {:?}",
-                error
-            );
-            self.fail_stop_lifecycle();
-            self.terminalize_idle_delalloc_after_fail_stop();
             return;
         }
         if let Err(error) = self.flush_dirty_inodes() {
@@ -1339,6 +1347,7 @@ impl Ext4FileSystem {
             });
 
         let fs = Arc::new(Ext4FileSystem {
+            writeback_domain: PageCacheWritebackDomain::new(),
             fs,
             raw_dev,
             _device_mount_holder: device_mount_holder,

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -337,7 +337,7 @@ impl FileSystem for Ext4FileSystem {
         Some(&self.writeback_domain)
     }
 
-    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+    fn quiesce_page_cache_producers(&self) -> Result<(), SystemError> {
         if self._mount_options.read_only {
             return Ok(());
         }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -457,9 +457,7 @@ impl Ext4DelallocProgress {
                                 .ready_prefix_end(pending.offset, usize::MAX)
                                 .unwrap_or(pending.offset)
                                 / MMArch::PAGE_SIZE;
-                            Ext4DelallocProducerAction::Dispatch(
-                                page_cache, first_page, last_page,
-                            )
+                            Ext4DelallocProducerAction::Dispatch(page_cache, first_page, last_page)
                         }
                         ProductionDelallocEntryState::Prepared(_)
                         | ProductionDelallocEntryState::Claimed { .. } => {
@@ -508,11 +506,7 @@ impl Ext4DelallocProgress {
                         | PageCacheWritebackDispatchOutcome::Deferred
                 )) | Ext4DelallocProducerRunOutcome::Passive
             ) {
-                Self::schedule_if_demanded_admitted(
-                    &progress,
-                    &inode_weak,
-                    domain_io.derive(),
-                );
+                Self::schedule_if_demanded_admitted(&progress, &inode_weak, domain_io.derive());
             }
 
             match outcome {

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -387,10 +387,15 @@ impl Ext4DelallocProgress {
         })
     }
 
-    fn ticket(self: &Arc<Self>, inode: Weak<LockedExt4Inode>) -> Arc<Ext4DelallocProgressTicket> {
+    fn ticket(
+        self: &Arc<Self>,
+        inode: Weak<LockedExt4Inode>,
+        page_cache: Weak<PageCache>,
+    ) -> Arc<Ext4DelallocProgressTicket> {
         Arc::new(Ext4DelallocProgressTicket {
             progress: self.clone(),
             inode,
+            page_cache,
             observed: self.sequence.load(Ordering::Acquire),
         })
     }
@@ -407,7 +412,11 @@ impl Ext4DelallocProgress {
         }
     }
 
-    fn schedule_if_demanded(progress: &Arc<Self>, inode: &Weak<LockedExt4Inode>) {
+    fn schedule_if_demanded_admitted(
+        progress: &Arc<Self>,
+        inode: &Weak<LockedExt4Inode>,
+        domain_io: crate::filesystem::page_cache::PageCacheDomainIoPermit,
+    ) {
         if !progress.demand.load(Ordering::Acquire)
             || progress
                 .work_scheduled
@@ -417,58 +426,94 @@ impl Ext4DelallocProgress {
             return;
         }
 
+        let Some(inode) = inode.upgrade() else {
+            progress.work_scheduled.store(false, Ordering::Release);
+            progress.publish(PageCacheWritebackProgressOutcome::Cancelled);
+            return;
+        };
         let progress = progress.clone();
-        let inode = inode.clone();
+        let inode_weak = Arc::downgrade(&inode);
+        let work_state = Mutex::new(Some((inode, domain_io)));
         schedule_work(Work::new(move || {
+            let Some((inode, domain_io)) = work_state.lock().take() else {
+                return;
+            };
+            // This producer is an admitted filesystem-I/O lineage. Keep the
+            // permit through state publication, callback execution, and the
+            // lost-wakeup handoff below; a dormant callback never owns it.
             // Consume only the demand observed by this invocation. A
             // concurrent arm() sets it again and is handed off below.
             progress.demand.store(false, Ordering::Release);
-            let outcome =
-                inode
-                    .upgrade()
-                    .map_or(Ext4DelallocProducerRunOutcome::Cancelled, |inode| {
-                        let head = {
-                            let guard = inode.inner.lock();
-                            guard.delalloc.production.head().map(|(_, head)| {
-                                let page_cache = guard.page_cache.clone();
-                                match &head.state {
-                                    ProductionDelallocEntryState::Ready(pending) => {
-                                        let first_page = pending.offset / MMArch::PAGE_SIZE;
-                                        let last_page = guard
-                                            .delalloc
-                                            .production
-                                            .ready_prefix_end(pending.offset, usize::MAX)
-                                            .unwrap_or(pending.offset)
-                                            / MMArch::PAGE_SIZE;
-                                        Ext4DelallocProducerAction::Dispatch(
-                                            page_cache, first_page, last_page,
-                                        )
-                                    }
-                                    ProductionDelallocEntryState::Prepared(_)
-                                    | ProductionDelallocEntryState::Claimed { .. } => {
-                                        Ext4DelallocProducerAction::Passive
-                                    }
-                                }
-                            })
-                        };
-                        match head {
-                            Some(Ext4DelallocProducerAction::Dispatch(
-                                Some(page_cache),
-                                first_page,
-                                last_page,
-                            )) => Ext4DelallocProducerRunOutcome::Dispatch(
-                                page_cache
-                                    .manager()
-                                    .dispatch_writeback_once(first_page, last_page),
-                            ),
-                            Some(Ext4DelallocProducerAction::Dispatch(None, _, _)) | None => {
-                                Ext4DelallocProducerRunOutcome::Cancelled
-                            }
-                            Some(Ext4DelallocProducerAction::Passive) => {
-                                Ext4DelallocProducerRunOutcome::Passive
-                            }
+            let head = {
+                let guard = inode.inner.lock();
+                guard.delalloc.production.head().map(|(_, head)| {
+                    let page_cache = guard.page_cache.clone();
+                    match &head.state {
+                        ProductionDelallocEntryState::Ready(pending) => {
+                            let first_page = pending.offset / MMArch::PAGE_SIZE;
+                            let last_page = guard
+                                .delalloc
+                                .production
+                                .ready_prefix_end(pending.offset, usize::MAX)
+                                .unwrap_or(pending.offset)
+                                / MMArch::PAGE_SIZE;
+                            Ext4DelallocProducerAction::Dispatch(
+                                page_cache, first_page, last_page,
+                            )
                         }
-                    });
+                        ProductionDelallocEntryState::Prepared(_)
+                        | ProductionDelallocEntryState::Claimed { .. } => {
+                            Ext4DelallocProducerAction::Passive
+                        }
+                    }
+                })
+            };
+            let outcome = match head {
+                Some(Ext4DelallocProducerAction::Dispatch(
+                    Some(page_cache),
+                    first_page,
+                    last_page,
+                )) => Ext4DelallocProducerRunOutcome::Dispatch(
+                    page_cache
+                        .manager()
+                        .dispatch_writeback_once(first_page, last_page, &domain_io),
+                ),
+                Some(Ext4DelallocProducerAction::Dispatch(None, _, _)) | None => {
+                    Ext4DelallocProducerRunOutcome::Cancelled
+                }
+                Some(Ext4DelallocProducerAction::Passive) => {
+                    Ext4DelallocProducerRunOutcome::Passive
+                }
+            };
+
+            // Publish terminal progress only after this producer has released
+            // its scheduling ownership and handed off any demand observed
+            // during the run. The producer permit remains held through this
+            // entire block; dormant callbacks never own a permit.
+            if matches!(
+                &outcome,
+                Ext4DelallocProducerRunOutcome::Dispatch(Ok(
+                    PageCacheWritebackDispatchOutcome::Deferred
+                ))
+            ) {
+                progress.demand.store(true, Ordering::Release);
+            }
+            progress.work_scheduled.store(false, Ordering::Release);
+            // Lost-wakeup handoff: arm-before-clear leaves demand set and this
+            // side schedules it; arm-after-clear wins the CAS on its own.
+            if matches!(
+                &outcome,
+                Ext4DelallocProducerRunOutcome::Dispatch(Ok(
+                    PageCacheWritebackDispatchOutcome::Progress
+                        | PageCacheWritebackDispatchOutcome::Deferred
+                )) | Ext4DelallocProducerRunOutcome::Passive
+            ) {
+                Self::schedule_if_demanded_admitted(
+                    &progress,
+                    &inode_weak,
+                    domain_io.derive(),
+                );
+            }
 
             match outcome {
                 Ext4DelallocProducerRunOutcome::Dispatch(Ok(
@@ -479,12 +524,7 @@ impl Ext4DelallocProgress {
                 }
                 Ext4DelallocProducerRunOutcome::Dispatch(Ok(
                     PageCacheWritebackDispatchOutcome::Deferred,
-                )) => {
-                    // EAGAIN left the same head Ready. This producer must make
-                    // another non-blocking attempt; it must never wait on the
-                    // ticket whose progress it owns.
-                    progress.demand.store(true, Ordering::Release);
-                }
+                )) => {}
                 Ext4DelallocProducerRunOutcome::Dispatch(Ok(
                     PageCacheWritebackDispatchOutcome::Idle,
                 ))
@@ -499,11 +539,6 @@ impl Ext4DelallocProgress {
                 }
                 Ext4DelallocProducerRunOutcome::Passive => {}
             }
-
-            progress.work_scheduled.store(false, Ordering::Release);
-            // Lost-wakeup handoff: arm-before-clear leaves demand set and this
-            // side schedules it; arm-after-clear wins the CAS on its own.
-            Self::schedule_if_demanded(&progress, &inode);
         }));
     }
 }
@@ -522,6 +557,7 @@ enum Ext4DelallocProducerRunOutcome {
 struct Ext4DelallocProgressTicket {
     progress: Arc<Ext4DelallocProgress>,
     inode: Weak<LockedExt4Inode>,
+    page_cache: Weak<PageCache>,
     observed: u64,
 }
 
@@ -556,7 +592,29 @@ impl Ext4DelallocProgressTicket {
 impl PageCacheWritebackProgress for Ext4DelallocProgressTicket {
     fn arm(&self) {
         self.progress.demand.store(true, Ordering::Release);
-        Ext4DelallocProgress::schedule_if_demanded(&self.progress, &self.inode);
+        let Some(page_cache) = self.page_cache.upgrade() else {
+            self.progress
+                .publish(PageCacheWritebackProgressOutcome::Cancelled);
+            return;
+        };
+        match page_cache.try_acquire_domain_io_classified() {
+            Ok(Some(permit)) => Ext4DelallocProgress::schedule_if_demanded_admitted(
+                &self.progress,
+                &self.inode,
+                permit,
+            ),
+            Ok(None) => self
+                .progress
+                .publish(PageCacheWritebackProgressOutcome::Cancelled),
+            Err(crate::filesystem::page_cache::PageCacheDomainIoAdmissionError::Closed) => self
+                .progress
+                .publish(PageCacheWritebackProgressOutcome::Cancelled),
+            Err(crate::filesystem::page_cache::PageCacheDomainIoAdmissionError::Unavailable(
+                error,
+            )) => self
+                .progress
+                .publish(PageCacheWritebackProgressOutcome::Failed(error)),
+        }
     }
 
     fn wait_for_progress(&self) -> PageCacheWritebackProgressOutcome {
@@ -1018,8 +1076,17 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
                 another_ext4::ErrCode::EAGAIN,
             ) => {
                 self.restore_ready(false)?;
+                let page_cache = self
+                    .inode
+                    .inner
+                    .lock()
+                    .page_cache
+                    .as_ref()
+                    .map(Arc::downgrade)
+                    .unwrap_or_default();
                 Ok(PageCacheWritebackSubmitResult::Deferred(
-                    self.progress.ticket(Arc::downgrade(&self.inode)),
+                    self.progress
+                        .ticket(Arc::downgrade(&self.inode), page_cache),
                 ))
             }
             another_ext4::DelallocAppendBlockSubmitOutcome::RetryableNotPublished(error) => {
@@ -1293,9 +1360,16 @@ impl PageCacheBackend for Ext4PageCacheBackend {
             if !matches_certificate {
                 return Err(SystemError::EIO);
             }
+            let page_cache = guard
+                .page_cache
+                .as_ref()
+                .map(Arc::downgrade)
+                .unwrap_or_default();
             drop(guard);
             return Ok(PageCacheWritebackBindResult::Deferred(
-                inode.delalloc_progress.ticket(Arc::downgrade(&inode)),
+                inode
+                    .delalloc_progress
+                    .ticket(Arc::downgrade(&inode), page_cache),
             ));
         }
         {
@@ -3029,7 +3103,14 @@ impl LockedExt4Inode {
                     return Ok(None);
                 }
                 if guard.delalloc.production.head_is_claimed() {
-                    let progress = self.delalloc_progress.ticket(guard.self_ref.clone());
+                    let page_cache = guard
+                        .page_cache
+                        .as_ref()
+                        .map(Arc::downgrade)
+                        .unwrap_or_default();
+                    let progress = self
+                        .delalloc_progress
+                        .ticket(guard.self_ref.clone(), page_cache);
                     drop(guard);
                     drop(_io);
                     drop(_size);
@@ -3812,10 +3893,11 @@ impl LockedExt4Inode {
                     Arc::downgrade(&inode) as Weak<dyn IndexNode>
                 ))
             };
-        let page_cache = PageCache::new(
-            Some(Arc::downgrade(&inode) as Weak<dyn IndexNode>),
-            Some(backend),
-        );
+        let page_cache = PageCache::new_file(
+            Arc::downgrade(&inode) as Weak<dyn IndexNode>,
+            backend,
+            &fs.writeback_domain,
+        )?;
         guard.page_cache = Some(page_cache);
 
         // 对于 FIFO，创建 pipe inode

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -18,7 +18,7 @@ use system_error::SystemError;
 
 use crate::driver::base::block::gendisk::{GenDisk, GenDiskMountGuard};
 use crate::driver::base::device::device_number::DeviceNumber;
-use crate::filesystem::page_cache::{AsyncPageCacheBackend, PageCache};
+use crate::filesystem::page_cache::{AsyncPageCacheBackend, PageCache, PageCacheWritebackDomain};
 use crate::filesystem::vfs::mount::filesystem_is_synchronous;
 use crate::filesystem::vfs::utils::DName;
 use crate::filesystem::vfs::{Magic, SpecialNodeData, SuperBlock};
@@ -93,6 +93,7 @@ impl Eq for Cluster {}
 
 #[derive(Debug)]
 pub struct FATFileSystem {
+    writeback_domain: Arc<PageCacheWritebackDomain>,
     /// 当前文件系统所在的分区
     pub gendisk: Arc<GenDisk>,
     /// Prevents loop clear/remove for the complete filesystem lifetime.
@@ -263,7 +264,7 @@ impl FATInode {
                     self.fs.upgrade().unwrap(),
                     self.self_ref.clone(),
                     fat_entry,
-                );
+                )?;
                 // 加入缓存区, 由于FAT文件系统的大小写不敏感问题，因此存入缓存区的key应当是全大写的
                 self.children
                     .insert(search_name.clone(), entry_inode.clone());
@@ -289,7 +290,7 @@ impl LockedFATInode {
         fs: Arc<FATFileSystem>,
         parent: Weak<LockedFATInode>,
         inode_type: FATDirEntry,
-    ) -> Arc<LockedFATInode> {
+    ) -> Result<Arc<LockedFATInode>, SystemError> {
         let file_type = if let FATDirEntry::Dir(_) = inode_type {
             FileType::Dir
         } else {
@@ -337,10 +338,11 @@ impl LockedFATInode {
             let backend = Arc::new(AsyncPageCacheBackend::new(
                 Arc::downgrade(&inode) as Weak<dyn IndexNode>
             ));
-            let page_cache = PageCache::new(
-                Some(Arc::downgrade(&inode) as Weak<dyn IndexNode>),
-                Some(backend),
-            );
+            let page_cache = PageCache::new_file(
+                Arc::downgrade(&inode) as Weak<dyn IndexNode>,
+                backend,
+                &fs.writeback_domain,
+            )?;
             inode.0.lock().page_cache = Some(page_cache);
         }
 
@@ -348,7 +350,7 @@ impl LockedFATInode {
 
         inode.0.lock().synchronize_metadata();
 
-        return inode;
+        Ok(inode)
     }
 
     #[inline(never)]
@@ -507,6 +509,9 @@ pub struct FATFsInfo {
 }
 
 impl FileSystem for FATFileSystem {
+    fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
+        Some(&self.writeback_domain)
+    }
     fn root_inode(&self) -> Arc<dyn crate::filesystem::vfs::IndexNode> {
         return self.root_inode.clone();
     }
@@ -775,6 +780,7 @@ impl FATFileSystem {
         ));
 
         let result: Arc<FATFileSystem> = Arc::new(FATFileSystem {
+            writeback_domain: PageCacheWritebackDomain::new(),
             gendisk,
             _device_mount_holder: device_mount_holder,
             bpb,
@@ -2264,7 +2270,7 @@ impl IndexNode for LockedFATInode {
                             guard.fs.upgrade().unwrap(),
                             guard.self_ref.clone(),
                             ent,
-                        );
+                        )?;
                         // 加入缓存区, 由于FAT文件系统的大小写不敏感问题，因此存入缓存区的key应当是全大写的
                         guard.negative_children.pop(&search_name);
                         guard.children.insert(search_name, entry_inode.clone());
@@ -2480,7 +2486,7 @@ impl IndexNode for LockedFATInode {
             inode.fs.upgrade().unwrap(),
             inode.self_ref.clone(),
             FATDirEntry::File(FATFile::default()),
-        );
+        )?;
 
         if file_type == FileType::Pipe {
             nod.0.lock().metadata.file_type = FileType::Pipe;

--- a/kernel/src/filesystem/fuse/conn.rs
+++ b/kernel/src/filesystem/fuse/conn.rs
@@ -11,7 +11,9 @@ use core::{
 
 use system_error::SystemError;
 
-use crate::filesystem::page_cache::PageCacheReadDmaReservation;
+use crate::filesystem::page_cache::{
+    PageCacheDomainIoPermit, PageCacheReadDmaReservation, PageCacheWritebackDomain,
+};
 use crate::{
     arch::MMArch,
     filesystem::epoll::{event_poll::EPollItemList, event_poll::EventPoll, EPollEventType},
@@ -297,11 +299,20 @@ struct FuseReadCompletion {
     observed_size: usize,
     observed_attr_version: u64,
     open_pin: Mutex<Option<super::private_data::FuseOpenLifetimePin>>,
+    domain_io: Mutex<Option<PageCacheDomainIoPermit>>,
 }
 
 impl FuseReadCompletion {
-    fn release_open_pin(&self) {
+    fn belongs_to_domain(&self, domain: &Arc<PageCacheWritebackDomain>) -> bool {
+        self.domain_io
+            .lock()
+            .as_ref()
+            .is_some_and(|permit| permit.belongs_to(domain))
+    }
+
+    fn release_io_ownership(&self) {
         self.open_pin.lock().take();
+        self.domain_io.lock().take();
     }
 
     fn finish(&self, result: &Result<FusePendingResult, SystemError>) -> Result<(), SystemError> {
@@ -474,6 +485,12 @@ enum FuseReadWaitOutcome {
 }
 
 impl FusePendingState {
+    fn belongs_to_page_cache_domain(&self, domain: &Arc<PageCacheWritebackDomain>) -> bool {
+        self.read_completion
+            .as_ref()
+            .is_some_and(|completion| completion.belongs_to_domain(domain))
+    }
+
     pub fn new(unique: u64, opcode: u32) -> Self {
         Self::new_with_credit(unique, opcode, None, None)
     }
@@ -563,7 +580,7 @@ impl FusePendingState {
                 v = Err(error);
                 kind = FuseCompletionKind::OutcomeUnknown;
             }
-            completion.release_open_pin();
+            completion.release_io_ownership();
         }
         let mut guard = self.response.lock();
         *guard = PendingCompletion::Ready(v, kind);
@@ -1654,6 +1671,53 @@ impl FuseConn {
             return;
         }
         self.wake_bridge(stats::VirtioFsBridgeWakeSource::Teardown);
+    }
+
+    /// Cancel page-cache reads owned by one filesystem shutdown domain.
+    ///
+    /// FUSE readahead may leave speculative READs outstanding after the
+    /// foreground read has completed.  Those requests own Loading page-cache
+    /// entries, so they must reach a terminal state before generic cache
+    /// retirement can wait on and remove the entries.  Domain admission is
+    /// closed by the caller before this scan, which prevents a new matching
+    /// request from being published after the cancellation snapshot.
+    pub(crate) fn cancel_page_cache_reads(&self, domain: &Arc<PageCacheWritebackDomain>) {
+        let (pending_reads, queued_count) = {
+            let mut inner = self.inner.lock();
+            let read_uniques = inner
+                .processing
+                .iter()
+                .filter_map(|(unique, pending)| {
+                    pending
+                        .belongs_to_page_cache_domain(domain)
+                        .then_some(*unique)
+                })
+                .collect::<Vec<_>>();
+
+            let queued_count = inner
+                .hiprio_pending
+                .iter()
+                .chain(inner.pending.iter())
+                .filter(|request| read_uniques.contains(&request.unique))
+                .count();
+            inner
+                .hiprio_pending
+                .retain(|request| !read_uniques.contains(&request.unique));
+            inner
+                .pending
+                .retain(|request| !read_uniques.contains(&request.unique));
+            let pending_reads = read_uniques
+                .into_iter()
+                .filter_map(|unique| inner.processing.remove(&unique))
+                .collect::<Vec<_>>();
+            (pending_reads, queued_count)
+        };
+
+        stats::on_fuse_requests_dropped_umount(queued_count);
+        stats::on_fuse_requests_aborted(pending_reads.len().saturating_sub(queued_count));
+        for pending in pending_reads {
+            pending.complete_disconnected(SystemError::ENOTCONN);
+        }
     }
 
     /// Acquire a new `/dev/fuse` file handle reference to this connection.

--- a/kernel/src/filesystem/fuse/conn/request.rs
+++ b/kernel/src/filesystem/fuse/conn/request.rs
@@ -27,7 +27,10 @@ use super::{
     FuseReplyCapacity, FuseReplyCapacitySource, FuseReplyContract, FuseRequest, FuseRequestCred,
 };
 use crate::filesystem::fuse::reply::FuseReply;
-use crate::filesystem::{fuse::reply::FuseReadPagesReply, page_cache::PageCacheReadDmaReservation};
+use crate::filesystem::{
+    fuse::reply::FuseReadPagesReply,
+    page_cache::{PageCacheDomainIoPermit, PageCacheReadDmaReservation},
+};
 
 /// How the reply for a request being built should be delivered back.
 ///
@@ -61,6 +64,7 @@ pub(crate) struct BackgroundReadPagesCtx {
     pub observed_size: usize,
     pub observed_attr_version: u64,
     pub open_pin: super::super::private_data::FuseOpenLifetimePin,
+    pub domain_io: Option<PageCacheDomainIoPermit>,
 }
 
 impl FuseConn {
@@ -316,6 +320,7 @@ impl FuseConn {
                 observed_size: ctx.observed_size,
                 observed_attr_version: ctx.observed_attr_version,
                 open_pin: crate::libs::mutex::Mutex::new(Some(ctx.open_pin)),
+                domain_io: crate::libs::mutex::Mutex::new(ctx.domain_io),
             }),
         ));
         let req = self.build_request(

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -690,6 +690,8 @@ impl FileSystem for FuseFS {
     }
 
     fn quiesce_page_cache_producers(&self) -> Result<(), SystemError> {
+        self.writeback_domain.close_background_admission();
+        self.conn.cancel_page_cache_reads(&self.writeback_domain);
         if !self.is_submount {
             self.conn.begin_dax_quiesce();
             self.conn.wait_dax_drained();

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -7,6 +7,7 @@ use core::sync::atomic::{AtomicU8, Ordering};
 use system_error::SystemError;
 
 use crate::{
+    filesystem::page_cache::PageCacheWritebackDomain,
     filesystem::vfs::{
         file::File, FilePrivateData, FileSystem, FileSystemMakerData, FileType, FsInfo, IndexNode,
         InodeFlags, InodeId, InodeMode, Magic, Metadata, MountableFileSystem, SuperBlock, FSMAKER,
@@ -95,6 +96,7 @@ impl FileSystemMakerData for FuseMountData {
 
 #[derive(Debug)]
 pub struct FuseFS {
+    writeback_domain: Arc<PageCacheWritebackDomain>,
     root: Arc<FuseNode>,
     super_block: SuperBlock,
     conn: Arc<FuseConn>,
@@ -421,6 +423,7 @@ impl FuseFS {
         let conn = parent.conn.clone();
         let parent_nodeid = root_parent.nodeid();
         let fs = Arc::new_cyclic(|weak| FuseFS {
+            writeback_domain: PageCacheWritebackDomain::new(),
             root: FuseNode::new(
                 weak.clone(),
                 conn.clone(),
@@ -647,6 +650,7 @@ impl MountableFileSystem for FuseFS {
         );
 
         let fs = Arc::new_cyclic(|weak_fs| FuseFS {
+            writeback_domain: PageCacheWritebackDomain::new(),
             root: FuseNode::new(
                 weak_fs.clone(),
                 conn.clone(),
@@ -681,6 +685,17 @@ impl MountableFileSystem for FuseFS {
 register_mountable_fs!(FuseFS, FUSEFSMAKER, "fuse");
 
 impl FileSystem for FuseFS {
+    fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
+        Some(&self.writeback_domain)
+    }
+
+    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+        if !self.is_submount {
+            self.conn.begin_dax_quiesce();
+            self.conn.wait_dax_drained();
+        }
+        Ok(())
+    }
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root.clone()
     }
@@ -919,10 +934,6 @@ impl FileSystem for FuseFS {
     }
 
     fn on_umount(&self) {
-        if !self.is_submount {
-            self.conn.begin_dax_quiesce();
-            self.conn.wait_dax_drained();
-        }
         self.teardown_nodes();
         if !self.is_submount {
             self.conn.on_umount();

--- a/kernel/src/filesystem/fuse/fs.rs
+++ b/kernel/src/filesystem/fuse/fs.rs
@@ -689,7 +689,7 @@ impl FileSystem for FuseFS {
         Some(&self.writeback_domain)
     }
 
-    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+    fn quiesce_page_cache_producers(&self) -> Result<(), SystemError> {
         if !self.is_submount {
             self.conn.begin_dax_quiesce();
             self.conn.wait_dax_drained();

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -548,7 +548,11 @@ impl FuseNode {
         let node = self.self_ref.upgrade().ok_or(SystemError::EIO)?;
         let inode: Arc<dyn IndexNode> = node;
         let backend = Arc::new(FusePageCacheBackend::new(self.self_ref.clone()));
-        let cache = PageCache::new(Some(Arc::downgrade(&inode)), Some(backend));
+        let domain = self
+            .try_fs()
+            .and_then(|fs| fs.page_cache_writeback_domain().cloned())
+            .ok_or(SystemError::ESTALE)?;
+        let cache = PageCache::new_file(Arc::downgrade(&inode), backend, &domain)?;
         *guard = Some(cache.clone());
         Ok(cache)
     }

--- a/kernel/src/filesystem/fuse/inode/file.rs
+++ b/kernel/src/filesystem/fuse/inode/file.rs
@@ -1533,6 +1533,7 @@ impl FuseNode {
             }
 
             let speculative = run_start >= demand_end_page;
+            let domain_io = page_cache.try_acquire_domain_io()?;
             let track_direct_read_stats = super::super::stats::optional_read_stats_enabled();
             let target = match page_cache.manager().reserve_read_dma(
                 run_start,
@@ -1581,6 +1582,7 @@ impl FuseNode {
                 observed_size: file_ctx.file_size,
                 observed_attr_version,
                 open_pin,
+                domain_io,
             };
             let pending = if async_read {
                 self.conn().enqueue_background_read_pages(

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -224,8 +224,8 @@ impl FileSystem for VirtioFsFs {
         self.inner.page_cache_writeback_domain()
     }
 
-    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
-        self.inner.prepare_page_cache_retirement()
+    fn quiesce_page_cache_producers(&self) -> Result<(), SystemError> {
+        self.inner.quiesce_page_cache_producers()
     }
 
     fn root_inode(&self) -> Arc<dyn IndexNode> {

--- a/kernel/src/filesystem/fuse/virtiofs/mount.rs
+++ b/kernel/src/filesystem/fuse/virtiofs/mount.rs
@@ -218,6 +218,16 @@ impl VirtioFsFs {
 }
 
 impl FileSystem for VirtioFsFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        self.inner.page_cache_writeback_domain()
+    }
+
+    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+        self.inner.prepare_page_cache_retirement()
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.inner.root_inode()
     }

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -35,6 +35,12 @@ pub struct KernFS {
 }
 
 impl FileSystem for KernFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn as_any_ref(&self) -> &dyn core::any::Any {
         self
     }

--- a/kernel/src/filesystem/mqueue.rs
+++ b/kernel/src/filesystem/mqueue.rs
@@ -70,6 +70,12 @@ impl MqueueFs {
 }
 
 impl FileSystem for MqueueFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root.clone()
     }

--- a/kernel/src/filesystem/overlayfs/fs.rs
+++ b/kernel/src/filesystem/overlayfs/fs.rs
@@ -183,6 +183,12 @@ pub(super) struct OverlayFS {
 }
 
 impl FileSystem for OverlayFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root_inode.clone()
     }

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -61,8 +61,8 @@ pub(crate) use writeback::{
 };
 use writeback::{
     run_async_writeback_budget_retry_selftest, ClaimedWritebackBatch, TaggedWritebackBudgetRetry,
-    TaggedWritebackIncarnationRetry, TaggedWritebackSubmission, WritebackClaimOutcome,
-    WritebackSubmitOutcome, PAGECACHE_WRITEBACK_WQS,
+    TaggedWritebackIncarnationRetry, TaggedWritebackSubmission, WritebackBatchRange,
+    WritebackClaimOutcome, WritebackSubmitOutcome, PAGECACHE_WRITEBACK_WQS,
 };
 pub use writeback::{
     AsyncPageCacheBackend, PageCacheBackend, PageCacheWritebackAdmissionOrder,

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -14,8 +14,8 @@ use system_error::SystemError;
 
 use super::vfs::{
     inode_lifecycle::{InodeRetentionGuard, InodeRetentionKind},
-    mount::record_writeback_error_for_fs,
-    FilePrivateData, IndexNode, WritebackControl,
+    mount::SuperBlockState,
+    FilePrivateData, FileSystem, IndexNode, WritebackControl,
 };
 use crate::exception::workqueue::{schedule_work, Work, WorkQueue};
 use crate::libs::errseq::{ErrSeq, ErrSeqValue};
@@ -351,6 +351,255 @@ lazy_static! {
     static ref PAGECACHE_REGISTRY: SpinLock<Vec<Weak<PageCache>>> = SpinLock::new(Vec::new());
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum DomainAdmission {
+    Active,
+    Closed,
+}
+
+struct PageCacheWritebackDomainBinding {
+    owner: Weak<dyn FileSystem>,
+    superblock: Weak<SuperBlockState>,
+}
+
+struct PageCacheWritebackDomainState {
+    binding: Option<PageCacheWritebackDomainBinding>,
+    admission: DomainAdmission,
+    io_in_flight: usize,
+    registrations_in_flight: usize,
+}
+
+/// Stable ownership and shutdown domain for file-backed page caches.
+///
+/// The registry is deliberately separate from `state`: registry compaction
+/// may scan and allocate, while I/O admission and completion require a short,
+/// non-allocating spin critical section.
+pub struct PageCacheWritebackDomain {
+    registry: Mutex<Vec<Weak<dyn PageCacheDomainMember>>>,
+    state: SpinLock<PageCacheWritebackDomainState>,
+    drained: Completion,
+}
+
+pub(crate) trait PageCacheDomainMember: Send + Sync {
+    fn has_dirty_or_writeback_work(&self) -> bool;
+    fn sync_for_domain(&self) -> Result<(), SystemError>;
+    fn retire_for_domain(&self) -> Result<(), SystemError>;
+}
+
+impl core::fmt::Debug for PageCacheWritebackDomain {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let state = self.state.lock_irqsave();
+        f.debug_struct("PageCacheWritebackDomain")
+            .field("admission", &state.admission)
+            .field("io_in_flight", &state.io_in_flight)
+            .field("registrations_in_flight", &state.registrations_in_flight)
+            .finish()
+    }
+}
+
+impl PageCacheWritebackDomain {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            registry: Mutex::new(Vec::new()),
+            state: SpinLock::new(PageCacheWritebackDomainState {
+                binding: None,
+                admission: DomainAdmission::Active,
+                io_in_flight: 0,
+                registrations_in_flight: 0,
+            }),
+            drained: Completion::new(),
+        })
+    }
+
+    pub fn bind(
+        &self,
+        owner: &Arc<dyn FileSystem>,
+        superblock: &Arc<SuperBlockState>,
+    ) -> Result<(), SystemError> {
+        let mut state = self.state.lock_irqsave();
+        match state.binding.as_ref() {
+            None if state.admission == DomainAdmission::Active => {
+                state.binding = Some(PageCacheWritebackDomainBinding {
+                    owner: Arc::downgrade(owner),
+                    superblock: Arc::downgrade(superblock),
+                });
+                Ok(())
+            }
+            Some(binding)
+                if Weak::ptr_eq(&binding.owner, &Arc::downgrade(owner))
+                    && Weak::ptr_eq(&binding.superblock, &Arc::downgrade(superblock)) =>
+            {
+                Ok(())
+            }
+            _ => Err(SystemError::EINVAL),
+        }
+    }
+
+    fn finish_registration(&self) {
+        let complete = {
+            let mut state = self.state.lock_irqsave();
+            state.registrations_in_flight -= 1;
+            state.admission == DomainAdmission::Closed
+                && state.io_in_flight == 0
+                && state.registrations_in_flight == 0
+        };
+        if complete {
+            self.drained.complete();
+        }
+    }
+
+    fn register(&self, cache: &Arc<PageCache>) -> Result<(), SystemError> {
+        {
+            let mut state = self.state.lock_irqsave();
+            if state.admission != DomainAdmission::Active {
+                return Err(SystemError::ESTALE);
+            }
+            state.registrations_in_flight = state
+                .registrations_in_flight
+                .checked_add(1)
+                .expect("page-cache domain registration count overflow");
+        }
+
+        {
+            let mut registry = self.registry.lock();
+            if registry.len() == registry.capacity() {
+                registry.retain(|entry| entry.strong_count() != 0);
+                let slack = core::cmp::max(8, registry.len() / 4);
+                registry.reserve(slack);
+            }
+            let member: Arc<dyn PageCacheDomainMember> = cache.clone();
+            registry.push(Arc::downgrade(&member));
+        }
+        self.finish_registration();
+        Ok(())
+    }
+
+    pub(crate) fn snapshot(&self) -> Vec<Arc<dyn PageCacheDomainMember>> {
+        let mut registry = self.registry.lock();
+        let mut result = Vec::new();
+        registry.retain(|entry| {
+            if let Some(cache) = entry.upgrade() {
+                result.push(cache);
+                true
+            } else {
+                false
+            }
+        });
+        result
+    }
+
+    pub fn record_writeback_error(&self, error: SystemError) {
+        let superblock = self
+            .state
+            .lock_irqsave()
+            .binding
+            .as_ref()
+            .and_then(|binding| binding.superblock.upgrade());
+        if let Some(superblock) = superblock {
+            superblock.record_wb_error(error);
+        }
+    }
+
+    pub fn close_background_admission(&self) {
+        let complete = {
+            let mut state = self.state.lock_irqsave();
+            state.admission = DomainAdmission::Closed;
+            state.io_in_flight == 0 && state.registrations_in_flight == 0
+        };
+        if complete {
+            self.drained.complete();
+        }
+    }
+
+    pub fn wait_drained(&self) -> Result<(), SystemError> {
+        self.drained.wait_for_completion().map(|_| ())
+    }
+
+    fn try_acquire_io_classified(
+        self: &Arc<Self>,
+    ) -> Result<PageCacheDomainIoPermit, PageCacheDomainIoAdmissionError> {
+        let owner = {
+            let mut state = self.state.lock_irqsave();
+            if state.admission != DomainAdmission::Active {
+                return Err(PageCacheDomainIoAdmissionError::Closed);
+            }
+            let owner = state
+                .binding
+                .as_ref()
+                .and_then(|binding| binding.owner.upgrade())
+                .ok_or(PageCacheDomainIoAdmissionError::Unavailable(
+                    SystemError::ESTALE,
+                ))?;
+            state.io_in_flight = state
+                .io_in_flight
+                .checked_add(1)
+                .expect("page-cache domain I/O count overflow");
+            owner
+        };
+        Ok(PageCacheDomainIoPermit {
+            domain: self.clone(),
+            _owner: owner,
+        })
+    }
+
+    pub fn try_acquire_io(self: &Arc<Self>) -> Result<PageCacheDomainIoPermit, SystemError> {
+        self.try_acquire_io_classified()
+            .map_err(|error| match error {
+                PageCacheDomainIoAdmissionError::Closed => SystemError::ESTALE,
+                PageCacheDomainIoAdmissionError::Unavailable(error) => error,
+            })
+    }
+}
+
+#[derive(Debug)]
+pub struct PageCacheDomainIoPermit {
+    domain: Arc<PageCacheWritebackDomain>,
+    _owner: Arc<dyn FileSystem>,
+}
+
+pub(crate) enum PageCacheDomainIoAdmissionError {
+    Closed,
+    Unavailable(SystemError),
+}
+
+impl Drop for PageCacheDomainIoPermit {
+    fn drop(&mut self) {
+        let complete = {
+            let mut state = self.domain.state.lock_irqsave();
+            state.io_in_flight -= 1;
+            state.admission == DomainAdmission::Closed
+                && state.io_in_flight == 0
+                && state.registrations_in_flight == 0
+        };
+        if complete {
+            self.domain.drained.complete();
+        }
+    }
+}
+
+impl PageCacheDomainIoPermit {
+    /// Derive a child permit from an already admitted I/O lineage.
+    ///
+    /// Closing a domain rejects new producers, but it must not revoke work
+    /// accepted before the close linearization point.  A child permit keeps
+    /// the same owner alive and extends the in-flight count without
+    /// consulting the public admission state.
+    pub(crate) fn derive(&self) -> Self {
+        {
+            let mut state = self.domain.state.lock_irqsave();
+            debug_assert!(state.io_in_flight != 0);
+            state.io_in_flight = state
+                .io_in_flight
+                .checked_add(1)
+                .expect("page-cache domain I/O count overflow");
+        }
+        Self {
+            domain: self.domain.clone(),
+            _owner: self._owner.clone(),
+        }
+    }
+}
+
 pub(crate) fn schedule_pagecache_io(work: Arc<Work>) {
     let idx = PAGECACHE_IO_RR.fetch_add(1, Ordering::Relaxed) % PAGECACHE_IO_WQS.len();
     PAGECACHE_IO_WQS[idx].enqueue(work);
@@ -387,6 +636,7 @@ pub struct PageCache {
     inner: Mutex<InnerPageCache>,
     inode: Lazy<Weak<dyn IndexNode>>,
     backend: Lazy<Arc<dyn PageCacheBackend>>,
+    writeback_domain: Option<Weak<PageCacheWritebackDomain>>,
     i_mmap_rwsem: RwSem<()>,
     invalidate_lock: RwSem<()>,
     file_vma_seq: AtomicU64,
@@ -1607,24 +1857,40 @@ impl Drop for InnerPageCache {
 impl PageCache {
     // Lock order: page_cache -> page_manager -> page_reclaimer.
     // Avoid holding page_cache lock while acquiring page_manager when possible.
-    pub fn new(
+    pub fn new_file(
+        inode: Weak<dyn IndexNode>,
+        backend: Arc<dyn PageCacheBackend>,
+        domain: &Arc<PageCacheWritebackDomain>,
+    ) -> Result<Arc<PageCache>, SystemError> {
+        let cache = Self::new_with_kind(
+            Some(inode),
+            Some(backend),
+            PageCacheKind::File,
+            Some(Arc::downgrade(domain)),
+        );
+        domain.register(&cache)?;
+        Ok(cache)
+    }
+
+    pub fn new_unowned(
         inode: Option<Weak<dyn IndexNode>>,
         backend: Option<Arc<dyn PageCacheBackend>>,
     ) -> Arc<PageCache> {
-        Self::new_with_kind(inode, backend, PageCacheKind::File)
+        Self::new_with_kind(inode, backend, PageCacheKind::File, None)
     }
 
     pub fn new_shmem(
         inode: Option<Weak<dyn IndexNode>>,
         backend: Option<Arc<dyn PageCacheBackend>>,
     ) -> Arc<PageCache> {
-        Self::new_with_kind(inode, backend, PageCacheKind::Shmem)
+        Self::new_with_kind(inode, backend, PageCacheKind::Shmem, None)
     }
 
     fn new_with_kind(
         inode: Option<Weak<dyn IndexNode>>,
         backend: Option<Arc<dyn PageCacheBackend>>,
         kind: PageCacheKind,
+        writeback_domain: Option<Weak<PageCacheWritebackDomain>>,
     ) -> Arc<PageCache> {
         let id = PAGE_CACHE_ID.fetch_add(1, Ordering::SeqCst);
         let instance_id = PAGE_CACHE_INSTANCE_ID
@@ -1664,6 +1930,7 @@ impl PageCache {
                 }
                 v
             },
+            writeback_domain,
             i_mmap_rwsem: RwSem::new(()),
             invalidate_lock: RwSem::new(()),
             file_vma_seq: AtomicU64::new(0),
@@ -1712,9 +1979,37 @@ impl PageCache {
     /// asynchronous writeback completion.
     pub fn record_writeback_error_with_superblock(&self, error: SystemError) {
         self.record_writeback_error(error.clone());
-        if let Some(inode) = self.inode().and_then(|w| w.upgrade()) {
-            if let Some(fs) = inode.try_fs() {
-                record_writeback_error_for_fs(&fs, error);
+        if let Some(domain) = self.writeback_domain.as_ref().and_then(Weak::upgrade) {
+            domain.record_writeback_error(error);
+        }
+    }
+
+    pub fn has_dirty_or_writeback_pages(&self) -> bool {
+        let inner = self.inner.lock();
+        !inner.dirty_pages.is_empty() || !inner.writeback_pages.is_empty()
+    }
+
+    pub fn try_acquire_domain_io(&self) -> Result<Option<PageCacheDomainIoPermit>, SystemError> {
+        self.try_acquire_domain_io_classified()
+            .map_err(|error| match error {
+                PageCacheDomainIoAdmissionError::Closed => SystemError::ESTALE,
+                PageCacheDomainIoAdmissionError::Unavailable(error) => error,
+            })
+    }
+
+    pub(crate) fn try_acquire_domain_io_classified(
+        &self,
+    ) -> Result<Option<PageCacheDomainIoPermit>, PageCacheDomainIoAdmissionError> {
+        match self.writeback_domain.as_ref() {
+            None => Ok(None),
+            Some(domain) => {
+                let domain =
+                    domain
+                        .upgrade()
+                        .ok_or(PageCacheDomainIoAdmissionError::Unavailable(
+                            SystemError::ESTALE,
+                        ))?;
+                domain.try_acquire_io_classified().map(Some)
             }
         }
     }
@@ -2009,6 +2304,7 @@ impl PageCache {
         page_index: usize,
         page: &Arc<Page>,
     ) -> Result<(), SystemError> {
+        let _domain_io = self.try_acquire_domain_io()?;
         let backend = self.backend();
         if let Some(backend) = backend {
             let waiter = backend.read_page_async(page_index, page);
@@ -2240,6 +2536,8 @@ impl PageCache {
             return Ok(());
         }
 
+        let domain_io = self.try_acquire_domain_io()?;
+
         let entry = {
             let guard = self.inner.lock();
             if guard.get_entry(page_index).is_some() {
@@ -2270,7 +2568,11 @@ impl PageCache {
         let entry_clone = entry.clone();
         let page = entry.page.clone();
 
+        let work_state = Mutex::new(Some(domain_io));
         let work = Work::new(move || {
+            let Some(_domain_io) = work_state.lock().take() else {
+                return;
+            };
             let read_len = if let Some(backend) = backend.as_ref() {
                 backend.read_page_async(page_index, &page).wait()
             } else if let Some(inode) = inode.as_ref().and_then(|inode| inode.upgrade()) {
@@ -2902,7 +3204,7 @@ impl PageCache {
     /// unevictable Normal pages.
     ///
     /// This narrow API is for private in-kernel ring backings created with
-    /// `PageCache::new(None, None)`. Caches with an accounting backend are
+    /// `PageCache::new_unowned(None, None)`. Caches with an accounting backend are
     /// rejected rather than exposing a partially reservable quota protocol.
     /// Until the final commit, `ManagedPageBatch` rolls PageManager membership
     /// back by identity on every error path.
@@ -3389,5 +3691,19 @@ impl PageCache {
         }
 
         Ok(ret)
+    }
+}
+
+impl PageCacheDomainMember for PageCache {
+    fn has_dirty_or_writeback_work(&self) -> bool {
+        self.has_dirty_or_writeback_pages()
+    }
+
+    fn sync_for_domain(&self) -> Result<(), SystemError> {
+        self.manager.sync()
+    }
+
+    fn retire_for_domain(&self) -> Result<(), SystemError> {
+        self.manager.resize(0)
     }
 }

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -1866,10 +1866,27 @@ impl PageCache {
         backend: Arc<dyn PageCacheBackend>,
         domain: &Arc<PageCacheWritebackDomain>,
     ) -> Result<Arc<PageCache>, SystemError> {
+        Self::new_filesystem_mapping(inode, backend, PageCacheKind::File, domain)
+    }
+
+    pub fn new_filesystem_shmem(
+        inode: Weak<dyn IndexNode>,
+        backend: Arc<dyn PageCacheBackend>,
+        domain: &Arc<PageCacheWritebackDomain>,
+    ) -> Result<Arc<PageCache>, SystemError> {
+        Self::new_filesystem_mapping(inode, backend, PageCacheKind::Shmem, domain)
+    }
+
+    fn new_filesystem_mapping(
+        inode: Weak<dyn IndexNode>,
+        backend: Arc<dyn PageCacheBackend>,
+        kind: PageCacheKind,
+        domain: &Arc<PageCacheWritebackDomain>,
+    ) -> Result<Arc<PageCache>, SystemError> {
         let cache = Self::new_with_kind(
             Some(inode),
             Some(backend),
-            PageCacheKind::File,
+            kind,
             Some(Arc::downgrade(domain)),
         );
         domain.register(&cache)?;

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -578,6 +578,10 @@ impl Drop for PageCacheDomainIoPermit {
 }
 
 impl PageCacheDomainIoPermit {
+    pub(crate) fn belongs_to(&self, domain: &Arc<PageCacheWritebackDomain>) -> bool {
+        Arc::ptr_eq(&self.domain, domain)
+    }
+
     /// Derive a child permit from an already admitted I/O lineage.
     ///
     /// Closing a domain rejects new producers, but it must not revoke work

--- a/kernel/src/filesystem/page_cache/selftest.rs
+++ b/kernel/src/filesystem/page_cache/selftest.rs
@@ -2179,8 +2179,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         &mut || {
             snapshot_error_outcome = Some(PageCacheManager::claim_and_snapshot_locked_with(
                 &submission_cache,
-                0,
-                0,
+                WritebackBatchRange::new(0, 0),
                 token_file_size,
                 None,
                 true,
@@ -2466,8 +2465,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         &mut || {
             tagged_snapshot_error_outcome = Some(PageCacheManager::claim_and_snapshot_locked_with(
                 &submission_cache,
-                0,
-                0,
+                WritebackBatchRange::new(0, 0),
                 token_file_size,
                 Some((0, &tagged_entry, tagged_epoch)),
                 true,
@@ -2716,8 +2714,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     let split_blocking_submit = match PageCacheManager::claim_and_snapshot_after_admission_with(
         &split_cache,
         &split_backend_dyn,
-        0,
-        0,
+        WritebackBatchRange::new(0, 0),
         None,
         None,
         || Ok(MMArch::PAGE_SIZE),
@@ -2736,8 +2733,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         PageCacheManager::claim_and_snapshot_after_admission_with(
             &split_cache,
             &split_backend_dyn,
-            0,
-            0,
+            WritebackBatchRange::new(0, 0),
             None,
             None,
             || Ok(MMArch::PAGE_SIZE),
@@ -2771,8 +2767,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         PageCacheManager::claim_and_snapshot_after_admission_with(
             &split_cache,
             &split_backend_dyn,
-            0,
-            0,
+            WritebackBatchRange::new(0, 0),
             None,
             None,
             || Ok(MMArch::PAGE_SIZE),
@@ -2997,8 +2992,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             &mut || {
                 claimed = PageCacheManager::claim_and_snapshot_locked_with(
                     &tagged_worker_cache,
-                    0,
-                    0,
+                    WritebackBatchRange::new(0, 0),
                     token_file_size,
                     Some((0, &tagged_worker_entry, tagged_submission_epoch)),
                     true,

--- a/kernel/src/filesystem/page_cache/selftest.rs
+++ b/kernel/src/filesystem/page_cache/selftest.rs
@@ -25,6 +25,53 @@ impl Drop for PageCacheAccountingSelftestGuard {
     }
 }
 
+fn run_writeback_domain_lifecycle_selftest() -> bool {
+    let domain = PageCacheWritebackDomain::new();
+    let cache = PageCache::new_unowned(None, None);
+    if domain.register(&cache).is_err() || domain.snapshot().len() != 1 {
+        return false;
+    }
+    domain.close_background_admission();
+    if domain.wait_drained().is_err()
+        || domain.try_acquire_io().is_ok()
+        || domain.register(&cache).is_ok()
+    {
+        return false;
+    }
+    drop(cache);
+    if !domain.snapshot().is_empty() {
+        return false;
+    }
+
+    let owner: Arc<dyn crate::filesystem::vfs::FileSystem> = crate::filesystem::ramfs::RamFS::new();
+    let owner_weak = Arc::downgrade(&owner);
+    let superblock = Arc::new(crate::filesystem::vfs::mount::SuperBlockState::new(
+        crate::filesystem::vfs::mount::MountFlags::empty(),
+    ));
+    let active = PageCacheWritebackDomain::new();
+    if active.bind(&owner, &superblock).is_err() {
+        return false;
+    }
+    let permit = match active.try_acquire_io() {
+        Ok(permit) => permit,
+        Err(_) => return false,
+    };
+    active.close_background_admission();
+    let child = permit.derive();
+    drop(owner);
+    if owner_weak.upgrade().is_none() || active.state.lock_irqsave().io_in_flight != 2 {
+        return false;
+    }
+    drop(permit);
+    if owner_weak.upgrade().is_none() || active.state.lock_irqsave().io_in_flight != 1 {
+        return false;
+    }
+    drop(child);
+    owner_weak.upgrade().is_none()
+        && active.state.lock_irqsave().io_in_flight == 0
+        && active.wait_drained().is_ok()
+}
+
 #[inline(never)]
 fn run_preallocated_batch_lifecycle_selftest() -> Result<bool, SystemError> {
     use crate::{
@@ -71,7 +118,7 @@ fn run_preallocated_batch_lifecycle_selftest() -> Result<bool, SystemError> {
         page.write().add_flags(PageFlags::PG_UPTODATE);
     }
 
-    let cache = PageCache::new(None, None);
+    let cache = PageCache::new_unowned(None, None);
     cache.adopt_preallocated_unevictable_batch(7, batch)?;
     if cache.inner.lock().pages_count() != 3
         || addresses
@@ -867,7 +914,7 @@ pub(crate) fn run_completion_domain_debug_selftest() -> Result<alloc::string::St
 fn run_invalidate_retry_lock_order_selftest() -> Result<bool, SystemError> {
     const SELFTEST_TIMEOUT: Duration = Duration::from_secs(2);
 
-    let cache = PageCache::new(None, None);
+    let cache = PageCache::new_unowned(None, None);
     let mm = Arc::new(RwSem::new(()));
     let state = Arc::new(PageCacheInvalidateRetrySelftestState::new());
 
@@ -1029,7 +1076,7 @@ fn run_tag_scan_chunk_release_selftest() -> Result<bool, SystemError> {
     const SELFTEST_PAGES: usize = 513;
     const SELFTEST_TIMEOUT: Duration = Duration::from_secs(2);
 
-    let cache = PageCache::new(None, None);
+    let cache = PageCache::new_unowned(None, None);
     let mut pages = Vec::with_capacity(SELFTEST_PAGES);
     for index in 0..SELFTEST_PAGES {
         let page = cache.get_or_create_page_zero(index)?;
@@ -1323,6 +1370,7 @@ fn run_dirty_incarnation_snapshot_successor_selftest() -> Result<bool, SystemErr
         MMArch::PAGE_SIZE,
         None,
         false,
+        None,
     )? {
         WritebackClaimOutcome::Claimed(batch) => batch,
         _ => return Ok(false),
@@ -1649,6 +1697,10 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     }
     let _running = PageCacheAccountingSelftestGuard;
 
+    if !run_writeback_domain_lifecycle_selftest() {
+        return Ok("status=fail stage=writeback_domain_lifecycle\n".into());
+    }
+
     if !run_preallocated_batch_lifecycle_selftest()? {
         return Ok("status=fail stage=preallocated_batch_lifecycle\n".into());
     }
@@ -1734,7 +1786,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         true,
     ));
     let admission_backend_dyn: Arc<dyn PageCacheBackend> = admission_backend.clone();
-    let admission_cache = PageCache::new(None, Some(admission_backend_dyn.clone()));
+    let admission_cache = PageCache::new_unowned(None, Some(admission_backend_dyn.clone()));
     *admission_backend.cache.lock() = Arc::downgrade(&admission_cache);
     let admission_page = admission_cache.get_or_create_page_zero(0)?;
     let mark_admission_dirty = || -> Result<(), SystemError> {
@@ -1831,6 +1883,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             &admission_backend_dyn,
             0,
             0,
+            None,
             || Ok(None),
         )?,
         WritebackClaimOutcome::NoBatch
@@ -1887,7 +1940,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         false,
     ));
     let legacy_backend_dyn: Arc<dyn PageCacheBackend> = legacy_backend.clone();
-    let legacy_cache = PageCache::new(None, Some(legacy_backend_dyn.clone()));
+    let legacy_cache = PageCache::new_unowned(None, Some(legacy_backend_dyn.clone()));
     *legacy_backend.cache.lock() = Arc::downgrade(&legacy_cache);
     let mut legacy_blocking_claim = || Ok(());
     let legacy_blocking = PageCacheManager::with_writeback_admission(
@@ -2131,6 +2184,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
                 token_file_size,
                 None,
                 true,
+                None,
                 |_batch| Err(SystemError::EIO),
             )?);
             Ok(())
@@ -2417,6 +2471,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
                 token_file_size,
                 Some((0, &tagged_entry, tagged_epoch)),
                 true,
+                None,
                 |_batch| Err(SystemError::EIO),
             )?);
             Ok(())
@@ -2513,7 +2568,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             admission_order: PageCacheWritebackAdmissionOrder::AdmissionBeforeInvalidate,
             snapshot_phase: PageCacheWritebackSnapshotPhase::WithinAdmission,
         });
-    let overflow_cache = PageCache::new(None, Some(overflow_backend.clone()));
+    let overflow_cache = PageCache::new_unowned(None, Some(overflow_backend.clone()));
     let overflow_page = overflow_cache.get_or_create_page_zero(0)?;
     let overflow_entry = {
         let inner = overflow_cache.inner.lock();
@@ -2605,6 +2660,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             &submission_backend_dyn,
             0,
             0,
+            None,
             || Ok(Some(token_file_size)),
         ),
         Ok(WritebackClaimOutcome::FailedRecorded(SystemError::EIO))
@@ -2663,6 +2719,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         0,
         0,
         None,
+        None,
         || Ok(MMArch::PAGE_SIZE),
         snapshot_after_admission,
     )? {
@@ -2681,6 +2738,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             &split_backend_dyn,
             0,
             0,
+            None,
             None,
             || Ok(MMArch::PAGE_SIZE),
             |_batch| {
@@ -2716,6 +2774,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             0,
             0,
             None,
+            None,
             || Ok(MMArch::PAGE_SIZE),
             snapshot_after_admission,
         ),
@@ -2734,6 +2793,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         &split_backend_dyn,
         0,
         0,
+        None,
         || Ok(Some(MMArch::PAGE_SIZE)),
         snapshot_after_admission,
     )? {
@@ -2755,6 +2815,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
             &split_backend_dyn,
             0,
             0,
+            None,
             || Ok(Some(MMArch::PAGE_SIZE)),
             snapshot_after_admission,
         ),
@@ -2776,6 +2837,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
                 &split_backend_dyn,
                 0,
                 0,
+                None,
                 || Ok(Some(MMArch::PAGE_SIZE)),
                 snapshot_after_admission,
             ),
@@ -2940,6 +3002,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
                     token_file_size,
                     Some((0, &tagged_worker_entry, tagged_submission_epoch)),
                     true,
+                    None,
                     |batch| {
                         tagged_worker_gate
                             .snapshot_entered
@@ -3110,7 +3173,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     }
 
     // Ordinary file membership: insert, explicit remove, and duplicate remove.
-    let file_cache = PageCache::new(None, None);
+    let file_cache = PageCache::new_unowned(None, None);
     let file_page = file_cache.get_or_create_page_zero(0)?;
     let file_entry = file_cache
         .inner
@@ -3169,7 +3232,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
 
     // Loading rollback consumes membership once; a late state publication on
     // the detached entry must not revive it.
-    let state_cache = PageCache::new(None, None);
+    let state_cache = PageCache::new_unowned(None, None);
     let loading_page = state_cache.allocate_page(Arc::downgrade(&state_cache), 0)?;
     let loading_entry = Arc::new(PageEntry::new(loading_page.clone(), PageState::Loading));
     state_cache
@@ -3191,7 +3254,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     // Exercise the production writeback claim/completion state machine. A
     // successful completion returns to UpToDate; an error completion redirties
     // the same attached entry before normal removal closes the accounting.
-    let writeback_cache = PageCache::new(None, None);
+    let writeback_cache = PageCache::new_unowned(None, None);
     let writeback_page = writeback_cache.get_or_create_page_zero(0)?;
     let writeback_entry = writeback_cache
         .inner
@@ -3322,7 +3385,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     // Exhaustion must fail before publishing any Legacy state transition.
     // Wrapping to zero would make a later frozen waiter indistinguishable
     // from an old incarnation.
-    let overflow_cache = PageCache::new(None, None);
+    let overflow_cache = PageCache::new_unowned(None, None);
     let overflow_page = overflow_cache.get_or_create_page_zero(0)?;
     let overflow_entry = overflow_cache
         .inner
@@ -3347,7 +3410,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     // Generic asynchronous reads may leave a Loading entry at final drop. A
     // late completion owns only the detached entry and must not revive its
     // mapping accounting or physical manager/reclaimer membership.
-    let drop_cache = PageCache::new(None, None);
+    let drop_cache = PageCache::new_unowned(None, None);
     let drop_page = drop_cache.allocate_page(Arc::downgrade(&drop_cache), 0)?;
     let drop_paddr = drop_page.phys_address();
     let drop_entry = Arc::new(PageEntry::new(drop_page, PageState::Loading));
@@ -3487,6 +3550,6 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     }
 
     Ok(alloc::format!(
-        "status=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
+        "status=ok\nwriteback_domain_lifecycle=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
     ))
 }

--- a/kernel/src/filesystem/page_cache/writeback.rs
+++ b/kernel/src/filesystem/page_cache/writeback.rs
@@ -236,15 +236,9 @@ pub(super) fn run_async_writeback_budget_retry_selftest() -> bool {
         entry.set_writeback_tag(0x6a04);
         inner.dirty_pages.insert(0);
     }
-    let drop_ticket = PageCacheManager::arm_tagged_writeback_budget_retry(
-        &drop_cache,
-        None,
-        0,
-        0,
-        0x6a04,
-        0,
-    )
-    .expect("drop selftest must create its ticket");
+    let drop_ticket =
+        PageCacheManager::arm_tagged_writeback_budget_retry(&drop_cache, None, 0, 0, 0x6a04, 0)
+            .expect("drop selftest must create its ticket");
     AsyncWritebackPermit::register_retry(drop_ticket.clone());
     drop(drop_page);
     drop(drop_cache);
@@ -1017,9 +1011,29 @@ pub(super) struct ClaimedWritebackBatch {
     data: Vec<u8>,
 }
 
+#[derive(Clone, Copy)]
+pub(super) struct WritebackBatchRange {
+    start_index: usize,
+    end_index: usize,
+}
+
+impl WritebackBatchRange {
+    pub(super) const fn new(start_index: usize, end_index: usize) -> Self {
+        Self {
+            start_index,
+            end_index,
+        }
+    }
+}
+
 /// Internal result of inspecting one dirty run.  A deferred claim has not
 /// altered any page state, while a deferred submission has already restored
 /// its claimed batch to Dirty.
+///
+/// Keep the claimed batch inline. It is consumed immediately and already
+/// owns the buffers used by writeback; boxing it would add an allocation to
+/// every actual I/O batch and deepen the PageCache/workqueue auto-trait cycle.
+#[allow(clippy::large_enum_variant)]
 pub(super) enum WritebackClaimOutcome {
     NoBatch,
     Claimed(ClaimedWritebackBatch),
@@ -1841,8 +1855,7 @@ impl PageCacheManager {
     /// machine rather than an obligation of individual claim callers.
     pub(super) fn claim_and_snapshot_locked_with(
         cache: &Arc<PageCache>,
-        start_index: usize,
-        end_index: usize,
+        range: WritebackBatchRange,
         file_size: usize,
         required_first: Option<(usize, &Arc<PageEntry>, u64)>,
         bind_submission: bool,
@@ -1851,8 +1864,8 @@ impl PageCacheManager {
     ) -> Result<WritebackClaimOutcome, SystemError> {
         let claim = Self::claim_next_writeback_batch(
             cache,
-            start_index,
-            end_index,
+            range.start_index,
+            range.end_index,
             file_size,
             required_first,
             bind_submission,
@@ -1875,8 +1888,7 @@ impl PageCacheManager {
     ) -> Result<WritebackClaimOutcome, SystemError> {
         Self::claim_and_snapshot_locked_with(
             cache,
-            start_index,
-            end_index,
+            WritebackBatchRange::new(start_index, end_index),
             file_size,
             None,
             bind_submission,
@@ -1887,8 +1899,7 @@ impl PageCacheManager {
 
     fn claim_and_snapshot_tagged_locked(
         cache: &Arc<PageCache>,
-        start_index: usize,
-        end_index: usize,
+        range: WritebackBatchRange,
         file_size: usize,
         required_entry: &Arc<PageEntry>,
         epoch: u64,
@@ -1897,10 +1908,9 @@ impl PageCacheManager {
     ) -> Result<WritebackClaimOutcome, SystemError> {
         Self::claim_and_snapshot_locked_with(
             cache,
-            start_index,
-            end_index,
+            range,
             file_size,
-            Some((start_index, required_entry, epoch)),
+            Some((range.start_index, required_entry, epoch)),
             bind_submission,
             admitted,
             Self::snapshot_writeback_batch,
@@ -1990,8 +2000,7 @@ impl PageCacheManager {
     pub(super) fn claim_and_snapshot_after_admission_with(
         cache: &Arc<PageCache>,
         backend: &Arc<dyn PageCacheBackend>,
-        start_index: usize,
-        end_index: usize,
+        range: WritebackBatchRange,
         required_first: Option<(usize, &Arc<PageEntry>, u64)>,
         admitted: Option<&super::PageCacheDomainIoPermit>,
         mut stable_size: impl FnMut() -> Result<usize, SystemError>,
@@ -2007,8 +2016,8 @@ impl PageCacheManager {
             let file_size = stable_size()?;
             claim = Self::claim_next_writeback_batch(
                 cache,
-                start_index,
-                end_index,
+                range.start_index,
+                range.end_index,
                 file_size,
                 required_first,
                 true,
@@ -2099,8 +2108,7 @@ impl PageCacheManager {
             let file_size = inode.metadata()?.size.max(0) as usize;
             return Self::claim_and_snapshot_locked_with(
                 cache,
-                start_index,
-                end_index,
+                WritebackBatchRange::new(start_index, end_index),
                 file_size,
                 None,
                 false,
@@ -2117,8 +2125,7 @@ impl PageCacheManager {
             return Self::claim_and_snapshot_after_admission_with(
                 cache,
                 &backend,
-                start_index,
-                end_index,
+                WritebackBatchRange::new(start_index, end_index),
                 None,
                 admitted,
                 || backend.stable_writeback_size(inode),
@@ -2130,8 +2137,7 @@ impl PageCacheManager {
             let file_size = backend.stable_writeback_size(inode)?;
             claimed = Self::claim_and_snapshot_locked_with(
                 cache,
-                start_index,
-                end_index,
+                WritebackBatchRange::new(start_index, end_index),
                 file_size,
                 None,
                 true,
@@ -2154,8 +2160,7 @@ impl PageCacheManager {
         &self,
         cache: &Arc<PageCache>,
         inode: &Arc<dyn IndexNode>,
-        start_index: usize,
-        end_index: usize,
+        range: WritebackBatchRange,
         required_entry: &Arc<PageEntry>,
         epoch: u64,
         admitted: Option<&super::PageCacheDomainIoPermit>,
@@ -2165,8 +2170,7 @@ impl PageCacheManager {
             let file_size = inode.metadata()?.size.max(0) as usize;
             return Self::claim_and_snapshot_tagged_locked(
                 cache,
-                start_index,
-                end_index,
+                range,
                 file_size,
                 required_entry,
                 epoch,
@@ -2183,9 +2187,8 @@ impl PageCacheManager {
             return Self::claim_and_snapshot_after_admission_with(
                 cache,
                 &backend,
-                start_index,
-                end_index,
-                Some((start_index, required_entry, epoch)),
+                range,
+                Some((range.start_index, required_entry, epoch)),
                 admitted,
                 || backend.stable_writeback_size(inode),
                 Self::snapshot_writeback_batch,
@@ -2196,8 +2199,7 @@ impl PageCacheManager {
             let file_size = backend.stable_writeback_size(inode)?;
             claimed = Self::claim_and_snapshot_tagged_locked(
                 cache,
-                start_index,
-                end_index,
+                range,
                 file_size,
                 required_entry,
                 epoch,
@@ -2288,8 +2290,7 @@ impl PageCacheManager {
             };
             claimed = Self::claim_and_snapshot_locked_with(
                 cache,
-                start_index,
-                end_index,
+                WritebackBatchRange::new(start_index, end_index),
                 file_size,
                 None,
                 true,
@@ -2601,13 +2602,7 @@ impl PageCacheManager {
             .inode()
             .and_then(|inode| inode.upgrade())
             .ok_or(SystemError::EIO)?;
-        match self.writeback_next_batch(
-            &cache,
-            &inode,
-            start_index,
-            end_index,
-            Some(admitted),
-        )? {
+        match self.writeback_next_batch(&cache, &inode, start_index, end_index, Some(admitted))? {
             WritebackNextBatchOutcome::NoBatch => Ok(PageCacheWritebackDispatchOutcome::Idle),
             WritebackNextBatchOutcome::Completed => Ok(PageCacheWritebackDispatchOutcome::Progress),
             WritebackNextBatchOutcome::Deferred(_) => {
@@ -3586,8 +3581,7 @@ impl PageCacheManager {
             let claim = match self.claim_tagged_batch_with_admission(
                 cache,
                 inode,
-                target_index,
-                tagged_end,
+                WritebackBatchRange::new(target_index, tagged_end),
                 &target_entry,
                 epoch,
                 domain_io.as_ref(),
@@ -3982,8 +3976,7 @@ impl PageCacheManager {
             let claim = match self.claim_tagged_batch_with_admission(
                 &cache,
                 &inode,
-                target_index,
-                tagged_end,
+                WritebackBatchRange::new(target_index, tagged_end),
                 &target_entry,
                 epoch,
                 _domain_io.as_ref(),
@@ -4160,15 +4153,13 @@ impl PageCacheManager {
             // again behind the cursor is intentionally left for a later scan.
             let mut cursor = start_index;
             while cursor <= end_index {
-                let claim = match manager
-                    .try_claim_next_batch_with_admission(
-                        &cache,
-                        &inode,
-                        cursor,
-                        end_index,
-                        _domain_io.as_ref(),
-                    )
-                {
+                let claim = match manager.try_claim_next_batch_with_admission(
+                    &cache,
+                    &inode,
+                    cursor,
+                    end_index,
+                    _domain_io.as_ref(),
+                ) {
                     Ok(claim) => claim,
                     Err(_) => break,
                 };

--- a/kernel/src/filesystem/page_cache/writeback.rs
+++ b/kernel/src/filesystem/page_cache/writeback.rs
@@ -149,7 +149,7 @@ pub(super) fn run_async_writeback_budget_retry_selftest() -> bool {
         permits.push(permit);
     }
 
-    let cache = PageCache::new(None, None);
+    let cache = PageCache::new_unowned(None, None);
     let predecessor_page = match cache.get_or_create_page_zero(0) {
         Ok(page) => page,
         Err(_) => {
@@ -214,7 +214,7 @@ pub(super) fn run_async_writeback_budget_retry_selftest() -> bool {
     drop(tagged_page);
     drop(cache);
 
-    let drop_cache = PageCache::new(None, None);
+    let drop_cache = PageCache::new_unowned(None, None);
     let drop_page = match drop_cache.get_or_create_page_zero(0) {
         Ok(page) => page,
         Err(_) => {
@@ -236,9 +236,15 @@ pub(super) fn run_async_writeback_budget_retry_selftest() -> bool {
         entry.set_writeback_tag(0x6a04);
         inner.dirty_pages.insert(0);
     }
-    let drop_ticket =
-        PageCacheManager::arm_tagged_writeback_budget_retry(&drop_cache, None, 0, 0, 0x6a04, 0)
-            .expect("drop selftest must create its ticket");
+    let drop_ticket = PageCacheManager::arm_tagged_writeback_budget_retry(
+        &drop_cache,
+        None,
+        0,
+        0,
+        0x6a04,
+        0,
+    )
+    .expect("drop selftest must create its ticket");
     AsyncWritebackPermit::register_retry(drop_ticket.clone());
     drop(drop_page);
     drop(drop_cache);
@@ -999,6 +1005,7 @@ impl Drop for WritebackGuard {
 
 pub(super) struct ClaimedWritebackBatch {
     cache: Arc<PageCache>,
+    _domain_io: Option<super::PageCacheDomainIoPermit>,
     backend: Option<Arc<dyn PageCacheBackend>>,
     first_index: usize,
     pub(super) descriptor: PageCacheWritebackDescriptor,
@@ -1129,7 +1136,12 @@ impl PageCacheManager {
         file_size: usize,
         required_first: Option<(usize, &Arc<PageEntry>, u64)>,
         bind_submission: bool,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
+        let domain_io = match admitted {
+            Some(permit) => Some(permit.derive()),
+            None => cache.try_acquire_domain_io()?,
+        };
         if start_index > end_index {
             return Ok(WritebackClaimOutcome::NoBatch);
         }
@@ -1471,6 +1483,7 @@ impl PageCacheManager {
         }
         Ok(WritebackClaimOutcome::Claimed(ClaimedWritebackBatch {
             cache: cache.clone(),
+            _domain_io: domain_io,
             backend,
             first_index,
             descriptor,
@@ -1833,6 +1846,7 @@ impl PageCacheManager {
         file_size: usize,
         required_first: Option<(usize, &Arc<PageEntry>, u64)>,
         bind_submission: bool,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
         snapshot: impl FnOnce(&mut ClaimedWritebackBatch) -> Result<(), SystemError>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         let claim = Self::claim_next_writeback_batch(
@@ -1842,6 +1856,7 @@ impl PageCacheManager {
             file_size,
             required_first,
             bind_submission,
+            admitted,
         )?;
         Self::snapshot_claimed_batch_with(
             claim,
@@ -1865,6 +1880,7 @@ impl PageCacheManager {
             file_size,
             None,
             bind_submission,
+            None,
             Self::snapshot_writeback_batch,
         )
     }
@@ -1877,6 +1893,7 @@ impl PageCacheManager {
         required_entry: &Arc<PageEntry>,
         epoch: u64,
         bind_submission: bool,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         Self::claim_and_snapshot_locked_with(
             cache,
@@ -1885,6 +1902,7 @@ impl PageCacheManager {
             file_size,
             Some((start_index, required_entry, epoch)),
             bind_submission,
+            admitted,
             Self::snapshot_writeback_batch,
         )
     }
@@ -1975,6 +1993,7 @@ impl PageCacheManager {
         start_index: usize,
         end_index: usize,
         required_first: Option<(usize, &Arc<PageEntry>, u64)>,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
         mut stable_size: impl FnMut() -> Result<usize, SystemError>,
         snapshot: impl FnOnce(&mut ClaimedWritebackBatch) -> Result<(), SystemError>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
@@ -1993,6 +2012,7 @@ impl PageCacheManager {
                 file_size,
                 required_first,
                 true,
+                admitted,
             )?;
             Ok(())
         });
@@ -2018,6 +2038,7 @@ impl PageCacheManager {
         backend: &Arc<dyn PageCacheBackend>,
         start_index: usize,
         end_index: usize,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
         mut stable_size: impl FnMut() -> Result<Option<usize>, SystemError>,
         snapshot: impl FnOnce(&mut ClaimedWritebackBatch) -> Result<(), SystemError>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
@@ -2042,6 +2063,7 @@ impl PageCacheManager {
                 file_size,
                 None,
                 true,
+                admitted,
             )?;
             Ok(())
         }) {
@@ -2070,16 +2092,20 @@ impl PageCacheManager {
         inode: &Arc<dyn IndexNode>,
         start_index: usize,
         end_index: usize,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         let Some(backend) = cache.backend() else {
             let _invalidate = cache.invalidate_read();
             let file_size = inode.metadata()?.size.max(0) as usize;
-            return Self::claim_and_snapshot_locked(
+            return Self::claim_and_snapshot_locked_with(
                 cache,
                 start_index,
                 end_index,
                 file_size,
+                None,
                 false,
+                admitted,
+                Self::snapshot_writeback_batch,
             );
         };
         if backend.writeback_snapshot_phase() == PageCacheWritebackSnapshotPhase::AfterAdmission {
@@ -2094,6 +2120,7 @@ impl PageCacheManager {
                 start_index,
                 end_index,
                 None,
+                admitted,
                 || backend.stable_writeback_size(inode),
                 Self::snapshot_writeback_batch,
             );
@@ -2101,8 +2128,16 @@ impl PageCacheManager {
         let mut claimed = WritebackClaimOutcome::NoBatch;
         let admission = Self::with_writeback_admission(cache, &backend, &mut || {
             let file_size = backend.stable_writeback_size(inode)?;
-            claimed =
-                Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size, true)?;
+            claimed = Self::claim_and_snapshot_locked_with(
+                cache,
+                start_index,
+                end_index,
+                file_size,
+                None,
+                true,
+                admitted,
+                Self::snapshot_writeback_batch,
+            )?;
             Ok(())
         });
         if let Err(error) = admission {
@@ -2123,6 +2158,7 @@ impl PageCacheManager {
         end_index: usize,
         required_entry: &Arc<PageEntry>,
         epoch: u64,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         let Some(backend) = cache.backend() else {
             let _invalidate = cache.invalidate_read();
@@ -2135,6 +2171,7 @@ impl PageCacheManager {
                 required_entry,
                 epoch,
                 false,
+                admitted,
             );
         };
         if backend.writeback_snapshot_phase() == PageCacheWritebackSnapshotPhase::AfterAdmission {
@@ -2149,6 +2186,7 @@ impl PageCacheManager {
                 start_index,
                 end_index,
                 Some((start_index, required_entry, epoch)),
+                admitted,
                 || backend.stable_writeback_size(inode),
                 Self::snapshot_writeback_batch,
             );
@@ -2164,6 +2202,7 @@ impl PageCacheManager {
                 required_entry,
                 epoch,
                 true,
+                admitted,
             )?;
             Ok(())
         });
@@ -2183,6 +2222,7 @@ impl PageCacheManager {
         inode: &Arc<dyn IndexNode>,
         start_index: usize,
         end_index: usize,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         let Some(backend) = cache.backend() else {
             let Some(_invalidate) = cache.try_invalidate_read() else {
@@ -2208,6 +2248,7 @@ impl PageCacheManager {
                 &backend,
                 start_index,
                 end_index,
+                admitted,
                 || backend.try_stable_writeback_size(inode),
                 Self::snapshot_writeback_batch,
             );
@@ -2217,6 +2258,7 @@ impl PageCacheManager {
             &backend,
             start_index,
             end_index,
+            admitted,
             || backend.try_stable_writeback_size(inode),
         )
     }
@@ -2230,6 +2272,7 @@ impl PageCacheManager {
         backend: &Arc<dyn PageCacheBackend>,
         start_index: usize,
         end_index: usize,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
         mut stable_size: impl FnMut() -> Result<Option<usize>, SystemError>,
     ) -> Result<WritebackClaimOutcome, SystemError> {
         // This helper is deliberately unavailable to split-phase backends:
@@ -2243,8 +2286,16 @@ impl PageCacheManager {
             let Some(file_size) = stable_size()? else {
                 return Ok(());
             };
-            claimed =
-                Self::claim_and_snapshot_locked(cache, start_index, end_index, file_size, true)?;
+            claimed = Self::claim_and_snapshot_locked_with(
+                cache,
+                start_index,
+                end_index,
+                file_size,
+                None,
+                true,
+                admitted,
+                Self::snapshot_writeback_batch,
+            )?;
             Ok(())
         }) {
             Ok(admitted) => admitted,
@@ -2268,8 +2319,15 @@ impl PageCacheManager {
         inode: &Arc<dyn IndexNode>,
         start_index: usize,
         end_index: usize,
+        admitted: Option<&super::PageCacheDomainIoPermit>,
     ) -> Result<WritebackNextBatchOutcome, SystemError> {
-        match self.claim_next_batch_with_admission(cache, inode, start_index, end_index)? {
+        match self.claim_next_batch_with_admission(
+            cache,
+            inode,
+            start_index,
+            end_index,
+            admitted,
+        )? {
             WritebackClaimOutcome::NoBatch => Ok(WritebackNextBatchOutcome::NoBatch),
             WritebackClaimOutcome::Deferred(progress) => {
                 Ok(WritebackNextBatchOutcome::Deferred(progress))
@@ -2419,7 +2477,7 @@ impl PageCacheManager {
             .ok_or(SystemError::EIO)?;
         loop {
             loop {
-                match self.writeback_next_batch(&cache, &inode, start_index, end_index)? {
+                match self.writeback_next_batch(&cache, &inode, start_index, end_index, None)? {
                     WritebackNextBatchOutcome::NoBatch => break,
                     WritebackNextBatchOutcome::Completed => continue,
                     WritebackNextBatchOutcome::Deferred(progress) => {
@@ -2450,12 +2508,18 @@ impl PageCacheManager {
         // page completing writeback and write_inode(). The aggregated dirty
         // owner may be released by finish_writeback_entry(), but eviction must
         // not enter that false-zero window before metadata is committed.
-        let sync_inode = cache
-            .inode()
-            .and_then(|inode| inode.upgrade())
-            .ok_or(SystemError::EIO)?;
+        let Some(sync_inode) = cache.inode().and_then(|inode| inode.upgrade()) else {
+            cache.record_writeback_error_with_superblock(SystemError::EIO);
+            return Err(SystemError::EIO);
+        };
         let _sync_retention =
-            InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork)?;
+            match InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork) {
+                Ok(guard) => guard,
+                Err(error) => {
+                    cache.record_writeback_error_with_superblock(error.clone());
+                    return Err(error);
+                }
+            };
         self.sync_data(0, usize::MAX)?;
 
         // 脏页写完后调 write_inode 回写元数据。
@@ -2474,12 +2538,18 @@ impl PageCacheManager {
     /// this as a substitute for `PageCacheBackend::with_write_admission`.
     pub(crate) fn sync_with_stable_size(&self, file_size: usize) -> Result<(), SystemError> {
         let cache = self.upgrade()?;
-        let sync_inode = cache
-            .inode()
-            .and_then(|inode| inode.upgrade())
-            .ok_or(SystemError::EIO)?;
+        let Some(sync_inode) = cache.inode().and_then(|inode| inode.upgrade()) else {
+            cache.record_writeback_error_with_superblock(SystemError::EIO);
+            return Err(SystemError::EIO);
+        };
         let _sync_retention =
-            InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork)?;
+            match InodeRetentionGuard::new(sync_inode.clone(), InodeRetentionKind::AsyncWork) {
+                Ok(guard) => guard,
+                Err(error) => {
+                    cache.record_writeback_error_with_superblock(error.clone());
+                    return Err(error);
+                }
+            };
         self.sync_data_admitted(0, usize::MAX, file_size)?;
 
         let wbc = WritebackControl::sync_all_for_sync();
@@ -2524,13 +2594,20 @@ impl PageCacheManager {
         &self,
         start_index: usize,
         end_index: usize,
+        admitted: &super::PageCacheDomainIoPermit,
     ) -> Result<PageCacheWritebackDispatchOutcome, SystemError> {
         let cache = self.upgrade()?;
         let inode = cache
             .inode()
             .and_then(|inode| inode.upgrade())
             .ok_or(SystemError::EIO)?;
-        match self.writeback_next_batch(&cache, &inode, start_index, end_index)? {
+        match self.writeback_next_batch(
+            &cache,
+            &inode,
+            start_index,
+            end_index,
+            Some(admitted),
+        )? {
             WritebackNextBatchOutcome::NoBatch => Ok(PageCacheWritebackDispatchOutcome::Idle),
             WritebackNextBatchOutcome::Completed => Ok(PageCacheWritebackDispatchOutcome::Progress),
             WritebackNextBatchOutcome::Deferred(_) => {
@@ -2570,7 +2647,7 @@ impl PageCacheManager {
                 let prepared = {
                     let _invalidate = cache.invalidate_read();
                     match Self::claim_next_writeback_batch(
-                        &cache, cursor, end_index, file_size, None, false,
+                        &cache, cursor, end_index, file_size, None, false, None,
                     ) {
                         Ok(WritebackClaimOutcome::Claimed(mut batch)) => {
                             pc_stats::record_invalidation_launder_batch(batch.entries.len());
@@ -2983,25 +3060,6 @@ impl PageCacheManager {
         }
     }
 
-    fn schedule_tagged_writeback_drain(
-        cache: Weak<PageCache>,
-        inode: Weak<dyn IndexNode>,
-        start_index: usize,
-        frozen_end: usize,
-        epoch: u64,
-        cursor: usize,
-    ) {
-        Self::schedule_tagged_writeback_drain_with_permit(
-            cache,
-            inode,
-            start_index,
-            frozen_end,
-            epoch,
-            cursor,
-            None,
-        );
-    }
-
     /// Register an exact completion continuation for a tagged page redirtied
     /// behind an older Writeback incarnation.
     ///
@@ -3060,13 +3118,14 @@ impl PageCacheManager {
                 epoch,
                 cursor,
             } = retry.continuation;
-            Self::schedule_tagged_writeback_drain(
+            Self::schedule_tagged_writeback_drain_with_permit(
                 Arc::downgrade(cache),
                 retry.inode,
                 start_index,
                 frozen_end,
                 epoch,
                 cursor,
+                None,
             );
         }
     }
@@ -3080,9 +3139,37 @@ impl PageCacheManager {
         cursor: usize,
         permit: Option<AsyncWritebackPermit>,
     ) {
-        let work_state = Mutex::new(Some(permit));
+        let Some(cache_arc) = cache.upgrade() else {
+            return;
+        };
+        let domain_io = match cache_arc.try_acquire_domain_io_classified() {
+            Ok(permit) => permit,
+            Err(super::PageCacheDomainIoAdmissionError::Closed) => {
+                Self::cancel_tagged_writeback_budget_retry(&cache_arc, epoch);
+                Self::retire_tagged_writeback_generation(
+                    &cache_arc,
+                    start_index,
+                    frozen_end,
+                    epoch,
+                );
+                return;
+            }
+            Err(super::PageCacheDomainIoAdmissionError::Unavailable(error)) => {
+                Self::cancel_tagged_writeback_budget_retry(&cache_arc, epoch);
+                Self::abandon_tagged_writeback_generation(
+                    &cache_arc,
+                    start_index,
+                    frozen_end,
+                    epoch,
+                    error,
+                );
+                return;
+            }
+        };
+        drop(cache_arc);
+        let work_state = Mutex::new(Some((permit, domain_io)));
         schedule_pagecache_writeback(Work::new(move || {
-            let Some(permit) = work_state.lock().take() else {
+            let Some((permit, domain_io)) = work_state.lock().take() else {
                 return;
             };
             let Some(cache) = cache.upgrade() else {
@@ -3110,6 +3197,7 @@ impl PageCacheManager {
                     cursor,
                 },
                 permit,
+                domain_io,
             );
         }));
     }
@@ -3267,13 +3355,14 @@ impl PageCacheManager {
                         }
                         return;
                     }
-                    Self::schedule_tagged_writeback_drain(
+                    Self::schedule_tagged_writeback_drain_with_permit(
                         cache.clone(),
                         inode.clone(),
                         start_index,
                         frozen_end,
                         epoch,
                         last_index + 1,
+                        None,
                     );
                 }
                 Ok(WritebackSubmitOutcome::Deferred(progress)) => {
@@ -3343,13 +3432,14 @@ impl PageCacheManager {
                 PageCacheWritebackProgressOutcome::Progress => {
                     Self::notify_tagged_writeback_progress(&cache_arc);
                     drop(cache_arc);
-                    Self::schedule_tagged_writeback_drain(
+                    Self::schedule_tagged_writeback_drain_with_permit(
                         cache.clone(),
                         inode.clone(),
                         start_index,
                         frozen_end,
                         epoch,
                         cursor,
+                        None,
                     );
                 }
                 PageCacheWritebackProgressOutcome::Cancelled => {
@@ -3360,23 +3450,43 @@ impl PageCacheManager {
                     // the whole epoch and letting WAIT_AFTER finish early.
                     Self::notify_tagged_writeback_progress(&cache_arc);
                     drop(cache_arc);
-                    Self::schedule_tagged_writeback_drain(
+                    Self::schedule_tagged_writeback_drain_with_permit(
                         cache.clone(),
                         inode.clone(),
                         start_index,
                         frozen_end,
                         epoch,
                         cursor,
+                        None,
                     );
                 }
                 PageCacheWritebackProgressOutcome::Failed(error) => {
-                    Self::abandon_tagged_writeback_generation(
-                        &cache_arc,
-                        start_index,
-                        frozen_end,
-                        epoch,
-                        error,
-                    );
+                    match cache_arc.try_acquire_domain_io_classified() {
+                        Ok(_permit) => Self::abandon_tagged_writeback_generation(
+                            &cache_arc,
+                            start_index,
+                            frozen_end,
+                            epoch,
+                            error,
+                        ),
+                        Err(super::PageCacheDomainIoAdmissionError::Closed) => {
+                            Self::retire_tagged_writeback_generation(
+                                &cache_arc,
+                                start_index,
+                                frozen_end,
+                                epoch,
+                            );
+                        }
+                        Err(super::PageCacheDomainIoAdmissionError::Unavailable(error)) => {
+                            Self::abandon_tagged_writeback_generation(
+                                &cache_arc,
+                                start_index,
+                                frozen_end,
+                                epoch,
+                                error,
+                            );
+                        }
+                    }
                 }
             }
         }));
@@ -3404,7 +3514,13 @@ impl PageCacheManager {
                 PageCacheWritebackProgressOutcome::Cancelled => {}
                 PageCacheWritebackProgressOutcome::Failed(error) => {
                     if let Ok(cache) = manager.upgrade() {
-                        cache.record_writeback_error_with_superblock(error);
+                        match cache.try_acquire_domain_io_classified() {
+                            Ok(_permit) => cache.record_writeback_error_with_superblock(error),
+                            Err(super::PageCacheDomainIoAdmissionError::Closed) => {}
+                            Err(super::PageCacheDomainIoAdmissionError::Unavailable(error)) => {
+                                cache.record_writeback_error(error);
+                            }
+                        }
                     }
                 }
             }
@@ -3417,6 +3533,7 @@ impl PageCacheManager {
         inode: &Arc<dyn IndexNode>,
         continuation: TaggedWritebackCursor,
         mut reserved_permit: Option<AsyncWritebackPermit>,
+        domain_io: Option<super::PageCacheDomainIoPermit>,
     ) {
         let TaggedWritebackCursor {
             start_index,
@@ -3473,6 +3590,7 @@ impl PageCacheManager {
                 tagged_end,
                 &target_entry,
                 epoch,
+                domain_io.as_ref(),
             ) {
                 Ok(claim) => claim,
                 Err(error) => {
@@ -3802,6 +3920,23 @@ impl PageCacheManager {
                 return Err(SystemError::EIO);
             }
         };
+        let _domain_io = match cache.try_acquire_domain_io_classified() {
+            Ok(permit) => permit,
+            Err(super::PageCacheDomainIoAdmissionError::Closed) => {
+                Self::retire_tagged_writeback_generation(&cache, start_index, frozen_end, epoch);
+                return Err(SystemError::ESTALE);
+            }
+            Err(super::PageCacheDomainIoAdmissionError::Unavailable(error)) => {
+                Self::abandon_tagged_writeback_generation(
+                    &cache,
+                    start_index,
+                    frozen_end,
+                    epoch,
+                    error.clone(),
+                );
+                return Err(error);
+            }
+        };
 
         // `SYNC_FILE_RANGE_WRITE` is an asynchronous writeout starter: it
         // publishes Dirty -> Writeback and queues legacy I/O, but must not
@@ -3851,6 +3986,7 @@ impl PageCacheManager {
                 tagged_end,
                 &target_entry,
                 epoch,
+                _domain_io.as_ref(),
             ) {
                 Ok(claim) => claim,
                 Err(error) => {
@@ -3993,6 +4129,11 @@ impl PageCacheManager {
         end_index: usize,
     ) -> Result<bool, SystemError> {
         let cache = self.upgrade()?;
+        let domain_io = match cache.try_acquire_domain_io() {
+            Ok(permit) => permit,
+            Err(SystemError::ESTALE) => return Ok(false),
+            Err(error) => return Err(error),
+        };
         let Some(runner) = ReclaimerRunnerGuard::try_acquire(&cache) else {
             return Ok(false);
         };
@@ -4004,13 +4145,14 @@ impl PageCacheManager {
             .and_then(|inode| inode.upgrade())
             .ok_or(SystemError::EIO)?;
         let manager = self.clone();
-        let work_state = Mutex::new(Some((runner, permit, cache, inode)));
+        let work_state = Mutex::new(Some((runner, permit, domain_io, cache, inode)));
         schedule_pagecache_io(Work::new(move || {
-            let Some((runner, permit, cache, inode)) = work_state.lock().take() else {
+            let Some((runner, permit, domain_io, cache, inode)) = work_state.lock().take() else {
                 return;
             };
             let _runner = runner;
             let _permit = permit;
+            let _domain_io = domain_io;
             // Drain the caller's bounded scan range in file-offset order.
             // Keeping one runner per cache prevents overlapping reclaimer
             // workers, while advancing after each submitted batch avoids the
@@ -4019,7 +4161,13 @@ impl PageCacheManager {
             let mut cursor = start_index;
             while cursor <= end_index {
                 let claim = match manager
-                    .try_claim_next_batch_with_admission(&cache, &inode, cursor, end_index)
+                    .try_claim_next_batch_with_admission(
+                        &cache,
+                        &inode,
+                        cursor,
+                        end_index,
+                        _domain_io.as_ref(),
+                    )
                 {
                     Ok(claim) => claim,
                     Err(_) => break,

--- a/kernel/src/filesystem/procfs/root.rs
+++ b/kernel/src/filesystem/procfs/root.rs
@@ -238,6 +238,12 @@ impl ProcFS {
 }
 
 impl FileSystem for ProcFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         self.root_inode.clone()
     }

--- a/kernel/src/filesystem/ramfs/mod.rs
+++ b/kernel/src/filesystem/ramfs/mod.rs
@@ -258,6 +258,12 @@ impl RamFSInode {
     }
 }
 impl FileSystem for RamFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn super::vfs::IndexNode> {
         return self.root_inode.clone();
     }

--- a/kernel/src/filesystem/sysfs/mod.rs
+++ b/kernel/src/filesystem/sysfs/mod.rs
@@ -236,6 +236,12 @@ impl SysFS {
 use linkme::distributed_slice;
 
 impl FileSystem for SysFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn super::vfs::IndexNode> {
         return self.root_inode.clone();
     }

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -453,6 +453,12 @@ impl FileSystemMakerData for TmpfsMountData {
 }
 
 impl FileSystem for Tmpfs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn supports_reliable_flush(&self) -> bool {
         // tmpfs has no crash-surviving backing state. A loop image stored here
         // disappears as a whole on power loss, so there is no partially

--- a/kernel/src/filesystem/tmpfs/mod.rs
+++ b/kernel/src/filesystem/tmpfs/mod.rs
@@ -3,7 +3,7 @@ use core::fmt::Write;
 use core::intrinsics::unlikely;
 use core::sync::atomic::{AtomicU64, Ordering};
 
-use crate::filesystem::page_cache::{PageCache, PageCacheBackend};
+use crate::filesystem::page_cache::{PageCache, PageCacheBackend, PageCacheWritebackDomain};
 use crate::filesystem::vfs::syscall::RenameFlags;
 use crate::filesystem::vfs::{FileSystemMakerData, FSMAKER};
 use crate::libs::rwsem::RwSem;
@@ -101,6 +101,18 @@ impl PageCacheBackend for TmpfsPageCacheBackend {
         if let Some(fs) = self.fs.upgrade() {
             fs.decrease_size(MMArch::PAGE_SIZE);
         }
+    }
+}
+
+fn new_tmpfs_page_cache(
+    inode: Weak<dyn IndexNode>,
+    backend: Arc<dyn PageCacheBackend>,
+    fs: &Weak<Tmpfs>,
+) -> Result<Arc<PageCache>, SystemError> {
+    let fs = fs.upgrade().ok_or(SystemError::EIO)?;
+    match fs.writeback_domain.as_ref() {
+        Some(domain) => PageCache::new_filesystem_shmem(inode, backend, domain),
+        None => Ok(PageCache::new_shmem(Some(inode), Some(backend))),
     }
 }
 
@@ -313,6 +325,7 @@ impl LockedTmpfsInode {
 #[derive(Debug)]
 pub struct Tmpfs {
     root_inode: Arc<LockedTmpfsInode>,
+    writeback_domain: Option<Arc<PageCacheWritebackDomain>>,
     super_block: RwSem<SuperBlock>,
     size_limit: RwSem<Option<u64>>,
     current_size: AtomicU64,
@@ -453,10 +466,8 @@ impl FileSystemMakerData for TmpfsMountData {
 }
 
 impl FileSystem for Tmpfs {
-    fn page_cache_writeback_domain(
-        &self,
-    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
-        None
+    fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
+        self.writeback_domain.as_ref()
     }
 
     fn supports_reliable_flush(&self) -> bool {
@@ -583,10 +594,18 @@ impl Tmpfs {
         let size_limit = mount_data
             .size_bytes
             .or_else(|| Some(Self::default_size_bytes() as u64));
-        Self::new_with_size_limit(mount_data.mode, size_limit)
+        Self::new_with_size_limit(
+            mount_data.mode,
+            size_limit,
+            Some(PageCacheWritebackDomain::new()),
+        )
     }
 
-    fn new_with_size_limit(mode: Option<InodeMode>, size_limit: Option<u64>) -> Arc<Self> {
+    fn new_with_size_limit(
+        mode: Option<InodeMode>,
+        size_limit: Option<u64>,
+        writeback_domain: Option<Arc<PageCacheWritebackDomain>>,
+    ) -> Arc<Self> {
         let mut sb = SuperBlock::new(
             Magic::TMPFS_MAGIC,
             TMPFS_BLOCK_SIZE,
@@ -604,6 +623,7 @@ impl Tmpfs {
 
         let result: Arc<Tmpfs> = Arc::new(Tmpfs {
             root_inode: root,
+            writeback_domain,
             super_block: RwSem::new(sb),
             size_limit: RwSem::new(size_limit),
             current_size: AtomicU64::new(0),
@@ -620,8 +640,8 @@ impl Tmpfs {
         result
     }
 
-    pub fn new_unlimited(mode: Option<InodeMode>) -> Arc<Self> {
-        Self::new_with_size_limit(mode, None)
+    fn new_internal_shmem(mode: Option<InodeMode>) -> Arc<Self> {
+        Self::new_with_size_limit(mode, None, None)
     }
 
     /// 原子地增加文件系统使用的大小
@@ -738,7 +758,7 @@ impl Tmpfs {
             Arc::downgrade(&inode_dyn),
             Arc::downgrade(self),
         ));
-        let pc = PageCache::new_shmem(Some(Arc::downgrade(&inode_dyn)), Some(backend));
+        let pc = new_tmpfs_page_cache(Arc::downgrade(&inode_dyn), backend, &Arc::downgrade(self))?;
         result.0.lock().page_cache = Some(pc.clone());
 
         Ok(Arc::new(TmpfsShmemFile {
@@ -752,7 +772,7 @@ impl Tmpfs {
 }
 
 lazy_static! {
-    static ref SYSV_SHMEM_TMPFS: Arc<Tmpfs> = Tmpfs::new_unlimited(Some(InodeMode::S_IRWXUGO));
+    static ref SYSV_SHMEM_TMPFS: Arc<Tmpfs> = Tmpfs::new_internal_shmem(Some(InodeMode::S_IRWXUGO));
 }
 
 pub fn create_unlinked_shmem_file(size: usize) -> Result<Arc<TmpfsShmemFile>, SystemError> {
@@ -1282,7 +1302,7 @@ impl IndexNode for LockedTmpfsInode {
                 Arc::downgrade(&inode_dyn),
                 parent.fs.clone(),
             ));
-            let page_cache = PageCache::new_shmem(Some(Arc::downgrade(&inode_dyn)), Some(backend));
+            let page_cache = new_tmpfs_page_cache(Arc::downgrade(&inode_dyn), backend, &parent.fs)?;
             result.0.lock().page_cache = Some(page_cache.clone());
             let page = page_cache.manager().commit_overwrite(0)?;
             let mut page_guard = page.write();
@@ -1357,10 +1377,11 @@ impl IndexNode for LockedTmpfsInode {
                 Arc::downgrade(&result) as Weak<dyn IndexNode>,
                 inode.fs.clone(),
             ));
-            let pc = PageCache::new_shmem(
-                Some(Arc::downgrade(&result) as Weak<dyn IndexNode>),
-                Some(backend),
-            );
+            let pc = new_tmpfs_page_cache(
+                Arc::downgrade(&result) as Weak<dyn IndexNode>,
+                backend,
+                &inode.fs,
+            )?;
             result.0.lock().page_cache = Some(pc);
         }
 

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -2161,7 +2161,7 @@ pub trait FileSystem: Any + Sync + Send + Debug {
 
     /// Stop filesystem-private page-cache producers before the generic
     /// writeback domain is closed and retired.
-    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
+    fn quiesce_page_cache_producers(&self) -> Result<(), SystemError> {
         Ok(())
     }
 

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -2086,6 +2086,12 @@ impl WritebackControl {
 
 /// @brief 所有文件系统都应该实现的trait
 pub trait FileSystem: Any + Sync + Send + Debug {
+    /// Return the stable writeback/shutdown domain for file-backed mappings.
+    /// In-memory and pseudo filesystems must explicitly return `None`.
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>>;
+
     /// Whether `sync_fs(true)` reaches a power-loss-safe backing barrier.
     fn supports_reliable_flush(&self) -> bool {
         false
@@ -2150,6 +2156,12 @@ pub trait FileSystem: Any + Sync + Send + Debug {
     /// Stop or finish asynchronous retention producers before the eviction
     /// queue is sealed.
     fn quiesce_async_inode_work(&self) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    /// Stop filesystem-private page-cache producers before the generic
+    /// writeback domain is closed and retired.
+    fn prepare_page_cache_retirement(&self) -> Result<(), SystemError> {
         Ok(())
     }
 

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -2607,7 +2607,7 @@ impl MountFS {
             log::warn!("final superblock sync failed during umount: {:?}", err);
             sb_state.record_wb_error(err);
         }
-        if let Err(err) = self.inner_filesystem.prepare_page_cache_retirement() {
+        if let Err(err) = self.inner_filesystem.quiesce_page_cache_producers() {
             log::warn!("final page-cache producer quiesce failed: {:?}", err);
             sb_state.record_wb_error(err);
         }

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -9,7 +9,6 @@ use crate::{
     driver::base::device::device_number::{DeviceNumber, Major},
     exception::workqueue::{schedule_work, Work},
     filesystem::{
-        page_cache::list_page_caches,
         page_cache::PageCache,
         vfs::{fcntl::AtFlags, syscall::RenameFlags, vcore::do_mkdir_at},
     },
@@ -1253,13 +1252,16 @@ impl MountFS {
         mnt_ns: Option<&Arc<MntNamespace>>,
         mount_flags: MountFlags,
         mount_source: Option<String>,
-    ) -> Arc<Self> {
+    ) -> Result<Arc<Self>, SystemError> {
         let super_block_state = Arc::new(SuperBlockState::new(mount_flags));
+        if let Some(domain) = inner_filesystem.page_cache_writeback_domain() {
+            domain.bind(&inner_filesystem, &super_block_state)?;
+        }
         assert!(
             super_block_state.try_add_external_pin(),
             "a fresh superblock accepts its construction reservation"
         );
-        Self::new_with_super_block_state(
+        Ok(Self::new_with_super_block_state(
             inner_filesystem,
             root_inner_inode,
             None,
@@ -1272,7 +1274,7 @@ impl MountFS {
                 mount_source,
                 construction_reserved: true,
             },
-        )
+        ))
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -1286,6 +1288,11 @@ impl MountFS {
         mount_flags: MountFlags,
         state_init: MountStateInit,
     ) -> Arc<Self> {
+        if let Some(domain) = inner_filesystem.page_cache_writeback_domain() {
+            domain
+                .bind(&inner_filesystem, &state_init.super_block_state)
+                .expect("MountFS domain identity must be validated before construction");
+        }
         let root_inner_inode = root_inner_inode.unwrap_or_else(|| inner_filesystem.root_inode());
         let root_dentry = root_dentry.unwrap_or_else(|| {
             state_init
@@ -1331,6 +1338,9 @@ impl MountFS {
         &self,
         self_mountpoint: Option<Arc<MountFSInode>>,
     ) -> Result<Arc<Self>, SystemError> {
+        if let Some(domain) = self.inner_filesystem.page_cache_writeback_domain() {
+            domain.bind(&self.inner_filesystem, &self.super_block_state)?;
+        }
         if !self.super_block_state.try_add_external_pin() {
             return Err(SystemError::ESTALE);
         }
@@ -2597,6 +2607,23 @@ impl MountFS {
             log::warn!("final superblock sync failed during umount: {:?}", err);
             sb_state.record_wb_error(err);
         }
+        if let Err(err) = self.inner_filesystem.prepare_page_cache_retirement() {
+            log::warn!("final page-cache producer quiesce failed: {:?}", err);
+            sb_state.record_wb_error(err);
+        }
+        if let Some(domain) = self.inner_filesystem.page_cache_writeback_domain() {
+            domain.close_background_admission();
+            if let Err(err) = domain.wait_drained() {
+                log::warn!("final page-cache I/O drain failed: {:?}", err);
+                sb_state.record_wb_error(err);
+            }
+            for cache in domain.snapshot() {
+                if let Err(err) = cache.retire_for_domain() {
+                    log::warn!("final page-cache retirement failed: {:?}", err);
+                    sb_state.record_wb_error(err);
+                }
+            }
+        }
         if let Err(err) = self.inner_filesystem.shrink_inode_cache_for_shutdown() {
             log::warn!("final inode cache shrink failed: {:?}", err);
             sb_state.record_wb_error(err);
@@ -2778,28 +2805,19 @@ impl MountFS {
     }
 
     /// Corresponds to Linux `sync_inodes_sb()`: write back all dirty page caches under the specified mount.
-    /// DragonOS has no per-sb dirty inode list, so it iterates the global `PAGECACHE_REGISTRY` to find matches.
+    /// Page caches are registered in their filesystem's stable writeback domain.
     fn sync_inodes_of_mount(&self) -> Result<(), SystemError> {
-        let inner_fs = self.inner_filesystem();
-        let caches = list_page_caches();
+        let Some(domain) = self.inner_filesystem.page_cache_writeback_domain() else {
+            return Ok(());
+        };
         let mut last_err = Ok(());
-        for page_cache in caches {
-            // Fast-skip page caches with no dirty pages, avoiding unnecessary inode.upgrade() and Arc::ptr_eq.
-            if !page_cache.has_dirty_pages() {
+        for page_cache in domain.snapshot() {
+            if !page_cache.has_dirty_or_writeback_work() {
                 continue;
             }
-
-            let belongs = page_cache
-                .inode()
-                .and_then(|weak| weak.upgrade())
-                .is_some_and(|inode| Arc::ptr_eq(&inode.fs(), &inner_fs));
-
-            if belongs {
-                if let Err(e) = page_cache.manager().sync() {
-                    log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
-                    self.record_wb_error(e.clone());
-                    last_err = Err(e);
-                }
+            if let Err(e) = page_cache.sync_for_domain() {
+                log::warn!("sync_inodes_of_mount: page cache sync failed: {:?}", e);
+                last_err = Err(e);
             }
         }
         last_err
@@ -2957,14 +2975,6 @@ pub fn list_unique_mounted_superblocks() -> Vec<Arc<MountFS>> {
         }
     });
     mounts
-}
-
-pub fn record_writeback_error_for_fs(inner_fs: &Arc<dyn FileSystem>, error: SystemError) {
-    for mount in list_unique_mounted_superblocks() {
-        if Arc::ptr_eq(&mount.inner_filesystem(), inner_fs) {
-            mount.record_wb_error(error.clone());
-        }
-    }
 }
 
 /// Query the canonical SB_SYNCHRONOUS state for a filesystem operation which
@@ -3283,22 +3293,17 @@ impl MountFSInode {
         // publication; a bind source may install an existing group below.
         let new_propagation = MountPropagation::new_private();
 
-        let (super_block_state, construction_reserved) = match super_block_state {
-            Some(super_block_state) => {
-                if !super_block_state.try_add_external_pin() {
-                    return Err(SystemError::ESTALE);
-                }
-                (super_block_state, true)
-            }
-            None => {
-                let super_block_state = Arc::new(SuperBlockState::new(mount_flags));
-                assert!(
-                    super_block_state.try_add_external_pin(),
-                    "a fresh superblock accepts its construction reservation"
-                );
-                (super_block_state, true)
-            }
+        let super_block_state = match super_block_state {
+            Some(super_block_state) => super_block_state,
+            None => Arc::new(SuperBlockState::new(mount_flags)),
         };
+        if let Some(domain) = inner_fs.page_cache_writeback_domain() {
+            domain.bind(&inner_fs, &super_block_state)?;
+        }
+        if !super_block_state.try_add_external_pin() {
+            return Err(SystemError::ESTALE);
+        }
+        let construction_reserved = true;
         let new_mount_fs = MountFS::new_with_super_block_state(
             inner_fs,
             Some(root_inner_inode),
@@ -4389,16 +4394,17 @@ impl IndexNode for MountFSInode {
         fs: Arc<dyn FileSystem>,
         mount_flags: MountFlags,
     ) -> Result<Arc<MountFS>, SystemError> {
-        let (to_mount_fs, root_inner_inode) = fs
-            .clone()
-            .downcast_arc::<MountFS>()
-            .map(|it| (it.inner_filesystem(), it.root_inner_inode()))
-            .unwrap_or_else(|| {
-                let root_inner_inode = fs.root_inode();
-                (fs, root_inner_inode)
-            });
-
-        self.mount_subtree(to_mount_fs, root_inner_inode, mount_flags)
+        if let Some(existing) = fs.clone().downcast_arc::<MountFS>() {
+            return self.mount_subtree_with_state(
+                existing.inner_filesystem(),
+                existing.root_inner_inode(),
+                mount_flags,
+                Some(existing.super_block_state()),
+                Some(&existing),
+            );
+        }
+        let root_inner_inode = fs.root_inode();
+        self.mount_subtree(fs, root_inner_inode, mount_flags)
     }
 
     fn mount_from(&self, from: Arc<dyn IndexNode>) -> Result<Arc<MountFS>, SystemError> {
@@ -4561,6 +4567,12 @@ impl IndexNode for MountFSInode {
 }
 
 impl FileSystem for MountFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        self.inner_filesystem.page_cache_writeback_domain()
+    }
+
     fn supports_reliable_flush(&self) -> bool {
         self.inner_filesystem.supports_reliable_flush()
     }

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -117,7 +117,7 @@ fn migrate_virtual_filesystem(
         Some(&current_mntns),
         root_mount_flags,
         old_mntfs.mount_source(),
-    );
+    )?;
 
     // 获取新的根文件系统的根节点的引用
     let new_root_inode = new_fs.root_inode();

--- a/kernel/src/init/initram.rs
+++ b/kernel/src/init/initram.rs
@@ -106,7 +106,7 @@ pub fn initramfs_init() -> Result<(), SystemError> {
         None,
         MountFlags::empty(),
         None,
-    );
+    )?;
     let root_inode = mount_fs.root_inode();
     unsafe {
         __INIT_ROOT_INODE = Some(root_inode.clone());

--- a/kernel/src/ipc/pipe.rs
+++ b/kernel/src/ipc/pipe.rs
@@ -177,6 +177,12 @@ lazy_static! {
 pub struct PipeFS;
 
 impl FileSystem for PipeFS {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         // PipeFS 没有真正的根 inode，但我们需要实现这个方法
         // 返回一个空的 pipe inode 作为占位符

--- a/kernel/src/ipc/signalfd.rs
+++ b/kernel/src/ipc/signalfd.rs
@@ -38,6 +38,12 @@ impl SignalFdFs {
 }
 
 impl FileSystem for SignalFdFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         // signalfd 为伪文件系统（anon_inode 风格），root inode 不会被真正使用。
         Arc::new(SignalFdInode::new(SigSet::empty(), SignalFdFlags::empty()))

--- a/kernel/src/net/socket/packet/ring.rs
+++ b/kernel/src/net/socket/packet/ring.rs
@@ -44,6 +44,12 @@ const PAGE_SIZE: usize = MMArch::PAGE_SIZE;
 pub struct PacketFakeFs;
 
 impl FileSystem for PacketFakeFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         panic!("PacketFakeFs has no root inode")
     }
@@ -241,7 +247,7 @@ impl PacketRing {
     ) -> Result<(Self, Arc<PageCache>), SystemError> {
         let pages_per_block = config.block_size / PAGE_SIZE;
         // PageCache::new already returns Arc<PageCache>.
-        let page_cache: Arc<PageCache> = PageCache::new(None, None);
+        let page_cache: Arc<PageCache> = PageCache::new_unowned(None, None);
         let mut block_vaddrs = Vec::new();
         block_vaddrs
             .try_reserve_exact(config.block_nr)

--- a/kernel/src/perf/bpf.rs
+++ b/kernel/src/perf/bpf.rs
@@ -234,7 +234,7 @@ impl BpfPerfEvent {
             data: SpinLock::new(BpfPerfEventData {
                 enabled: false,
                 mmap_page: RingPage::empty(),
-                page_cache: PageCache::new(None, None),
+                page_cache: PageCache::new_unowned(None, None),
                 offset: 0,
             }),
         }
@@ -266,7 +266,7 @@ impl BpfPerfEvent {
             }
         }
 
-        let page_cache = PageCache::new(None, None);
+        let page_cache = PageCache::new_unowned(None, None);
         let batch = allocate_registered_intrinsic_unevictable_pages_exact(PageFrameCount::new(
             len / PAGE_SIZE,
         ))?;

--- a/kernel/src/perf/mod.rs
+++ b/kernel/src/perf/mod.rs
@@ -327,6 +327,12 @@ impl PollableInode for PerfEventInode {
 struct PerfFakeFs;
 
 impl FileSystem for PerfFakeFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         panic!("PerfFakeFs does not have a root inode")
     }

--- a/kernel/src/process/namespace/mnt.rs
+++ b/kernel/src/process/namespace/mnt.rs
@@ -231,7 +231,8 @@ impl MntNamespace {
             None,
             MountFlags::empty(),
             None,
-        );
+        )
+        .expect("a fresh mount namespace root has a unique superblock");
 
         let result = Arc::new_cyclic(|self_ref| Self {
             ns_common: NsCommon::new(0, NamespaceType::Mount),
@@ -1007,6 +1008,7 @@ mod tests {
             MountFlags::empty(),
             None,
         )
+        .unwrap()
     }
 
     fn install_attached_root(namespace: &Arc<MntNamespace>) -> Arc<MountFS> {
@@ -1018,7 +1020,8 @@ mod tests {
             Some(namespace),
             MountFlags::empty(),
             None,
-        );
+        )
+        .unwrap();
         root.activate().unwrap();
         namespace.force_change_root_mountfs(root.clone(), RootMountAttachment::Attached);
         root

--- a/kernel/src/process/namespace/propagation/tests.rs
+++ b/kernel/src/process/namespace/propagation/tests.rs
@@ -77,7 +77,8 @@ fn new_test_mount(propagation: Arc<MountPropagation>) -> Arc<MountFS> {
         None,
         MountFlags::empty(),
         None,
-    );
+    )
+    .unwrap();
     // Test fixtures represent mounts that have already been published.
     // Production constructors intentionally remain in Constructing until
     // their topology/namespace insertion commits.

--- a/kernel/src/process/pidfd.rs
+++ b/kernel/src/process/pidfd.rs
@@ -34,6 +34,12 @@ impl PidFdFs {
 }
 
 impl FileSystem for PidFdFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
     fn root_inode(&self) -> Arc<dyn IndexNode> {
         Arc::new(PidFdInode::new())
     }


### PR DESCRIPTION
## Summary

- replace global page-cache ownership scans with per-filesystem writeback domains bound to one superblock
- add admission, owner pinning, in-flight draining, and deterministic retirement for asynchronous page-cache and ext4 delayed-allocation work
- route writeback errors directly to the affected mapping and superblock errseq
- make file-backed page-cache construction and filesystem domain participation explicit
- harden mount binding and final shutdown ordering so stale filesystem owners cannot be reached

## Root cause

Mount synchronization scanned the global page-cache registry and queried each inode for its owning filesystem. Dirty caches could outlive an ext4 filesystem whose inode held only a weak owner reference, so a later mount shutdown could traverse an unrelated stale inode and panic while upgrading the dead filesystem owner.

The fix establishes stable per-filesystem ownership and an explicit shutdown barrier instead of converting the panic into an error or skipping dirty data.

## Validation

- `RUST_MIN_STACK=16777216 make kernel`
- RISC-V64 release `cargo check`
- LoongArch64 release `cargo check`
- x86_64 QEMU boot to userspace
- page-cache accounting self-test: `status=ok`
- targeted page-cache, ext4 inode identity, syncfs, and loop dunitest regressions
- `git diff --check`
- adversarial lifecycle, Linux semantics, architecture, performance, and randomized multi-agent review

Closes #2193