### PR TITLE
fix(ext4): preserve delalloc cleanup across metadata contention

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -787,6 +787,17 @@ impl Ext4 {
     }
 
     #[cfg(test)]
+    pub(super) fn test_reserve_clean_delalloc_lease_counts(
+        &self,
+        data_blocks: u64,
+        metadata_blocks: u64,
+    ) -> Result<DelallocLease> {
+        self.mutate_clean_delalloc_ledger(|allocation| {
+            allocation.reserve_delalloc(8, data_blocks, metadata_blocks)
+        })
+    }
+
+    #[cfg(test)]
     pub(super) fn test_release_clean_delalloc_lease(
         &self,
         lease: &mut DelallocLease,
@@ -869,8 +880,29 @@ impl Ext4 {
     /// inactive before this method returns.  This is a low-level primitive for
     /// a consuming VFS bridge, not a permission to release a partial mapping.
     pub fn release_delalloc_lease_batch(&self, leases: &mut [&mut DelallocLease]) -> Result<()> {
+        // Releasing no capability is a semantic no-op.  In particular it must
+        // not contend with a transactional metadata owner: callers use this
+        // boundary while tearing down an empty delayed-allocation pool.
+        if leases.is_empty() {
+            return Ok(());
+        }
         self.ensure_mutable()?;
         let _mutation_guard = self.lock_direct_metadata_mutation()?;
+        self.mutate_clean_delalloc_ledger(|allocation| allocation.release_delalloc_batch(leases))
+    }
+
+    /// Release leases while the caller already owns the direct metadata
+    /// exclusion domain.  Keeping projected admission and its local rollback
+    /// in one domain prevents ordinary gate contention from stranding a
+    /// partially constructed capability set.
+    pub(super) fn release_delalloc_lease_batch_in_direct_mutation_domain(
+        &self,
+        leases: &mut [&mut DelallocLease],
+    ) -> Result<()> {
+        if leases.is_empty() {
+            return Ok(());
+        }
+        self.ensure_mutable()?;
         self.mutate_clean_delalloc_ledger(|allocation| allocation.release_delalloc_batch(leases))
     }
 

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -53,6 +53,19 @@ pub(super) struct ExtentRightSpineProjection {
     inline_root_capacity: u16,
 }
 
+#[cfg(test)]
+impl ExtentRightSpineProjection {
+    pub(super) fn test_empty(next_lblock: LBlockId) -> Self {
+        Self {
+            next_lblock,
+            counts: Vec::new(),
+            capacities: Vec::new(),
+            external_capacity: 0,
+            inline_root_capacity: 0,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(super) struct RightSpineAppendPlan {
     pub start_lblock: LBlockId,

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -595,8 +595,12 @@ impl Ext4 {
             return Err(Ext4Error::new(ErrCode::ENOTSUP));
         }
 
+        // Shape validation, all ledger claims, and any local rollback share a
+        // single direct-metadata ownership window.  Re-entering the public
+        // reservation/release APIs here would race a transactional owner and
+        // could turn ordinary EAGAIN into a leaked partial capability set.
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
         let (inode_generation, expected_lblock, mut projection) = {
-            let _metadata_guard = self.lock_direct_metadata_mutation()?;
             let _mutation_guard =
                 self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
             let inode = self.read_inode(id)?;
@@ -621,31 +625,28 @@ impl Ext4 {
         };
         let new_nodes = projection.append_nonmerge_at(expected_lblock, 1)?;
 
-        let mut data_lease = self.reserve_delalloc_lease(1, 0)?;
+        let mut data_lease = self.reserve_delalloc_lease_in_direct_mutation_domain(1, 0)?;
         if let Err(error) = data_lease.bind_append_block_certificate(
             id,
             inode_generation,
             offset,
             expected_durable_eof_before,
         ) {
-            let _ = self.release_delalloc_lease_batch(&mut [&mut data_lease]);
-            return Err(error);
+            return match self
+                .rollback_projected_delalloc_leases_in_direct_domain(&mut [&mut data_lease])
+            {
+                Ok(()) => Err(error),
+                Err(cleanup_error) => Err(cleanup_error),
+            };
         }
         let mut new_metadata = Vec::new();
         for _ in 0..new_nodes {
-            match self.reserve_delalloc_lease(0, 1) {
+            match self.reserve_delalloc_lease_in_direct_mutation_domain(0, 1) {
                 Ok(lease) => new_metadata.push(lease),
                 Err(error) => {
                     let mut leases: Vec<&mut DelallocLease> = new_metadata.iter_mut().collect();
                     leases.push(&mut data_lease);
-                    if self.release_delalloc_lease_batch(&mut leases).is_err() {
-                        self.poison(ErrCode::EIO);
-                        for lease in &mut new_metadata {
-                            lease.deactivate();
-                        }
-                        data_lease.deactivate();
-                        return Err(Ext4Error::new(ErrCode::EIO));
-                    }
+                    self.rollback_projected_delalloc_leases_in_direct_domain(&mut leases)?;
                     return Err(error);
                 }
             }
@@ -661,6 +662,32 @@ impl Ext4 {
             pool_checkpoint: Some(checkpoint),
             journal_credits_bound: DELALLOC_APPEND_MAX_JOURNAL_CREDITS,
         })
+    }
+
+    /// Roll back capabilities created by projected admission while the caller
+    /// still owns the direct metadata domain.  A concurrent fail-stop is not
+    /// excluded by that domain; once observed, consume every local capability
+    /// through the terminal path rather than letting an active lease drop.
+    fn rollback_projected_delalloc_leases_in_direct_domain(
+        &self,
+        leases: &mut [&mut DelallocLease],
+    ) -> Result<()> {
+        if self
+            .release_delalloc_lease_batch_in_direct_mutation_domain(leases)
+            .is_ok()
+        {
+            return Ok(());
+        }
+
+        if !self.metadata_mutations_terminal() {
+            self.poison(ErrCode::EIO);
+        }
+        for lease in leases.iter_mut() {
+            if lease.active {
+                self.abandon_delalloc_lease_after_fail_stop(lease)?;
+            }
+        }
+        Err(Ext4Error::new(ErrCode::EIO))
     }
 
     #[cfg(any(test, feature = "test-api"))]
@@ -1681,6 +1708,14 @@ impl Ext4 {
         pool: &mut DelallocExtentNodePool,
     ) -> Result<()> {
         self.validate_delalloc_append_mapper_authority(authority)?;
+        self.cancel_projected_delalloc_append_block_inner(reservation, pool)
+    }
+
+    fn cancel_projected_delalloc_append_block_inner(
+        &self,
+        reservation: &mut DelallocAppendBlockReservation,
+        pool: &mut DelallocExtentNodePool,
+    ) -> Result<()> {
         let checkpoint = reservation
             .pool_checkpoint
             .as_ref()
@@ -1738,6 +1773,15 @@ impl Ext4 {
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
         pool.projection = checkpoint.before;
         Ok(())
+    }
+
+    #[cfg(test)]
+    fn test_cancel_projected_delalloc_append_block(
+        &self,
+        reservation: &mut DelallocAppendBlockReservation,
+        pool: &mut DelallocExtentNodePool,
+    ) -> Result<()> {
+        self.cancel_projected_delalloc_append_block_inner(reservation, pool)
     }
 
     pub fn release_delalloc_append_block_authorized(
@@ -4877,6 +4921,141 @@ mod tests {
         let allocation = fs.alloc_lock.lock();
         assert_eq!(allocation.reserved_data_blocks, 1);
         assert_eq!(allocation.delalloc_claims.len(), 1);
+    }
+
+    #[test]
+    fn empty_delalloc_release_is_a_noop_under_transactional_metadata_owner() {
+        let fs = make_test_fs(16);
+        let _transaction = fs
+            .lock_transactional_metadata_mutation()
+            .expect("fixture must acquire the transactional metadata owner");
+        let mut empty: [&mut DelallocLease; 0] = [];
+
+        fs.release_delalloc_lease_batch(&mut empty)
+            .expect("an empty release must not enter the metadata gate");
+    }
+
+    #[test]
+    fn nonempty_delalloc_release_preserves_capability_across_gate_contention() {
+        let fs = make_test_fs(16);
+        let mut lease = fs
+            .test_reserve_clean_delalloc_lease_with_hook(|| {})
+            .expect("fixture must reserve one delayed-allocation lease");
+        let transaction = fs
+            .lock_transactional_metadata_mutation()
+            .expect("fixture must acquire the transactional metadata owner");
+
+        assert_eq!(
+            fs.release_delalloc_lease_batch(&mut [&mut lease])
+                .expect_err("a real release must report gate contention")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        assert!(lease.active, "EAGAIN must preserve exact lease ownership");
+
+        drop(transaction);
+        fs.release_delalloc_lease_batch(&mut [&mut lease])
+            .expect("the preserved lease must release after gate progress");
+        assert!(!lease.active);
+    }
+
+    #[test]
+    fn projected_cancel_preserves_checkpoint_across_gate_contention() {
+        let fs = make_test_fs(16);
+        let inode_id: InodeId = 2;
+        let before = super::super::extent::ExtentRightSpineProjection::test_empty(0);
+        let after = super::super::extent::ExtentRightSpineProjection::test_empty(1);
+        let mut data_lease = fs
+            .test_reserve_clean_delalloc_lease_counts(1, 0)
+            .expect("fixture must reserve the data lease");
+        data_lease
+            .bind_append_block_certificate(inode_id, 1, 0, 0)
+            .expect("fresh data lease must accept its append certificate");
+        let metadata_lease = fs
+            .test_reserve_clean_delalloc_lease_counts(0, 1)
+            .expect("fixture must reserve the projected metadata lease");
+        let mut reservation = DelallocAppendBlockReservation {
+            lease: data_lease,
+            pool_checkpoint: Some(DelallocPoolCheckpoint {
+                before: before.clone(),
+                after: after.clone(),
+                added_metadata_leases: 1,
+            }),
+            journal_credits_bound: DELALLOC_APPEND_MAX_JOURNAL_CREDITS,
+        };
+        let mut pool = DelallocExtentNodePool {
+            inode_id,
+            inode_generation: 1,
+            projection: after.clone(),
+            leases: vec![metadata_lease],
+        };
+        let transaction = fs
+            .lock_transactional_metadata_mutation()
+            .expect("fixture must acquire the transactional metadata owner");
+
+        assert_eq!(
+            fs.test_cancel_projected_delalloc_append_block(&mut reservation, &mut pool)
+                .expect_err("cancel must report gate contention")
+                .code(),
+            ErrCode::EAGAIN
+        );
+        assert!(reservation.lease.active);
+        assert_eq!(pool.projection, after);
+        assert_eq!(pool.leases.len(), 1);
+        assert!(pool.leases[0].active);
+
+        drop(transaction);
+        fs.test_cancel_projected_delalloc_append_block(&mut reservation, &mut pool)
+            .expect("the intact checkpoint must cancel after gate progress");
+        assert!(!reservation.lease.active);
+        assert!(reservation.pool_checkpoint.is_none());
+        assert_eq!(pool.projection, before);
+        assert!(pool.leases.is_empty());
+    }
+
+    #[test]
+    fn projected_local_rollback_consumes_all_leases_in_healthy_domain() {
+        let fs = make_test_fs(16);
+        let mut data = fs
+            .test_reserve_clean_delalloc_lease_counts(1, 0)
+            .expect("fixture must reserve data");
+        let mut metadata = fs
+            .test_reserve_clean_delalloc_lease_counts(0, 1)
+            .expect("fixture must reserve metadata");
+        let _direct = fs
+            .lock_direct_metadata_mutation()
+            .expect("fixture must enter the direct domain");
+
+        fs.rollback_projected_delalloc_leases_in_direct_domain(&mut [&mut data, &mut metadata])
+            .expect("healthy in-domain rollback must release the whole local set");
+        assert!(!data.active);
+        assert!(!metadata.active);
+    }
+
+    #[test]
+    fn projected_local_rollback_abandons_all_leases_after_concurrent_fail_stop() {
+        let fs = make_test_fs(16);
+        let mut data = fs
+            .test_reserve_clean_delalloc_lease_counts(1, 0)
+            .expect("fixture must reserve data");
+        let mut metadata = fs
+            .test_reserve_clean_delalloc_lease_counts(0, 1)
+            .expect("fixture must reserve metadata");
+        let _direct = fs
+            .lock_direct_metadata_mutation()
+            .expect("fixture must enter the direct domain");
+        fs.fail_stop_mutations();
+
+        assert_eq!(
+            fs.rollback_projected_delalloc_leases_in_direct_domain(
+                &mut [&mut data, &mut metadata,]
+            )
+            .expect_err("terminal rollback reports the fail-stop")
+            .code(),
+            ErrCode::EIO
+        );
+        assert!(!data.active);
+        assert!(!metadata.active);
     }
 
     #[test]

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -583,7 +583,7 @@ impl Ext4FileSystem {
         }
     }
 
-    fn terminalize_idle_delalloc_after_fail_stop(&self) {
+    pub(super) fn terminalize_idle_delalloc_after_fail_stop(&self) {
         loop {
             let owners: Vec<_> = self.delalloc_inodes.lock().values().cloned().collect();
             let mut progressed = false;

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -198,6 +198,19 @@ pub(super) struct ProductionDelallocAdmissionGuard<'a> {
     inode: &'a LockedExt4Inode,
 }
 
+/// Owns every inode-local object that must outlive the queue-empty
+/// linearization point.  The admission guard prevents a new first entry from
+/// being published until the detached reservation/pool generation has been
+/// fully consumed.
+#[must_use]
+struct EmptyDelallocCleanup<'a> {
+    _admission: ProductionDelallocAdmissionGuard<'a>,
+    inode_num: u32,
+    pool: Option<another_ext4::DelallocExtentNodePool>,
+    owner: Option<Ext4InodeOperation>,
+    registered: bool,
+}
+
 impl Drop for ProductionDelallocAdmissionGuard<'_> {
     fn drop(&mut self) {
         let _io = self.inode.io_lock.lock();
@@ -805,6 +818,11 @@ impl Ext4DelayedSubmission {
         if self.entries.is_empty() {
             return Err(SystemError::EIO);
         }
+        let authority = self
+            .fs
+            .delalloc_mapper_authority
+            .as_ref()
+            .ok_or(SystemError::EIO)?;
         let entries = core::mem::take(&mut self.entries);
         let empty_cleanup = {
             let _io = self.inode.io_lock.lock();
@@ -815,9 +833,32 @@ impl Ext4DelayedSubmission {
                 self.claim_incarnation,
             ) {
                 drop(guard);
-                self.fs.fail_stop_lifecycle();
+                drop(_io);
+                self.entries = entries;
+                self.finish_terminal();
                 return Err(SystemError::EIO);
             }
+            let becomes_empty = guard.delalloc.production.entries.len() == entries.len();
+            if becomes_empty && guard.delalloc.production.queue_operation.is_none() {
+                drop(guard);
+                drop(_io);
+                self.entries = entries;
+                self.finish_terminal();
+                return Err(SystemError::EIO);
+            }
+            let admission = if becomes_empty {
+                if guard.delalloc.production.admission_closed == usize::MAX {
+                    drop(guard);
+                    drop(_io);
+                    self.entries = entries;
+                    self.finish_terminal();
+                    return Err(SystemError::EIO);
+                }
+                guard.delalloc.production.admission_closed += 1;
+                Some(ProductionDelallocAdmissionGuard { inode: &self.inode })
+            } else {
+                None
+            };
             for claimed in entries.iter() {
                 let removed = guard
                     .delalloc
@@ -826,28 +867,26 @@ impl Ext4DelayedSubmission {
                     .remove(&claimed.pending.offset);
                 debug_assert!(removed.is_some());
             }
-            if guard.delalloc.production.entries.is_empty() {
-                let owner = guard
-                    .delalloc
-                    .production
-                    .queue_operation
-                    .take()
-                    .ok_or(SystemError::EIO)?;
-                Some((guard.inner_inode_num, owner))
+            if becomes_empty {
+                let inode_num = guard.inner_inode_num;
+                let owner = guard.delalloc.production.queue_operation.take();
+                let admission = admission.expect("empty queue preflight produced admission guard");
+                drop(guard);
+                let pool = self.inode.delalloc_pool.lock().take();
+                Some(EmptyDelallocCleanup {
+                    _admission: admission,
+                    inode_num,
+                    pool,
+                    owner,
+                    registered: true,
+                })
             } else {
                 None
             }
         };
-        if let Some((inode_num, owner)) = empty_cleanup {
-            let authority = self
-                .fs
-                .delalloc_mapper_authority
-                .as_ref()
-                .ok_or(SystemError::EIO)?;
+        if let Some(cleanup) = empty_cleanup {
             self.inode
-                .release_empty_delalloc_pool(&self.fs, authority)?;
-            self.fs.unregister_delalloc_inode(inode_num);
-            drop(owner);
+                .finish_empty_delalloc_cleanup(&self.fs, authority, None, cleanup, false)?;
         }
         drop(entries);
         Ok(())
@@ -2888,18 +2927,100 @@ impl IndexNode for LockedExt4Inode {
 }
 
 impl LockedExt4Inode {
+    fn close_production_delalloc_admission_locked<'a>(
+        &'a self,
+        production: &mut ProductionDelallocState,
+    ) -> Result<ProductionDelallocAdmissionGuard<'a>, SystemError> {
+        production.admission_closed = production
+            .admission_closed
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(ProductionDelallocAdmissionGuard { inode: self })
+    }
+
     pub(super) fn close_production_delalloc_admission(
         &self,
     ) -> Result<ProductionDelallocAdmissionGuard<'_>, SystemError> {
         let _io = self.io_lock.lock();
         let mut guard = self.inner.lock();
-        guard.delalloc.production.admission_closed = guard
-            .delalloc
-            .production
-            .admission_closed
-            .checked_add(1)
-            .ok_or(SystemError::EOVERFLOW)?;
-        Ok(ProductionDelallocAdmissionGuard { inode: self })
+        self.close_production_delalloc_admission_locked(&mut guard.delalloc.production)
+    }
+
+    /// Consume a queue generation after its last entry has been detached.
+    /// This is deliberately finally-style: no cleanup error may bypass
+    /// registry removal or drop a still-active capability.
+    fn finish_empty_delalloc_cleanup(
+        &self,
+        fs: &Arc<Ext4FileSystem>,
+        authority: &another_ext4::DelallocAppendMapperAuthority,
+        mut reservation: Option<&mut another_ext4::DelallocAppendBlockReservation>,
+        mut cleanup: EmptyDelallocCleanup<'_>,
+        terminal_only: bool,
+    ) -> Result<(), SystemError> {
+        let mut first_error = None;
+        let mut terminal = terminal_only;
+
+        if !terminal {
+            match cleanup.pool.as_mut() {
+                Some(pool) => {
+                    if let Some(reservation) = reservation.as_deref_mut() {
+                        if let Err(error) = fs.retry_metadata_contention(|| {
+                            fs.fs.cancel_projected_delalloc_append_block_authorized(
+                                authority,
+                                reservation,
+                                pool,
+                            )
+                        }) {
+                            first_error = Some(error);
+                            terminal = true;
+                        }
+                    }
+                }
+                None => {
+                    first_error = Some(SystemError::EIO);
+                    terminal = true;
+                }
+            }
+        }
+
+        if terminal {
+            fs.fail_stop_lifecycle();
+            if let Some(reservation) = reservation {
+                let _ = fs
+                    .fs
+                    .terminalize_delalloc_append_block_authorized_after_fail_stop(
+                        authority,
+                        reservation,
+                    );
+            }
+            if let Some(pool) = cleanup.pool.as_mut() {
+                let _ = fs
+                    .fs
+                    .terminalize_delalloc_extent_node_pool_authorized_after_fail_stop(
+                        authority, pool,
+                    );
+            }
+        } else if let Some(pool) = cleanup.pool.as_mut() {
+            if let Err(error) = fs.retry_metadata_contention(|| {
+                fs.fs
+                    .release_delalloc_extent_node_pool_authorized(authority, pool)
+            }) {
+                first_error = Some(error);
+                fs.fail_stop_lifecycle();
+                let _ = fs
+                    .fs
+                    .terminalize_delalloc_extent_node_pool_authorized_after_fail_stop(
+                        authority, pool,
+                    );
+            }
+        }
+
+        if cleanup.registered {
+            fs.unregister_delalloc_inode(cleanup.inode_num);
+        }
+        drop(cleanup.owner.take());
+        drop(cleanup);
+        first_error.map_or(Ok(()), Err)
     }
 
     fn try_merge_delalloc_tail_segment(
@@ -3171,13 +3292,28 @@ impl LockedExt4Inode {
                 // this is internal metadata contention, not userspace
                 // nonblocking I/O, so keep the write admission pending until
                 // the owner releases the gate.
-                let pool = fs.retry_metadata_contention(|| {
-                    fs.fs
-                        .create_delalloc_extent_node_pool_authorized(authority, inode_num)
-                })?;
-                let mut slot = self.delalloc_pool.lock();
-                if slot.is_none() {
-                    *slot = Some(pool);
+                let observed = fs.fs.metadata_mutation_generation();
+                match fs
+                    .fs
+                    .create_delalloc_extent_node_pool_authorized(authority, inode_num)
+                {
+                    Ok(pool) => {
+                        let mut slot = self.delalloc_pool.lock();
+                        debug_assert!(slot.is_none());
+                        *slot = Some(pool);
+                    }
+                    Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                        // Never sleep for the metadata gate while holding the
+                        // PageCache/inode admission locks.  Sampling the
+                        // generation before the attempt also closes the
+                        // owner-release/lost-wakeup window.
+                        drop(_io);
+                        drop(_size);
+                        drop(_invalidate);
+                        fs.wait_metadata_mutation_progress(observed)?;
+                        continue 'admission;
+                    }
+                    Err(error) => return Err(error.into()),
                 }
             }
             let observed = fs.fs.metadata_mutation_generation();
@@ -3208,13 +3344,33 @@ impl LockedExt4Inode {
                     ) =>
                 {
                     if was_empty {
+                        let admission = {
+                            let mut guard = self.inner.lock();
+                            self.close_production_delalloc_admission_locked(
+                                &mut guard.delalloc.production,
+                            )?
+                        };
+                        drop(_io);
+                        drop(_size);
+                        drop(_invalidate);
                         self.release_empty_delalloc_pool(&fs, authority)?;
+                        drop(admission);
                     }
                     return Ok(None);
                 }
                 Err(error) => {
                     if was_empty {
+                        let admission = {
+                            let mut guard = self.inner.lock();
+                            self.close_production_delalloc_admission_locked(
+                                &mut guard.delalloc.production,
+                            )?
+                        };
+                        drop(_io);
+                        drop(_size);
+                        drop(_invalidate);
                         self.release_empty_delalloc_pool(&fs, authority)?;
+                        drop(admission);
                     }
                     return Err(error.into());
                 }
@@ -3232,6 +3388,7 @@ impl LockedExt4Inode {
                         ProductionDelallocEntryState::Claimed { durable_eof, .. } => *durable_eof,
                     })
                     .unwrap_or(old_size);
+                let operation_missing = was_empty && operation.is_none();
                 if guard.delalloc.production.admission_closed != 0
                     || guard.cached_file_size != Some(old_size)
                     || guard.cached_times.mtime != old_mtime
@@ -3239,31 +3396,67 @@ impl LockedExt4Inode {
                     || tail_eof != expected_durable_eof_before
                     || guard.delalloc.production.entries.contains_key(&page_start)
                     || guard.delalloc.production.entries.is_empty() != was_empty
+                    || guard.delalloc.production.next_sequence != sequence
+                    || operation_missing
                 {
-                    drop(guard);
-                    let mut reservation = reservation;
-                    self.cancel_projected_delalloc_reservation(&fs, authority, &mut reservation)?;
-                    return Ok(None);
-                }
-                if guard.delalloc.production.next_sequence != sequence {
-                    drop(guard);
-                    let mut reservation = reservation;
-                    self.cancel_projected_delalloc_reservation(&fs, authority, &mut reservation)?;
-                    return Ok(None);
-                }
-                guard.delalloc.production.next_sequence = sequence + 1;
-                if was_empty {
-                    let Some(queue_operation) = operation.take() else {
+                    let mut admission = Some(self.close_production_delalloc_admission_locked(
+                        &mut guard.delalloc.production,
+                    )?);
+                    let empty_cleanup = if was_empty {
+                        let inode_num = guard.inner_inode_num;
                         drop(guard);
-                        let mut reservation = reservation;
-                        self.cancel_projected_delalloc_reservation(
+                        let pool = self.delalloc_pool.lock().take();
+                        Some(EmptyDelallocCleanup {
+                            _admission: admission
+                                .take()
+                                .expect("empty rollback owns its admission guard"),
+                            inode_num,
+                            pool,
+                            owner: None,
+                            registered: false,
+                        })
+                    } else {
+                        drop(guard);
+                        None
+                    };
+                    drop(_io);
+                    drop(_size);
+                    drop(_invalidate);
+                    let mut reservation = reservation;
+                    let cleanup_result = if let Some(cleanup) = empty_cleanup {
+                        self.finish_empty_delalloc_cleanup(
+                            &fs,
+                            authority,
+                            Some(&mut reservation),
+                            cleanup,
+                            false,
+                        )
+                    } else {
+                        let result = self.cancel_projected_delalloc_reservation(
                             &fs,
                             authority,
                             &mut reservation,
-                        )?;
-                        return Err(SystemError::EIO);
+                        );
+                        drop(admission.take());
+                        if result.is_err() {
+                            fs.terminalize_idle_delalloc_after_fail_stop();
+                        }
+                        result
                     };
-                    guard.delalloc.production.queue_operation = Some(queue_operation);
+                    cleanup_result?;
+                    return if operation_missing {
+                        Err(SystemError::EIO)
+                    } else {
+                        Ok(None)
+                    };
+                }
+                guard.delalloc.production.next_sequence = sequence + 1;
+                if was_empty {
+                    guard.delalloc.production.queue_operation = Some(
+                        operation
+                            .take()
+                            .expect("first delayed entry preflighted its queue owner"),
+                    );
                 }
                 guard.delalloc.production.entries.insert(
                     page_start,
@@ -3285,34 +3478,88 @@ impl LockedExt4Inode {
             };
             if was_empty {
                 if let Err(error) = fs.register_delalloc_inode(inode_num, self_arc) {
-                    let (mut pending, owner) = {
+                    let detached = {
                         let mut guard = self.inner.lock();
-                        let entry = guard
+                        let matches_generation = guard
                             .delalloc
                             .production
                             .entries
-                            .remove(&page_start)
-                            .ok_or(SystemError::EIO)?;
-                        let owner = guard.delalloc.production.queue_operation.take();
-                        let pending = match entry {
+                            .get(&page_start)
+                            .is_some_and(|entry| {
+                                matches!(entry,
                             ProductionDelallocEntry {
                                 sequence: current,
-                                state: ProductionDelallocEntryState::Prepared(pending),
-                            } if current == sequence => pending,
-                            _ => return Err(SystemError::EIO),
-                        };
-                        (pending, owner)
+                                state: ProductionDelallocEntryState::Prepared(_),
+                            } if *current == sequence)
+                            });
+                        if !matches_generation
+                            || guard.delalloc.production.entries.len() != 1
+                            || guard.delalloc.production.queue_operation.is_none()
+                        {
+                            None
+                        } else {
+                            let admission = self
+                                .close_production_delalloc_admission_locked(
+                                    &mut guard.delalloc.production,
+                                )
+                                .ok();
+                            admission.map(|admission| {
+                                let entry = guard
+                                    .delalloc
+                                    .production
+                                    .entries
+                                    .remove(&page_start)
+                                    .expect("registration rollback preflighted its entry");
+                                let pending = match entry.state {
+                                    ProductionDelallocEntryState::Prepared(pending) => pending,
+                                    _ => unreachable!(),
+                                };
+                                let owner = guard.delalloc.production.queue_operation.take();
+                                let inode_num = guard.inner_inode_num;
+                                drop(guard);
+                                let pool = self.delalloc_pool.lock().take();
+                                (
+                                    pending,
+                                    EmptyDelallocCleanup {
+                                        _admission: admission,
+                                        inode_num,
+                                        pool,
+                                        owner,
+                                        registered: false,
+                                    },
+                                )
+                            })
+                        }
                     };
                     drop(_io);
                     drop(_size);
-                    self.cancel_projected_delalloc_reservation(
+                    drop(_invalidate);
+                    let Some((mut pending, cleanup)) = detached else {
+                        fs.fail_stop_lifecycle();
+                        self.terminalize_idle_delalloc_after_fail_stop_inner(&fs, false);
+                        fs.terminalize_idle_delalloc_after_fail_stop();
+                        return Err(SystemError::EIO);
+                    };
+                    let duplicate_owner = error == SystemError::EIO;
+                    if duplicate_owner {
+                        // A duplicate key is a structural ownership conflict,
+                        // not this generation's registry entry.  Freeze the
+                        // mount before consuming our local capabilities and
+                        // never remove the unknown owner by key.
+                        fs.fail_stop_lifecycle();
+                    }
+                    let cleanup_result = self.finish_empty_delalloc_cleanup(
                         &fs,
                         authority,
-                        &mut pending.reservation,
-                    )?;
-                    self.release_empty_delalloc_pool(&fs, authority)?;
+                        Some(&mut pending.reservation),
+                        cleanup,
+                        duplicate_owner,
+                    );
                     drop(pending);
-                    drop(owner);
+                    if duplicate_owner {
+                        fs.terminalize_idle_delalloc_after_fail_stop();
+                    }
+                    cleanup_result?;
                     return Err(error);
                 }
             }
@@ -3331,25 +3578,44 @@ impl LockedExt4Inode {
             return match publication {
                 Ok(written) => {
                     let Some(certificate) = published else {
+                        drop(_io);
+                        drop(_size);
+                        drop(_invalidate);
                         fs.fail_stop_lifecycle();
+                        fs.terminalize_idle_delalloc_after_fail_stop();
                         return Err(SystemError::EIO);
                     };
                     let mut guard = self.inner.lock();
+                    let matches_generation = guard
+                        .delalloc
+                        .production
+                        .entries
+                        .get(&page_start)
+                        .is_some_and(|entry| {
+                            matches!(entry,
+                        ProductionDelallocEntry {
+                            sequence: current,
+                            state: ProductionDelallocEntryState::Prepared(_),
+                        } if *current == sequence)
+                        });
+                    if !matches_generation {
+                        drop(guard);
+                        drop(_io);
+                        drop(_size);
+                        drop(_invalidate);
+                        fs.fail_stop_lifecycle();
+                        fs.terminalize_idle_delalloc_after_fail_stop();
+                        return Err(SystemError::EIO);
+                    }
                     let entry = guard
                         .delalloc
                         .production
                         .entries
                         .remove(&page_start)
-                        .ok_or(SystemError::EIO)?;
-                    let mut pending = match entry {
-                        ProductionDelallocEntry {
-                            sequence: current,
-                            state: ProductionDelallocEntryState::Prepared(pending),
-                        } if current == sequence => pending,
-                        _ => {
-                            fs.fail_stop_lifecycle();
-                            return Err(SystemError::EIO);
-                        }
+                        .expect("publication preflighted its prepared entry");
+                    let mut pending = match entry.state {
+                        ProductionDelallocEntryState::Prepared(pending) => pending,
+                        _ => unreachable!(),
                     };
                     pending.certificate = Some(certificate);
                     guard.cached_file_size = Some(new_eof);
@@ -3367,43 +3633,97 @@ impl LockedExt4Inode {
                     Ok(Some(written))
                 }
                 Err(error) => {
-                    let (mut pending, became_empty, owner) = {
+                    let detached = {
                         let mut guard = self.inner.lock();
-                        let entry = guard
+                        let matches_generation = guard
                             .delalloc
                             .production
                             .entries
-                            .remove(&page_start)
-                            .ok_or(SystemError::EIO)?;
-                        let pending = match entry {
+                            .get(&page_start)
+                            .is_some_and(|entry| {
+                                matches!(entry,
                             ProductionDelallocEntry {
                                 sequence: current,
-                                state: ProductionDelallocEntryState::Prepared(pending),
-                            } if current == sequence => pending,
-                            _ => {
-                                fs.fail_stop_lifecycle();
-                                return Err(SystemError::EIO);
+                                state: ProductionDelallocEntryState::Prepared(_),
+                            } if *current == sequence)
+                            });
+                        if !matches_generation {
+                            None
+                        } else {
+                            let became_empty = guard.delalloc.production.entries.len() == 1;
+                            if became_empty && guard.delalloc.production.queue_operation.is_none() {
+                                None
+                            } else {
+                                let admission = self
+                                    .close_production_delalloc_admission_locked(
+                                        &mut guard.delalloc.production,
+                                    )
+                                    .ok();
+                                admission.map(|admission| {
+                                    let entry = guard
+                                        .delalloc
+                                        .production
+                                        .entries
+                                        .remove(&page_start)
+                                        .expect("publication rollback preflighted its entry");
+                                    let pending = match entry.state {
+                                        ProductionDelallocEntryState::Prepared(pending) => pending,
+                                        _ => unreachable!(),
+                                    };
+                                    if became_empty {
+                                        let inode_num = guard.inner_inode_num;
+                                        let owner =
+                                            guard.delalloc.production.queue_operation.take();
+                                        drop(guard);
+                                        let pool = self.delalloc_pool.lock().take();
+                                        (
+                                            pending,
+                                            Some(EmptyDelallocCleanup {
+                                                _admission: admission,
+                                                inode_num,
+                                                pool,
+                                                owner,
+                                                registered: true,
+                                            }),
+                                            None,
+                                        )
+                                    } else {
+                                        (pending, None, Some(admission))
+                                    }
+                                })
                             }
-                        };
-                        let became_empty = guard.delalloc.production.entries.is_empty();
-                        let owner = became_empty
-                            .then(|| guard.delalloc.production.queue_operation.take())
-                            .flatten();
-                        (pending, became_empty, owner)
+                        }
                     };
                     drop(_io);
                     drop(_size);
-                    self.cancel_projected_delalloc_reservation(
-                        &fs,
-                        authority,
-                        &mut pending.reservation,
-                    )?;
-                    if became_empty {
-                        self.release_empty_delalloc_pool(&fs, authority)?;
-                        fs.unregister_delalloc_inode(inode_num);
-                    }
+                    drop(_invalidate);
+                    let Some((mut pending, empty_cleanup, admission)) = detached else {
+                        fs.fail_stop_lifecycle();
+                        fs.terminalize_idle_delalloc_after_fail_stop();
+                        return Err(SystemError::EIO);
+                    };
+                    let cleanup_result = if let Some(cleanup) = empty_cleanup {
+                        self.finish_empty_delalloc_cleanup(
+                            &fs,
+                            authority,
+                            Some(&mut pending.reservation),
+                            cleanup,
+                            false,
+                        )
+                    } else {
+                        let result = self.cancel_projected_delalloc_reservation(
+                            &fs,
+                            authority,
+                            &mut pending.reservation,
+                        );
+                        drop(admission);
+                        if result.is_err() {
+                            fs.terminalize_idle_delalloc_after_fail_stop();
+                        }
+                        result
+                    };
                     drop(pending);
-                    drop(owner);
+                    cleanup_result?;
                     if error == SystemError::EAGAIN_OR_EWOULDBLOCK {
                         Ok(None)
                     } else {
@@ -3420,21 +3740,23 @@ impl LockedExt4Inode {
         authority: &another_ext4::DelallocAppendMapperAuthority,
         reservation: &mut another_ext4::DelallocAppendBlockReservation,
     ) -> Result<(), SystemError> {
-        {
+        let result = fs.retry_metadata_contention(|| {
             let mut slot = self.delalloc_pool.lock();
-            let pool = slot.as_mut().ok_or(SystemError::EIO)?;
-            if fs
-                .fs
+            let pool = slot
+                .as_mut()
+                .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO))?;
+            fs.fs
                 .cancel_projected_delalloc_append_block_authorized(authority, reservation, pool)
-                .is_ok()
-            {
-                return Ok(());
-            }
+        });
+        if result.is_ok() {
+            return Ok(());
         }
         fs.fail_stop_lifecycle();
-        fs.fs
+        let terminal = fs
+            .fs
             .terminalize_delalloc_append_block_authorized_after_fail_stop(authority, reservation)
-            .map_err(SystemError::from)
+            .map_err(SystemError::from);
+        terminal.and(result)
     }
 
     fn release_empty_delalloc_pool(
@@ -3445,17 +3767,19 @@ impl LockedExt4Inode {
         let Some(mut pool) = self.delalloc_pool.lock().take() else {
             return Ok(());
         };
-        if fs
-            .fs
-            .release_delalloc_extent_node_pool_authorized(authority, &mut pool)
-            .is_ok()
-        {
+        let result = fs.retry_metadata_contention(|| {
+            fs.fs
+                .release_delalloc_extent_node_pool_authorized(authority, &mut pool)
+        });
+        if result.is_ok() {
             return Ok(());
         }
         fs.fail_stop_lifecycle();
-        fs.fs
+        let terminal = fs
+            .fs
             .terminalize_delalloc_extent_node_pool_authorized_after_fail_stop(authority, &mut pool)
-            .map_err(SystemError::from)
+            .map_err(SystemError::from);
+        terminal.and(result)
     }
 
     pub(super) fn drain_delalloc_before_eager(&self) -> Result<(), SystemError> {
@@ -3574,6 +3898,14 @@ impl LockedExt4Inode {
     /// holds the filesystem); Prepared/Ready heads have no other terminal
     /// owner and must be consumed here before filesystem teardown.
     pub(super) fn terminalize_idle_delalloc_after_fail_stop(&self, fs: &Ext4FileSystem) -> bool {
+        self.terminalize_idle_delalloc_after_fail_stop_inner(fs, true)
+    }
+
+    fn terminalize_idle_delalloc_after_fail_stop_inner(
+        &self,
+        fs: &Ext4FileSystem,
+        registered: bool,
+    ) -> bool {
         let (inode_num, pending, owner) =
             {
                 let _io = self.io_lock.lock();
@@ -3612,7 +3944,9 @@ impl LockedExt4Inode {
                     );
             }
         }
-        fs.unregister_delalloc_inode(inode_num);
+        if registered {
+            fs.unregister_delalloc_inode(inode_num);
+        }
         drop(owner);
         true
     }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -2959,6 +2959,7 @@ impl LockedExt4Inode {
     ) -> Result<(), SystemError> {
         let mut first_error = None;
         let mut terminal = terminal_only;
+        let mut fail_stopped = terminal_only;
 
         if !terminal {
             match cleanup.pool.as_mut() {
@@ -2985,6 +2986,7 @@ impl LockedExt4Inode {
 
         if terminal {
             fs.fail_stop_lifecycle();
+            fail_stopped = true;
             if let Some(reservation) = reservation {
                 let _ = fs
                     .fs
@@ -3007,6 +3009,7 @@ impl LockedExt4Inode {
             }) {
                 first_error = Some(error);
                 fs.fail_stop_lifecycle();
+                fail_stopped = true;
                 let _ = fs
                     .fs
                     .terminalize_delalloc_extent_node_pool_authorized_after_fail_stop(
@@ -3020,6 +3023,18 @@ impl LockedExt4Inode {
         }
         drop(cleanup.owner.take());
         drop(cleanup);
+        // An unrelated thread may have fail-stopped the mount before this
+        // helper entered.  Empty pool release remains a successful no-op in
+        // that state, so sample the terminal state after releasing the local
+        // admission guard to ensure the remaining idle registry is drained.
+        fail_stopped |= fs.fs.metadata_mutations_terminal();
+        if fail_stopped {
+            // The current bundle no longer owns inode locks, admission, or a
+            // registry entry.  Only now is it safe to drain other idle
+            // Prepared/Ready owners through the filesystem-wide fail-stop
+            // terminalizer; claimed owners remain with their live submission.
+            fs.terminalize_idle_delalloc_after_fail_stop();
+        }
         first_error.map_or(Ok(()), Err)
     }
 
@@ -3556,9 +3571,6 @@ impl LockedExt4Inode {
                         duplicate_owner,
                     );
                     drop(pending);
-                    if duplicate_owner {
-                        fs.terminalize_idle_delalloc_after_fail_stop();
-                    }
                     cleanup_result?;
                     return Err(error);
                 }


### PR DESCRIPTION
## Summary

- make empty delayed-allocation lease release a true no-op before metadata-gate admission
- keep projected admission and rollback in one direct metadata ownership domain
- linearize queue-empty cleanup across reservation, pool, registry, and inode-operation ownership
- preserve capabilities across retryable metadata contention and terminalize them safely after fail-stop
- add deterministic coverage for empty and non-empty contention, projected cancellation, rollback, and concurrent fail-stop

## Root cause

An empty delayed-allocation pool release still entered the metadata mutation gate. When a transactional metadata owner was active, the lower layer returned `EAGAIN`, but the inode cleanup path classified every release failure as structural corruption and fail-stopped the filesystem. Later metadata writeback consequently surfaced `EIO` during package installation.

Several adjacent rollback paths also separated capability creation from cleanup across independently acquired gate windows or could return before pool and registry ownership had been fully retired.

## Implementation

- short-circuit empty lease batches before mutability and gate checks
- use direct-domain reservation and rollback primitives for projected append admission
- retry retryable cancellation and pool release only after dropping inode and page-cache locks
- close delayed-allocation admission and detach queue-empty resources under the inode I/O lock
- use a local cleanup bundle to guarantee reservation, pool, registry, and owner retirement on every exit
- distinguish unregistered generations and registry conflicts during fail-stop cleanup

## Validation

- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml` — 168 passed
- `cargo check --manifest-path kernel/Cargo.toml --target x86_64-unknown-none`
- `make fmt -C kernel` — formatting and all-features clippy passed
- `make kernel`
- `git diff --check`
