### PR TITLE
fix(vfs): preserve poll timeout without wait sources

### DIFF
--- a/kernel/src/filesystem/poll.rs
+++ b/kernel/src/filesystem/poll.rs
@@ -202,11 +202,14 @@ impl<'a> PollAdapter<'a> {
     }
 
     fn poll_all_fds(&mut self, timeout: Option<Instant>) -> Result<usize, SystemError> {
-        // 如果没有添加任何有效 fd 到 epoll，直接计算已有 revents 的数量并返回
-        // 这处理了所有 fd 都无效（POLLNVAL）的情况
+        // No epoll registration can mean either an immediate result (for example,
+        // POLLNVAL) or no wait source at all (for example, all negative fds).
         if self.added_fds.is_empty() {
             let count = self.poll_fds.iter().filter(|pfd| pfd.revents != 0).count();
-            return Ok(count);
+            if count != 0 {
+                return Ok(count);
+            }
+            return poll_wait_timeout_only(timeout);
         }
 
         // 检查是否已经有无效 fd（POLLNVAL）
@@ -284,20 +287,14 @@ pub fn do_sys_poll(
     Ok(nevents)
 }
 
-/// 处理 nfds=0 的情况：纯等待超时或信号
+/// Handle a poll request with no ready result and no event source.
 ///
 /// 根据 Linux 语义：
-/// - 如果 timeout=0，立即返回 0
+/// - 如果存在未屏蔽的 pending signal，返回 ERESTARTNOHAND
+/// - 如果 timeout=0，且没有上述 signal，立即返回 0
 /// - 如果 timeout>0，等待指定时间后返回 0
 /// - 如果 timeout=-1(None)，无限等待直到被信号中断，返回 ERESTARTNOHAND
 fn poll_wait_timeout_only(timeout: Option<Instant>) -> Result<usize, SystemError> {
-    // 如果有超时时间且已过期，直接返回
-    if let Some(end_time) = timeout {
-        if Instant::now() >= end_time {
-            return Ok(0);
-        }
-    }
-
     loop {
         // 检查是否有未被掩码屏蔽的待处理信号
         // ppoll 应该只被未被屏蔽的信号中断，被屏蔽的信号应保持 pending 状态

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -7,3 +7,4 @@ normal/open_dangling_symlink
 normal/rtnetlink_link_semantics
 normal/socket_getsockopt_semantics
 normal/tcp_self_connect_semantics
+normal/poll_timeout_semantics

--- a/user/apps/tests/dunitest/suites/normal/poll_timeout_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/poll_timeout_semantics.cc
@@ -1,0 +1,154 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
+#include <time.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+
+namespace {
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+class SignalStateGuard {
+  public:
+    SignalStateGuard(int signal_number, void (*handler)(int)) : signal_number_(signal_number) {
+        struct sigaction action {};
+        action.sa_handler = handler;
+        sigemptyset(&action.sa_mask);
+        action.sa_flags = 0;
+        action_saved_ = sigaction(signal_number_, &action, &old_action_) == 0;
+        mask_saved_ = sigprocmask(SIG_SETMASK, nullptr, &old_mask_) == 0;
+    }
+
+    SignalStateGuard(const SignalStateGuard&) = delete;
+    SignalStateGuard& operator=(const SignalStateGuard&) = delete;
+    ~SignalStateGuard() {
+        if (mask_saved_) {
+            sigprocmask(SIG_SETMASK, &old_mask_, nullptr);
+        }
+        if (action_saved_) {
+            sigaction(signal_number_, &old_action_, nullptr);
+        }
+    }
+
+    bool Ready() const { return action_saved_ && mask_saved_; }
+
+  private:
+    int signal_number_;
+    bool action_saved_ = false;
+    bool mask_saved_ = false;
+    struct sigaction old_action_ {};
+    sigset_t old_mask_ {};
+};
+
+volatile sig_atomic_t alarm_fired = 0;
+
+void RecordAlarm(int) { alarm_fired = 1; }
+
+void IgnoreSignal(int) {}
+
+std::int64_t MonotonicMilliseconds() {
+    struct timespec now {};
+    EXPECT_EQ(clock_gettime(CLOCK_MONOTONIC, &now), 0);
+    return static_cast<std::int64_t>(now.tv_sec) * 1000 + now.tv_nsec / 1000000;
+}
+
+void ExpectTimeoutElapsed(struct pollfd* fds, nfds_t nfds) {
+    constexpr int kTimeoutMs = 50;
+    constexpr std::int64_t kMinimumElapsedMs = 20;
+
+    const std::int64_t start = MonotonicMilliseconds();
+    ASSERT_EQ(poll(fds, nfds, kTimeoutMs), 0) << "poll failed with errno " << errno;
+    const std::int64_t elapsed = MonotonicMilliseconds() - start;
+    EXPECT_GE(elapsed, kMinimumElapsedMs);
+}
+
+TEST(PollTimeoutSemantics, NegativeDescriptorsStillWaitForTimeout) {
+    std::array<struct pollfd, 3> fds {{{-1, POLLIN, static_cast<short>(-1)},
+                                      {-2, POLLOUT, static_cast<short>(-1)},
+                                      {-3, 0, static_cast<short>(-1)}}};
+
+    ExpectTimeoutElapsed(fds.data(), fds.size());
+    for (const auto& fd : fds) {
+        EXPECT_EQ(fd.revents, 0);
+    }
+}
+
+TEST(PollTimeoutSemantics, RegularFileWithNoRequestedEventsStillWaits) {
+    char path[] = "/tmp/poll_timeout_semantics.XXXXXX";
+    FdGuard file(mkstemp(path));
+    ASSERT_GE(file.Get(), 0) << "mkstemp failed with errno " << errno;
+    ASSERT_EQ(unlink(path), 0) << "unlink failed with errno " << errno;
+    struct pollfd fd {file.Get(), 0, static_cast<short>(-1)};
+
+    ExpectTimeoutElapsed(&fd, 1);
+    EXPECT_EQ(fd.revents, 0);
+}
+
+TEST(PollTimeoutSemantics, InvalidDescriptorReturnsBeforeTimeout) {
+    int pipe_fds[2];
+    ASSERT_EQ(pipe(pipe_fds), 0) << "pipe failed with errno " << errno;
+    FdGuard read_end(pipe_fds[0]);
+    const int invalid_fd = pipe_fds[1];
+    ASSERT_EQ(close(pipe_fds[1]), 0);
+
+    SignalStateGuard signals(SIGALRM, RecordAlarm);
+    ASSERT_TRUE(signals.Ready()) << "failed to install SIGALRM state with errno " << errno;
+    alarm_fired = 0;
+    alarm(1);
+    struct pollfd fd {invalid_fd, POLLIN, 0};
+    const int result = poll(&fd, 1, 5000);
+    alarm(0);
+
+    ASSERT_EQ(result, 1) << "poll failed with errno " << errno;
+    EXPECT_EQ(fd.revents, POLLNVAL);
+    EXPECT_EQ(alarm_fired, 0);
+}
+
+TEST(PollTimeoutSemantics, PendingSignalWinsOverZeroTimeout) {
+    SignalStateGuard signals(SIGUSR1, IgnoreSignal);
+    ASSERT_TRUE(signals.Ready()) << "failed to install SIGUSR1 state with errno " << errno;
+
+    sigset_t blocked;
+    sigemptyset(&blocked);
+    sigaddset(&blocked, SIGUSR1);
+    ASSERT_EQ(sigprocmask(SIG_BLOCK, &blocked, nullptr), 0);
+    ASSERT_EQ(raise(SIGUSR1), 0);
+
+    sigset_t temporary_mask;
+    sigemptyset(&temporary_mask);
+    struct timespec timeout {};
+    struct pollfd fd {-1, POLLIN, static_cast<short>(-1)};
+    errno = 0;
+    EXPECT_EQ(ppoll(&fd, 1, &timeout, &temporary_mask), -1);
+    EXPECT_EQ(errno, EINTR);
+    EXPECT_EQ(fd.revents, 0);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -49,6 +49,7 @@ normal/uts_namespace
 normal/tcp_bind_semantics
 normal/tcp_close_semantics
 normal/tcp_self_connect_semantics
+normal/poll_timeout_semantics
 normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics
 normal/unix_socket_shutdown


### PR DESCRIPTION
## Summary

- distinguish immediate `poll()` results from an empty wait-source set
- preserve timeout and signal handling when all descriptors are ignored
- check pending signals before an expired zero timeout, matching Linux ordering
- add mandatory deterministic `poll`/`ppoll` regression coverage

## Root cause

`PollAdapter` returned immediately whenever no descriptor had been registered in its internal epoll instance. That state also occurs when every descriptor is negative or otherwise produces neither an event nor a wait source. As a result, callers using `poll()` as a bounded wait loop could consume a multi-second timeout budget in milliseconds.

The fix keeps immediate `revents` handling unchanged, continues to use epoll when wait sources exist, and routes only the no-result/no-source state through the existing timeout-only wait path.

## Validation

- `make fmt`
- `make kernel`
- new dunitest on Linux host: 4/4
- new dunitest on DragonOS guest: 4/4
- `SpawnExecPipeRace.GtestHelpSpawnAfterSiblingExecStress`: four consecutive 512-iteration runs passed
- gVisor `poll_test`: 23/23
- gVisor `ppoll_test`: 9/9
- gVisor `select_test`: 9/9
- gVisor `pselect_test`: 11/11
