### PR TITLE
feat(rcu): support CPU hotplug lifecycle

### DIFF
--- a/kernel/src/arch/riscv64/process/kthread.rs
+++ b/kernel/src/arch/riscv64/process/kthread.rs
@@ -42,6 +42,7 @@ impl KernelThreadMechanism {
         let mut clone_args = KernelCloneArgs::new();
         clone_args.flags = clone_flags;
         clone_args.kthread = true;
+        clone_args.kthread_flags = info.flags();
         if info
             .flags()
             .contains(crate::process::kthread::KernelThreadFlags::IS_PER_CPU)

--- a/kernel/src/arch/x86_64/process/kthread.rs
+++ b/kernel/src/arch/x86_64/process/kthread.rs
@@ -46,6 +46,7 @@ impl KernelThreadMechanism {
         let mut clone_args = KernelCloneArgs::new();
         clone_args.flags = clone_flags | CloneFlags::CLONE_UNTRACED;
         clone_args.kthread = true;
+        clone_args.kthread_flags = info.flags();
         if info
             .flags()
             .contains(crate::process::kthread::KernelThreadFlags::IS_PER_CPU)

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -1020,9 +1020,7 @@ pub(crate) fn stop_this_cpu() -> ! {
         CurrentIrqArch::interrupt_disable();
     }
 
-    crate::rcu::cpu_offline(cpu_id);
-    // 将当前cpu标记为offline
-    smp_cpu_manager().set_online_cpu(cpu_id, false);
+    smp_cpu_manager().shutdown_current_cpu(cpu_id);
     CurrentApic.disable_local_apic();
 
     loop {

--- a/kernel/src/arch/x86_64/process/mod.rs
+++ b/kernel/src/arch/x86_64/process/mod.rs
@@ -1020,8 +1020,9 @@ pub(crate) fn stop_this_cpu() -> ! {
         CurrentIrqArch::interrupt_disable();
     }
 
-    smp_cpu_manager().shutdown_current_cpu(cpu_id);
+    smp_cpu_manager().begin_shutdown_current_cpu(cpu_id);
     CurrentApic.disable_local_apic();
+    smp_cpu_manager().complete_shutdown_current_cpu(cpu_id);
 
     loop {
         native_halt();

--- a/kernel/src/arch/x86_64/reboot.rs
+++ b/kernel/src/arch/x86_64/reboot.rs
@@ -191,7 +191,9 @@ fn stop_other_cpus() {
         return;
     }
 
-    crate::arch::interrupt::ipi::send_ipi(IpiKind::StopCpu, IpiTarget::Other);
+    for cpu in targets.iter_cpu() {
+        crate::arch::interrupt::ipi::send_ipi(IpiKind::StopCpu, IpiTarget::Specified(cpu));
+    }
 
     for _ in 0..STOP_OTHER_CPUS_TIMEOUT_LOOPS {
         if targets

--- a/kernel/src/arch/x86_64/reboot.rs
+++ b/kernel/src/arch/x86_64/reboot.rs
@@ -196,7 +196,7 @@ fn stop_other_cpus() {
     for _ in 0..STOP_OTHER_CPUS_TIMEOUT_LOOPS {
         if targets
             .iter_cpu()
-            .all(|cpu| !smp_cpu_manager().is_online_cpu(cpu))
+            .all(|cpu| smp_cpu_manager().is_dead_cpu(cpu))
         {
             return;
         }
@@ -204,10 +204,11 @@ fn stop_other_cpus() {
     }
 
     for cpu in targets.iter_cpu() {
-        if smp_cpu_manager().is_online_cpu(cpu) {
+        if !smp_cpu_manager().is_dead_cpu(cpu) {
             log::warn!(
-                "stop_other_cpus: CPU {} did not stop before timeout",
-                cpu.data()
+                "stop_other_cpus: CPU {} did not reach Dead before timeout (state: {:?})",
+                cpu.data(),
+                smp_cpu_manager().cpuhp_state(cpu).state()
             );
         }
     }

--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -1,6 +1,6 @@
 use super::{
     account_successful_fork, alloc_pid, inc_visible_thread_count,
-    kthread::{KernelThreadPcbPrivate, WorkerPrivate},
+    kthread::{KernelThreadFlags, KernelThreadPcbPrivate, WorkerPrivate},
     lock_fs_refs_copy,
     pid::{Pid, PidType},
     FsRefsReadGuard, KernelStack, ProcessControlBlock, ProcessManager, RawPid,
@@ -133,6 +133,9 @@ pub struct KernelCloneArgs {
 
     pub io_thread: bool,
     pub kthread: bool,
+    /// Creation-time kernel-thread properties that must be visible before the
+    /// child is published in the task table.
+    pub kthread_flags: KernelThreadFlags,
     pub idle: bool,
     pub func: VirtAddr,
     pub fn_arg: VirtAddr,
@@ -158,6 +161,7 @@ impl KernelCloneArgs {
             cgroup: 0,
             io_thread: false,
             kthread: false,
+            kthread_flags: KernelThreadFlags::empty(),
             idle: false,
             func: null_addr,
             fn_arg: null_addr,
@@ -668,9 +672,10 @@ impl ProcessManager {
         drop(guard);
 
         // 为内核线程设置WorkerPrivate
-        if current_pcb.flags().contains(ProcessFlags::KTHREAD) {
-            *pcb.worker_private() =
-                Some(WorkerPrivate::KernelThread(KernelThreadPcbPrivate::new()));
+        if clone_args.kthread {
+            let mut private = KernelThreadPcbPrivate::new();
+            *private.flags_mut() |= clone_args.kthread_flags;
+            *pcb.worker_private() = Some(WorkerPrivate::KernelThread(private));
         }
 
         // 设置clear_child_tid，在线程结束时将其置0以通知父进程

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -319,12 +319,15 @@ impl KernelThreadCreateInfo {
             return;
         }
 
-        let mut worker_private_guard = pcb.worker_private();
+        let worker_private_guard = pcb.worker_private();
         let worker_private = worker_private_guard
-            .as_mut()
-            .and_then(|x| x.kernel_thread_mut())
+            .as_ref()
+            .and_then(|x| x.kernel_thread())
             .expect("kthread create: missing worker_private");
-        worker_private.flags |= flags;
+        assert!(
+            worker_private.flags.contains(flags),
+            "kthread create: creation flags were not published before the task"
+        );
         drop(worker_private_guard);
 
         if flags.contains(KernelThreadFlags::IS_PER_CPU) {

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -350,6 +350,15 @@ impl KernelThreadCreateInfo {
 pub struct KernelThreadMechanism;
 
 impl KernelThreadMechanism {
+    fn submit_create_info(info: Arc<KernelThreadCreateInfo>) -> Option<Arc<ProcessControlBlock>> {
+        while !KTHREAD_DAEMON_READY.load(Ordering::Acquire) {
+            spin_loop()
+        }
+        KTHREAD_CREATE_LIST.lock().push_back(info.clone());
+        Self::notify_daemon();
+        info.poll_result()
+    }
+
     pub fn init_stage1() {
         assert!(ProcessManager::current_pcb().raw_pid() == RawPid::new(0));
         info!("Initializing kernel thread mechanism stage1...");
@@ -421,13 +430,19 @@ impl KernelThreadMechanism {
     #[allow(dead_code)]
     pub fn create(func: KernelThreadClosure, name: String) -> Option<Arc<ProcessControlBlock>> {
         let info = KernelThreadCreateInfo::new(func, name);
-        while !KTHREAD_DAEMON_READY.load(Ordering::Acquire) {
-            // 等待kthreadd启动
-            spin_loop()
-        }
-        KTHREAD_CREATE_LIST.lock().push_back(info.clone());
-        Self::notify_daemon();
-        return info.poll_result();
+        Self::submit_create_info(info)
+    }
+
+    /// Creates a stopped per-CPU kthread whose affinity is installed before
+    /// its first instruction can run.
+    pub fn create_on_cpu(
+        func: KernelThreadClosure,
+        name: String,
+        cpu: ProcessorId,
+    ) -> Option<Arc<ProcessControlBlock>> {
+        let info = KernelThreadCreateInfo::new(func, name);
+        info.set_per_cpu(cpu).ok()?;
+        Self::submit_create_info(info)
     }
 
     /// Notify kthreadd after publishing create or zombie-reap work.
@@ -455,6 +470,19 @@ impl KernelThreadMechanism {
         ProcessManager::wakeup(&pcb)
             .unwrap_or_else(|_| panic!("Failed to wakeup kthread: {:?}", pcb.raw_pid()));
         return Some(pcb);
+    }
+
+    /// Creates and wakes a per-CPU kthread. Its affinity cannot be changed by
+    /// userspace after creation.
+    pub fn create_and_run_on_cpu(
+        func: KernelThreadClosure,
+        name: String,
+        cpu: ProcessorId,
+    ) -> Option<Arc<ProcessControlBlock>> {
+        let pcb = Self::create_on_cpu(func, name, cpu)?;
+        ProcessManager::wakeup(&pcb)
+            .unwrap_or_else(|_| panic!("Failed to wakeup kthread: {:?}", pcb.raw_pid()));
+        Some(pcb)
     }
 
     /// 停止一个内核线程

--- a/kernel/src/rcu/context.rs
+++ b/kernel/src/rcu/context.rs
@@ -221,6 +221,17 @@ impl RcuContextTracker {
         }
     }
 
+    /// Resets an AP's context before it becomes eligible for future GPs.
+    ///
+    /// The hotplug coordinator must exclude this CPU from both the RCU
+    /// participation mask and the active GP while this runs. There can be no
+    /// local context transition because the AP has not started executing yet.
+    pub(super) fn reset_for_cpu_starting(&self) {
+        self.gp_report_needed.store(false, Ordering::SeqCst);
+        self.state
+            .store(BaseContext::Kernel as u64, Ordering::SeqCst);
+    }
+
     /// Must be published before the coordinator snapshots this CPU.
     #[inline]
     pub(super) fn prepare_gp_report(&self) {

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -24,15 +24,11 @@ use core::{
 use log::warn;
 
 use crate::{
-    init::initial_kthread::{get_system_state, SystemState},
     libs::{cpumask::CpuMask, spinlock::SpinLock, wait_queue::WaitQueue},
     mm::percpu::PerCpu,
     process::{kthread::KernelThreadClosure, kthread::KernelThreadMechanism, ProcessManager},
     sched::{sched_yield, SchedPolicy},
-    smp::{
-        core::smp_get_processor_id,
-        cpu::{AtomicProcessorId, ProcessorId},
-    },
+    smp::{core::smp_get_processor_id, cpu::ProcessorId},
 };
 
 mod callback;
@@ -389,7 +385,6 @@ struct RcuState {
     worker_starting: AtomicBool,
     worker_started: AtomicBool,
     worker_should_stop: AtomicBool,
-    callback_worker_cpu: AtomicProcessorId,
     gp_active: AtomicBool,
     contexts: [RcuContextTracker; PerCpu::MAX_CPU_NUM as usize],
     inner: SpinLock<RcuStateInner>,
@@ -404,7 +399,6 @@ impl RcuState {
             worker_starting: AtomicBool::new(false),
             worker_started: AtomicBool::new(false),
             worker_should_stop: AtomicBool::new(false),
-            callback_worker_cpu: AtomicProcessorId::new(ProcessorId::INVALID),
             gp_active: AtomicBool::new(false),
             contexts: [const { RcuContextTracker::new() }; PerCpu::MAX_CPU_NUM as usize],
             inner: SpinLock::new(RcuStateInner::new()),
@@ -796,18 +790,12 @@ pub fn start_worker() {
     }
 
     let worker_cpu = smp_get_processor_id();
-    RCU_STATE
-        .callback_worker_cpu
-        .store(worker_cpu, Ordering::Release);
     let closure = KernelThreadClosure::EmptyClosure((Box::new(worker_main), ()));
     if KernelThreadMechanism::create_and_run_on_cpu(closure, "rcu_gp".to_string(), worker_cpu)
         .is_none()
     {
         let _inner = RCU_STATE.inner.lock_irqsave();
         RCU_STATE.worker_starting.store(false, Ordering::Release);
-        RCU_STATE
-            .callback_worker_cpu
-            .store(ProcessorId::INVALID, Ordering::Release);
         panic!("failed to create the bound RCU callback worker");
     }
 
@@ -1287,12 +1275,6 @@ pub fn cpu_dying(cpu: ProcessorId) {
     if !rcu_enabled() {
         return;
     }
-
-    let worker_cpu = RCU_STATE.callback_worker_cpu.load(Ordering::Acquire);
-    assert!(
-        get_system_state() != SystemState::Running || cpu != worker_cpu,
-        "cannot offline the RCU callback-worker CPU while the system is running"
-    );
 
     let wake_worker = {
         let mut inner = RCU_STATE.inner.lock_irqsave();

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -24,13 +24,14 @@ use core::{
 use log::warn;
 
 use crate::{
+    init::initial_kthread::{get_system_state, SystemState},
     libs::{cpumask::CpuMask, spinlock::SpinLock, wait_queue::WaitQueue},
     mm::percpu::PerCpu,
     process::{kthread::KernelThreadClosure, kthread::KernelThreadMechanism, ProcessManager},
     sched::{sched_yield, SchedPolicy},
     smp::{
         core::smp_get_processor_id,
-        cpu::{smp_cpu_manager, smp_cpu_manager_initialized, ProcessorId},
+        cpu::{AtomicProcessorId, ProcessorId},
     },
 };
 
@@ -349,6 +350,9 @@ where
 
 struct RcuStateInner {
     gp: GracePeriodState,
+    /// CPUs that have executed the RCU starting hook and are eligible for
+    /// future GP snapshots. The active GP keeps its own immutable snapshot.
+    participating_cpus: CpuMask,
     callbacks: CallbackTracker,
     callback_queue: RcuCallbackList,
 }
@@ -357,6 +361,7 @@ impl RcuStateInner {
     fn new() -> Self {
         Self {
             gp: GracePeriodState::new(),
+            participating_cpus: CpuMask::new(),
             callbacks: CallbackTracker::new(),
             callback_queue: RcuCallbackList::new(),
         }
@@ -384,6 +389,7 @@ struct RcuState {
     worker_starting: AtomicBool,
     worker_started: AtomicBool,
     worker_should_stop: AtomicBool,
+    callback_worker_cpu: AtomicProcessorId,
     gp_active: AtomicBool,
     contexts: [RcuContextTracker; PerCpu::MAX_CPU_NUM as usize],
     inner: SpinLock<RcuStateInner>,
@@ -398,6 +404,7 @@ impl RcuState {
             worker_starting: AtomicBool::new(false),
             worker_started: AtomicBool::new(false),
             worker_should_stop: AtomicBool::new(false),
+            callback_worker_cpu: AtomicProcessorId::new(ProcessorId::INVALID),
             gp_active: AtomicBool::new(false),
             contexts: [const { RcuContextTracker::new() }; PerCpu::MAX_CPU_NUM as usize],
             inner: SpinLock::new(RcuStateInner::new()),
@@ -413,7 +420,7 @@ impl RcuState {
     fn pump_grace_periods(inner: &mut RcuStateInner) -> bool {
         Self::pump_grace_periods_with(
             inner,
-            online_context_snapshot,
+            participating_context_snapshot,
             credit_context_progress_locked,
             publish_gp_active,
         )
@@ -421,7 +428,7 @@ impl RcuState {
 
     fn pump_grace_periods_with(
         inner: &mut RcuStateInner,
-        mut waiting_snapshot: impl FnMut() -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]),
+        mut waiting_snapshot: impl FnMut(&CpuMask) -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]),
         mut credit_context: impl FnMut(&mut GracePeriodState),
         mut publish_active: impl FnMut(bool),
     ) -> bool {
@@ -450,7 +457,7 @@ impl RcuState {
             // ordered before the fresh CPU snapshot that defines GP start.
             publish_active(true);
             fence(Ordering::SeqCst);
-            let (waiting_cpus, context_generations) = waiting_snapshot();
+            let (waiting_cpus, context_generations) = waiting_snapshot(&inner.participating_cpus);
             inner.gp.start_requested(waiting_cpus, context_generations);
         }
 
@@ -550,29 +557,13 @@ fn publish_gp_active(active: bool) {
     }
 }
 
-fn online_context_snapshot() -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]) {
+fn participating_context_snapshot(
+    participating_cpus: &CpuMask,
+) -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]) {
     let mut waiting = CpuMask::new();
     let mut generations = [0; PerCpu::MAX_CPU_NUM as usize];
 
-    if smp_cpu_manager_initialized() {
-        let cpu_manager = smp_cpu_manager();
-        for cpu in cpu_manager.present_cpus().iter_cpu() {
-            if !cpu_manager.is_online_cpu(cpu) {
-                continue;
-            }
-
-            let context = &RCU_STATE.contexts[cpu.data() as usize];
-            context.prepare_gp_report();
-            let snapshot = context.snapshot();
-            generations[cpu.data() as usize] = snapshot.generation();
-            if snapshot.is_watching() {
-                waiting.set(cpu, true);
-            } else {
-                context.clear_gp_report();
-            }
-        }
-    } else {
-        let cpu = smp_get_processor_id();
+    for cpu in participating_cpus.iter_cpu() {
         let context = &RCU_STATE.contexts[cpu.data() as usize];
         context.prepare_gp_report();
         let snapshot = context.snapshot();
@@ -624,6 +615,19 @@ fn report_quiescent_state_locked(inner: &mut RcuStateInner, cpu: ProcessorId) ->
         RCU_STATE.contexts[cpu.data() as usize].clear_gp_report();
     }
     cleared
+}
+
+fn prepare_cpu_starting_locked(inner: &RcuStateInner, cpu: ProcessorId) -> bool {
+    !inner.participating_cpus.get(cpu).unwrap_or(false) && !inner.gp.is_waiting_for(cpu)
+}
+
+fn cpu_starting_locked(inner: &mut RcuStateInner, cpu: ProcessorId) {
+    inner.participating_cpus.set(cpu, true);
+}
+
+fn cpu_dying_locked(inner: &mut RcuStateInner, cpu: ProcessorId) {
+    inner.participating_cpus.set(cpu, false);
+    report_quiescent_state_locked(inner, cpu);
 }
 
 fn report_quiescent_state(cpu: ProcessorId) {
@@ -759,10 +763,20 @@ fn worker_main() -> i32 {
 }
 
 pub fn init() {
-    let already = RCU_STATE.initialized.swap(true, Ordering::AcqRel);
-    if already {
+    if RCU_STATE.initialized.load(Ordering::Acquire) {
         return;
     }
+
+    // The BSP is already executing and may have used its persistent context
+    // before the SMP manager exists. Admit it without applying the AP restart
+    // reset protocol.
+    let boot_cpu = smp_get_processor_id();
+    let mut inner = RCU_STATE.inner.lock_irqsave();
+    let previous = inner.participating_cpus.set(boot_cpu, true);
+    debug_assert_eq!(previous, Some(false));
+    drop(inner);
+
+    RCU_STATE.initialized.store(true, Ordering::Release);
 }
 
 pub fn start_worker() {
@@ -781,9 +795,21 @@ pub fn start_worker() {
         RCU_STATE.worker_starting.store(true, Ordering::Release);
     }
 
+    let worker_cpu = smp_get_processor_id();
+    RCU_STATE
+        .callback_worker_cpu
+        .store(worker_cpu, Ordering::Release);
     let closure = KernelThreadClosure::EmptyClosure((Box::new(worker_main), ()));
-    KernelThreadMechanism::create_and_run(closure, "rcu_gp".to_string())
-        .expect("failed to create required RCU callback worker");
+    if KernelThreadMechanism::create_and_run_on_cpu(closure, "rcu_gp".to_string(), worker_cpu)
+        .is_none()
+    {
+        let _inner = RCU_STATE.inner.lock_irqsave();
+        RCU_STATE.worker_starting.store(false, Ordering::Release);
+        RCU_STATE
+            .callback_worker_cpu
+            .store(ProcessorId::INVALID, Ordering::Release);
+        panic!("failed to create the bound RCU callback worker");
+    }
 
     RCU_STATE.wake_worker();
 }
@@ -1218,14 +1244,60 @@ pub fn irq_exit(token: RcuIrqToken, disposition: RcuIrqDisposition) {
     note_context_eqs_transition(transition);
 }
 
-pub fn cpu_offline(cpu: ProcessorId) {
+/// Prepares an AP's context before the SMP coordinator publishes Starting.
+///
+/// Returns false if a previous lifecycle still owns RCU participation or GP
+/// responsibility. The caller must not start the AP in that case.
+pub fn prepare_cpu_starting(cpu: ProcessorId) -> bool {
+    if !rcu_enabled() {
+        return true;
+    }
+
+    let inner = RCU_STATE.inner.lock_irqsave();
+    if !prepare_cpu_starting_locked(&inner, cpu) {
+        return false;
+    }
+    RCU_STATE.contexts[cpu.data() as usize].reset_for_cpu_starting();
+    true
+}
+
+/// Admits the current AP to future GP snapshots.
+///
+/// This must run on the incoming CPU with interrupts disabled, before its
+/// startup path first uses ordinary RCU. It deliberately does not modify the
+/// immutable waiting snapshot of an already-active GP.
+pub fn cpu_starting(cpu: ProcessorId) {
     if !rcu_enabled() {
         return;
     }
 
+    let mut inner = RCU_STATE.inner.lock_irqsave();
+    cpu_starting_locked(&mut inner, cpu);
+    drop(inner);
+
+    // Match Linux rcu_cpu_starting(): no ordinary RCU read-side operation on
+    // the incoming AP may become visible before its context initialization
+    // and future-GP admission are globally published.
+    fence(Ordering::SeqCst);
+}
+
+/// Removes a CPU from future GP admission and transfers its active-GP
+/// responsibility before the CPU becomes unable to report.
+pub fn cpu_dying(cpu: ProcessorId) {
+    if !rcu_enabled() {
+        return;
+    }
+
+    let worker_cpu = RCU_STATE.callback_worker_cpu.load(Ordering::Acquire);
+    assert!(
+        get_system_state() != SystemState::Running || cpu != worker_cpu,
+        "cannot offline the RCU callback-worker CPU while the system is running"
+    );
+
     let wake_worker = {
         let mut inner = RCU_STATE.inner.lock_irqsave();
-        report_quiescent_state_locked(&mut inner, cpu);
+        cpu_dying_locked(&mut inner, cpu);
+        RCU_STATE.contexts[cpu.data() as usize].clear_gp_report();
         let ready_changed = RcuState::pump_grace_periods(&mut inner);
         ready_changed || inner.has_ready_work()
     };

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     process::kthread::{KernelThreadClosure, KernelThreadMechanism},
     sched::completion::Completion,
-    smp::cpu::ProcessorId,
+    smp::cpu::{smp_cpu_manager, ProcessorId},
 };
 use system_error::SystemError;
 
@@ -214,6 +214,8 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
     context::run_context_selftests()?;
     run_callback_generation_selftest()?;
     run_duplicate_claim_selftest()?;
+    run_cpu_hotplug_lifecycle_selftest()?;
+    run_cpu_hotplug_concurrent_selftest()?;
 
     if ProcessManager::current_pcb().rcu_read_depth() != 0 {
         return Err("initial rcu_read_depth was not zero");
@@ -434,7 +436,7 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
     }
     let first_ready_changed = RcuState::pump_grace_periods_with(
         &mut inner,
-        || (CpuMask::from_cpu(cpu1), [0; PerCpu::MAX_CPU_NUM as usize]),
+        |_| (CpuMask::from_cpu(cpu1), [0; PerCpu::MAX_CPU_NUM as usize]),
         |_| {},
         |_| {},
     );
@@ -452,7 +454,7 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
     }
     let second_ready_changed = RcuState::pump_grace_periods_with(
         &mut inner,
-        || (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
+        |_| (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
         |_| {},
         |_| {},
     );
@@ -475,6 +477,258 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
     }
     if !inner.callback_queue.is_empty() {
         return Err("callback generation transition did not drain its FIFO");
+    }
+
+    Ok(())
+}
+
+fn run_cpu_hotplug_lifecycle_selftest() -> Result<(), &'static str> {
+    let cpu = ProcessorId::new(PerCpu::MAX_CPU_NUM - 1);
+    let incoming = ProcessorId::new(PerCpu::MAX_CPU_NUM - 2);
+    let snapshot =
+        |participants: &CpuMask| (participants.clone(), [0; PerCpu::MAX_CPU_NUM as usize]);
+    let mut inner = RcuStateInner::new();
+
+    if !prepare_cpu_starting_locked(&inner, cpu) {
+        return Err("fresh offline CPU was not eligible for RCU preparation");
+    }
+
+    // BSP publication of Starting does not admit an AP that has not executed
+    // its local RCU starting hook.
+    let before_ap_runs = inner.gp.request_future();
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    if !inner.gp.has_completed(before_ap_runs) || inner.gp.is_waiting_for(cpu) {
+        return Err("RCU waited for a Starting CPU before its AP-side hook");
+    }
+
+    cpu_starting_locked(&mut inner, cpu);
+    let after_ap_runs = inner.gp.request_future();
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    if !inner.gp.is_waiting_for(cpu) || inner.gp.has_completed(after_ap_runs) {
+        return Err("RCU did not admit a CPU after its AP-side starting hook");
+    }
+    if prepare_cpu_starting_locked(&inner, cpu) {
+        return Err("RCU allowed an active participant to be prepared again");
+    }
+
+    // An AP becoming RCU-ready during an active GP must join only the next
+    // fresh snapshot.
+    if !prepare_cpu_starting_locked(&inner, incoming) {
+        return Err("incoming CPU could not be prepared during an active GP");
+    }
+    cpu_starting_locked(&mut inner, incoming);
+    if inner.gp.is_waiting_for(incoming) {
+        return Err("incoming CPU was added to an already-active GP");
+    }
+    let next_gp = inner.gp.request_future();
+
+    // This is the original offline/new-GP race in deterministic order: the
+    // first GP observed the CPU, Dying removes both future admission and its
+    // existing responsibility under the same lock, and the next GP snapshot
+    // must not add it back.
+    cpu_dying_locked(&mut inner, cpu);
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    if inner.gp.is_waiting_for(cpu)
+        || !inner.gp.is_waiting_for(incoming)
+        || inner.gp.has_completed(next_gp)
+    {
+        return Err("Dying CPU was re-admitted or incoming CPU missed the next GP");
+    }
+
+    cpu_dying_locked(&mut inner, incoming);
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    if !inner.gp.has_completed(next_gp) {
+        return Err("CPU Dying did not complete the GP it was responsible for");
+    }
+
+    // Repeated model transitions use the same production mask operations and
+    // ensure no waiting bit leaks across generations. This is not presented as
+    // a substitute for a future platform-level CPU restart stress test.
+    for _ in 0..32 {
+        if !prepare_cpu_starting_locked(&inner, cpu) {
+            return Err("completed CPU teardown left stale RCU responsibility");
+        }
+        cpu_starting_locked(&mut inner, cpu);
+        let target = inner.gp.request_future();
+        RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+        if !inner.gp.is_waiting_for(cpu) {
+            return Err("repeated RCU lifecycle did not admit its online CPU");
+        }
+        cpu_dying_locked(&mut inner, cpu);
+        RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+        if !inner.gp.has_completed(target) || inner.gp.is_waiting_for(cpu) {
+            return Err("repeated RCU lifecycle leaked a GP holdout");
+        }
+    }
+
+    // Queue ownership and barrier tickets remain global while Dying advances
+    // the target GP. The bound worker invariant covers the later execution.
+    cpu_starting_locked(&mut inner, cpu);
+    unsafe fn noop_callback(_head: NonNull<RcuHead>) {}
+    let callback_head = RcuHead::new();
+    if !callback_head.try_claim() {
+        return Err("fresh hotplug callback head could not be claimed");
+    }
+    enqueue_callback_locked(&mut inner, NonNull::from(&callback_head), noop_callback);
+    let barrier_target = inner
+        .callbacks
+        .barrier_target()
+        .ok_or("hotplug callback did not create a barrier target")?;
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    cpu_dying_locked(&mut inner, cpu);
+    RcuState::pump_grace_periods_with(&mut inner, snapshot, |_| {}, |_| {});
+    let callback = inner
+        .callback_queue
+        .pop_ready(inner.gp.completed())
+        .ok_or("Dying CPU did not advance its pending callback")?;
+    inner.callbacks.complete(callback.seq);
+    if !inner.callbacks.has_completed(barrier_target) {
+        return Err("callback barrier ticket was lost across CPU Dying");
+    }
+
+    Ok(())
+}
+
+fn run_cpu_hotplug_concurrent_selftest() -> Result<(), &'static str> {
+    const ROUNDS: usize = 32;
+
+    // Use an absent logical CPU so the test exercises the production global
+    // lifecycle hooks without racing a real CPU's context tracker. This is a
+    // concurrency test for the RCU protocol, not a claim that platform-level
+    // CPU reset/restart has been implemented.
+    let Some(synthetic_cpu) = (0..PerCpu::MAX_CPU_NUM)
+        .rev()
+        .map(ProcessorId::new)
+        .find(|&cpu| !smp_cpu_manager().present_cpus().get(cpu).unwrap_or(false))
+    else {
+        // A machine using every representable logical CPU has no context slot
+        // that a synthetic lifecycle test may safely borrow.
+        return Ok(());
+    };
+
+    let round_ready = Arc::new(Completion::new());
+    let round_release = Arc::new(Completion::new());
+    let round_withdrawn = Arc::new(Completion::new());
+    let round_advance = Arc::new(Completion::new());
+    let finished = Arc::new(Completion::new());
+    let failed = Arc::new(AtomicBool::new(false));
+    let completed_rounds = Arc::new(AtomicUsize::new(0));
+    let callback_hits = Arc::new(AtomicUsize::new(0));
+
+    let round_ready_worker = round_ready.clone();
+    let round_release_worker = round_release.clone();
+    let round_withdrawn_worker = round_withdrawn.clone();
+    let round_advance_worker = round_advance.clone();
+    let finished_worker = finished.clone();
+    let failed_worker = failed.clone();
+    let completed_rounds_worker = completed_rounds.clone();
+    let callback_hits_worker = callback_hits.clone();
+    let closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            for _ in 0..ROUNDS {
+                if !prepare_cpu_starting(synthetic_cpu) {
+                    failed_worker.store(true, Ordering::Release);
+                    round_ready_worker.complete_all();
+                    round_withdrawn_worker.complete_all();
+                    round_advance_worker.complete_all();
+                    break;
+                }
+                cpu_starting(synthetic_cpu);
+
+                // Exercise a real read-side section and global callback
+                // admission while the lifecycle participant is visible.
+                {
+                    let _guard = rcu_read_lock();
+                    core::hint::black_box(0usize);
+                }
+                rcu_defer({
+                    let callback_hits = callback_hits_worker.clone();
+                    move || {
+                        callback_hits.fetch_add(1, Ordering::AcqRel);
+                    }
+                });
+
+                // Hold the synthetic participant until the main task has
+                // admitted its concurrent reader/callback workload. Explicit
+                // handoff avoids relying on scheduler yield fairness.
+                round_ready_worker.complete();
+                if round_release_worker.wait_for_completion().is_err() {
+                    failed_worker.store(true, Ordering::Release);
+                    cpu_dying(synthetic_cpu);
+                    round_withdrawn_worker.complete_all();
+                    round_advance_worker.complete_all();
+                    break;
+                }
+                cpu_dying(synthetic_cpu);
+                completed_rounds_worker.fetch_add(1, Ordering::AcqRel);
+                round_withdrawn_worker.complete();
+                if round_advance_worker.wait_for_completion().is_err() {
+                    failed_worker.store(true, Ordering::Release);
+                    break;
+                }
+            }
+
+            // Idempotent cleanup keeps a failed round from poisoning later GPs.
+            cpu_dying(synthetic_cpu);
+            finished_worker.complete();
+            0
+        }),
+        (),
+    ));
+    let Some(worker) = KernelThreadMechanism::create_and_run(
+        closure,
+        "rcu-hotplug-concurrency-selftest".to_string(),
+    ) else {
+        return Err("RCU hotplug concurrency selftest could not create its worker");
+    };
+
+    for _ in 0..ROUNDS {
+        if round_ready.wait_for_completion().is_err() {
+            round_release.complete_all();
+            round_advance.complete_all();
+            let _ = KernelThreadMechanism::stop(&worker);
+            return Err("RCU hotplug concurrency selftest missed lifecycle admission");
+        }
+        {
+            let _guard = rcu_read_lock();
+            core::hint::black_box(1usize);
+        }
+        rcu_defer({
+            let callback_hits = callback_hits.clone();
+            move || {
+                callback_hits.fetch_add(1, Ordering::AcqRel);
+            }
+        });
+        round_release.complete();
+        synchronize_rcu();
+        rcu_barrier();
+        if round_withdrawn.wait_for_completion().is_err() {
+            round_release.complete_all();
+            round_advance.complete_all();
+            let _ = KernelThreadMechanism::stop(&worker);
+            return Err("RCU hotplug concurrency selftest missed lifecycle withdrawal");
+        }
+        // Do not let the next synthetic Starting race ahead of this round's
+        // synchronize/barrier completion and become an unintended holdout.
+        round_advance.complete();
+    }
+
+    let finished_result = finished.wait_for_completion();
+    let stop_result = KernelThreadMechanism::stop(&worker);
+    cpu_dying(synthetic_cpu);
+    rcu_barrier();
+
+    if finished_result.is_err() || stop_result.is_err() {
+        return Err("RCU hotplug concurrency selftest worker did not finish cleanly");
+    }
+    if failed.load(Ordering::Acquire) {
+        return Err("RCU hotplug concurrency selftest rejected a clean lifecycle round");
+    }
+    if completed_rounds.load(Ordering::Acquire) != ROUNDS {
+        return Err("RCU hotplug concurrency selftest lost a lifecycle transition");
+    }
+    if callback_hits.load(Ordering::Acquire) != ROUNDS * 2 {
+        return Err("RCU hotplug concurrency selftest lost or duplicated a callback");
     }
 
     Ok(())

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -317,17 +317,34 @@ impl SmpCpuManager {
 
         if let Err(e) = self.do_cpuhp_kick_ap(cpu_id) {
             let ap_parked = cpu_state.bringup_result.load(Ordering::Acquire) < 0;
-            cpu_state.publish_state(if ap_parked {
+            let failure_state = if ap_parked {
                 CpuHpState::FailedParked
             } else {
                 prev_state
-            });
-            rcu::cpu_dying(cpu_id);
+            };
+            let _ = cpu_state.state.compare_exchange(
+                CpuHpState::Starting as u32,
+                failure_state as u32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            );
             unsafe { cpu_state.configure_bringup(prev_state, false) };
             return Err(e);
         }
 
-        cpu_state.publish_state(target_state);
+        if cpu_state
+            .state
+            .compare_exchange(
+                CpuHpState::Starting as u32,
+                target_state as u32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_err()
+        {
+            unsafe { cpu_state.configure_bringup(prev_state, false) };
+            return Err(SystemError::EBUSY);
+        }
         unsafe { cpu_state.configure_bringup(target_state, false) };
 
         Ok(())
@@ -392,25 +409,60 @@ impl SmpCpuManager {
         }
     }
 
-    /// Runs the irreversible local CPU shutdown lifecycle.
+    /// Begins the irreversible local CPU shutdown lifecycle.
     ///
     /// The caller must be the target CPU, have interrupts disabled, and must
     /// not execute ordinary RCU read-side code after entering this method.
-    pub fn shutdown_current_cpu(&self, cpu_id: ProcessorId) {
+    pub fn begin_shutdown_current_cpu(&self, cpu_id: ProcessorId) {
         assert_eq!(cpu_id, smp_get_processor_id());
         let cpu_state = self.cpuhp_state(cpu_id);
+
+        loop {
+            let state = cpu_state.state();
+            match state {
+                CpuHpState::Dying | CpuHpState::Dead => return,
+                _ => {
+                    if cpu_state
+                        .state
+                        .compare_exchange(
+                            state as u32,
+                            CpuHpState::Dying as u32,
+                            Ordering::AcqRel,
+                            Ordering::Acquire,
+                        )
+                        .is_ok()
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        rcu::cpu_dying(cpu_id);
+    }
+
+    /// Publishes terminal teardown only after architecture-local interrupt
+    /// sources can no longer deliver work to this CPU.
+    ///
+    /// The caller must be the target CPU and must have completed the matching
+    /// architecture-local interrupt shutdown after `begin_shutdown_current_cpu`.
+    pub fn complete_shutdown_current_cpu(&self, cpu_id: ProcessorId) {
+        assert_eq!(cpu_id, smp_get_processor_id());
+        let cpu_state = self.cpuhp_state(cpu_id);
+        if cpu_state.state() == CpuHpState::Dead {
+            return;
+        }
         cpu_state
             .state
             .compare_exchange(
-                CpuHpState::Online as u32,
                 CpuHpState::Dying as u32,
-                Ordering::AcqRel,
+                CpuHpState::Dead as u32,
+                Ordering::Release,
                 Ordering::Acquire,
             )
-            .unwrap_or_else(|state| panic!("invalid CPU shutdown transition from state {state}"));
-
-        rcu::cpu_dying(cpu_id);
-        cpu_state.publish_state(CpuHpState::Dead);
+            .unwrap_or_else(|state| {
+                panic!("invalid terminal CPU shutdown transition from state {state}")
+            });
     }
 }
 

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -12,6 +12,7 @@ use crate::{
     libs::cpumask::CpuMask,
     mm::percpu::{PerCpu, PerCpuVar},
     process::{ProcessControlBlock, ProcessManager},
+    rcu,
     sched::completion::Completion,
 };
 
@@ -50,6 +51,12 @@ pub enum CpuHpState {
     /// 该CPU是在线的
     Online,
 
+    /// CPU 已进入不可逆停止路径，不再接受普通工作或加入新的 RCU GP。
+    Dying,
+
+    /// CPU 已完成 RCU teardown，可以永久停止。
+    Dead,
+
     /// AP 已经运行并在初始化失败后进入终止 park，不能按 Offline 重试。
     FailedParked,
 }
@@ -77,7 +84,8 @@ pub struct CpuHpCpuState {
 
 // SAFETY: `state`, `bringup_result` and `comp_done_up` provide their own
 // synchronization. `control` is private and is only accessed by the single
-// BSP hotplug coordinator; APs never read or write it.
+// BSP hotplug coordinator. AP-side lifecycle publications go through the
+// manager methods and never access `control`.
 unsafe impl Sync for CpuHpCpuState {}
 
 impl CpuHpCpuState {
@@ -106,6 +114,8 @@ impl CpuHpCpuState {
             value if value == CpuHpState::Offline as u32 => CpuHpState::Offline,
             value if value == CpuHpState::Starting as u32 => CpuHpState::Starting,
             value if value == CpuHpState::Online as u32 => CpuHpState::Online,
+            value if value == CpuHpState::Dying as u32 => CpuHpState::Dying,
+            value if value == CpuHpState::Dead as u32 => CpuHpState::Dead,
             value if value == CpuHpState::FailedParked as u32 => CpuHpState::FailedParked,
             _ => CpuHpState::FailedParked,
         }
@@ -233,19 +243,15 @@ impl SmpCpuManager {
         unsafe { self.cpuhp_state.force_get(cpu_id) }
     }
 
-    pub fn set_online_cpu(&self, cpu_id: ProcessorId, is_online: bool) {
-        let target_state = if is_online {
-            CpuHpState::Online
-        } else {
-            CpuHpState::Offline
-        };
-        self.cpuhp_state(cpu_id).publish_state(target_state);
-    }
-
     #[inline]
     #[allow(dead_code)]
     pub fn is_online_cpu(&self, cpu_id: ProcessorId) -> bool {
         self.cpuhp_state(cpu_id).state.load(Ordering::Acquire) == CpuHpState::Online as u32
+    }
+
+    #[inline]
+    pub fn is_dead_cpu(&self, cpu_id: ProcessorId) -> bool {
+        self.cpuhp_state(cpu_id).state.load(Ordering::Acquire) == CpuHpState::Dead as u32
     }
 
     /// 获取出现在系统中的CPU
@@ -286,9 +292,11 @@ impl SmpCpuManager {
         match cpu_state {
             CpuHpState::Online if target_state == CpuHpState::Online => return Ok(()),
             CpuHpState::Offline => {}
-            CpuHpState::Starting | CpuHpState::FailedParked | CpuHpState::Online => {
-                return Err(SystemError::EBUSY)
-            }
+            CpuHpState::Starting
+            | CpuHpState::Online
+            | CpuHpState::Dying
+            | CpuHpState::Dead
+            | CpuHpState::FailedParked => return Err(SystemError::EBUSY),
         }
 
         self.cpuhp_kick_ap(cpu_id, target_state)
@@ -301,6 +309,9 @@ impl SmpCpuManager {
     ) -> Result<(), SystemError> {
         let cpu_state = self.cpuhp_state(cpu_id);
         let prev_state = cpu_state.state();
+        if !rcu::prepare_cpu_starting(cpu_id) {
+            return Err(SystemError::EBUSY);
+        }
         unsafe { cpu_state.configure_bringup(target_state, true) };
         cpu_state.publish_state(CpuHpState::Starting);
 
@@ -311,6 +322,7 @@ impl SmpCpuManager {
             } else {
                 prev_state
             });
+            rcu::cpu_dying(cpu_id);
             unsafe { cpu_state.configure_bringup(prev_state, false) };
             return Err(e);
         }
@@ -379,6 +391,27 @@ impl SmpCpuManager {
             todo!("complete_ap_thread")
         }
     }
+
+    /// Runs the irreversible local CPU shutdown lifecycle.
+    ///
+    /// The caller must be the target CPU, have interrupts disabled, and must
+    /// not execute ordinary RCU read-side code after entering this method.
+    pub fn shutdown_current_cpu(&self, cpu_id: ProcessorId) {
+        assert_eq!(cpu_id, smp_get_processor_id());
+        let cpu_state = self.cpuhp_state(cpu_id);
+        cpu_state
+            .state
+            .compare_exchange(
+                CpuHpState::Online as u32,
+                CpuHpState::Dying as u32,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .unwrap_or_else(|state| panic!("invalid CPU shutdown transition from state {state}"));
+
+        rcu::cpu_dying(cpu_id);
+        cpu_state.publish_state(CpuHpState::Dead);
+    }
 }
 
 pub fn smp_cpu_manager_init(boot_cpu: ProcessorId) {
@@ -388,7 +421,9 @@ pub fn smp_cpu_manager_init(boot_cpu: ProcessorId) {
 
     unsafe { smp_cpu_manager().set_possible_cpu(boot_cpu, true) };
     unsafe { smp_cpu_manager().set_present_cpu(boot_cpu, true) };
-    smp_cpu_manager().set_online_cpu(boot_cpu, true);
+    smp_cpu_manager()
+        .cpuhp_state(boot_cpu)
+        .publish_state(CpuHpState::Online);
 
     SmpCpuManager::arch_init(boot_cpu);
 }

--- a/kernel/src/smp/init.rs
+++ b/kernel/src/smp/init.rs
@@ -11,8 +11,17 @@ use crate::{
 #[inline(never)]
 pub fn smp_ap_start_stage2() -> ! {
     assert!(!CurrentIrqArch::is_irq_enabled());
+    let cpu = smp_get_processor_id();
+
+    // Match Linux's rcu_cpu_starting() placement: the AP is executing with
+    // interrupts disabled, and RCU admission precedes startup code that may
+    // use ordinary RCU. An already-active GP keeps its earlier snapshot.
+    crate::rcu::cpu_starting(cpu);
 
     if let Err(error) = do_ap_start_stage2() {
+        // Withdraw GP responsibility before publishing completion and
+        // entering the terminal park where this AP can no longer report.
+        crate::rcu::cpu_dying(cpu);
         smp_cpu_manager().complete_ap_thread(true, Err(error));
         park_failed_ap();
     }

--- a/kernel/src/smp/syscall/sys_sched_setaffinity.rs
+++ b/kernel/src/smp/syscall/sys_sched_setaffinity.rs
@@ -6,7 +6,7 @@ use system_error::SystemError;
 use crate::arch::interrupt::TrapFrame;
 use crate::arch::syscall::nr::SYS_SCHED_SETAFFINITY;
 use crate::libs::cpumask::CpuMask;
-use crate::process::{ProcessFlags, ProcessManager, RawPid};
+use crate::process::{kthread::KernelThreadFlags, ProcessFlags, ProcessManager, RawPid};
 use crate::sched::{
     request_task_migration, select_task_rq, syscall::util::has_sched_setaffinity_permission,
 };
@@ -40,6 +40,17 @@ impl Syscall for SysSchedSetaffinity {
         let current_pcb = ProcessManager::current_pcb();
         if !has_sched_setaffinity_permission(&current_pcb, &target_pcb) {
             return Err(SystemError::EPERM);
+        }
+
+        if target_pcb.flags().contains(ProcessFlags::KTHREAD) {
+            let worker_private = target_pcb.worker_private();
+            let is_per_cpu = worker_private
+                .as_ref()
+                .and_then(|private| private.kernel_thread())
+                .is_some_and(|private| private.flags().contains(KernelThreadFlags::IS_PER_CPU));
+            if is_per_cpu {
+                return Err(SystemError::EINVAL);
+            }
         }
 
         let reader = UserBufferReader::new(set_vaddr as *const u8, size, frame.is_from_user())?;


### PR DESCRIPTION
## Summary

- track RCU-participating CPUs independently from the generic SMP online mask so an incoming CPU joins only future grace-period snapshots
- coordinate AP Starting, Dying, and Dead transitions with RCU context reset and grace-period responsibility transfer
- bind the global callback worker to its creation CPU and protect per-CPU kthread affinity from userspace changes
- add deterministic repeated-lifecycle and concurrent callback/grace-period selftests

## Design

The SMP coordinator prepares an AP's RCU context before publishing Starting. The AP then admits itself to future grace-period snapshots with interrupts disabled. A dying CPU removes itself from future snapshots and reports any active grace-period responsibility before the architecture stop path publishes Dead.

RCU callback ownership remains global and continues to use the intrusive callback queue from the current master. The callback worker is pinned before its first instruction runs, making its CPU ownership explicit instead of relying on a later affinity update.

## Validation

- `make kernel`
- `cargo +nightly-2026-02-24 fmt --all -- --check`
- `git diff --cached --check`

Closes #2211
