### PR TITLE
fix(net): prevent TCP self-connect shutdown deadlock

### DIFF
--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -322,27 +322,16 @@ impl TcpSocket {
             self.notify();
         }
 
-        if let Some(iface) = self
-            .inner
-            .read()
-            .as_ref()
-            .and_then(|inner| inner.iface())
-            .cloned()
-        {
+        if let Some(iface) = self.stack_poll_iface_snapshot() {
             // After a successful TCP recv() we may have just freed a significant portion of the
             // receive window. On loopback/blocking-large-send paths, sender progress depends on
             // promptly turning that freed window into ACK/window-update processing and sender-side
             // wakeups. A single poll is not always enough to complete the roundtrip, so mirror the
             // send path and drive the stack until quiescent.
-            if !matches!(
-                self.inner.read().as_ref(),
-                Some(inner::Inner::SelfConnected(_))
-            ) {
-                if let Some(netns) = iface.common().net_namespace() {
-                    netns.wakeup_poll_thread();
-                }
-                super::poll_util::poll_iface_until_quiescent(iface.as_ref());
+            if let Some(netns) = iface.common().net_namespace() {
+                netns.wakeup_poll_thread();
             }
+            super::poll_util::poll_iface_until_quiescent(iface.as_ref());
         }
     }
 
@@ -356,23 +345,11 @@ impl TcpSocket {
         loop {
             // SelfConnected does not rely on protocol-stack progress; avoid calling iface.poll()
             // here to prevent hangs when running the whole syscall test suite.
-            let skip_iface_poll = matches!(
-                self.inner.read().as_ref(),
-                Some(inner::Inner::SelfConnected(_))
-            );
-            if !skip_iface_poll {
-                if let Some(iface) = self
-                    .inner
-                    .read()
-                    .as_ref()
-                    .and_then(|inner| inner.iface())
-                    .cloned()
-                {
-                    if let Some(netns) = iface.common().net_namespace() {
-                        netns.wakeup_poll_thread();
-                    }
-                    super::poll_util::poll_iface_until_quiescent(iface.as_ref());
+            if let Some(iface) = self.stack_poll_iface_snapshot() {
+                if let Some(netns) = iface.common().net_namespace() {
+                    netns.wakeup_poll_thread();
                 }
+                super::poll_util::poll_iface_until_quiescent(iface.as_ref());
             }
 
             let iter_result = match self
@@ -479,23 +456,11 @@ impl TcpSocket {
         let mut total_read = 0usize;
 
         loop {
-            let skip_iface_poll = matches!(
-                self.inner.read().as_ref(),
-                Some(inner::Inner::SelfConnected(_))
-            );
-            if !skip_iface_poll {
-                if let Some(iface) = self
-                    .inner
-                    .read()
-                    .as_ref()
-                    .and_then(|inner| inner.iface())
-                    .cloned()
-                {
-                    if let Some(netns) = iface.common().net_namespace() {
-                        netns.wakeup_poll_thread();
-                    }
-                    super::poll_util::poll_iface_until_quiescent(iface.as_ref());
+            if let Some(iface) = self.stack_poll_iface_snapshot() {
+                if let Some(netns) = iface.common().net_namespace() {
+                    netns.wakeup_poll_thread();
                 }
+                super::poll_util::poll_iface_until_quiescent(iface.as_ref());
             }
 
             let iter_result = match self
@@ -588,8 +553,7 @@ impl TcpSocket {
         loop {
             match self.try_read_to_user_buffer(user_buffer) {
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                    if let Some(iface) = self.inner.read().as_ref().and_then(|i| i.iface()).cloned()
-                    {
+                    if let Some(iface) = self.stack_poll_iface_snapshot() {
                         super::poll_util::poll_iface_until_quiescent(iface.as_ref());
                     }
                     let events = self.check_io_event();
@@ -736,14 +700,20 @@ impl TcpSocket {
 
     fn try_send_direct(&self, buf: &[u8]) -> Result<usize, SystemError> {
         // Self-connect fast path: avoid smoltcp and iface polling.
-        {
+        let self_connected_result = {
             let inner_guard = self.inner.read();
             if let Some(inner::Inner::SelfConnected(sc)) = inner_guard.as_ref() {
-                let n = sc.send_slice(buf, self.is_send_shutdown())?;
-                // Wake reader (same fd in another thread) and refresh events.
-                self.notify();
-                return Ok(n);
+                Some(sc.send_slice(buf, self.is_send_shutdown()))
+            } else {
+                None
             }
+        };
+        if let Some(result) = self_connected_result {
+            let n = result?;
+            // Wake reader (same fd in another thread) and refresh events. `inner_guard`
+            // must be gone because notify() refreshes events by reading `inner` again.
+            self.notify();
+            return Ok(n);
         }
         // TODO: add nonblock check of connecting socket
         //
@@ -752,12 +722,7 @@ impl TcpSocket {
         // - poll BEFORE sending: to drain acks/advance state and make more send capacity available
         // - poll AFTER sending: to actually transmit queued segments and process immediate loopback delivery
         // Additionally, wake the netns poll thread so timers/retransmits can progress even if callers sleep.
-        let maybe_iface = self
-            .inner
-            .read()
-            .as_ref()
-            .and_then(|inner| inner.iface())
-            .cloned();
+        let maybe_iface = self.stack_poll_iface_snapshot();
         if let Some(iface) = maybe_iface.as_ref() {
             if let Some(netns) = iface.common().net_namespace() {
                 netns.wakeup_poll_thread();

--- a/kernel/src/net/socket/inet/stream/lifecycle.rs
+++ b/kernel/src/net/socket/inet/stream/lifecycle.rs
@@ -213,20 +213,26 @@ impl TcpSocket {
     pub fn try_accept(&self) -> Result<(Arc<TcpSocket>, smoltcp::wire::IpEndpoint), SystemError> {
         // 主动推进协议栈：避免依赖后台 poll 线程，保证 accept 在无事件通知场景下也能前进。
         // For INADDR_ANY listeners, poll all interfaces that have listen sockets.
-        {
+        let ifaces = {
             let reader = self.inner.read();
             if let Some(inner::Inner::Listening(listening)) = reader.as_ref() {
-                let mut polled_nics: alloc::vec::Vec<usize> = alloc::vec::Vec::new();
+                let mut ifaces: alloc::vec::Vec<Arc<dyn crate::net::Iface>> =
+                    alloc::vec::Vec::new();
                 for b in &listening.inners {
                     let nic_id = b.iface().nic_id();
-                    if !polled_nics.contains(&nic_id) {
-                        b.iface().poll();
-                        polled_nics.push(nic_id);
+                    if !ifaces.iter().any(|iface| iface.nic_id() == nic_id) {
+                        ifaces.push(b.iface().clone());
                     }
                 }
+                ifaces
             } else if let Some(iface) = reader.as_ref().and_then(|inner| inner.iface()).cloned() {
-                iface.poll();
+                alloc::vec![iface]
+            } else {
+                alloc::vec::Vec::new()
             }
+        };
+        for iface in ifaces {
+            iface.poll();
         }
 
         match self
@@ -377,13 +383,7 @@ impl TcpSocket {
 
     pub fn check_connect(&self) -> Result<(), SystemError> {
         // 主动推进协议栈：connect 阻塞等待期间也要持续 poll，否则状态不会从 Connecting 前进。
-        if let Some(iface) = self
-            .inner
-            .read()
-            .as_ref()
-            .and_then(|inner| inner.iface())
-            .cloned()
-        {
+        if let Some(iface) = self.stack_poll_iface_snapshot() {
             iface.poll();
         }
 

--- a/kernel/src/net/socket/inet/stream/mod.rs
+++ b/kernel/src/net/socket/inet/stream/mod.rs
@@ -202,8 +202,7 @@ impl Socket for TcpSocket {
                     // - Poll 1: TX sends data to loopback queue, RX processes existing packets
                     // - Poll 2: RX processes the data we just transmitted (loopback roundtrip)
                     // Without this loop, we'd wait for the poll thread to complete the roundtrip.
-                    if let Some(iface) = self.inner.read().as_ref().and_then(|i| i.iface()).cloned()
-                    {
+                    if let Some(iface) = self.stack_poll_iface_snapshot() {
                         poll_util::poll_iface_until_quiescent(iface.as_ref());
                     }
                     // 与 connect() 同理，不能只依赖缓存的 pollee 位。
@@ -291,8 +290,7 @@ impl Socket for TcpSocket {
                 }
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
                     // loopback 场景需要把协议栈推进到“真正可写/不可写”的稳定状态，避免丢唤醒。
-                    if let Some(iface) = self.inner.read().as_ref().and_then(|i| i.iface()).cloned()
-                    {
+                    if let Some(iface) = self.stack_poll_iface_snapshot() {
                         poll_util::poll_iface_until_quiescent(iface.as_ref());
                     }
 

--- a/kernel/src/net/socket/inet/stream/stream_core.rs
+++ b/kernel/src/net/socket/inet/stream/stream_core.rs
@@ -233,6 +233,19 @@ impl TcpSocket {
             .load(core::sync::atomic::Ordering::Relaxed)
     }
 
+    /// Returns an owned interface snapshot for paths that need to progress smoltcp.
+    ///
+    /// The `inner` guard is always released before this function returns. Callers may
+    /// therefore poll the interface without allowing `Iface::poll() -> notify()` to
+    /// recursively acquire `inner` while an outer read guard is still alive.
+    pub(super) fn stack_poll_iface_snapshot(&self) -> Option<Arc<dyn crate::net::Iface>> {
+        let inner = self.inner.read();
+        match inner.as_ref() {
+            Some(inner::Inner::SelfConnected(_)) | None => None,
+            Some(inner) => inner.iface().cloned(),
+        }
+    }
+
     #[inline]
     pub(crate) fn timestamp_enabled(&self) -> bool {
         self.options

--- a/user/apps/tests/dunitest/suites/normal/tcp_self_connect_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/tcp_self_connect_semantics.cc
@@ -4,6 +4,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <pthread.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -12,6 +13,7 @@
 #include <cstdint>
 #include <cstring>
 #include <string>
+#include <vector>
 
 namespace {
 
@@ -88,6 +90,69 @@ FdGuard CreateSelfConnectedSocket(int family) {
 
 class TcpSelfConnectSemantics : public testing::TestWithParam<int> {};
 
+struct ReaderResult {
+    int socket_fd;
+    pthread_barrier_t* start;
+    std::uint8_t expected_byte;
+    std::size_t bytes_read {0};
+    int error {0};
+    bool saw_eof {false};
+    bool data_mismatch {false};
+};
+
+void* ReadSelfConnectedStream(void* opaque) {
+    auto* result = static_cast<ReaderResult*>(opaque);
+    pthread_barrier_wait(result->start);
+
+    std::array<std::uint8_t, 2500> buffer {};
+    for (;;) {
+        const ssize_t count = read(result->socket_fd, buffer.data(), buffer.size());
+        if (count > 0) {
+            result->bytes_read += static_cast<std::size_t>(count);
+            result->data_mismatch |= !std::all_of(
+                buffer.begin(), buffer.begin() + count,
+                [result](std::uint8_t byte) { return byte == result->expected_byte; });
+            continue;
+        }
+        if (count == 0) {
+            result->saw_eof = true;
+            return nullptr;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        result->error = errno;
+        return nullptr;
+    }
+}
+
+struct SendAllResult {
+    std::size_t bytes_sent {0};
+    int error {0};
+};
+
+SendAllResult SendAll(int socket_fd, const std::uint8_t* data, std::size_t length) {
+    SendAllResult result;
+    while (result.bytes_sent < length) {
+        const ssize_t count =
+            send(socket_fd, data + result.bytes_sent, length - result.bytes_sent, 0);
+        if (count > 0) {
+            result.bytes_sent += static_cast<std::size_t>(count);
+            continue;
+        }
+        if (count == 0) {
+            result.error = EIO;
+            break;
+        }
+        if (errno == EINTR) {
+            continue;
+        }
+        result.error = errno;
+        break;
+    }
+    return result;
+}
+
 TEST_P(TcpSelfConnectSemantics, PartialProgressWinsOverWouldBlock) {
     FdGuard socket_fd = CreateSelfConnectedSocket(GetParam());
     ASSERT_GE(socket_fd.Get(), 0);
@@ -158,6 +223,61 @@ TEST_P(TcpSelfConnectSemantics, ReceiveShutdownDoesNotEraseCurrentReadProgress) 
         << ErrnoString(errno);
     EXPECT_TRUE(std::equal(kPayload.begin(), kPayload.end(), buffer.begin()));
     EXPECT_EQ(recv(recv_socket_fd.Get(), buffer.data(), buffer.size(), 0), 0);
+}
+
+TEST_P(TcpSelfConnectSemantics, ConcurrentReadSendAndWriteShutdownCompletes) {
+    // This is a bounded in-tree stress/smoke test for the lock-lifetime regression exercised by
+    // gVisor SelfConnectSendRecv. The high-count validation remains in the gVisor test because a
+    // scheduler race cannot be made deterministic without adding a test-only kernel hook.
+    constexpr std::size_t kIterations = 64;
+    constexpr std::size_t kPayloadSize = 1U << 20;
+    constexpr std::uint8_t kPayloadByte = 0x5a;
+    const std::vector<std::uint8_t> payload(kPayloadSize, kPayloadByte);
+
+    for (std::size_t iteration = 0; iteration < kIterations; ++iteration) {
+        FdGuard socket_fd = CreateSelfConnectedSocket(GetParam());
+        ASSERT_GE(socket_fd.Get(), 0) << "iteration " << iteration;
+
+        pthread_barrier_t start;
+        ASSERT_EQ(pthread_barrier_init(&start, nullptr, 2), 0) << "iteration " << iteration;
+
+        ReaderResult reader_result {};
+        reader_result.socket_fd = socket_fd.Get();
+        reader_result.start = &start;
+        reader_result.expected_byte = kPayloadByte;
+        pthread_t reader;
+        const int create_error =
+            pthread_create(&reader, nullptr, ReadSelfConnectedStream, &reader_result);
+        if (create_error != 0) {
+            pthread_barrier_destroy(&start);
+            FAIL() << "pthread_create failed at iteration " << iteration << ": "
+                   << ErrnoString(create_error);
+        }
+
+        pthread_barrier_wait(&start);
+        const SendAllResult send_result =
+            SendAll(socket_fd.Get(), payload.data(), payload.size());
+        const int shutdown_result = shutdown(socket_fd.Get(), SHUT_WR);
+        const int shutdown_error = shutdown_result == 0 ? 0 : errno;
+        const int join_error = pthread_join(reader, nullptr);
+        const int barrier_error = pthread_barrier_destroy(&start);
+
+        EXPECT_EQ(send_result.error, 0)
+            << "send failed at iteration " << iteration << ": "
+            << ErrnoString(send_result.error);
+        EXPECT_EQ(send_result.bytes_sent, payload.size()) << "iteration " << iteration;
+        EXPECT_EQ(shutdown_result, 0)
+            << "shutdown(SHUT_WR) failed at iteration " << iteration << ": "
+            << ErrnoString(shutdown_error);
+        EXPECT_EQ(join_error, 0) << "pthread_join failed at iteration " << iteration;
+        EXPECT_EQ(barrier_error, 0) << "pthread_barrier_destroy failed at iteration " << iteration;
+        EXPECT_EQ(reader_result.error, 0)
+            << "read failed at iteration " << iteration << ": "
+            << ErrnoString(reader_result.error);
+        EXPECT_TRUE(reader_result.saw_eof) << "iteration " << iteration;
+        EXPECT_FALSE(reader_result.data_mismatch) << "iteration " << iteration;
+        EXPECT_EQ(reader_result.bytes_read, payload.size()) << "iteration " << iteration;
+    }
 }
 
 INSTANTIATE_TEST_SUITE_P(IPv4AndIPv6, TcpSelfConnectSemantics,


### PR DESCRIPTION
## Summary

- release TCP socket inner read guards before interface polling or notification callbacks
- snapshot interface references in short critical sections across receive, send, connect, and accept paths
- add bounded IPv4 and IPv6 regression coverage for concurrent self-connect read, send, SHUT_WR, payload integrity, and EOF

## Root cause

Rust extends the temporary read guard created by an if-let scrutinee through the statement body. During self-connect receive progress, a concurrent shutdown writer could register behind that outer reader while a nested read waited behind the writer, creating a lock dependency cycle.

The fix preserves writer fairness and TCP semantics by structurally preventing polling and notification callbacks from running while an inner guard is held. It does not change RwSem behavior, buffer sizing, or waiting policy.

## Validation

- make fmt
- make kernel
- targeted DragonOS dunitest: 6/6 passed, including 64 IPv4 and 64 IPv6 regression iterations
- gVisor SelfConnectSendRecv: 10,000 IPv4 and 10,000 IPv6 iterations passed
- tcp_socket_test: 184/184 passed
- socket_ip_tcp_generic_loopback_test: 792/792 passed
- make test-syscall: 128/128 test binaries passed