### PR TITLE
fix(signal): preserve fatal delivery during sibling exec

### DIFF
--- a/kernel/src/ipc/signal.rs
+++ b/kernel/src/ipc/signal.rs
@@ -494,11 +494,22 @@ impl Signal {
             .sighand()
             .start_group_exit_for_fatal_signal(*self as usize)
         {
-            return true;
+            // Linux only performs the O(n) fatal broadcast for the first
+            // transition to SIGNAL_GROUP_EXIT.  A later delivery still follows
+            // complete_signal()'s ordinary pending/wakeup path; consuming it
+            // here would make SIGKILL disappear without waking any task.
+            return false;
         }
 
-        let tasks = ProcessManager::thread_group_tasks_snapshot(target);
+        // Preserve the old ordering: collect the group before the first wake
+        // can let another CPU change membership.  The explicit target below
+        // remains independent of this second group-leader lookup.
+        let tasks = ProcessManager::thread_group_tasks_snapshot(target.clone());
+        Self::queue_private_sigkill_to_thread(&target);
         for task in tasks {
+            if Arc::ptr_eq(&task, &target) {
+                continue;
+            }
             Self::queue_private_sigkill_to_thread(&task);
         }
 


### PR DESCRIPTION
## Summary

- keep SIGKILL on the ordinary pending and wakeup path when group exit is already active
- explicitly cover the selected signal target across non-leader exec identity exchange
- preserve snapshot-before-wakeup ordering and avoid duplicate target wakeups
- leave group-exec ownership, wait barriers, and identity handoff unchanged

## Linux semantics

Linux only performs the full fatal broadcast for the first transition to `SIGNAL_GROUP_EXIT`. Later deliveries retain their normal pending state and wake the selected target. The DragonOS fast path previously consumed such a delivery before establishing pending state.

## Validation

- `make fmt`
- `make kernel`
- complete `spawn_exec_pipe_race_test`: 3/3 passed in QEMU
- targeted fatal sibling-exec stress: 1,280 internal race iterations passed on a fresh boot
- `git diff --check`