### PR TITLE
refactor(rcu): extract grace period state machine

### DIFF
--- a/kernel/src/rcu/gp.rs
+++ b/kernel/src/rcu/gp.rs
@@ -1,0 +1,338 @@
+//! Deterministic state transitions for ordinary RCU grace periods.
+//!
+//! This module deliberately contains no locking, CPU-topology lookup, wakeup,
+//! or callback invocation. Callers serialize it with `RcuState::inner` and are
+//! responsible for the full memory barriers documented in `rcu/mod.rs`.
+
+use crate::{libs::cpumask::CpuMask, smp::cpu::ProcessorId};
+
+const SEQUENCE_HALF_RANGE: u64 = 1_u64 << 63;
+
+/// A wrapping RCU progress ticket.
+///
+/// Comparisons are valid while the distance between an outstanding ticket and
+/// the current value is less than half the sequence space. Grace-period
+/// requests are at most one generation ahead, and the number of outstanding
+/// callbacks is bounded by available memory, so both users satisfy this rule.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RcuSequence(u64);
+
+impl RcuSequence {
+    const ZERO: Self = Self(0);
+    const FIRST_CALLBACK: Self = Self(1);
+
+    #[inline]
+    pub(super) const fn raw(self) -> u64 {
+        self.0
+    }
+
+    #[inline]
+    pub(super) const fn next(self) -> Self {
+        Self(self.0.wrapping_add(1))
+    }
+
+    /// Returns whether `self` is at or after `target` in wrapping order.
+    #[inline]
+    pub(super) const fn has_reached(self, target: Self) -> bool {
+        self.0.wrapping_sub(target.0) < SEQUENCE_HALF_RANGE
+    }
+}
+
+struct ActiveGracePeriod {
+    seq: RcuSequence,
+    waiting_cpus: CpuMask,
+}
+
+/// The minimal ordinary-RCU grace-period state machine.
+///
+/// `next_requested` coalesces all requests for the one future generation that
+/// can be required beyond the active GP. A request made during an active GP
+/// must target the following GP because the active GP's CPU snapshot predates
+/// that request.
+pub(super) struct GracePeriodState {
+    completed: RcuSequence,
+    active: Option<ActiveGracePeriod>,
+    next_requested: bool,
+}
+
+impl GracePeriodState {
+    pub(super) fn new() -> Self {
+        Self::with_completed(RcuSequence::ZERO)
+    }
+
+    fn with_completed(completed: RcuSequence) -> Self {
+        Self {
+            completed,
+            active: None,
+            next_requested: false,
+        }
+    }
+
+    /// Requests a GP that starts after this call and returns its completion
+    /// ticket. Concurrent requests for the same future generation coalesce.
+    pub(super) fn request_future(&mut self) -> RcuSequence {
+        self.assert_invariants();
+        self.next_requested = true;
+        self.active
+            .as_ref()
+            .map_or_else(|| self.completed.next(), |active| active.seq.next())
+    }
+
+    pub(super) fn has_request(&self) -> bool {
+        self.next_requested
+    }
+
+    pub(super) fn is_active(&self) -> bool {
+        self.active.is_some()
+    }
+
+    /// Starts the requested GP with a freshly collected CPU snapshot.
+    pub(super) fn start_requested(&mut self, waiting_cpus: CpuMask) -> RcuSequence {
+        self.assert_invariants();
+        debug_assert!(
+            self.active.is_none(),
+            "started an RCU GP while one is active"
+        );
+        debug_assert!(self.next_requested, "started an unrequested RCU GP");
+
+        let seq = self.completed.next();
+        self.next_requested = false;
+        self.active = Some(ActiveGracePeriod { seq, waiting_cpus });
+        self.assert_invariants();
+        seq
+    }
+
+    pub(super) fn is_waiting_for(&self, cpu: ProcessorId) -> bool {
+        self.active
+            .as_ref()
+            .and_then(|active| active.waiting_cpus.get(cpu))
+            .unwrap_or(false)
+    }
+
+    /// Clears a CPU from the active GP. Repeated/non-waiting reports are
+    /// intentionally idempotent and return false.
+    pub(super) fn report_quiescent_state(&mut self, cpu: ProcessorId) -> bool {
+        self.assert_invariants();
+        let Some(active) = self.active.as_mut() else {
+            return false;
+        };
+        if !active.waiting_cpus.get(cpu).unwrap_or(false) {
+            return false;
+        }
+
+        active.waiting_cpus.set(cpu, false);
+        true
+    }
+
+    pub(super) fn ready_to_complete(&self) -> bool {
+        self.active
+            .as_ref()
+            .is_some_and(|active| active.waiting_cpus.is_empty())
+    }
+
+    /// Completes the active GP after the coordinator has executed the GP-end
+    /// full barrier.
+    pub(super) fn complete_ready(&mut self) -> RcuSequence {
+        self.assert_invariants();
+        let active = self
+            .active
+            .take()
+            .expect("completed RCU GP while no GP is active");
+        debug_assert!(
+            active.waiting_cpus.is_empty(),
+            "completed RCU GP with waiting CPUs"
+        );
+        debug_assert_eq!(active.seq, self.completed.next());
+        self.completed = active.seq;
+        self.assert_invariants();
+        self.completed
+    }
+
+    pub(super) fn has_completed(&self, target: RcuSequence) -> bool {
+        self.completed.has_reached(target)
+    }
+
+    pub(super) fn current(&self) -> RcuSequence {
+        self.active
+            .as_ref()
+            .map_or(self.completed, |active| active.seq)
+    }
+
+    pub(super) fn completed(&self) -> RcuSequence {
+        self.completed
+    }
+
+    fn assert_invariants(&self) {
+        if let Some(active) = &self.active {
+            debug_assert_eq!(
+                active.seq,
+                self.completed.next(),
+                "active RCU GP must immediately follow the completed generation"
+            );
+        }
+    }
+}
+
+/// Callback admission/completion tickets plus unique drainer ownership.
+///
+/// Callback storage remains in `RcuStateInner`; this type only centralizes the
+/// ordering facts required by `rcu_barrier()`.
+pub(super) struct CallbackTracker {
+    next: RcuSequence,
+    last_admitted: Option<RcuSequence>,
+    completed: Option<RcuSequence>,
+    draining: bool,
+}
+
+impl CallbackTracker {
+    pub(super) fn new() -> Self {
+        Self::with_next(RcuSequence::FIRST_CALLBACK)
+    }
+
+    fn with_next(next: RcuSequence) -> Self {
+        Self {
+            next,
+            last_admitted: None,
+            completed: None,
+            draining: false,
+        }
+    }
+
+    pub(super) fn admit(&mut self) -> RcuSequence {
+        let seq = self.next;
+        self.next = self.next.next();
+        self.last_admitted = Some(seq);
+        seq
+    }
+
+    pub(super) fn barrier_target(&self) -> Option<RcuSequence> {
+        self.last_admitted
+    }
+
+    pub(super) fn has_completed(&self, target: RcuSequence) -> bool {
+        self.completed
+            .is_some_and(|completed| completed.has_reached(target))
+    }
+
+    pub(super) fn complete(&mut self, seq: RcuSequence) {
+        debug_assert!(
+            self.last_admitted.is_some_and(|last| last.has_reached(seq)),
+            "completed a callback that was not admitted"
+        );
+        if let Some(completed) = self.completed {
+            debug_assert_eq!(
+                seq,
+                completed.next(),
+                "RCU callbacks must complete in admission order"
+            );
+        }
+        self.completed = Some(seq);
+    }
+
+    pub(super) fn try_claim_drainer(&mut self) -> bool {
+        if self.draining {
+            return false;
+        }
+        self.draining = true;
+        true
+    }
+
+    pub(super) fn release_drainer(&mut self) {
+        debug_assert!(self.draining, "released an unclaimed RCU callback drainer");
+        self.draining = false;
+    }
+
+    pub(super) fn drainer_available(&self) -> bool {
+        !self.draining
+    }
+
+    pub(super) fn completed_raw(&self) -> u64 {
+        self.completed.map_or(0, RcuSequence::raw)
+    }
+}
+
+fn one_cpu_mask(cpu: u32) -> CpuMask {
+    CpuMask::from_cpu(ProcessorId::new(cpu))
+}
+
+/// Runs deterministic tests against the production state-transition methods.
+pub(super) fn run_state_machine_selftests() -> Result<(), &'static str> {
+    let cpu0 = ProcessorId::new(0);
+    let cpu1 = ProcessorId::new(1);
+
+    let mut gp = GracePeriodState::new();
+    let first = gp.request_future();
+    if gp.request_future() != first {
+        return Err("idle RCU GP requests did not coalesce");
+    }
+    if gp.start_requested(one_cpu_mask(0)) != first || !gp.is_waiting_for(cpu0) {
+        return Err("RCU GP did not start with the requested waiting mask");
+    }
+    let second = gp.request_future();
+    if second != first.next() || gp.request_future() != second {
+        return Err("active RCU GP requests did not coalesce into the next generation");
+    }
+    if !gp.report_quiescent_state(cpu0) || gp.report_quiescent_state(cpu0) {
+        return Err("RCU GP quiescent-state reporting was not idempotent");
+    }
+    if gp.complete_ready() != first || gp.has_completed(second) {
+        return Err("RCU GP completed a nested future request too early");
+    }
+    if gp.start_requested(one_cpu_mask(1)) != second || !gp.is_waiting_for(cpu1) {
+        return Err("consecutive RCU GP did not use its fresh waiting mask");
+    }
+    if !gp.report_quiescent_state(cpu1) || gp.complete_ready() != second {
+        return Err("consecutive RCU GP did not complete in sequence");
+    }
+
+    let mut empty_gp = GracePeriodState::new();
+    let empty_target = empty_gp.request_future();
+    empty_gp.start_requested(CpuMask::new());
+    if !empty_gp.ready_to_complete()
+        || empty_gp.complete_ready() != empty_target
+        || empty_gp.is_active()
+    {
+        return Err("RCU GP with an empty waiting mask did not complete immediately");
+    }
+
+    let mut wrapping_gp = GracePeriodState::with_completed(RcuSequence(u64::MAX.wrapping_sub(1)));
+    let max_target = wrapping_gp.request_future();
+    wrapping_gp.start_requested(CpuMask::new());
+    if max_target.raw() != u64::MAX || wrapping_gp.complete_ready() != max_target {
+        return Err("RCU GP did not advance to u64::MAX");
+    }
+    let zero_target = wrapping_gp.request_future();
+    wrapping_gp.start_requested(CpuMask::new());
+    if zero_target.raw() != 0
+        || wrapping_gp.complete_ready() != zero_target
+        || !wrapping_gp.has_completed(max_target)
+        || !wrapping_gp.has_completed(zero_target)
+    {
+        return Err("RCU GP sequence did not wrap from u64::MAX to zero");
+    }
+
+    let mut callbacks = CallbackTracker::with_next(RcuSequence(u64::MAX));
+    let max_callback = callbacks.admit();
+    if callbacks.barrier_target() != Some(max_callback) || callbacks.has_completed(max_callback) {
+        return Err("RCU callback tracker corrupted its pre-wrap barrier target");
+    }
+    callbacks.complete(max_callback);
+    let zero_callback = callbacks.admit();
+    if zero_callback.raw() != 0 || callbacks.barrier_target() != Some(zero_callback) {
+        return Err("RCU callback tracker treated wrapped zero as an empty target");
+    }
+    callbacks.complete(zero_callback);
+    if !callbacks.has_completed(max_callback) || !callbacks.has_completed(zero_callback) {
+        return Err("RCU callback completion comparison failed across sequence wrap");
+    }
+    if !callbacks.try_claim_drainer() || callbacks.try_claim_drainer() {
+        return Err("RCU callback tracker allowed two simultaneous drainers");
+    }
+    callbacks.release_drainer();
+    if !callbacks.try_claim_drainer() {
+        return Err("RCU callback tracker did not release drainer ownership");
+    }
+    callbacks.release_drainer();
+
+    Ok(())
+}

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -1,7 +1,22 @@
 #![allow(dead_code)]
 
