### PR TITLE
fix(rcu): move context trackers out of lazy state

### DIFF
--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -423,7 +423,7 @@ struct RcuState {
     worker_started: AtomicBool,
     worker_should_stop: AtomicBool,
     gp_active: AtomicBool,
-    contexts: [RcuContextTracker; PerCpu::MAX_CPU_NUM as usize],
+    contexts: Box<[RcuContextTracker]>,
     cpu_callbacks: Box<[RcuCpuCallbacks]>,
     inner: SpinLock<RcuStateInner>,
     callback_ownership: SpinLock<()>,
@@ -440,9 +440,11 @@ struct RcuState {
 
 impl RcuState {
     fn new() -> Self {
-        // Construct the cache-line-aligned per-CPU records directly in heap
-        // storage. Materializing the complete array in this function's stack
-        // frame can exhaust the BSP's fixed 32-KiB boot stack.
+        // Construct both per-CPU arrays directly in heap storage. Embedding
+        // contexts in RcuState makes lazy initialization reserve a large stack
+        // frame even on the already-initialized fast path.
+        let mut contexts = Vec::with_capacity(PerCpu::MAX_CPU_NUM as usize);
+        contexts.resize_with(PerCpu::MAX_CPU_NUM as usize, RcuContextTracker::new);
         let mut cpu_callbacks = Vec::with_capacity(PerCpu::MAX_CPU_NUM as usize);
         cpu_callbacks.resize_with(PerCpu::MAX_CPU_NUM as usize, RcuCpuCallbacks::new);
 
@@ -452,7 +454,7 @@ impl RcuState {
             worker_started: AtomicBool::new(false),
             worker_should_stop: AtomicBool::new(false),
             gp_active: AtomicBool::new(false),
-            contexts: [const { RcuContextTracker::new() }; PerCpu::MAX_CPU_NUM as usize],
+            contexts: contexts.into_boxed_slice(),
             cpu_callbacks: cpu_callbacks.into_boxed_slice(),
             inner: SpinLock::new(RcuStateInner::new()),
             callback_ownership: SpinLock::new(()),


### PR DESCRIPTION
## Summary

- store per-CPU RCU context trackers in a fixed heap-backed slice
- keep the lazy RCU state value independent of `MAX_CPU_NUM`
- preserve tracker indexing, alignment, lifetime, synchronization, and CPU hotplug behavior

## Root cause

`RcuState` embedded the complete per-CPU context tracker array. The generated `spin::Once<RcuState>` lazy access path therefore reserved about 17 KiB of kernel stack even on the already-initialized fast path. When reached through a deep IRQ/softirq block-I/O completion and task wakeup chain, that frame could exhaust the fixed 32 KiB task kernel stack and corrupt current-PCB metadata.

The tracker array is persistent per-CPU state rather than function-local state. Constructing it directly in heap storage removes the CPU-count-sized value from the lazy state without changing RCU concurrency semantics.

## Validation

- `make kernel`
- final lazy/Once access frame reduced to about 440 bytes with no 4 KiB stack probes
- RCU selftests: PR1, PR2, PR3, and PR5 passed before and after stress
- three cold-cache `apt update` runs completed successfully
- one cached `apt update` run completed successfully
- 200-process execution stress run completed successfully