### PR TITLE
refactor(rcu): make raw callback admission intrusive

### DIFF
--- a/kernel/src/rcu/callback.rs
+++ b/kernel/src/rcu/callback.rs
@@ -1,0 +1,199 @@
+use core::{
+    cell::UnsafeCell,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use super::{gp::RcuSequence, RcuRawCallback};
+
+struct RcuHeadNode {
+    next: Option<NonNull<RcuHead>>,
+    func: Option<RcuRawCallback>,
+    target_gp: Option<RcuSequence>,
+    callback_seq: Option<RcuSequence>,
+}
+
+impl RcuHeadNode {
+    const fn new() -> Self {
+        Self {
+            next: None,
+            func: None,
+            target_gp: None,
+            callback_seq: None,
+        }
+    }
+}
+
+/// Intrusive storage for one ordinary-RCU callback.
+///
+/// Once submitted, this value must remain initialized at the same address
+/// until its callback starts. `queued` detects duplicate admission; it is not
+/// a lifetime reference count.
+pub struct RcuHead {
+    queued: AtomicBool,
+    node: UnsafeCell<RcuHeadNode>,
+}
+
+impl RcuHead {
+    pub const fn new() -> Self {
+        Self {
+            queued: AtomicBool::new(false),
+            node: UnsafeCell::new(RcuHeadNode::new()),
+        }
+    }
+
+    /// Claims this head for one admission without modifying its queue node.
+    pub(super) fn try_claim(&self) -> bool {
+        self.queued
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+    }
+
+    pub(super) fn is_queued(&self) -> bool {
+        self.queued.load(Ordering::Acquire)
+    }
+}
+
+impl core::fmt::Debug for RcuHead {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("RcuHead")
+            .field("queued", &self.queued.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+// SAFETY: `queued` is atomic. All access to `node` is encapsulated by
+// `RcuCallbackList` and serialized by `RcuState::inner`. The unsafe admission
+// contract keeps a queued head initialized at a stable address.
+unsafe impl Send for RcuHead {}
+// SAFETY: Shared references only expose atomic duplicate admission. The
+// non-atomic node remains protected by the global RCU state lock.
+unsafe impl Sync for RcuHead {}
+
+pub(super) struct ReadyRcuCallback {
+    pub(super) head: NonNull<RcuHead>,
+    pub(super) func: RcuRawCallback,
+    pub(super) seq: RcuSequence,
+}
+
+/// The one global intrusive callback FIFO.
+///
+/// The containing `RcuState::inner` lock must be held for every operation.
+pub(super) struct RcuCallbackList {
+    head: Option<NonNull<RcuHead>>,
+    tail: Option<NonNull<RcuHead>>,
+    len: usize,
+}
+
+impl RcuCallbackList {
+    pub(super) const fn new() -> Self {
+        Self {
+            head: None,
+            tail: None,
+            len: 0,
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.head.is_none()
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.len
+    }
+
+    pub(super) fn front_target(&self) -> Option<RcuSequence> {
+        let head = self.head?;
+        // SAFETY: Queue operations are serialized by `RcuState::inner`, and
+        // admission keeps every linked head alive at a stable address.
+        unsafe { (*head.as_ref().node.get()).target_gp }
+    }
+
+    pub(super) fn push(
+        &mut self,
+        head: NonNull<RcuHead>,
+        func: RcuRawCallback,
+        target_gp: RcuSequence,
+        callback_seq: RcuSequence,
+    ) {
+        // SAFETY: The caller holds `RcuState::inner`, has exclusively claimed
+        // `head`, and guarantees its address and lifetime through callback
+        // start. A queued node is mutated only through this list.
+        unsafe {
+            let node = &mut *head.as_ref().node.get();
+            debug_assert!(head.as_ref().queued.load(Ordering::Acquire));
+            debug_assert!(node.next.is_none());
+            debug_assert!(node.func.is_none());
+            debug_assert!(node.target_gp.is_none());
+            debug_assert!(node.callback_seq.is_none());
+
+            node.func = Some(func);
+            node.target_gp = Some(target_gp);
+            node.callback_seq = Some(callback_seq);
+
+            if let Some(tail) = self.tail {
+                let tail_node = &mut *tail.as_ref().node.get();
+                debug_assert!(tail_node.next.is_none());
+                tail_node.next = Some(head);
+            } else {
+                debug_assert!(self.head.is_none());
+                self.head = Some(head);
+            }
+        }
+
+        self.tail = Some(head);
+        self.len = self
+            .len
+            .checked_add(1)
+            .expect("RCU callback count overflow");
+        self.assert_invariants();
+    }
+
+    pub(super) fn pop_ready(&mut self, completed_gp: RcuSequence) -> Option<ReadyRcuCallback> {
+        let head = self.head?;
+        // SAFETY: The global RCU state lock serializes the list. The head is
+        // still linked, so the admission lifetime contract keeps it valid.
+        let node = unsafe { &mut *head.as_ref().node.get() };
+        let target_gp = node
+            .target_gp
+            .expect("queued RCU callback has no target grace period");
+        if !completed_gp.has_reached(target_gp) {
+            return None;
+        }
+
+        self.head = node.next.take();
+        if self.head.is_none() {
+            self.tail = None;
+        }
+        self.len -= 1;
+
+        let func = node
+            .func
+            .take()
+            .expect("queued RCU callback has no function");
+        let seq = node
+            .callback_seq
+            .take()
+            .expect("queued RCU callback has no admission sequence");
+        node.target_gp = None;
+
+        // Publish complete detachment before the callback receives ownership.
+        // After this store the drainer must not dereference `head` again.
+        unsafe { head.as_ref() }
+            .queued
+            .store(false, Ordering::Release);
+        self.assert_invariants();
+
+        Some(ReadyRcuCallback { head, func, seq })
+    }
+
+    fn assert_invariants(&self) {
+        debug_assert_eq!(self.head.is_none(), self.tail.is_none());
+        debug_assert_eq!(self.len == 0, self.head.is_none());
+    }
+}
+
+// SAFETY: The list's raw pointers are non-owning tokens transferred between
+// CPUs only as part of `RcuStateInner`. Every dereference is serialized by its
+// global spin lock, and admission guarantees stable pointee addresses.
+unsafe impl Send for RcuCallbackList {}

--- a/kernel/src/rcu/gp.rs
+++ b/kernel/src/rcu/gp.rs
@@ -213,6 +213,7 @@ impl GracePeriodState {
 /// ordering facts required by `rcu_barrier()`.
 pub(super) struct CallbackTracker {
     next: RcuSequence,
+    next_completion: RcuSequence,
     last_admitted: Option<RcuSequence>,
     completed: Option<RcuSequence>,
     draining: bool,
@@ -226,6 +227,7 @@ impl CallbackTracker {
     fn with_next(next: RcuSequence) -> Self {
         Self {
             next,
+            next_completion: next,
             last_admitted: None,
             completed: None,
             draining: false,
@@ -253,14 +255,12 @@ impl CallbackTracker {
             self.last_admitted.is_some_and(|last| last.has_reached(seq)),
             "completed a callback that was not admitted"
         );
-        if let Some(completed) = self.completed {
-            debug_assert_eq!(
-                seq,
-                completed.next(),
-                "RCU callbacks must complete in admission order"
-            );
-        }
+        debug_assert_eq!(
+            seq, self.next_completion,
+            "RCU callbacks must complete in admission order"
+        );
         self.completed = Some(seq);
+        self.next_completion = self.next_completion.next();
     }
 
     pub(super) fn try_claim_drainer(&mut self) -> bool {

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -21,7 +21,7 @@ use core::{
     sync::atomic::{fence, AtomicBool, AtomicPtr, Ordering},
 };
 
-use log::{error, warn};
+use log::warn;
 
 use crate::{
     libs::{cpumask::CpuMask, spinlock::SpinLock, wait_queue::WaitQueue},
@@ -782,15 +782,8 @@ pub fn start_worker() {
     }
 
     let closure = KernelThreadClosure::EmptyClosure((Box::new(worker_main), ()));
-    if KernelThreadMechanism::create_and_run(closure, "rcu_gp".to_string()).is_none() {
-        {
-            let _inner = RCU_STATE.inner.lock_irqsave();
-            RCU_STATE.worker_starting.store(false, Ordering::Release);
-        }
-        RCU_STATE.wake_state_waiters();
-        error!("failed to create RCU callback worker");
-        return;
-    }
+    KernelThreadMechanism::create_and_run(closure, "rcu_gp".to_string())
+        .expect("failed to create required RCU callback worker");
 
     RCU_STATE.wake_worker();
 }

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -14,7 +14,7 @@
 //! the happens-before chain from callback admission to callback invocation or
 //! `synchronize_rcu()` return.
 
-use alloc::{boxed::Box, collections::VecDeque, rc::Rc, string::ToString, sync::Arc};
+use alloc::{boxed::Box, rc::Rc, string::ToString, sync::Arc};
 use core::{
     marker::PhantomData,
     ptr::{self, NonNull},
@@ -34,40 +34,20 @@ use crate::{
     },
 };
 
+mod callback;
 mod context;
 mod gp;
 mod selftest;
+use callback::RcuCallbackList;
+pub use callback::RcuHead;
 use context::{
     BaseContext, ContextTransition, ContextTransitionError, IdleTransition, IrqDisposition,
     IrqEntry, RcuContextTracker,
 };
-use gp::{CallbackTracker, GracePeriodState, RcuSequence};
+use gp::{CallbackTracker, GracePeriodState};
 pub use selftest::run_debug_selftests;
 
 pub(crate) type RcuRawCallback = unsafe fn(NonNull<RcuHead>);
-
-#[derive(Clone, Copy)]
-struct QueuedRcuHead(NonNull<RcuHead>);
-
-// SAFETY: the wrapped head is an opaque token that may be transferred to the
-// RCU worker thread after `call_rcu_raw()` publishes it. The caller must keep
-// the underlying allocation alive until the callback runs, and the token is not
-// dereferenced except when the worker invokes that callback after a grace
-// period.
-unsafe impl Send for QueuedRcuHead {}
-
-#[derive(Debug)]
-pub struct RcuHead {
-    queued: AtomicBool,
-}
-
-impl RcuHead {
-    pub const fn new() -> Self {
-        Self {
-            queued: AtomicBool::new(false),
-        }
-    }
-}
 
 pub struct RcuReadGuard {
     active: bool,
@@ -108,20 +88,12 @@ impl Drop for RcuReadGuard {
     }
 }
 
-trait DeferredCall: Send {
-    fn invoke(self: Box<Self>);
-}
-
-impl<F> DeferredCall for F
-where
-    F: FnOnce() + Send,
-{
-    fn invoke(self: Box<Self>) {
-        (*self)();
-    }
-}
-
 #[derive(Debug)]
+/// An RCU-published non-null `Arc` slot.
+///
+/// Deferred updates and destruction allocate callback storage, so this type
+/// must be updated and dropped only from a task context where allocation is
+/// permitted. Its read-side operations do not inherit that restriction.
 pub struct RcuArcSlot<T>
 where
     T: Send + Sync + 'static,
@@ -238,6 +210,11 @@ where
 }
 
 #[derive(Debug)]
+/// An RCU-published optional `Arc` slot.
+///
+/// Deferred updates and destruction allocate callback storage, so this type
+/// must be updated and dropped only from a task context where allocation is
+/// permitted. Its read-side operations do not inherit that restriction.
 pub struct RcuOptionArcSlot<T>
 where
     T: Send + Sync + 'static,
@@ -370,25 +347,10 @@ where
     }
 }
 
-enum CallbackKind {
-    RawHead {
-        head: QueuedRcuHead,
-        func: RcuRawCallback,
-    },
-    Deferred(Box<dyn DeferredCall>),
-}
-
-struct CallbackItem {
-    target_gp: RcuSequence,
-    seq: RcuSequence,
-    kind: CallbackKind,
-}
-
 struct RcuStateInner {
     gp: GracePeriodState,
     callbacks: CallbackTracker,
-    pending_callbacks: VecDeque<CallbackItem>,
-    ready_callbacks: VecDeque<CallbackItem>,
+    callback_queue: RcuCallbackList,
 }
 
 impl RcuStateInner {
@@ -396,22 +358,30 @@ impl RcuStateInner {
         Self {
             gp: GracePeriodState::new(),
             callbacks: CallbackTracker::new(),
-            pending_callbacks: VecDeque::new(),
-            ready_callbacks: VecDeque::new(),
+            callback_queue: RcuCallbackList::new(),
         }
     }
 
     fn has_ready_work(&self) -> bool {
-        !self.ready_callbacks.is_empty()
+        self.callback_queue
+            .front_target()
+            .is_some_and(|target| self.gp.has_completed(target))
     }
 
     fn has_drainable_work(&self) -> bool {
         self.has_ready_work() && self.callbacks.drainer_available()
     }
+
+    fn has_worker_work(&self) -> bool {
+        self.has_drainable_work()
+            || self.gp.ready_to_complete()
+            || (!self.gp.is_active() && self.gp.has_request())
+    }
 }
 
 struct RcuState {
     initialized: AtomicBool,
+    worker_starting: AtomicBool,
     worker_started: AtomicBool,
     worker_should_stop: AtomicBool,
     gp_active: AtomicBool,
@@ -425,6 +395,7 @@ impl RcuState {
     fn new() -> Self {
         Self {
             initialized: AtomicBool::new(false),
+            worker_starting: AtomicBool::new(false),
             worker_started: AtomicBool::new(false),
             worker_should_stop: AtomicBool::new(false),
             gp_active: AtomicBool::new(false),
@@ -462,25 +433,8 @@ impl RcuState {
                 // Pair all real quiescent-state reports with GP completion.
                 // This is a GP slow path and does not affect RCU readers.
                 fence(Ordering::SeqCst);
-                let completed = inner.gp.complete_ready();
-
-                while inner
-                    .pending_callbacks
-                    .front()
-                    .is_some_and(|cb| cb.target_gp == completed)
-                {
-                    if let Some(cb) = inner.pending_callbacks.pop_front() {
-                        inner.ready_callbacks.push_back(cb);
-                        ready_changed = true;
-                    }
-                }
-                debug_assert!(
-                    inner
-                        .pending_callbacks
-                        .front()
-                        .is_none_or(|cb| !inner.gp.has_completed(cb.target_gp)),
-                    "pending RCU callback targets an already completed GP"
-                );
+                inner.gp.complete_ready();
+                ready_changed |= inner.has_ready_work();
                 continue;
             }
 
@@ -504,8 +458,11 @@ impl RcuState {
 
         debug_assert!(inner.gp.is_active() || !inner.gp.has_request());
         debug_assert!(
-            inner.pending_callbacks.is_empty() || inner.gp.is_active() || inner.gp.has_request(),
-            "pending RCU callbacks exist without active or requested GP work"
+            inner.callback_queue.is_empty()
+                || inner.has_ready_work()
+                || inner.gp.is_active()
+                || inner.gp.has_request(),
+            "RCU callbacks exist without ready, active, or requested GP work"
         );
         ready_changed
     }
@@ -518,7 +475,7 @@ impl RcuState {
         self.worker_wait.wake_all();
     }
 
-    fn maybe_process_ready_callbacks_inline(&self) {
+    fn progress_and_drain_inline_if_no_worker(&self) {
         if self.worker_started.load(Ordering::Acquire) {
             return;
         }
@@ -529,7 +486,8 @@ impl RcuState {
     fn process_ready_callbacks(&self) {
         {
             let mut inner = self.inner.lock_irqsave();
-            if !inner.callbacks.try_claim_drainer() {
+            Self::pump_grace_periods(&mut inner);
+            if !inner.has_ready_work() || !inner.callbacks.try_claim_drainer() {
                 return;
             }
         }
@@ -537,7 +495,8 @@ impl RcuState {
         loop {
             let next = {
                 let mut inner = self.inner.lock_irqsave();
-                match inner.ready_callbacks.pop_front() {
+                let completed_gp = inner.gp.completed();
+                match inner.callback_queue.pop_ready(completed_gp) {
                     Some(callback) => Some(callback),
                     None => {
                         inner.callbacks.release_drainer();
@@ -550,18 +509,10 @@ impl RcuState {
                 break;
             };
 
-            match callback.kind {
-                CallbackKind::RawHead { head, func } => {
-                    let head = head.0;
-                    // SAFETY: `head` is queued only once and the callback owns
-                    // the right to recycle or requeue it after execution.
-                    unsafe {
-                        head.as_ref().queued.store(false, Ordering::Release);
-                        func(head);
-                    }
-                }
-                CallbackKind::Deferred(call) => call.invoke(),
-            }
+            // SAFETY: `pop_ready()` detached the head, copied all state needed
+            // after invocation, and released duplicate ownership. The unsafe
+            // admission contract keeps the head valid until this call starts.
+            unsafe { (callback.func)(callback.head) };
 
             {
                 let mut inner = self.inner.lock_irqsave();
@@ -692,100 +643,100 @@ fn report_quiescent_state(cpu: ProcessorId) {
     }
     if wake_worker {
         RCU_STATE.wake_worker();
-        RCU_STATE.maybe_process_ready_callbacks_inline();
     }
 }
 
-fn reserve_callback_capacity(inner: &mut RcuStateInner) {
-    let ready_additional = inner
-        .pending_callbacks
-        .len()
-        .checked_add(1)
-        .expect("RCU callback count overflow");
-    inner.pending_callbacks.reserve(1);
-    inner.ready_callbacks.reserve(ready_additional);
-}
-
-fn try_reserve_callback_capacity(inner: &mut RcuStateInner) -> Result<(), ()> {
-    let ready_additional = inner.pending_callbacks.len().checked_add(1).ok_or(())?;
-    inner.pending_callbacks.try_reserve(1).map_err(|_| ())?;
-    inner
-        .ready_callbacks
-        .try_reserve(ready_additional)
-        .map_err(|_| ())?;
-    Ok(())
-}
-
-fn admit_callback_locked(inner: &mut RcuStateInner, kind: CallbackKind) {
+fn enqueue_callback_locked(
+    inner: &mut RcuStateInner,
+    head: NonNull<RcuHead>,
+    func: RcuRawCallback,
+) {
     let target_gp = inner.gp.request_future();
     let seq = inner.callbacks.admit();
-    inner.pending_callbacks.push_back(CallbackItem {
-        target_gp,
-        seq,
-        kind,
-    });
-}
-
-fn enqueue_callback_locked(inner: &mut RcuStateInner, kind: CallbackKind) -> bool {
-    admit_callback_locked(inner, kind);
-    let ready_changed = RcuState::pump_grace_periods(inner);
-    ready_changed || inner.has_ready_work()
-}
-
-fn queue_callback(kind: CallbackKind) {
-    let wake_worker = {
-        let mut inner = RCU_STATE.inner.lock_irqsave();
-        // Admission reserves the destination capacity as well, so grace-period
-        // completion can move every pending callback to the ready queue without
-        // allocating in IRQ or other non-fallible progress paths.
-        reserve_callback_capacity(&mut inner);
-        enqueue_callback_locked(&mut inner, kind)
-    };
-
-    RCU_STATE.wake_state_waiters();
-    if wake_worker {
-        RCU_STATE.wake_worker();
-        RCU_STATE.maybe_process_ready_callbacks_inline();
-    }
+    inner.callback_queue.push(head, func, target_gp, seq);
 }
 
 fn queue_raw_callback(head: NonNull<RcuHead>, func: RcuRawCallback) {
-    queue_callback(CallbackKind::RawHead {
-        head: QueuedRcuHead(head),
-        func,
-    });
-}
-
-fn queue_deferred_callback(call: Box<dyn DeferredCall>) {
-    queue_callback(CallbackKind::Deferred(call));
-}
-
-fn try_queue_deferred_callback(call: Box<dyn DeferredCall>) -> Result<(), Box<dyn DeferredCall>> {
-    let mut call = Some(call);
     let wake_worker = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        if try_reserve_callback_capacity(&mut inner).is_err() {
-            return Err(call.take().unwrap());
-        }
-        enqueue_callback_locked(&mut inner, CallbackKind::Deferred(call.take().unwrap()))
+        enqueue_callback_locked(&mut inner, head, func);
+        inner.has_worker_work()
     };
 
-    RCU_STATE.wake_state_waiters();
     if wake_worker {
         RCU_STATE.wake_worker();
-        RCU_STATE.maybe_process_ready_callbacks_inline();
     }
+}
+
+#[repr(C)]
+struct DeferredRcuCall<F> {
+    head: RcuHead,
+    call: Option<F>,
+}
+
+impl<F> DeferredRcuCall<F> {
+    fn new(call: F) -> Self {
+        Self {
+            head: RcuHead::new(),
+            call: Some(call),
+        }
+    }
+}
+
+unsafe fn invoke_deferred_rcu_call<F>(head: NonNull<RcuHead>)
+where
+    F: FnOnce() + Send + 'static,
+{
+    // SAFETY: `DeferredRcuCall` is repr(C) with `head` as its first field, and
+    // `submit_deferred_rcu_call()` transferred this Box to the callback.
+    let mut deferred = unsafe { Box::from_raw(head.as_ptr().cast::<DeferredRcuCall<F>>()) };
+    let call = deferred
+        .call
+        .take()
+        .expect("deferred RCU callback invoked more than once");
+    call();
+}
+
+fn submit_deferred_rcu_call<F>(deferred: Box<DeferredRcuCall<F>>)
+where
+    F: FnOnce() + Send + 'static,
+{
+    let deferred = Box::into_raw(deferred);
+    // SAFETY: the Box has been transferred to `invoke_deferred_rcu_call`, so
+    // it remains at this address until callback invocation starts.
+    unsafe {
+        call_rcu_raw(
+            NonNull::new_unchecked(core::ptr::addr_of_mut!((*deferred).head)),
+            invoke_deferred_rcu_call::<F>,
+        );
+    }
+}
+
+fn try_queue_deferred_callback_with<F, A>(call: F, allocate: A) -> Result<(), ()>
+where
+    F: FnOnce() + Send + 'static,
+    A: FnOnce(DeferredRcuCall<F>) -> Result<Box<DeferredRcuCall<F>>, ()>,
+{
+    let deferred = allocate(DeferredRcuCall::new(call))?;
+    submit_deferred_rcu_call(deferred);
     Ok(())
 }
 
 fn worker_main() -> i32 {
+    {
+        let _inner = RCU_STATE.inner.lock_irqsave();
+        RCU_STATE.worker_started.store(true, Ordering::Release);
+        RCU_STATE.worker_starting.store(false, Ordering::Release);
+    }
+    RCU_STATE.wake_state_waiters();
+
     loop {
         RCU_STATE.worker_wait.wait_until(|| {
             if RCU_STATE.worker_should_stop.load(Ordering::Acquire) {
                 return Some(());
             }
 
-            if RCU_STATE.inner.lock_irqsave().has_drainable_work() {
+            if RCU_STATE.inner.lock_irqsave().has_worker_work() {
                 return Some(());
             }
 
@@ -799,6 +750,11 @@ fn worker_main() -> i32 {
         RCU_STATE.process_ready_callbacks();
     }
 
+    {
+        let _inner = RCU_STATE.inner.lock_irqsave();
+        RCU_STATE.worker_started.store(false, Ordering::Release);
+    }
+    RCU_STATE.wake_state_waiters();
     0
 }
 
@@ -814,14 +770,24 @@ pub fn start_worker() {
         return;
     }
 
-    let already = RCU_STATE.worker_started.swap(true, Ordering::AcqRel);
-    if already {
-        return;
+    {
+        let _inner = RCU_STATE.inner.lock_irqsave();
+        if RCU_STATE.worker_should_stop.load(Ordering::Acquire)
+            || RCU_STATE.worker_started.load(Ordering::Acquire)
+            || RCU_STATE.worker_starting.load(Ordering::Acquire)
+        {
+            return;
+        }
+        RCU_STATE.worker_starting.store(true, Ordering::Release);
     }
 
     let closure = KernelThreadClosure::EmptyClosure((Box::new(worker_main), ()));
     if KernelThreadMechanism::create_and_run(closure, "rcu_gp".to_string()).is_none() {
-        RCU_STATE.worker_started.store(false, Ordering::Release);
+        {
+            let _inner = RCU_STATE.inner.lock_irqsave();
+            RCU_STATE.worker_starting.store(false, Ordering::Release);
+        }
+        RCU_STATE.wake_state_waiters();
         error!("failed to create RCU callback worker");
         return;
     }
@@ -829,13 +795,25 @@ pub fn start_worker() {
     RCU_STATE.wake_worker();
 }
 
+/// Requests terminal asynchronous shutdown of the RCU worker.
+///
+/// This is a teardown operation: the global RCU worker is initialized once
+/// and must not be restarted after shutdown has been requested.
 pub fn shutdown_worker() {
-    if !rcu_enabled() || !RCU_STATE.worker_started.load(Ordering::Acquire) {
+    if !rcu_enabled() {
         return;
     }
 
-    RCU_STATE.worker_should_stop.store(true, Ordering::Release);
-    RCU_STATE.wake_worker();
+    let wake_worker = {
+        let _inner = RCU_STATE.inner.lock_irqsave();
+        let wake_worker = RCU_STATE.worker_started.load(Ordering::Acquire)
+            || RCU_STATE.worker_starting.load(Ordering::Acquire);
+        RCU_STATE.worker_should_stop.store(true, Ordering::Release);
+        wake_worker
+    };
+    if wake_worker {
+        RCU_STATE.wake_worker();
+    }
 }
 
 /// Enters a non-preemptible, non-sleepable ordinary-RCU read-side section.
@@ -910,8 +888,9 @@ pub fn rcu_assign_pointer<T>(ptr: &AtomicPtr<T>, value: *mut T) {
 ///
 /// # Safety
 ///
-/// `head` must remain valid until `func` runs and must not be queued again
-/// before that invocation begins.
+/// `head` must remain initialized at the same address until `func` begins. It
+/// must not be queued again before that point. Clearing the duplicate state
+/// does not transfer ownership to an unsynchronized third party.
 pub(crate) unsafe fn call_rcu_raw(head: NonNull<RcuHead>, func: RcuRawCallback) {
     if !rcu_enabled() {
         // SAFETY: before RCU init there is no concurrent reader relying on
@@ -920,16 +899,20 @@ pub(crate) unsafe fn call_rcu_raw(head: NonNull<RcuHead>, func: RcuRawCallback) 
         return;
     }
 
-    // SAFETY: the caller guarantees that `head` is valid until callback
-    // completion and not queued twice concurrently.
-    let already = unsafe { head.as_ref().queued.swap(true, Ordering::AcqRel) };
-    if already {
+    // SAFETY: the caller guarantees that `head` remains initialized at this
+    // address until callback invocation starts.
+    if !unsafe { head.as_ref() }.try_claim() {
         panic!("call_rcu_raw received a duplicated rcu_head enqueue");
     }
 
     queue_raw_callback(head, func);
 }
 
+/// Defers a closure until after a future grace period.
+///
+/// This convenience API allocates before raw callback admission. It must not
+/// be called from IRQ or other contexts where allocation is forbidden; use an
+/// object-embedded [`RcuHead`] with `call_rcu_raw()` there.
 pub fn rcu_defer<F>(f: F)
 where
     F: FnOnce() + Send + 'static,
@@ -939,9 +922,12 @@ where
         return;
     }
 
-    queue_deferred_callback(Box::new(f));
+    submit_deferred_rcu_call(Box::new(DeferredRcuCall::new(f)));
 }
 
+/// Defers destruction using the allocating [`rcu_defer`] helper.
+///
+/// This must not be called from IRQ or another non-allocating context.
 pub fn rcu_defer_drop<T>(value: T)
 where
     T: Send + 'static,
@@ -957,6 +943,8 @@ where
 /// On failure, the original reference is returned and has not been published
 /// to the RCU callback queue. The caller must keep it alive through a grace
 /// period before dropping it.
+///
+/// This helper still invokes the allocator and is not an IRQ-context API.
 pub(crate) fn try_rcu_defer_drop_arc<T>(value: Arc<T>) -> Result<(), Arc<T>>
 where
     T: Send + Sync + 'static,
@@ -967,13 +955,12 @@ where
     }
 
     let queued_value = value.clone();
-    let call: Box<dyn DeferredCall> = match Box::try_new(move || drop(queued_value)) {
-        Ok(call) => call,
-        Err(_) => return Err(value),
-    };
-
-    if let Err(call) = try_queue_deferred_callback(call) {
-        drop(call);
+    if try_queue_deferred_callback_with(
+        move || drop(queued_value),
+        |deferred| Box::try_new(deferred).map_err(|_| ()),
+    )
+    .is_err()
+    {
         return Err(value);
     }
 
@@ -1075,9 +1062,7 @@ pub fn rcu_barrier() {
     };
 
     loop {
-        if !RCU_STATE.worker_started.load(Ordering::Acquire) {
-            RCU_STATE.maybe_process_ready_callbacks_inline();
-        }
+        RCU_STATE.progress_and_drain_inline_if_no_worker();
 
         let done = {
             let inner = RCU_STATE.inner.lock_irqsave();
@@ -1088,6 +1073,7 @@ pub fn rcu_barrier() {
         }
 
         RCU_STATE.state_wait.wait_until(|| {
+            RCU_STATE.progress_and_drain_inline_if_no_worker();
             let completed = RCU_STATE
                 .inner
                 .lock_irqsave()
@@ -1254,19 +1240,18 @@ pub fn cpu_offline(cpu: ProcessorId) {
     RCU_STATE.wake_state_waiters();
     if wake_worker {
         RCU_STATE.wake_worker();
-        RCU_STATE.maybe_process_ready_callbacks_inline();
     }
 }
 
 #[allow(dead_code)]
-pub fn debug_snapshot() -> (u64, u64, u64, usize, usize) {
+pub fn debug_snapshot() -> (u64, u64, u64, usize, bool) {
     let inner = RCU_STATE.inner.lock_irqsave();
     (
         inner.gp.current().raw(),
         inner.gp.completed().raw(),
         inner.callbacks.completed_raw(),
-        inner.pending_callbacks.len(),
-        inner.ready_callbacks.len(),
+        inner.callback_queue.len(),
+        inner.has_ready_work(),
     )
 }
 

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -6,6 +6,8 @@ use core::{
 };
 
 use crate::{
+    arch::CurrentIrqArch,
+    exception::InterruptArch,
     ipc::sighand::SigHand,
     libs::{
         notifier::{AtomicNotifierChain, NotifierBlock, NotifyResult},
@@ -123,10 +125,95 @@ unsafe fn rcu_selftest_callback(head: NonNull<RcuHead>) {
     probe.hits.fetch_add(1, Ordering::SeqCst);
 }
 
+#[repr(C)]
+struct RcuSelftestRequeueProbe {
+    head: RcuHead,
+    hits: Arc<AtomicUsize>,
+}
+
+unsafe fn rcu_selftest_requeue_callback(head: NonNull<RcuHead>) {
+    let probe = head.as_ptr().cast::<RcuSelftestRequeueProbe>();
+    // SAFETY: `head` is the first field of the live boxed probe.
+    let hit = unsafe { (*probe).hits.fetch_add(1, Ordering::SeqCst) };
+    if hit == 0 {
+        // SAFETY: callback invocation has detached and released this head, and
+        // the Box remains at the same address until the second invocation.
+        unsafe { call_rcu_raw(head, rcu_selftest_requeue_callback) };
+    } else {
+        // SAFETY: the second callback owns the Box transferred by the test.
+        drop(unsafe { Box::from_raw(probe) });
+    }
+}
+
+fn run_duplicate_claim_selftest() -> Result<(), &'static str> {
+    let head = Arc::new(RcuHead::new());
+    let successes = Arc::new(AtomicUsize::new(0));
+    let ready = Arc::new(Completion::new());
+    let start = Arc::new(Completion::new());
+    let done = Arc::new(Completion::new());
+
+    let spawn = |name: &'static str| {
+        let head = head.clone();
+        let successes = successes.clone();
+        let ready = ready.clone();
+        let start = start.clone();
+        let done = done.clone();
+        let closure = KernelThreadClosure::EmptyClosure((
+            Box::new(move || {
+                ready.complete();
+                if start.wait_for_completion().is_err() {
+                    done.complete();
+                    return 1;
+                }
+                if head.try_claim() {
+                    successes.fetch_add(1, Ordering::SeqCst);
+                }
+                done.complete();
+                0
+            }),
+            (),
+        ));
+        KernelThreadMechanism::create_and_run(closure, name.to_string())
+    };
+
+    let first = spawn("rcu-duplicate-claim-a")
+        .ok_or("duplicate claim selftest could not create its first worker")?;
+    let Some(second) = spawn("rcu-duplicate-claim-b") else {
+        start.complete_all();
+        let _ = KernelThreadMechanism::stop(&first);
+        return Err("duplicate claim selftest could not create its second worker");
+    };
+
+    if ready.wait_for_completion().is_err() || ready.wait_for_completion().is_err() {
+        start.complete_all();
+        let _ = KernelThreadMechanism::stop(&first);
+        let _ = KernelThreadMechanism::stop(&second);
+        return Err("duplicate claim selftest workers did not reach their start gate");
+    }
+    start.complete_all();
+    if done.wait_for_completion().is_err() || done.wait_for_completion().is_err() {
+        let _ = KernelThreadMechanism::stop(&first);
+        let _ = KernelThreadMechanism::stop(&second);
+        return Err("duplicate claim selftest workers did not finish their claims");
+    }
+
+    let first_stopped = KernelThreadMechanism::stop(&first).is_ok();
+    let second_stopped = KernelThreadMechanism::stop(&second).is_ok();
+    if !first_stopped || !second_stopped {
+        return Err("duplicate claim selftest could not stop its workers");
+    }
+    if successes.load(Ordering::SeqCst) != 1 || !head.is_queued() {
+        return Err("duplicate claim did not have exactly one state transition");
+    }
+
+    Ok(())
+}
+
 fn run_pr1_selftest() -> Result<(), &'static str> {
     gp::run_state_machine_selftests()?;
     context::run_context_selftests()?;
     run_callback_generation_selftest()?;
+    run_duplicate_claim_selftest()?;
 
     if ProcessManager::current_pcb().rcu_read_depth() != 0 {
         return Err("initial rcu_read_depth was not zero");
@@ -155,9 +242,9 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
     }
 
     rcu_barrier();
-    let (_, completed_gp_before, completed_cb_before, pending_before, ready_before) =
+    let (_, completed_gp_before, completed_cb_before, queued_before, ready_before) =
         debug_snapshot();
-    if pending_before != 0 || ready_before != 0 {
+    if queued_before != 0 || ready_before {
         return Err("rcu callback queues were not empty before blocked-reader selftest");
     }
 
@@ -175,7 +262,7 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
             Err("rcu_defer callback ran before leaving the read-side critical section")
         } else {
             note_context_switch();
-            let (_, completed_gp_mid, completed_cb_mid, pending_mid, ready_mid) = debug_snapshot();
+            let (_, completed_gp_mid, completed_cb_mid, queued_mid, ready_mid) = debug_snapshot();
 
             if blocked_hits.load(Ordering::SeqCst) != 0 {
                 Err("context switch inside rcu_read_lock executed callback early")
@@ -183,7 +270,7 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
                 Err("context switch inside rcu_read_lock incorrectly completed a grace period")
             } else if completed_cb_mid != completed_cb_before {
                 Err("context switch inside rcu_read_lock incorrectly completed a callback")
-            } else if pending_mid != 1 || ready_mid != 0 {
+            } else if queued_mid != 1 || ready_mid {
                 Err("context switch inside rcu_read_lock corrupted callback queue state")
             } else {
                 Ok(())
@@ -200,6 +287,21 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
     }
 
     rcu_barrier();
+
+    let failed_allocation_drops = Arc::new(AtomicUsize::new(0));
+    let failed_allocation_probe = RcuSelftestDropProbe {
+        id: 30,
+        drops: failed_allocation_drops.clone(),
+    };
+    if try_queue_deferred_callback_with(move || drop(failed_allocation_probe), |_deferred| Err(()))
+        .is_ok()
+    {
+        return Err("injected deferred allocation failure unexpectedly published a callback");
+    }
+    if failed_allocation_drops.load(Ordering::SeqCst) != 1 {
+        return Err("deferred allocation failure did not return closure ownership");
+    }
+
     let callback_hits = Arc::new(AtomicUsize::new(0));
     let callback_probe = Box::new(RcuSelftestCallbackProbe {
         head: RcuHead::new(),
@@ -209,17 +311,42 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
 
     // SAFETY: `callback_probe` stays alive until `rcu_selftest_callback()`
     // reconstructs and consumes the allocation.
-    unsafe {
-        call_rcu_raw(
-            NonNull::new_unchecked(ptr::addr_of_mut!((*callback_probe).head)),
-            rcu_selftest_callback,
-        );
+    {
+        let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
+        // SAFETY: `callback_probe` remains boxed at this address until the
+        // callback reconstructs it. Raw admission is allocation-free and is
+        // permitted while IRQs are disabled.
+        unsafe {
+            call_rcu_raw(
+                NonNull::new_unchecked(ptr::addr_of_mut!((*callback_probe).head)),
+                rcu_selftest_callback,
+            );
+        }
     }
 
     rcu_barrier();
 
     if callback_hits.load(Ordering::SeqCst) != 1 {
         return Err("call_rcu callback was not executed exactly once");
+    }
+
+    let requeue_hits = Arc::new(AtomicUsize::new(0));
+    let requeue_probe = Box::into_raw(Box::new(RcuSelftestRequeueProbe {
+        head: RcuHead::new(),
+        hits: requeue_hits.clone(),
+    }));
+    // SAFETY: the Box is transferred to the callback and stays at a stable
+    // address through both the initial admission and callback-side requeue.
+    unsafe {
+        call_rcu_raw(
+            NonNull::new_unchecked(ptr::addr_of_mut!((*requeue_probe).head)),
+            rcu_selftest_requeue_callback,
+        );
+    }
+    rcu_barrier();
+    rcu_barrier();
+    if requeue_hits.load(Ordering::SeqCst) != 2 {
+        return Err("callback-side RcuHead requeue did not execute exactly twice");
     }
 
     let deferred_drops = Arc::new(AtomicUsize::new(0));
@@ -269,9 +396,13 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
 }
 
 fn run_callback_generation_selftest() -> Result<(), &'static str> {
+    unsafe fn noop_callback(_head: NonNull<RcuHead>) {}
+
     let cpu0 = ProcessorId::new(0);
     let cpu1 = ProcessorId::new(1);
     let mut inner = RcuStateInner::new();
+    let first_head = RcuHead::new();
+    let second_head = RcuHead::new();
 
     let first_gp = inner.gp.request_future();
     if inner
@@ -282,35 +413,36 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
         return Err("callback generation selftest failed to start its first GP");
     }
 
-    // Admission and GP pumping are separate responsibilities. Keep this
-    // deterministic state-machine test independent of the live per-CPU
-    // context snapshots used by the production coordinator.
-    admit_callback_locked(&mut inner, CallbackKind::Deferred(Box::new(|| {})));
-    admit_callback_locked(&mut inner, CallbackKind::Deferred(Box::new(|| {})));
+    if !first_head.try_claim() || !second_head.try_claim() {
+        return Err("fresh callback generation heads could not be claimed");
+    }
+    enqueue_callback_locked(&mut inner, NonNull::from(&first_head), noop_callback);
+    enqueue_callback_locked(&mut inner, NonNull::from(&second_head), noop_callback);
 
     let expected_second_gp = first_gp.next();
-    if inner.pending_callbacks.len() != 2
-        || inner
-            .pending_callbacks
-            .iter()
-            .any(|callback| callback.target_gp != expected_second_gp)
+    if inner.callback_queue.len() != 2
+        || inner.callback_queue.front_target() != Some(expected_second_gp)
     {
         return Err("callback admitted during an active GP targeted the wrong generation");
+    }
+    if inner.has_worker_work() {
+        return Err("worker would spin on a future GP blocked by the active waiting mask");
     }
 
     if !inner.gp.report_quiescent_state(cpu0) {
         return Err("callback generation selftest could not complete its first waiting mask");
     }
-    RcuState::pump_grace_periods_with(
+    let first_ready_changed = RcuState::pump_grace_periods_with(
         &mut inner,
         || (CpuMask::from_cpu(cpu1), [0; PerCpu::MAX_CPU_NUM as usize]),
         |_| {},
         |_| {},
     );
-    if inner.gp.completed() != first_gp
+    if first_ready_changed
+        || inner.gp.completed() != first_gp
         || !inner.gp.is_waiting_for(cpu1)
-        || inner.pending_callbacks.len() != 2
-        || !inner.ready_callbacks.is_empty()
+        || inner.callback_queue.len() != 2
+        || inner.has_ready_work()
     {
         return Err("callbacks became ready before their post-admission GP completed");
     }
@@ -318,23 +450,31 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
     if !inner.gp.report_quiescent_state(cpu1) {
         return Err("callback generation selftest could not complete its second waiting mask");
     }
-    RcuState::pump_grace_periods_with(
+    let second_ready_changed = RcuState::pump_grace_periods_with(
         &mut inner,
         || (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
         |_| {},
         |_| {},
     );
-    if inner.gp.completed() != expected_second_gp
-        || !inner.pending_callbacks.is_empty()
-        || inner.ready_callbacks.len() != 2
+    if !second_ready_changed
+        || inner.gp.completed() != expected_second_gp
+        || inner.callback_queue.len() != 2
+        || !inner.has_ready_work()
     {
         return Err("callbacks did not become ready after their target GP completed");
     }
+    if !inner.has_worker_work() {
+        return Err("worker did not recognize a ready intrusive callback");
+    }
 
-    let first_callback = inner.ready_callbacks.pop_front().unwrap();
-    let second_callback = inner.ready_callbacks.pop_front().unwrap();
+    let completed_gp = inner.gp.completed();
+    let first_callback = inner.callback_queue.pop_ready(completed_gp).unwrap();
+    let second_callback = inner.callback_queue.pop_ready(completed_gp).unwrap();
     if second_callback.seq != first_callback.seq.next() {
         return Err("callback generation transition did not preserve admission FIFO");
+    }
+    if !inner.callback_queue.is_empty() {
+        return Err("callback generation transition did not drain its FIFO");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

- replace growable pending/ready callback queues with one global intrusive FIFO backed by `RcuHead`
- make raw callback publication bounded and allocation-free under the RCU IRQ-saving lock
- preserve FIFO, grace-period, exactly-once, callback reuse, and `rcu_barrier()` sequencing
- keep allocating closure helpers separate and document their task-context restriction
- harden worker wake/lifecycle handling without introducing per-CPU or segmented callback queues

## Safety and ordering

- callback nodes remain address-stable from admission until invocation starts
- dequeue copies callback metadata and detaches the head before clearing its queued state
- callbacks may destroy or requeue their embedded head without post-callback dereferences
- a unique drainer and continuous callback sequence tracking preserve global completion order

## Validation

- `make fmt`
- `make kernel`
- x86_64 two-CPU QEMU boot
- `/sys/kernel/debug/rcu/selftest`: `status=ok`
- `rcu_selftest_test`: all tests passed, including repeated stability runs

Closes #2212