-use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
+//! DragonOS ordinary RCU.
+//!
+//! This is a non-preemptible, non-sleepable RCU flavor. Read-side critical
+//! sections may nest, but must remain on the creating task and must not block.
+//! A completed grace period covers every read-side critical section that
+//! existed before that GP began. It need not wait for readers that started
+//! afterward.
+//!
+//! Pointer publication uses Release operations and subscription uses Acquire
+//! operations. The global RCU state lock plus full barriers at real GP start,
+//! real quiescent-state reporting, GP completion, and synchronous return form
+//! the happens-before chain from callback admission to callback invocation or
+//! `synchronize_rcu()` return.
+
+use alloc::{boxed::Box, collections::VecDeque, rc::Rc, string::ToString, sync::Arc};
 use core::{
+    marker::PhantomData,
     ptr::{self, NonNull},
     sync::atomic::{fence, AtomicBool, AtomicPtr, Ordering},
 };
@@ -19,7 +34,9 @@ use crate::{
     },
 };
 
+mod gp;
 mod selftest;
+use gp::{CallbackTracker, GracePeriodState, RcuSequence};
 pub use selftest::run_debug_selftests;
 
 pub(crate) type RcuRawCallback = unsafe fn(NonNull<RcuHead>);
@@ -49,6 +66,7 @@ impl RcuHead {
 
 pub struct RcuReadGuard {
     active: bool,
+    _not_send: PhantomData<Rc<()>>,
 }
 
 impl Drop for RcuReadGuard {
@@ -330,8 +348,8 @@ enum CallbackKind {
 }
 
 struct CallbackItem {
-    target_gp: u64,
-    seq: u64,
+    target_gp: RcuSequence,
+    seq: RcuSequence,
     kind: CallbackKind,
 }
 
@@ -343,13 +361,8 @@ struct RcuCpuState {
 }
 
 struct RcuStateInner {
-    gp_seq: u64,
-    completed_gp_seq: u64,
-    requested_gp_seq: u64,
-    next_callback_seq: u64,
-    completed_callback_seq: u64,
-    gp_active: bool,
-    waiting_cpus: CpuMask,
+    gp: GracePeriodState,
+    callbacks: CallbackTracker,
     cpu_states: [RcuCpuState; PerCpu::MAX_CPU_NUM as usize],
     pending_callbacks: VecDeque<CallbackItem>,
     ready_callbacks: VecDeque<CallbackItem>,
@@ -358,35 +371,20 @@ struct RcuStateInner {
 impl RcuStateInner {
     fn new() -> Self {
         Self {
-            gp_seq: 0,
-            completed_gp_seq: 0,
-            requested_gp_seq: 0,
-            next_callback_seq: 1,
-            completed_callback_seq: 0,
-            gp_active: false,
-            waiting_cpus: CpuMask::new(),
+            gp: GracePeriodState::new(),
+            callbacks: CallbackTracker::new(),
             cpu_states: [RcuCpuState::default(); PerCpu::MAX_CPU_NUM as usize],
             pending_callbacks: VecDeque::new(),
             ready_callbacks: VecDeque::new(),
         }
     }
 
-    fn allocate_callback_seq(&mut self) -> u64 {
-        let seq = self.next_callback_seq;
-        self.next_callback_seq += 1;
-        seq
-    }
-
-    fn request_future_gp(&mut self) -> u64 {
-        let target_gp = self.gp_seq + 1;
-        if self.requested_gp_seq < target_gp {
-            self.requested_gp_seq = target_gp;
-        }
-        target_gp
-    }
-
     fn has_ready_work(&self) -> bool {
         !self.ready_callbacks.is_empty()
+    }
+
+    fn has_drainable_work(&self) -> bool {
+        self.has_ready_work() && self.callbacks.drainer_available()
     }
 }
 
@@ -416,42 +414,61 @@ impl RcuState {
     }
 
     fn pump_grace_periods(inner: &mut RcuStateInner) -> bool {
+        Self::pump_grace_periods_with(inner, online_non_idle_cpus)
+    }
+
+    fn pump_grace_periods_with(
+        inner: &mut RcuStateInner,
+        mut waiting_snapshot: impl FnMut(&[RcuCpuState; PerCpu::MAX_CPU_NUM as usize]) -> CpuMask,
+    ) -> bool {
         let mut ready_changed = false;
         loop {
-            if inner.gp_active {
-                if !inner.waiting_cpus.is_empty() {
-                    break;
-                }
-                inner.completed_gp_seq = inner.gp_seq;
-                inner.gp_active = false;
+            if inner.gp.ready_to_complete() {
+                // Pair all real quiescent-state reports with GP completion.
+                // This is a GP slow path and does not affect RCU readers.
+                fence(Ordering::SeqCst);
+                let completed = inner.gp.complete_ready();
 
                 while inner
                     .pending_callbacks
                     .front()
-                    .is_some_and(|cb| cb.target_gp <= inner.completed_gp_seq)
+                    .is_some_and(|cb| cb.target_gp == completed)
                 {
                     if let Some(cb) = inner.pending_callbacks.pop_front() {
                         inner.ready_callbacks.push_back(cb);
                         ready_changed = true;
                     }
                 }
+                debug_assert!(
+                    inner
+                        .pending_callbacks
+                        .front()
+                        .is_none_or(|cb| !inner.gp.has_completed(cb.target_gp)),
+                    "pending RCU callback targets an already completed GP"
+                );
                 continue;
             }
 
-            let need_gp = inner.requested_gp_seq > inner.completed_gp_seq
-                || inner
-                    .pending_callbacks
-                    .front()
-                    .is_some_and(|cb| cb.target_gp > inner.completed_gp_seq);
-            if !need_gp {
+            if inner.gp.is_active() {
                 break;
             }
 
-            inner.gp_seq += 1;
-            inner.gp_active = true;
-            inner.waiting_cpus = online_non_idle_cpus(&inner.cpu_states);
+            if !inner.gp.has_request() {
+                break;
+            }
+
+            // Admission/request operations preceding this point must be
+            // ordered before the fresh CPU snapshot that defines GP start.
+            fence(Ordering::SeqCst);
+            let waiting_cpus = waiting_snapshot(&inner.cpu_states);
+            inner.gp.start_requested(waiting_cpus);
         }
 
+        debug_assert!(inner.gp.is_active() || !inner.gp.has_request());
+        debug_assert!(
+            inner.pending_callbacks.is_empty() || inner.gp.is_active() || inner.gp.has_request(),
+            "pending RCU callbacks exist without active or requested GP work"
+        );
         ready_changed
     }
 
@@ -472,10 +489,23 @@ impl RcuState {
     }
 
     fn process_ready_callbacks(&self) {
+        {
+            let mut inner = self.inner.lock_irqsave();
+            if !inner.callbacks.try_claim_drainer() {
+                return;
+            }
+        }
+
         loop {
             let next = {
                 let mut inner = self.inner.lock_irqsave();
-                inner.ready_callbacks.pop_front()
+                match inner.ready_callbacks.pop_front() {
+                    Some(callback) => Some(callback),
+                    None => {
+                        inner.callbacks.release_drainer();
+                        None
+                    }
+                }
             };
 
             let Some(callback) = next else {
@@ -497,7 +527,7 @@ impl RcuState {
 
             {
                 let mut inner = self.inner.lock_irqsave();
-                inner.completed_callback_seq = callback.seq;
+                inner.callbacks.complete(callback.seq);
             }
 
             self.wake_state_waiters();
@@ -552,17 +582,29 @@ fn enter_cpu_idle_eqs(inner: &mut RcuStateInner, cpu: ProcessorId) -> bool {
     debug_assert_eq!(inner.cpu_states[cpu_idx].irq_nesting, 0);
 
     inner.cpu_states[cpu_idx].in_idle_eqs = true;
-    let ready_changed = if inner.gp_active && inner.waiting_cpus.get(cpu).unwrap_or(false) {
-        inner.waiting_cpus.set(cpu, false);
-        RcuState::pump_grace_periods(inner)
-    } else {
-        false
-    };
+    let ready_changed =
+        report_quiescent_state_locked(inner, cpu) && RcuState::pump_grace_periods(inner);
     ready_changed || inner.has_ready_work()
 }
 
 fn exit_cpu_idle_eqs(inner: &mut RcuStateInner, cpu: ProcessorId) {
     inner.cpu_states[cpu.data() as usize].in_idle_eqs = false;
+}
+
+/// Reports a real quiescent state while `RcuState::inner` is held.
+///
+/// The full barrier is paid only when this CPU is actually a holdout for an
+/// active GP. Context switches, user returns, and duplicate reports that do
+/// not advance a GP stay free of this extra barrier.
+fn report_quiescent_state_locked(inner: &mut RcuStateInner, cpu: ProcessorId) -> bool {
+    if !inner.gp.is_waiting_for(cpu) {
+        return false;
+    }
+
+    fence(Ordering::SeqCst);
+    let cleared = inner.gp.report_quiescent_state(cpu);
+    debug_assert!(cleared, "RCU holdout disappeared before QS reporting");
+    cleared
 }
 
 fn report_quiescent_state(cpu: ProcessorId) {
@@ -572,9 +614,7 @@ fn report_quiescent_state(cpu: ProcessorId) {
 
     let (wake_worker, wake_waiters) = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        if inner.gp_active && inner.waiting_cpus.get(cpu).unwrap_or(false) {
-            inner.waiting_cpus.set(cpu, false);
-        }
+        report_quiescent_state_locked(&mut inner, cpu);
         let ready_changed = RcuState::pump_grace_periods(&mut inner);
         (ready_changed || inner.has_ready_work(), true)
     };
@@ -609,8 +649,8 @@ fn try_reserve_callback_capacity(inner: &mut RcuStateInner) -> Result<(), ()> {
 }
 
 fn enqueue_callback_locked(inner: &mut RcuStateInner, kind: CallbackKind) -> bool {
-    let target_gp = inner.request_future_gp();
-    let seq = inner.allocate_callback_seq();
+    let target_gp = inner.gp.request_future();
+    let seq = inner.callbacks.admit();
     inner.pending_callbacks.push_back(CallbackItem {
         target_gp,
         seq,
@@ -673,7 +713,7 @@ fn worker_main() -> i32 {
                 return Some(());
             }
 
-            if RCU_STATE.inner.lock_irqsave().has_ready_work() {
+            if RCU_STATE.inner.lock_irqsave().has_drainable_work() {
                 return Some(());
             }
 
@@ -732,14 +772,25 @@ pub fn shutdown_worker() {
     RCU_STATE.wake_worker();
 }
 
+/// Enters a non-preemptible, non-sleepable ordinary-RCU read-side section.
+///
+/// Sections may nest. The returned guard is task-bound and must be dropped on
+/// the task that created it. Do not block or call an RCU synchronization API
+/// while the guard is alive.
 pub fn rcu_read_lock() -> RcuReadGuard {
     if !rcu_enabled() {
-        return RcuReadGuard { active: false };
+        return RcuReadGuard {
+            active: false,
+            _not_send: PhantomData,
+        };
     }
 
     ProcessManager::preempt_disable();
     ProcessManager::current_pcb().rcu_read_lock();
-    RcuReadGuard { active: true }
+    RcuReadGuard {
+        active: true,
+        _not_send: PhantomData,
+    }
 }
 
 pub fn rcu_read_unlock() {
@@ -761,16 +812,29 @@ pub fn rcu_read_lock_held() -> bool {
 }
 
 #[inline]
+/// Subscribes to a pointer published with `rcu_assign_pointer()`.
+///
+/// The returned raw pointer must only be dereferenced while protected by an
+/// ordinary-RCU read-side critical section or another proven lifetime pin.
 pub fn rcu_dereference<T>(ptr: &AtomicPtr<T>) -> *mut T {
     ptr.load(Ordering::Acquire)
 }
 
 #[inline]
+/// Publishes a fully initialized RCU-protected pointer with Release ordering.
 pub fn rcu_assign_pointer<T>(ptr: &AtomicPtr<T>, value: *mut T) {
     fence(Ordering::Release);
     ptr.store(value, Ordering::Release);
 }
 
+/// Queues `func` for exactly-once invocation after a GP that starts after
+/// admission. Before RCU initialization, boot-time no-reader rules make the
+/// callback execute synchronously instead.
+///
+/// # Safety
+///
+/// `head` must remain valid until `func` runs and must not be queued again
+/// before that invocation begins.
 pub(crate) unsafe fn call_rcu_raw(head: NonNull<RcuHead>, func: RcuRawCallback) {
     if !rcu_enabled() {
         // SAFETY: before RCU init there is no concurrent reader relying on
@@ -839,6 +903,10 @@ where
     Ok(())
 }
 
+/// Waits for a GP that starts after this call.
+///
+/// This function may sleep and must not be called from an RCU read-side
+/// critical section.
 pub fn synchronize_rcu() {
     if !rcu_enabled() {
         return;
@@ -851,7 +919,7 @@ pub fn synchronize_rcu() {
 
     let target_gp = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        let target_gp = inner.request_future_gp();
+        let target_gp = inner.gp.request_future();
         RcuState::pump_grace_periods(&mut inner);
         target_gp
     };
@@ -860,13 +928,14 @@ pub fn synchronize_rcu() {
     RCU_STATE.wake_worker();
 
     RCU_STATE.state_wait.wait_until(|| {
-        let completed = RCU_STATE.inner.lock_irqsave().completed_gp_seq;
-        if completed >= target_gp {
+        let completed = RCU_STATE.inner.lock_irqsave().gp.has_completed(target_gp);
+        if completed {
             Some(())
         } else {
             None
         }
     });
+    fence(Ordering::SeqCst);
 }
 
 /// Waits for a grace period without registering a waiter or allocating.
@@ -886,7 +955,7 @@ pub(crate) fn synchronize_rcu_noalloc() {
 
     let target_gp = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        let target_gp = inner.request_future_gp();
+        let target_gp = inner.gp.request_future();
         RcuState::pump_grace_periods(&mut inner);
         target_gp
     };
@@ -895,27 +964,38 @@ pub(crate) fn synchronize_rcu_noalloc() {
     RCU_STATE.wake_worker();
 
     loop {
-        let completed = RCU_STATE.inner.lock_irqsave().completed_gp_seq;
-        if completed >= target_gp {
+        let completed = RCU_STATE.inner.lock_irqsave().gp.has_completed(target_gp);
+        if completed {
             break;
         }
         sched_yield();
     }
+    fence(Ordering::SeqCst);
 }
 
+/// Waits until every callback admitted before this call has finished.
+///
+/// This does not necessarily start a GP when no callbacks are pending. It must
+/// not be called from an RCU read-side critical section or from an RCU callback
+/// that would be included in its own barrier snapshot.
 pub fn rcu_barrier() {
     if !rcu_enabled() {
         return;
     }
 
+    if rcu_read_lock_held() {
+        warn!("rcu_barrier() called inside rcu_read_lock() region");
+        debug_assert!(!rcu_read_lock_held());
+    }
+
     let target_cb = {
         let inner = RCU_STATE.inner.lock_irqsave();
-        inner.next_callback_seq.saturating_sub(1)
+        inner.callbacks.barrier_target()
     };
 
-    if target_cb == 0 {
+    let Some(target_cb) = target_cb else {
         return;
-    }
+    };
 
     loop {
         if !RCU_STATE.worker_started.load(Ordering::Acquire) {
@@ -924,15 +1004,19 @@ pub fn rcu_barrier() {
 
         let done = {
             let inner = RCU_STATE.inner.lock_irqsave();
-            inner.completed_callback_seq >= target_cb
+            inner.callbacks.has_completed(target_cb)
         };
         if done {
             return;
         }
 
         RCU_STATE.state_wait.wait_until(|| {
-            let completed = RCU_STATE.inner.lock_irqsave().completed_callback_seq;
-            if completed >= target_cb {
+            let completed = RCU_STATE
+                .inner
+                .lock_irqsave()
+                .callbacks
+                .has_completed(target_cb);
+            if completed {
                 Some(())
             } else {
                 None
@@ -1074,9 +1158,7 @@ pub fn cpu_offline(cpu: ProcessorId) {
 
     let wake_worker = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        if inner.gp_active && inner.waiting_cpus.get(cpu).unwrap_or(false) {
-            inner.waiting_cpus.set(cpu, false);
-        }
+        report_quiescent_state_locked(&mut inner, cpu);
         let ready_changed = RcuState::pump_grace_periods(&mut inner);
         ready_changed || inner.has_ready_work()
     };
@@ -1092,9 +1174,9 @@ pub fn cpu_offline(cpu: ProcessorId) {
 pub fn debug_snapshot() -> (u64, u64, u64, usize, usize) {
     let inner = RCU_STATE.inner.lock_irqsave();
     (
-        inner.gp_seq,
-        inner.completed_gp_seq,
-        inner.completed_callback_seq,
+        inner.gp.current().raw(),
+        inner.gp.completed().raw(),
+        inner.callbacks.completed_raw(),
         inner.pending_callbacks.len(),
         inner.ready_callbacks.len(),
     )

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -156,9 +156,7 @@ fn restore_cpu_state_after_selftest(cpu: ProcessorId, saved: RcuCpuState) {
         let mut inner = RCU_STATE.inner.lock_irqsave();
         let cpu_idx = cpu.data() as usize;
         inner.cpu_states[cpu_idx] = saved;
-        if inner.gp_active && inner.waiting_cpus.get(cpu).unwrap_or(false) {
-            inner.waiting_cpus.set(cpu, false);
-        }
+        report_quiescent_state_locked(&mut inner, cpu);
         RcuState::pump_grace_periods(&mut inner) || inner.has_ready_work()
     };
 
@@ -218,7 +216,7 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
         let inner = RCU_STATE.inner.lock_irqsave();
         if idle_hits.load(Ordering::SeqCst) != 0 {
             Some("idle IRQ callback ran before the interrupted CPU returned to idle")
-        } else if !inner.gp_active || !inner.waiting_cpus.get(cpu).unwrap_or(false) {
+        } else if !inner.gp.is_active() || !inner.gp.is_waiting_for(cpu) {
             Some("idle IRQ selftest did not put the current CPU in waiting_cpus")
         } else if inner.pending_callbacks.len() != 1 || !inner.ready_callbacks.is_empty() {
             Some("idle IRQ selftest corrupted callback queue state before irq_exit")
@@ -256,7 +254,7 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
 
     let post_exit_waiting = {
         let inner = RCU_STATE.inner.lock_irqsave();
-        inner.waiting_cpus.get(cpu).unwrap_or(false)
+        inner.gp.is_waiting_for(cpu)
     };
     if post_exit_waiting {
         return Err("idle IRQ exit left the current CPU in waiting_cpus");
@@ -276,6 +274,9 @@ fn run_idle_irq_wakeup_selftest() -> Result<(), &'static str> {
 }
 
 fn run_pr1_selftest() -> Result<(), &'static str> {
+    gp::run_state_machine_selftests()?;
+    run_callback_generation_selftest()?;
+
     if ProcessManager::current_pcb().rcu_read_depth() != 0 {
         return Err("initial rcu_read_depth was not zero");
     }
@@ -395,10 +396,10 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
         return Err("try_rcu_defer_drop_arc did not run after rcu_barrier");
     }
 
-    let completed_gp_before = RCU_STATE.inner.lock_irqsave().completed_gp_seq;
+    let completed_gp_before = RCU_STATE.inner.lock_irqsave().gp.completed();
     synchronize_rcu_noalloc();
-    let completed_gp_after = RCU_STATE.inner.lock_irqsave().completed_gp_seq;
-    if completed_gp_after <= completed_gp_before {
+    let completed_gp_after = RCU_STATE.inner.lock_irqsave().gp.completed();
+    if !completed_gp_after.has_reached(completed_gp_before.next()) {
         return Err("synchronize_rcu_noalloc did not complete a new grace period");
     }
 
@@ -413,6 +414,61 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
 
     if deferred_hits.load(Ordering::SeqCst) != 1 {
         return Err("rcu_defer closure did not run after rcu_barrier");
+    }
+
+    Ok(())
+}
+
+fn run_callback_generation_selftest() -> Result<(), &'static str> {
+    let cpu0 = ProcessorId::new(0);
+    let cpu1 = ProcessorId::new(1);
+    let mut inner = RcuStateInner::new();
+
+    let first_gp = inner.gp.request_future();
+    if inner.gp.start_requested(CpuMask::from_cpu(cpu0)) != first_gp {
+        return Err("callback generation selftest failed to start its first GP");
+    }
+
+    enqueue_callback_locked(&mut inner, CallbackKind::Deferred(Box::new(|| {})));
+    enqueue_callback_locked(&mut inner, CallbackKind::Deferred(Box::new(|| {})));
+
+    let expected_second_gp = first_gp.next();
+    if inner.pending_callbacks.len() != 2
+        || inner
+            .pending_callbacks
+            .iter()
+            .any(|callback| callback.target_gp != expected_second_gp)
+    {
+        return Err("callback admitted during an active GP targeted the wrong generation");
+    }
+
+    if !inner.gp.report_quiescent_state(cpu0) {
+        return Err("callback generation selftest could not complete its first waiting mask");
+    }
+    RcuState::pump_grace_periods_with(&mut inner, |_| CpuMask::from_cpu(cpu1));
+    if inner.gp.completed() != first_gp
+        || !inner.gp.is_waiting_for(cpu1)
+        || inner.pending_callbacks.len() != 2
+        || !inner.ready_callbacks.is_empty()
+    {
+        return Err("callbacks became ready before their post-admission GP completed");
+    }
+
+    if !inner.gp.report_quiescent_state(cpu1) {
+        return Err("callback generation selftest could not complete its second waiting mask");
+    }
+    RcuState::pump_grace_periods_with(&mut inner, |_| CpuMask::new());
+    if inner.gp.completed() != expected_second_gp
+        || !inner.pending_callbacks.is_empty()
+        || inner.ready_callbacks.len() != 2
+    {
+        return Err("callbacks did not become ready after their target GP completed");
+    }
+
+    let first_callback = inner.ready_callbacks.pop_front().unwrap();
+    let second_callback = inner.ready_callbacks.pop_front().unwrap();
+    if second_callback.seq != first_callback.seq.next() {
+        return Err("callback generation transition did not preserve admission FIFO");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- replace redundant grace-period fields with a deterministic state machine for request coalescing, CPU waiting masks, and wrap-safe sequence transitions
- track callback generations with wrap-safe tickets and a single drainer owner so barrier completion remains FIFO-correct
- define the ordinary non-preemptible RCU contract in code and place memory barriers at the GP ordering boundaries
- add deterministic regression coverage for nested requests, empty masks, consecutive GPs, callback generations, FIFO ordering, drainer ownership, and sequence wraparound

## Compatibility

The existing public RCU APIs, worker model, callback queue layout, and debug snapshot format remain unchanged.

## Testing

- `make fmt`
- `make kernel`
- `/opt/tests/dunitest/bin/normal/rcu_selftest_test` in a 2-vCPU QEMU guest, run twice (2/2 passed each run)

Closes #2209