### PR TITLE
fix(rcu): guarantee grace-period forward progress

### DIFF
--- a/kernel/src/arch/x86_64/time.rs
+++ b/kernel/src/arch/x86_64/time.rs
@@ -12,9 +12,22 @@ pub fn time_init() {
 pub struct X86_64TimeArch;
 
 #[inline(always)]
+fn scale_by_ratio(value: usize, numerator: usize, denominator: usize) -> usize {
+    debug_assert_ne!(denominator, 0);
+    // `remainder < denominator`, so this proves that the only ordinary
+    // multiplication cannot overflow. The quotient term intentionally wraps
+    // with the architecture cycle counter, matching TimeArch's API.
+    debug_assert!(numerator <= usize::MAX / denominator);
+    let quotient = value / denominator;
+    let remainder = value - quotient * denominator;
+    quotient
+        .wrapping_mul(numerator)
+        .wrapping_add(remainder * numerator / denominator)
+}
+
+#[inline(always)]
 pub(crate) fn cycles_to_ns(cycles: usize, cpu_khz: u64) -> usize {
-    debug_assert_ne!(cpu_khz, 0);
-    ((cycles as u128 * 1_000_000u128) / cpu_khz as u128) as usize
+    scale_by_ratio(cycles, 1_000_000, cpu_khz as usize)
 }
 
 impl TimeArch for X86_64TimeArch {
@@ -24,7 +37,7 @@ impl TimeArch for X86_64TimeArch {
     }
 
     fn cal_expire_cycles(ns: usize) -> usize {
-        let delta = (ns as u128 * TSCManager::cpu_khz() as u128 / 1_000_000u128) as usize;
+        let delta = scale_by_ratio(ns, TSCManager::cpu_khz() as usize, 1_000_000);
         Self::get_cycles().wrapping_add(delta)
     }
 

--- a/kernel/src/arch/x86_64/time.rs
+++ b/kernel/src/arch/x86_64/time.rs
@@ -11,6 +11,12 @@ pub fn time_init() {
 
 pub struct X86_64TimeArch;
 
+#[inline(always)]
+pub(crate) fn cycles_to_ns(cycles: usize, cpu_khz: u64) -> usize {
+    debug_assert_ne!(cpu_khz, 0);
+    ((cycles as u128 * 1_000_000u128) / cpu_khz as u128) as usize
+}
+
 impl TimeArch for X86_64TimeArch {
     #[inline(always)]
     fn get_cycles() -> usize {
@@ -18,12 +24,13 @@ impl TimeArch for X86_64TimeArch {
     }
 
     fn cal_expire_cycles(ns: usize) -> usize {
-        Self::get_cycles() + ns * TSCManager::cpu_khz() as usize / 1000000
+        let delta = (ns as u128 * TSCManager::cpu_khz() as u128 / 1_000_000u128) as usize;
+        Self::get_cycles().wrapping_add(delta)
     }
 
     /// 将CPU的时钟周期数转换为纳秒
     #[inline(always)]
     fn cycles2ns(cycles: usize) -> usize {
-        cycles * 1000000 / TSCManager::cpu_khz() as usize
+        cycles_to_ns(cycles, TSCManager::cpu_khz())
     }
 }

--- a/kernel/src/debug/rcu.rs
+++ b/kernel/src/debug/rcu.rs
@@ -1,10 +1,17 @@
-use alloc::string::ToString;
+use alloc::string::{String, ToString};
 
 use crate::debug::sysfs::debugfs_kobj;
 use crate::driver::base::kobject::KObject;
 use crate::filesystem::kernfs::callback::{KernCallbackData, KernFSCallback, KernFilePrivateData};
 use crate::filesystem::vfs::{InodeMode, PollStatus};
+use crate::libs::mutex::Mutex;
 use system_error::SystemError;
+
+lazy_static! {
+    /// The production-path selftest intentionally holds a remote CPU until
+    /// escalation. Run it once and serve immutable snapshots thereafter.
+    static ref RCU_SELFTEST_REPORT: Mutex<Option<String>> = Mutex::new(None);
+}
 
 #[derive(Debug)]
 struct RcuDirCallBack;
@@ -43,9 +50,38 @@ struct RcuSelftestCallBack;
 #[derive(Debug)]
 struct RcuCallbacksCallBack;
 
+#[derive(Debug)]
+struct RcuStateCallBack;
+
+#[derive(Debug)]
+struct RcuStatsCallBack;
+
+fn read_debug_text(
+    data: KernCallbackData,
+    buf: &mut [u8],
+    offset: usize,
+) -> Result<usize, SystemError> {
+    let report = match data.file_private_data() {
+        Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
+        _ => return Err(SystemError::EINVAL),
+    };
+    let bytes = report.as_bytes();
+    if offset >= bytes.len() {
+        return Ok(0);
+    }
+    let len = buf.len().min(bytes.len() - offset);
+    buf[..len].copy_from_slice(&bytes[offset..offset + len]);
+    Ok(len)
+}
+
 impl KernFSCallback for RcuSelftestCallBack {
     fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
-        let report = crate::rcu::run_debug_selftests();
+        let report = {
+            let mut cached = RCU_SELFTEST_REPORT.lock();
+            cached
+                .get_or_insert_with(crate::rcu::run_debug_selftests)
+                .clone()
+        };
         data.file_private_data_mut()
             .replace(KernFilePrivateData::RcuSelftestReport(report));
         Ok(())
@@ -100,17 +136,7 @@ impl KernFSCallback for RcuCallbacksCallBack {
         buf: &mut [u8],
         offset: usize,
     ) -> Result<usize, SystemError> {
-        let report = match data.file_private_data() {
-            Some(KernFilePrivateData::DebugTextSnapshot(report)) => report,
-            _ => return Err(SystemError::EINVAL),
-        };
-        let bytes = report.as_bytes();
-        if offset >= bytes.len() {
-            return Ok(0);
-        }
-        let len = buf.len().min(bytes.len() - offset);
-        buf[..len].copy_from_slice(&bytes[offset..offset + len]);
-        Ok(len)
+        read_debug_text(data, buf, offset)
     }
 
     fn write(
@@ -127,6 +153,43 @@ impl KernFSCallback for RcuCallbacksCallBack {
     }
 }
 
+macro_rules! impl_rcu_snapshot_callback {
+    ($callback:ty, $snapshot:path) => {
+        impl KernFSCallback for $callback {
+            fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+                data.file_private_data_mut()
+                    .replace(KernFilePrivateData::DebugTextSnapshot($snapshot()));
+                Ok(())
+            }
+
+            fn read(
+                &self,
+                data: KernCallbackData,
+                buf: &mut [u8],
+                offset: usize,
+            ) -> Result<usize, SystemError> {
+                read_debug_text(data, buf, offset)
+            }
+
+            fn write(
+                &self,
+                _data: KernCallbackData,
+                _buf: &[u8],
+                _offset: usize,
+            ) -> Result<usize, SystemError> {
+                Err(SystemError::EPERM)
+            }
+
+            fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+                Ok(PollStatus::READ)
+            }
+        }
+    };
+}
+
+impl_rcu_snapshot_callback!(RcuStateCallBack, crate::rcu::state_debug_report);
+impl_rcu_snapshot_callback!(RcuStatsCallBack, crate::rcu::stats_debug_report);
+
 pub fn init_debugfs_rcu() -> Result<(), SystemError> {
     let debugfs = debugfs_kobj();
     let root_dir = debugfs.inode().ok_or(SystemError::ENOENT)?;
@@ -139,7 +202,7 @@ pub fn init_debugfs_rcu() -> Result<(), SystemError> {
 
     rcu_root.add_file(
         "selftest".to_string(),
-        InodeMode::S_IRUGO,
+        InodeMode::S_IRUSR,
         Some(4096),
         None,
         Some(&RcuSelftestCallBack),
@@ -150,6 +213,20 @@ pub fn init_debugfs_rcu() -> Result<(), SystemError> {
         Some(32 * 1024),
         None,
         Some(&RcuCallbacksCallBack),
+    )?;
+    rcu_root.add_file(
+        "state".to_string(),
+        InodeMode::S_IRUGO,
+        Some(32 * 1024),
+        None,
+        Some(&RcuStateCallBack),
+    )?;
+    rcu_root.add_file(
+        "stats".to_string(),
+        InodeMode::S_IRUGO,
+        Some(4096),
+        None,
+        Some(&RcuStatsCallBack),
     )?;
 
     Ok(())

--- a/kernel/src/exception/ipi.rs
+++ b/kernel/src/exception/ipi.rs
@@ -73,6 +73,7 @@ impl IrqHandler for KickCpuIpiHandler {
         ProcessManager::current_pcb()
             .flags()
             .insert(ProcessFlags::NEED_SCHEDULE);
+        crate::smp::note_kick_cpu_received();
         Ok(IrqReturn::Handled)
     }
 }

--- a/kernel/src/exception/softirq.rs
+++ b/kernel/src/exception/softirq.rs
@@ -74,6 +74,7 @@ pub enum SoftirqNumber {
     TIMER = 0,
     VideoRefresh = 1, //帧缓冲区刷新软中断
     TASKLET = 2,
+    RCU = 3,
 }
 
 impl From<u64> for SoftirqNumber {
@@ -88,6 +89,7 @@ bitflags! {
         const TIMER = 1 << 0;
         const VIDEO_REFRESH = 1 << 1;
         const TASKLET = 1 << 2;
+        const RCU = 1 << 3;
     }
 }
 

--- a/kernel/src/process/kthread.rs
+++ b/kernel/src/process/kthread.rs
@@ -477,6 +477,7 @@ impl KernelThreadMechanism {
 
     /// Creates and wakes a per-CPU kthread. Its affinity cannot be changed by
     /// userspace after creation.
+    #[allow(dead_code)]
     pub fn create_and_run_on_cpu(
         func: KernelThreadClosure,
         name: String,

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -656,6 +656,11 @@ impl ProcessControlBlock {
         return self.basic.read_irqsave();
     }
 
+    /// Non-blocking basic-info snapshot guard for lockup diagnostics.
+    pub(crate) fn try_basic(&self) -> Option<RwLockReadGuard<'_, ProcessBasicInfo>> {
+        self.basic.try_read_irqsave()
+    }
+
     /// Acquire the exec_update_lock read lock
     pub fn exec_update_read(&self) -> crate::libs::rwsem::RwSemReadGuard<'_, ()> {
         self.exec_update_lock.read()

--- a/kernel/src/rcu/context.rs
+++ b/kernel/src/rcu/context.rs
@@ -211,6 +211,12 @@ pub(super) struct RcuContextTracker {
     /// Coordinator-owned filter for the GP slow path. The GP waiting mask,
     /// not this hint, remains the source of truth for progress.
     gp_report_needed: AtomicBool,
+    /// Cooperative request for this CPU to reach a real scheduling/QS
+    /// boundary. The coordinator clears it; the local tick only observes it.
+    urgent_qs: AtomicBool,
+    /// Successful reschedule IPIs targeted at this CPU. Besides diagnostics,
+    /// this lets the production-path selftest identify its exact target.
+    resched_ipis: AtomicU64,
 }
 
 impl RcuContextTracker {
@@ -218,6 +224,8 @@ impl RcuContextTracker {
         Self {
             state: AtomicU64::new(BaseContext::Kernel as u64),
             gp_report_needed: AtomicBool::new(false),
+            urgent_qs: AtomicBool::new(false),
+            resched_ipis: AtomicU64::new(0),
         }
     }
 
@@ -228,6 +236,7 @@ impl RcuContextTracker {
     /// local context transition because the AP has not started executing yet.
     pub(super) fn reset_for_cpu_starting(&self) {
         self.gp_report_needed.store(false, Ordering::SeqCst);
+        self.urgent_qs.store(false, Ordering::Release);
         self.state
             .store(BaseContext::Kernel as u64, Ordering::SeqCst);
     }
@@ -246,6 +255,31 @@ impl RcuContextTracker {
     #[inline]
     pub(super) fn gp_report_needed(&self) -> bool {
         self.gp_report_needed.load(Ordering::SeqCst)
+    }
+
+    #[inline]
+    pub(super) fn request_urgent_qs(&self) {
+        self.urgent_qs.store(true, Ordering::Release);
+    }
+
+    #[inline]
+    pub(super) fn urgent_qs(&self) -> bool {
+        self.urgent_qs.load(Ordering::Acquire)
+    }
+
+    #[inline]
+    pub(super) fn clear_urgent_qs(&self) {
+        self.urgent_qs.store(false, Ordering::Release);
+    }
+
+    #[inline]
+    pub(super) fn note_resched_ipi(&self) {
+        self.resched_ipis.fetch_add(1, Ordering::Release);
+    }
+
+    #[inline]
+    pub(super) fn resched_ipis(&self) -> u64 {
+        self.resched_ipis.load(Ordering::Acquire)
     }
 
     /// Returns one coherent view of all context fields.
@@ -663,6 +697,8 @@ pub(super) fn run_context_selftests() -> Result<(), &'static str> {
     let overflow_irq = RcuContextTracker {
         state: AtomicU64::new(with_irq_depth(BaseContext::Kernel as u64, MAX_DEPTH)),
         gp_report_needed: AtomicBool::new(false),
+        urgent_qs: AtomicBool::new(false),
+        resched_ipis: AtomicU64::new(0),
     };
     if overflow_irq.irq_enter() != Err(ContextTransitionError::IrqDepthOverflow) {
         return Err("IRQ depth overflow was not rejected");
@@ -670,6 +706,8 @@ pub(super) fn run_context_selftests() -> Result<(), &'static str> {
     let overflow_nmi = RcuContextTracker {
         state: AtomicU64::new(with_nmi_depth(BaseContext::Kernel as u64, MAX_DEPTH)),
         gp_report_needed: AtomicBool::new(false),
+        urgent_qs: AtomicBool::new(false),
+        resched_ipis: AtomicU64::new(0),
     };
     if overflow_nmi.nmi_enter() != Err(ContextTransitionError::NmiDepthOverflow) {
         return Err("NMI depth overflow was not rejected");
@@ -704,6 +742,25 @@ pub(super) fn run_context_selftests() -> Result<(), &'static str> {
     mismatch
         .irq_exit(&outer_irq, IrqDisposition::ResumeInterrupted)
         .map_err(|_| "outer IRQ mismatch cleanup failed")?;
+
+    let urgent = RcuContextTracker::new();
+    urgent.request_urgent_qs();
+    if !urgent.urgent_qs() {
+        return Err("urgent-QS request was not published");
+    }
+    // Local observation deliberately does not consume the request.
+    if !urgent.urgent_qs() {
+        return Err("urgent-QS request was consumed by a reader");
+    }
+    urgent.clear_urgent_qs();
+    if urgent.urgent_qs() {
+        return Err("urgent-QS request was not cleared by the coordinator");
+    }
+    urgent.request_urgent_qs();
+    urgent.reset_for_cpu_starting();
+    if urgent.urgent_qs() {
+        return Err("CPU starting reset retained an old urgent-QS request");
+    }
 
     Ok(())
 }

--- a/kernel/src/rcu/context.rs
+++ b/kernel/src/rcu/context.rs
@@ -214,8 +214,7 @@ pub(super) struct RcuContextTracker {
     /// Cooperative request for this CPU to reach a real scheduling/QS
     /// boundary. The coordinator clears it; the local tick only observes it.
     urgent_qs: AtomicBool,
-    /// Successful reschedule IPIs targeted at this CPU. Besides diagnostics,
-    /// this lets the production-path selftest identify its exact target.
+    /// RCU reschedule IPIs successfully submitted to this CPU.
     resched_ipis: AtomicU64,
 }
 
@@ -274,12 +273,12 @@ impl RcuContextTracker {
 
     #[inline]
     pub(super) fn note_resched_ipi(&self) {
-        self.resched_ipis.fetch_add(1, Ordering::Release);
+        self.resched_ipis.fetch_add(1, Ordering::Relaxed);
     }
 
     #[inline]
     pub(super) fn resched_ipis(&self) -> u64 {
-        self.resched_ipis.load(Ordering::Acquire)
+        self.resched_ipis.load(Ordering::Relaxed)
     }
 
     /// Returns one coherent view of all context fields.

--- a/kernel/src/rcu/gp.rs
+++ b/kernel/src/rcu/gp.rs
@@ -120,6 +120,10 @@ impl GracePeriodState {
             .unwrap_or(false)
     }
 
+    pub(super) fn waiting_cpus_ref(&self) -> Option<&CpuMask> {
+        self.active.as_ref().map(|active| &active.waiting_cpus)
+    }
+
     /// Clears a CPU from the active GP. Repeated/non-waiting reports are
     /// intentionally idempotent and return false.
     pub(super) fn report_quiescent_state(&mut self, cpu: ProcessorId) -> bool {

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -25,28 +25,31 @@ use core::{
     fmt::Write,
     marker::PhantomData,
     ptr::{self, NonNull},
-    sync::atomic::{fence, AtomicBool, AtomicPtr, AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering},
 };
 
 use log::warn;
 
 use crate::{
+    exception::softirq::{softirq_vectors, SoftirqNumber, SoftirqVec},
     libs::{cpumask::CpuMask, mutex::Mutex, spinlock::SpinLock, wait_queue::WaitQueue},
     mm::percpu::PerCpu,
     process::{
         kthread::KernelThreadClosure, kthread::KernelThreadMechanism, preempt::PreemptGuard,
-        ProcessManager,
+        ProcessFlags, ProcessManager,
     },
-    sched::{cond_resched, sched_yield, SchedPolicy},
+    sched::{clock::SchedClock, cond_resched, sched_yield, SchedPolicy},
     smp::{
         core::smp_get_processor_id,
         cpu::{smp_cpu_manager, smp_cpu_manager_initialized, ProcessorId},
+        kick_cpu,
     },
 };
 
 mod callback;
 mod context;
 mod gp;
+mod progress;
 mod selftest;
 pub use callback::RcuHead;
 use callback::{RcuCallbackQueueDepth, RcuSegmentedCallbacks};
@@ -55,6 +58,9 @@ use context::{
     IrqEntry, RcuContextTracker,
 };
 use gp::{GracePeriodState, RcuSequence};
+use progress::{
+    validate_and_commit_stall, ActiveGpProgress, ProgressActions, ProgressCpuMask, StallCandidate,
+};
 pub use selftest::run_debug_selftests;
 
 pub(crate) type RcuRawCallback = unsafe fn(NonNull<RcuHead>);
@@ -359,6 +365,9 @@ where
 
 struct RcuStateInner {
     gp: GracePeriodState,
+    progress: Option<ActiveGpProgress>,
+    /// Fixed-size diagnostic handoff from timer IRQ to the RCU worker.
+    pending_stall: Option<StallCandidate>,
     /// CPUs that have executed the RCU starting hook and are eligible for
     /// future GP snapshots. The active GP keeps its own immutable snapshot.
     participating_cpus: CpuMask,
@@ -368,7 +377,45 @@ impl RcuStateInner {
     fn new() -> Self {
         Self {
             gp: GracePeriodState::new(),
+            progress: None,
+            pending_stall: None,
             participating_cpus: CpuMask::new(),
+        }
+    }
+}
+
+struct RcuStats {
+    gp_started: AtomicU64,
+    gp_completed: AtomicU64,
+    gp_total_ns: AtomicU64,
+    gp_max_ns: AtomicU64,
+    soft_requests: AtomicU64,
+    ipi_attempted: AtomicU64,
+    ipi_submitted: AtomicU64,
+    ipi_failed: AtomicU64,
+    stall_reports: AtomicU64,
+    callback_batches: AtomicU64,
+    callback_time_budget_hits: AtomicU64,
+    slow_callbacks: AtomicU64,
+    max_callback_ns: AtomicU64,
+}
+
+impl RcuStats {
+    const fn new() -> Self {
+        Self {
+            gp_started: AtomicU64::new(0),
+            gp_completed: AtomicU64::new(0),
+            gp_total_ns: AtomicU64::new(0),
+            gp_max_ns: AtomicU64::new(0),
+            soft_requests: AtomicU64::new(0),
+            ipi_attempted: AtomicU64::new(0),
+            ipi_submitted: AtomicU64::new(0),
+            ipi_failed: AtomicU64::new(0),
+            stall_reports: AtomicU64::new(0),
+            callback_batches: AtomicU64::new(0),
+            callback_time_budget_hits: AtomicU64::new(0),
+            slow_callbacks: AtomicU64::new(0),
+            max_callback_ns: AtomicU64::new(0),
         }
     }
 }
@@ -416,6 +463,18 @@ impl RcuCpuCallbacks {
 
 const RCU_CALLBACK_BATCH_LIMIT: usize = 64;
 const RCU_CALLBACK_CPU_QUANTUM: usize = 8;
+const RCU_CALLBACK_TIME_BUDGET_NS: u64 = 3_000_000;
+const RCU_SLOW_CALLBACK_NS: u64 = 10_000_000;
+const RCU_SLOW_WARNING_INTERVAL_NS: u64 = 1_000_000_000;
+
+#[inline]
+fn callback_duration_ns(started_at: u64, finished_at: u64) -> Option<u64> {
+    if started_at == 0 || !progress::deadline_reached(finished_at, started_at) {
+        None
+    } else {
+        Some(finished_at.wrapping_sub(started_at))
+    }
+}
 
 struct RcuState {
     initialized: AtomicBool,
@@ -423,6 +482,7 @@ struct RcuState {
     worker_started: AtomicBool,
     worker_should_stop: AtomicBool,
     gp_active: AtomicBool,
+    next_progress_at: AtomicU64,
     contexts: Box<[RcuContextTracker]>,
     cpu_callbacks: Box<[RcuCpuCallbacks]>,
     inner: SpinLock<RcuStateInner>,
@@ -431,6 +491,8 @@ struct RcuState {
     worker_kick_pending: AtomicBool,
     next_scan_cpu: AtomicUsize,
     callbacks_invoked: AtomicUsize,
+    stats: RcuStats,
+    next_slow_warning_at: AtomicU64,
     barrier_mutex: Mutex<()>,
     barrier_remaining: AtomicUsize,
     barrier_wait: WaitQueue,
@@ -454,6 +516,7 @@ impl RcuState {
             worker_started: AtomicBool::new(false),
             worker_should_stop: AtomicBool::new(false),
             gp_active: AtomicBool::new(false),
+            next_progress_at: AtomicU64::new(0),
             contexts: contexts.into_boxed_slice(),
             cpu_callbacks: cpu_callbacks.into_boxed_slice(),
             inner: SpinLock::new(RcuStateInner::new()),
@@ -462,6 +525,8 @@ impl RcuState {
             worker_kick_pending: AtomicBool::new(false),
             next_scan_cpu: AtomicUsize::new(0),
             callbacks_invoked: AtomicUsize::new(0),
+            stats: RcuStats::new(),
+            next_slow_warning_at: AtomicU64::new(0),
             barrier_mutex: Mutex::new(()),
             barrier_remaining: AtomicUsize::new(0),
             barrier_wait: WaitQueue::default(),
@@ -475,33 +540,73 @@ impl RcuState {
     }
 
     fn pump_grace_periods(inner: &mut RcuStateInner) -> bool {
-        Self::pump_grace_periods_with(
+        let now = rcu_now();
+        let ready_changed = Self::pump_grace_periods_with(
             inner,
+            now,
             participating_context_snapshot,
             credit_context_progress_locked,
             publish_gp_active,
             |completed| RCU_STATE.complete_callback_gp(completed),
             |starting| RCU_STATE.prepare_callback_gp_start(starting),
-        )
+            |_| {
+                RCU_STATE.stats.gp_started.fetch_add(1, Ordering::Relaxed);
+            },
+            |completed_progress| RCU_STATE.record_gp_completion(completed_progress, now),
+        );
+        RCU_STATE.publish_progress_deadline_locked(inner, now);
+        ready_changed
+    }
+
+    fn record_gp_completion(&self, progress: ActiveGpProgress, now: u64) {
+        let elapsed = now.wrapping_sub(progress.started_at());
+        self.stats.gp_completed.fetch_add(1, Ordering::Relaxed);
+        self.stats.gp_total_ns.fetch_add(elapsed, Ordering::Relaxed);
+        self.stats.gp_max_ns.fetch_max(elapsed, Ordering::Relaxed);
+        for context in &self.contexts {
+            context.clear_urgent_qs();
+        }
+    }
+
+    fn publish_progress_deadline_locked(&self, inner: &RcuStateInner, now: u64) {
+        let deadline = inner
+            .progress
+            .as_ref()
+            .map(|progress| progress.next_deadline(now))
+            .unwrap_or(0);
+        self.next_progress_at.store(deadline, Ordering::Release);
     }
 
     fn pump_grace_periods_with(
         inner: &mut RcuStateInner,
+        now: u64,
         mut waiting_snapshot: impl FnMut(&CpuMask) -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]),
-        mut credit_context: impl FnMut(&mut GracePeriodState),
+        mut credit_context: impl FnMut(&mut GracePeriodState) -> bool,
         mut publish_active: impl FnMut(bool),
         mut complete_callbacks: impl FnMut(RcuSequence) -> bool,
         mut prepare_callbacks: impl FnMut(RcuSequence),
+        mut note_gp_start: impl FnMut(RcuSequence),
+        mut note_gp_complete: impl FnMut(ActiveGpProgress),
     ) -> bool {
         let mut ready_changed = false;
         loop {
-            credit_context(&mut inner.gp);
+            if credit_context(&mut inner.gp) {
+                if let Some(progress) = inner.progress.as_mut() {
+                    progress.note_progress(now);
+                }
+            }
 
             if inner.gp.ready_to_complete() {
                 // Pair all real quiescent-state reports with GP completion.
                 // This is a GP slow path and does not affect RCU readers.
                 fence(Ordering::SeqCst);
+                let progress = inner
+                    .progress
+                    .take()
+                    .expect("ready RCU GP has no progress metadata");
                 let completed = inner.gp.complete_ready();
+                debug_assert_eq!(progress.seq(), completed);
+                note_gp_complete(progress);
                 ready_changed |= complete_callbacks(completed);
                 continue;
             }
@@ -523,6 +628,8 @@ impl RcuState {
             let (waiting_cpus, context_generations) = waiting_snapshot(&inner.participating_cpus);
             let started = inner.gp.start_requested(waiting_cpus, context_generations);
             debug_assert_eq!(started, starting);
+            inner.progress = Some(ActiveGpProgress::new(started, now));
+            note_gp_start(started);
         }
 
         publish_active(inner.gp.is_active());
@@ -644,7 +751,9 @@ impl RcuState {
             return true;
         }
         let inner = self.inner.lock_irqsave();
-        inner.gp.ready_to_complete() || (!inner.gp.is_active() && inner.gp.has_request())
+        inner.pending_stall.is_some()
+            || inner.gp.ready_to_complete()
+            || (!inner.gp.is_active() && inner.gp.has_request())
     }
 
     fn wake_state_waiters(&self) {
@@ -657,6 +766,185 @@ impl RcuState {
         // waitqueue's internal lock.
         if !self.worker_kick_pending.swap(true, Ordering::AcqRel) {
             self.worker_wait.wake_all();
+        }
+    }
+
+    fn defer_worker_wake(&self) {
+        // Timer hardirq publishes only an atomic bit and a per-CPU softirq.
+        // WaitQueue wakeup may free waiter nodes, so it belongs in bottom-half
+        // context instead of the scheduler tick.
+        if !self.worker_kick_pending.swap(true, Ordering::AcqRel) {
+            softirq_vectors().raise_softirq(SoftirqNumber::RCU);
+        }
+    }
+
+    fn flush_deferred_worker_wake(&self) {
+        if self.worker_kick_pending.load(Ordering::Acquire) {
+            self.worker_wait.wake_all();
+        }
+    }
+
+    fn claim_progress_actions(&self, now: u64) -> Option<ProgressActions> {
+        let mut inner = self.inner.try_lock_irqsave().ok()?;
+        if !inner.gp.is_active() {
+            return None;
+        }
+        let deadline = self.next_progress_at.load(Ordering::Acquire);
+        if !progress::deadline_reached(now, deadline) {
+            return None;
+        }
+
+        if credit_context_progress_locked(&mut inner.gp) {
+            if let Some(progress) = inner.progress.as_mut() {
+                progress.note_progress(now);
+            }
+        }
+        if inner.gp.ready_to_complete() {
+            self.next_progress_at.store(0, Ordering::Release);
+            drop(inner);
+            self.defer_worker_wake();
+            return None;
+        }
+
+        let holdouts = ProgressCpuMask::from_cpu_mask(
+            inner
+                .gp
+                .waiting_cpus_ref()
+                .expect("active RCU GP has no holdout state"),
+        );
+        let active_seq = inner.gp.current();
+        let progress = inner
+            .progress
+            .as_mut()
+            .expect("active RCU GP has no progress metadata");
+        debug_assert_eq!(progress.seq(), active_seq);
+        let mut actions = progress.actions(now, holdouts);
+        for cpu in actions.soft.iter_cpu() {
+            self.contexts[cpu.data() as usize].request_urgent_qs();
+        }
+        self.next_progress_at
+            .store(actions.next_deadline, Ordering::Release);
+        if let Some(candidate) = actions.stall.take() {
+            inner.pending_stall = Some(candidate);
+        }
+        Some(actions)
+    }
+
+    fn execute_progress_actions(&self, actions: ProgressActions) {
+        if !actions.soft.is_empty() {
+            self.stats.soft_requests.fetch_add(1, Ordering::Relaxed);
+        }
+
+        for cpu in actions.resched.iter_cpu() {
+            self.stats.ipi_attempted.fetch_add(1, Ordering::Relaxed);
+            if kick_cpu(cpu).is_ok() {
+                self.stats.ipi_submitted.fetch_add(1, Ordering::Relaxed);
+                self.contexts[cpu.data() as usize].note_resched_ipi();
+            } else {
+                self.stats.ipi_failed.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        // The worker performs another GP scan and emits any queued diagnostic
+        // in process context. This wake is also the worker's bounded progress
+        // role for active GPs; it does not depend on CPU0 jiffies.
+        self.defer_worker_wake();
+    }
+
+    fn process_pending_stall(&self) {
+        let candidate = self.inner.lock_irqsave().pending_stall.take();
+        if let Some(candidate) = candidate {
+            self.emit_stall_report(rcu_now(), candidate);
+        }
+    }
+
+    fn emit_stall_report(&self, now: u64, mut candidate: StallCandidate) {
+        let mut inner = self.inner.lock_irqsave();
+        if !inner.gp.is_active() || inner.gp.current() != candidate.seq {
+            return;
+        }
+        let current_seq = inner.gp.current();
+        let current_holdouts = ProgressCpuMask::from_cpu_mask(
+            inner
+                .gp
+                .waiting_cpus_ref()
+                .expect("active RCU GP has no holdout state"),
+        );
+        let Some(progress) = inner.progress.as_mut() else {
+            return;
+        };
+        let Some(committed) =
+            validate_and_commit_stall(current_seq, current_holdouts, progress, candidate, now)
+        else {
+            return;
+        };
+        candidate = committed;
+        self.next_progress_at
+            .store(progress.next_deadline(now), Ordering::Release);
+        drop(inner);
+
+        self.stats.stall_reports.fetch_add(1, Ordering::Relaxed);
+        warn!(
+            "RCU stall snapshot: gp={} report={} age_ms={} no_progress_ms={}",
+            candidate.seq.raw(),
+            candidate.report_number,
+            now.wrapping_sub(candidate.started_at) / 1_000_000,
+            now.wrapping_sub(candidate.last_progress_at) / 1_000_000,
+        );
+        for cpu in candidate.holdouts.iter_cpu() {
+            let context = &self.contexts[cpu.data() as usize];
+            let snapshot = context.snapshot();
+            let task = crate::sched::try_current_task(cpu);
+            let depth = self.cpu_callbacks[cpu.data() as usize]
+                .state
+                .try_lock_irqsave()
+                .ok()
+                .map(|state| state.depth());
+            warn!(
+                "RCU holdout cpu={} context={:?} irq={} nmi={} generation={} urgent={}",
+                cpu.data(),
+                snapshot.base(),
+                snapshot.irq_depth(),
+                snapshot.nmi_depth(),
+                snapshot.generation(),
+                context.urgent_qs(),
+            );
+            if let Some(task) = task {
+                if let Some(basic) = task.try_basic() {
+                    warn!(
+                        "RCU holdout task cpu={} pid={} name={} preempt={} read_depth={}",
+                        cpu.data(),
+                        task.raw_pid().data(),
+                        basic.name(),
+                        task.preempt_count(),
+                        task.rcu_read_depth(),
+                    );
+                } else {
+                    warn!(
+                        "RCU holdout task cpu={} pid={} name=<lock-busy> preempt={} read_depth={}",
+                        cpu.data(),
+                        task.raw_pid().data(),
+                        task.preempt_count(),
+                        task.rcu_read_depth(),
+                    );
+                }
+            } else {
+                warn!("RCU holdout task cpu={} <rq-lock-busy>", cpu.data());
+            }
+            if let Some(depth) = depth {
+                warn!(
+                    "RCU holdout callbacks cpu={} total={} done={} wait={} next_ready={} next={} executing={}",
+                    cpu.data(),
+                    depth.total(),
+                    depth.done,
+                    depth.wait,
+                    depth.next_ready,
+                    depth.next,
+                    depth.executing,
+                );
+            } else {
+                warn!("RCU holdout callbacks cpu={} <queue-lock-busy>", cpu.data());
+            }
         }
     }
 
@@ -733,8 +1021,8 @@ impl RcuState {
     }
 
     fn process_callback_batch(&self) -> usize {
+        self.process_pending_stall();
         let Some(_executor) = self.try_claim_executor() else {
-            self.wake_worker();
             return 0;
         };
 
@@ -744,6 +1032,8 @@ impl RcuState {
         // ready. One wake per batch is sufficient.
         self.wake_state_waiters();
         let mut count = 0;
+        let mut batch_elapsed_ns = 0u64;
+        let mut time_budget_hit = false;
         let mut preferred_cpu = None;
         let mut cpu_quantum = 0;
         while count < RCU_CALLBACK_BATCH_LIMIT {
@@ -753,10 +1043,51 @@ impl RcuState {
             // SAFETY: `pop_ready()` detached the head, copied all state needed
             // after invocation, and released duplicate ownership. The unsafe
             // admission contract keeps the head valid until this call starts.
+            let started_at = rcu_now();
             unsafe { (callback.func)(callback.head) };
+            let finished_at = rcu_now();
             self.callbacks_invoked.fetch_add(1, Ordering::Relaxed);
             self.finish_callback(cpu);
             count += 1;
+
+            if let Some(duration) = callback_duration_ns(started_at, finished_at) {
+                batch_elapsed_ns = batch_elapsed_ns.saturating_add(duration);
+                self.stats
+                    .max_callback_ns
+                    .fetch_max(duration, Ordering::Relaxed);
+                if duration >= RCU_SLOW_CALLBACK_NS {
+                    let slow_count = self
+                        .stats
+                        .slow_callbacks
+                        .fetch_add(1, Ordering::Relaxed)
+                        .wrapping_add(1);
+                    let next_warning = self.next_slow_warning_at.load(Ordering::Acquire);
+                    if next_warning == 0 || progress::deadline_reached(finished_at, next_warning) {
+                        let next = finished_at.wrapping_add(RCU_SLOW_WARNING_INTERVAL_NS);
+                        if self
+                            .next_slow_warning_at
+                            .compare_exchange(
+                                next_warning,
+                                next,
+                                Ordering::AcqRel,
+                                Ordering::Acquire,
+                            )
+                            .is_ok()
+                        {
+                            warn!(
+                                "slow RCU callback: queue_cpu={} duration_us={} slow_count={} batch_count={}",
+                                cpu,
+                                duration / 1_000,
+                                slow_count,
+                                count,
+                            );
+                        }
+                    }
+                }
+                if batch_elapsed_ns >= RCU_CALLBACK_TIME_BUDGET_NS {
+                    time_budget_hit = true;
+                }
+            }
 
             if preferred_cpu == Some(cpu) {
                 cpu_quantum += 1;
@@ -768,6 +1099,18 @@ impl RcuState {
                 preferred_cpu = None;
                 cpu_quantum = 0;
             }
+            if time_budget_hit {
+                break;
+            }
+        }
+
+        if count != 0 {
+            self.stats.callback_batches.fetch_add(1, Ordering::Relaxed);
+        }
+        if time_budget_hit {
+            self.stats
+                .callback_time_budget_hits
+                .fetch_add(1, Ordering::Relaxed);
         }
 
         let more = self.has_worker_work();
@@ -805,6 +1148,11 @@ fn rcu_enabled() -> bool {
     RCU_STATE.is_initialized()
 }
 
+#[inline]
+fn rcu_now() -> u64 {
+    SchedClock::sched_clock_cpu(smp_get_processor_id())
+}
+
 fn publish_gp_active(active: bool) {
     // Production callers hold `RCU_STATE.inner`, so GP-active publishers are
     // serialized. Avoid a write RMW on the common inactive -> inactive path:
@@ -820,6 +1168,47 @@ fn publish_gp_active(active: bool) {
             context.clear_gp_report();
         }
     }
+}
+
+/// Scheduler-tick hook for cooperative QS requests and bounded GP progress.
+///
+/// The inactive path performs only two cold atomic loads. Deadline work uses
+/// a try-lock so a diagnostic facility cannot make a timer interrupt spin on
+/// a remote CPU holding the RCU coordinator lock.
+pub fn scheduler_tick() {
+    if !rcu_enabled() {
+        return;
+    }
+
+    let cpu = smp_get_processor_id();
+    if RCU_STATE.contexts[cpu.data() as usize].urgent_qs() {
+        ProcessManager::current_pcb()
+            .flags()
+            .insert(ProcessFlags::NEED_SCHEDULE);
+    }
+
+    if !RCU_STATE.gp_active.load(Ordering::Acquire) {
+        return;
+    }
+    let now = rcu_now();
+    if now == 0 {
+        return;
+    }
+    let deadline = RCU_STATE.next_progress_at.load(Ordering::Acquire);
+    if !progress::deadline_reached(now, deadline) {
+        return;
+    }
+
+    scheduler_tick_slow(now);
+}
+
+#[cold]
+#[inline(never)]
+fn scheduler_tick_slow(now: u64) {
+    let Some(actions) = RCU_STATE.claim_progress_actions(now) else {
+        return;
+    };
+    RCU_STATE.execute_progress_actions(actions);
 }
 
 fn participating_context_snapshot(
@@ -849,7 +1238,8 @@ fn current_task_is_idle() -> bool {
 }
 
 #[inline]
-fn credit_context_progress_locked(gp: &mut GracePeriodState) {
+fn credit_context_progress_locked(gp: &mut GracePeriodState) -> bool {
+    let mut progressed = false;
     for cpu_idx in 0..PerCpu::MAX_CPU_NUM as usize {
         let cpu = ProcessorId::new(cpu_idx as u32);
         if !gp.is_waiting_for(cpu) {
@@ -859,8 +1249,11 @@ fn credit_context_progress_locked(gp: &mut GracePeriodState) {
         let snapshot = context.snapshot();
         if gp.report_context_progress(cpu, snapshot.generation(), snapshot.in_eqs()) {
             context.clear_gp_report();
+            context.clear_urgent_qs();
+            progressed = true;
         }
     }
+    progressed
 }
 
 /// Reports a real quiescent state while `RcuState::inner` is held.
@@ -877,7 +1270,12 @@ fn report_quiescent_state_locked(inner: &mut RcuStateInner, cpu: ProcessorId) ->
     let cleared = inner.gp.report_quiescent_state(cpu);
     debug_assert!(cleared, "RCU holdout disappeared before QS reporting");
     if cleared {
-        RCU_STATE.contexts[cpu.data() as usize].clear_gp_report();
+        let context = &RCU_STATE.contexts[cpu.data() as usize];
+        context.clear_gp_report();
+        context.clear_urgent_qs();
+        if let Some(progress) = inner.progress.as_mut() {
+            progress.note_progress(rcu_now());
+        }
     }
     cleared
 }
@@ -893,8 +1291,10 @@ fn cpu_starting_locked(inner: &mut RcuStateInner, cpu: ProcessorId) {
 fn cpu_dying_locked(inner: &mut RcuStateInner, cpu: ProcessorId) {
     inner.participating_cpus.set(cpu, false);
     report_quiescent_state_locked(inner, cpu);
+    RCU_STATE.contexts[cpu.data() as usize].clear_urgent_qs();
 }
 
+#[inline(never)]
 fn report_quiescent_state(cpu: ProcessorId) {
     if !rcu_enabled() {
         return;
@@ -985,6 +1385,15 @@ where
     Ok(())
 }
 
+#[derive(Debug)]
+struct RcuSoftirq;
+
+impl SoftirqVec for RcuSoftirq {
+    fn run(&self) {
+        RCU_STATE.flush_deferred_worker_wake();
+    }
+}
+
 fn worker_main() -> i32 {
     {
         let _inner = RCU_STATE.inner.lock_irqsave();
@@ -999,20 +1408,17 @@ fn worker_main() -> i32 {
                 return Some(());
             }
 
-            if RCU_STATE.has_worker_work() {
-                return Some(());
-            }
-
-            // Retire the coalesced kick only after observing no work, then
-            // recheck. A publisher racing either side of this store will
-            // therefore be observed by the predicate or issue a fresh wake.
-            RCU_STATE
-                .worker_kick_pending
-                .store(false, Ordering::Release);
+            // Consume a pure progress kick even when no callback or completed
+            // GP is visible yet. This gives the worker one bounded rescan after
+            // a scheduler-tick escalation. Consuming before the work check also
+            // avoids retaining an ordinary callback kick for an empty batch.
+            let had_kick = RCU_STATE.worker_kick_pending.swap(false, Ordering::AcqRel);
             if RCU_STATE.worker_should_stop.load(Ordering::Acquire) {
                 return Some(());
             }
-            if RCU_STATE.has_worker_work() {
+            // A publisher racing after the exchange either makes work visible
+            // to this check or observes `false` and issues a fresh wake.
+            if had_kick || RCU_STATE.has_worker_work() {
                 return Some(());
             }
 
@@ -1072,14 +1478,15 @@ pub fn start_worker() {
         RCU_STATE.worker_starting.store(true, Ordering::Release);
     }
 
-    let worker_cpu = smp_get_processor_id();
+    softirq_vectors()
+        .register_softirq(SoftirqNumber::RCU, Arc::new(RcuSoftirq))
+        .expect("failed to register the RCU softirq");
+
     let closure = KernelThreadClosure::EmptyClosure((Box::new(worker_main), ()));
-    if KernelThreadMechanism::create_and_run_on_cpu(closure, "rcu_gp".to_string(), worker_cpu)
-        .is_none()
-    {
+    if KernelThreadMechanism::create_and_run(closure, "rcu_gp".to_string()).is_none() {
         let _inner = RCU_STATE.inner.lock_irqsave();
         RCU_STATE.worker_starting.store(false, Ordering::Release);
-        panic!("failed to create the bound RCU callback worker");
+        panic!("failed to create the RCU callback worker");
     }
 
     RCU_STATE.wake_worker();
@@ -1394,12 +1801,11 @@ unsafe fn rcu_barrier_callback(_head: NonNull<RcuHead>) {
     }
 }
 
-pub fn note_context_switch() {
+pub fn note_context_switch(current: &crate::process::ProcessControlBlock) {
     if !rcu_enabled() {
         return;
     }
 
-    let current = ProcessManager::current_pcb();
     if current.rcu_read_depth() != 0 {
         warn!("context switch observed while still inside rcu_read_lock()");
         debug_assert_eq!(current.rcu_read_depth(), 0);
@@ -1676,6 +2082,119 @@ pub(crate) fn callback_queue_debug_report() -> String {
         )
         .expect("writing RCU per-CPU callback snapshot to String failed");
     }
+    report
+}
+
+pub(crate) fn state_debug_report() -> String {
+    let inner = RCU_STATE.inner.lock_irqsave();
+    let current = inner.gp.current().raw();
+    let completed = inner.gp.completed().raw();
+    let holdouts = inner
+        .gp
+        .waiting_cpus_ref()
+        .map(ProgressCpuMask::from_cpu_mask)
+        .unwrap_or_else(ProgressCpuMask::new);
+    let progress = inner.progress.as_ref().map(|progress| {
+        (
+            progress.started_at(),
+            progress.last_progress_at(),
+            progress.seq().raw(),
+        )
+    });
+    drop(inner);
+    let now = rcu_now();
+
+    let mut report = String::new();
+    writeln!(
+        report,
+        "active={} current_seq={} completed_seq={} next_progress_ns={}",
+        usize::from(progress.is_some()),
+        current,
+        completed,
+        RCU_STATE.next_progress_at.load(Ordering::Acquire),
+    )
+    .expect("writing RCU state snapshot failed");
+    if let Some((started, last_progress, seq)) = progress {
+        writeln!(
+            report,
+            "gp_seq={} age_ms={} no_progress_ms={}",
+            seq,
+            now.wrapping_sub(started) / 1_000_000,
+            now.wrapping_sub(last_progress) / 1_000_000,
+        )
+        .expect("writing RCU progress snapshot failed");
+    }
+    for cpu in holdouts.iter_cpu() {
+        let context = &RCU_STATE.contexts[cpu.data() as usize];
+        let snapshot = context.snapshot();
+        writeln!(
+            report,
+            "holdout_cpu={} context={:?} irq={} nmi={} generation={} urgent={}",
+            cpu.data(),
+            snapshot.base(),
+            snapshot.irq_depth(),
+            snapshot.nmi_depth(),
+            snapshot.generation(),
+            usize::from(context.urgent_qs()),
+        )
+        .expect("writing RCU holdout snapshot failed");
+    }
+    report
+}
+
+pub(crate) fn stats_debug_report() -> String {
+    let stats = &RCU_STATE.stats;
+    let started = stats.gp_started.load(Ordering::Relaxed);
+    let completed = stats.gp_completed.load(Ordering::Relaxed);
+    let total_ns = stats.gp_total_ns.load(Ordering::Relaxed);
+    let mut report = String::new();
+    writeln!(report, "gp_started={started}").unwrap();
+    writeln!(report, "gp_completed={completed}").unwrap();
+    writeln!(
+        report,
+        "gp_average_ns={}",
+        if completed == 0 {
+            0
+        } else {
+            total_ns / completed
+        }
+    )
+    .unwrap();
+    writeln!(
+        report,
+        "gp_max_ns={}",
+        stats.gp_max_ns.load(Ordering::Relaxed)
+    )
+    .unwrap();
+    writeln!(
+        report,
+        "soft_requests={}",
+        stats.soft_requests.load(Ordering::Relaxed)
+    )
+    .unwrap();
+    writeln!(
+        report,
+        "ipi_attempted={} ipi_submitted={} ipi_failed={}",
+        stats.ipi_attempted.load(Ordering::Relaxed),
+        stats.ipi_submitted.load(Ordering::Relaxed),
+        stats.ipi_failed.load(Ordering::Relaxed),
+    )
+    .unwrap();
+    writeln!(
+        report,
+        "stall_reports={}",
+        stats.stall_reports.load(Ordering::Relaxed)
+    )
+    .unwrap();
+    writeln!(
+        report,
+        "callback_batches={} callback_time_budget_hits={} slow_callbacks={} max_callback_ns={}",
+        stats.callback_batches.load(Ordering::Relaxed),
+        stats.callback_time_budget_hits.load(Ordering::Relaxed),
+        stats.slow_callbacks.load(Ordering::Relaxed),
+        stats.max_callback_ns.load(Ordering::Relaxed),
+    )
+    .unwrap();
     report
 }
 

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -373,6 +373,16 @@ struct RcuStateInner {
     participating_cpus: CpuMask,
 }
 
+struct GracePeriodPumpHooks<W, C, P, CC, PC, NS, NC> {
+    waiting_snapshot: W,
+    credit_context: C,
+    publish_active: P,
+    complete_callbacks: CC,
+    prepare_callbacks: PC,
+    note_gp_start: NS,
+    note_gp_complete: NC,
+}
+
 impl RcuStateInner {
     fn new() -> Self {
         Self {
@@ -544,15 +554,19 @@ impl RcuState {
         let ready_changed = Self::pump_grace_periods_with(
             inner,
             now,
-            participating_context_snapshot,
-            credit_context_progress_locked,
-            publish_gp_active,
-            |completed| RCU_STATE.complete_callback_gp(completed),
-            |starting| RCU_STATE.prepare_callback_gp_start(starting),
-            |_| {
-                RCU_STATE.stats.gp_started.fetch_add(1, Ordering::Relaxed);
+            GracePeriodPumpHooks {
+                waiting_snapshot: participating_context_snapshot,
+                credit_context: credit_context_progress_locked,
+                publish_active: publish_gp_active,
+                complete_callbacks: |completed| RCU_STATE.complete_callback_gp(completed),
+                prepare_callbacks: |starting| RCU_STATE.prepare_callback_gp_start(starting),
+                note_gp_start: |_| {
+                    RCU_STATE.stats.gp_started.fetch_add(1, Ordering::Relaxed);
+                },
+                note_gp_complete: |completed_progress| {
+                    RCU_STATE.record_gp_completion(completed_progress, now)
+                },
             },
-            |completed_progress| RCU_STATE.record_gp_completion(completed_progress, now),
         );
         RCU_STATE.publish_progress_deadline_locked(inner, now);
         ready_changed
@@ -577,17 +591,29 @@ impl RcuState {
         self.next_progress_at.store(deadline, Ordering::Release);
     }
 
-    fn pump_grace_periods_with(
+    fn pump_grace_periods_with<W, C, P, CC, PC, NS, NC>(
         inner: &mut RcuStateInner,
         now: u64,
-        mut waiting_snapshot: impl FnMut(&CpuMask) -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]),
-        mut credit_context: impl FnMut(&mut GracePeriodState) -> bool,
-        mut publish_active: impl FnMut(bool),
-        mut complete_callbacks: impl FnMut(RcuSequence) -> bool,
-        mut prepare_callbacks: impl FnMut(RcuSequence),
-        mut note_gp_start: impl FnMut(RcuSequence),
-        mut note_gp_complete: impl FnMut(ActiveGpProgress),
-    ) -> bool {
+        hooks: GracePeriodPumpHooks<W, C, P, CC, PC, NS, NC>,
+    ) -> bool
+    where
+        W: FnMut(&CpuMask) -> (CpuMask, [u64; PerCpu::MAX_CPU_NUM as usize]),
+        C: FnMut(&mut GracePeriodState) -> bool,
+        P: FnMut(bool),
+        CC: FnMut(RcuSequence) -> bool,
+        PC: FnMut(RcuSequence),
+        NS: FnMut(RcuSequence),
+        NC: FnMut(ActiveGpProgress),
+    {
+        let GracePeriodPumpHooks {
+            mut waiting_snapshot,
+            mut credit_context,
+            mut publish_active,
+            mut complete_callbacks,
+            mut prepare_callbacks,
+            mut note_gp_start,
+            mut note_gp_complete,
+        } = hooks;
         let mut ready_changed = false;
         loop {
             if credit_context(&mut inner.gp) {
@@ -2153,11 +2179,7 @@ pub(crate) fn stats_debug_report() -> String {
     writeln!(
         report,
         "gp_average_ns={}",
-        if completed == 0 {
-            0
-        } else {
-            total_ns / completed
-        }
+        total_ns.checked_div(completed).unwrap_or(0)
     )
     .unwrap();
     writeln!(

--- a/kernel/src/rcu/progress.rs
+++ b/kernel/src/rcu/progress.rs
@@ -1,0 +1,492 @@
+//! Deterministic grace-period escalation policy.
+//!
+//! This module owns no locks, clocks, IPI delivery, or logging. The RCU
+//! coordinator supplies a timestamp and the authoritative holdout mask, then
+//! executes the returned actions after dropping its lock.
+
+use crate::{libs::cpumask::CpuMask, mm::percpu::PerCpu, smp::cpu::ProcessorId};
+
+use super::gp::RcuSequence;
+
+pub(super) const SOFT_REQUEST_NS: u64 = 100_000_000;
+pub(super) const RESCHED_DELAY_NS: u64 = 1_000_000_000;
+pub(super) const RESCHED_REPEAT_NS: u64 = 1_000_000_000;
+pub(super) const STALL_TIMEOUT_NS: u64 = 21_000_000_000;
+pub(super) const STALL_REPEAT_NS: u64 = 63_000_000_000;
+const STALL_RETRY_NS: u64 = 1_000_000_000;
+
+const HALF_RANGE: u64 = 1_u64 << 63;
+const MASK_WORDS: usize = (PerCpu::MAX_CPU_NUM as usize).div_ceil(u64::BITS as usize);
+
+/// Allocation-free holdout snapshot used by timer-interrupt escalation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct ProgressCpuMask {
+    words: [u64; MASK_WORDS],
+}
+
+impl ProgressCpuMask {
+    pub(super) const fn new() -> Self {
+        Self {
+            words: [0; MASK_WORDS],
+        }
+    }
+
+    pub(super) fn from_cpu_mask(mask: &CpuMask) -> Self {
+        let mut result = Self::new();
+        for cpu in mask.iter_cpu() {
+            result.set(cpu, true);
+        }
+        result
+    }
+
+    fn from_cpu(cpu: ProcessorId) -> Self {
+        let mut result = Self::new();
+        result.set(cpu, true);
+        result
+    }
+
+    pub(super) fn set(&mut self, cpu: ProcessorId, value: bool) {
+        let index = cpu.data() as usize;
+        debug_assert!(index < PerCpu::MAX_CPU_NUM as usize);
+        let word = index / u64::BITS as usize;
+        let bit = 1u64 << (index % u64::BITS as usize);
+        if value {
+            self.words[word] |= bit;
+        } else {
+            self.words[word] &= !bit;
+        }
+    }
+
+    fn get(&self, cpu: ProcessorId) -> bool {
+        let index = cpu.data() as usize;
+        let word = index / u64::BITS as usize;
+        let bit = 1u64 << (index % u64::BITS as usize);
+        self.words[word] & bit != 0
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.words.iter().all(|word| *word == 0)
+    }
+
+    fn intersect(&mut self, other: &Self) {
+        for (word, other_word) in self.words.iter_mut().zip(other.words.iter()) {
+            *word &= *other_word;
+        }
+    }
+
+    pub(super) fn iter_cpu(&self) -> ProgressCpuMaskIter<'_> {
+        ProgressCpuMaskIter {
+            mask: self,
+            next: 0,
+        }
+    }
+}
+
+pub(super) struct ProgressCpuMaskIter<'a> {
+    mask: &'a ProgressCpuMask,
+    next: u32,
+}
+
+impl Iterator for ProgressCpuMaskIter<'_> {
+    type Item = ProcessorId;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.next < PerCpu::MAX_CPU_NUM {
+            let cpu = ProcessorId::new(self.next);
+            self.next += 1;
+            if self.mask.get(cpu) {
+                return Some(cpu);
+            }
+        }
+        None
+    }
+}
+
+#[inline]
+pub(super) const fn elapsed_at_least(now: u64, origin: u64, interval: u64) -> bool {
+    now.wrapping_sub(origin) >= interval && now.wrapping_sub(origin) < HALF_RANGE
+}
+
+#[inline]
+pub(super) const fn deadline_reached(now: u64, deadline: u64) -> bool {
+    now.wrapping_sub(deadline) < HALF_RANGE
+}
+
+#[derive(Clone, Copy)]
+pub(super) struct StallCandidate {
+    pub(super) seq: RcuSequence,
+    pub(super) started_at: u64,
+    pub(super) last_progress_at: u64,
+    pub(super) holdouts: ProgressCpuMask,
+    pub(super) report_number: u64,
+}
+
+pub(super) struct ProgressActions {
+    pub(super) soft: ProgressCpuMask,
+    pub(super) resched: ProgressCpuMask,
+    pub(super) stall: Option<StallCandidate>,
+    pub(super) next_deadline: u64,
+}
+
+pub(super) struct ActiveGpProgress {
+    seq: RcuSequence,
+    started_at: u64,
+    last_progress_at: u64,
+    soft_requested: bool,
+    last_resched_at: Option<u64>,
+    last_stall_attempt_at: Option<u64>,
+    last_stall_report_at: Option<u64>,
+    stall_reports: u64,
+}
+
+impl ActiveGpProgress {
+    pub(super) fn new(seq: RcuSequence, now: u64) -> Self {
+        Self {
+            seq,
+            started_at: now,
+            last_progress_at: now,
+            soft_requested: false,
+            last_resched_at: None,
+            last_stall_attempt_at: None,
+            last_stall_report_at: None,
+            stall_reports: 0,
+        }
+    }
+
+    #[inline]
+    pub(super) fn seq(&self) -> RcuSequence {
+        self.seq
+    }
+
+    #[inline]
+    pub(super) fn started_at(&self) -> u64 {
+        self.started_at
+    }
+
+    #[inline]
+    pub(super) fn last_progress_at(&self) -> u64 {
+        self.last_progress_at
+    }
+
+    #[inline]
+    pub(super) fn note_progress(&mut self, now: u64) {
+        self.last_progress_at = now;
+    }
+
+    pub(super) fn next_deadline(&self, now: u64) -> u64 {
+        let soft_remaining = if self.soft_requested {
+            u64::MAX
+        } else {
+            remaining(now, self.started_at, SOFT_REQUEST_NS)
+        };
+        let resched_remaining = match self.last_resched_at {
+            Some(last) => remaining(now, last, RESCHED_REPEAT_NS),
+            None => remaining(now, self.started_at, RESCHED_DELAY_NS),
+        };
+        let report_remaining = match self.last_stall_report_at {
+            Some(last) => remaining(now, last, STALL_REPEAT_NS),
+            None => remaining(now, self.started_at, STALL_TIMEOUT_NS),
+        };
+        let retry_remaining = self
+            .last_stall_attempt_at
+            .map(|last| remaining(now, last, STALL_RETRY_NS))
+            .unwrap_or(0);
+        let stall_remaining = report_remaining.max(retry_remaining);
+        now.wrapping_add(soft_remaining.min(resched_remaining).min(stall_remaining))
+    }
+
+    pub(super) fn actions(&mut self, now: u64, holdouts: ProgressCpuMask) -> ProgressActions {
+        let soft_due =
+            !self.soft_requested && elapsed_at_least(now, self.started_at, SOFT_REQUEST_NS);
+        if soft_due {
+            self.soft_requested = true;
+        }
+
+        let resched_due = match self.last_resched_at {
+            Some(last) => elapsed_at_least(now, last, RESCHED_REPEAT_NS),
+            None => elapsed_at_least(now, self.started_at, RESCHED_DELAY_NS),
+        };
+        if resched_due {
+            self.last_resched_at = Some(now);
+        }
+
+        let report_due = match self.last_stall_report_at {
+            Some(last) => elapsed_at_least(now, last, STALL_REPEAT_NS),
+            None => elapsed_at_least(now, self.started_at, STALL_TIMEOUT_NS),
+        };
+        let retry_due = self
+            .last_stall_attempt_at
+            .map(|last| elapsed_at_least(now, last, STALL_RETRY_NS))
+            .unwrap_or(true);
+        let stall_due = report_due && retry_due;
+        let stall = if stall_due {
+            self.last_stall_attempt_at = Some(now);
+            Some(StallCandidate {
+                seq: self.seq,
+                started_at: self.started_at,
+                last_progress_at: self.last_progress_at,
+                holdouts,
+                report_number: self.stall_reports.wrapping_add(1),
+            })
+        } else {
+            None
+        };
+
+        ProgressActions {
+            soft: if soft_due {
+                holdouts
+            } else {
+                ProgressCpuMask::new()
+            },
+            resched: if resched_due {
+                holdouts
+            } else {
+                ProgressCpuMask::new()
+            },
+            stall,
+            next_deadline: self.next_deadline(now),
+        }
+    }
+
+    /// Commits rate limiting only after the reporter has revalidated the GP.
+    pub(super) fn commit_stall_report(
+        &mut self,
+        seq: RcuSequence,
+        report_number: u64,
+        now: u64,
+    ) -> bool {
+        if self.seq != seq || report_number != self.stall_reports.wrapping_add(1) {
+            return false;
+        }
+        self.stall_reports = report_number;
+        self.last_stall_report_at = Some(now);
+        self.last_stall_attempt_at = None;
+        true
+    }
+}
+
+/// Revalidates and commits a stall candidate against the coordinator's
+/// current fixed-size snapshot. Production and deterministic tests share this
+/// transition so a stale or already-satisfied report cannot consume the
+/// report-rate-limit state.
+pub(super) fn validate_and_commit_stall(
+    current_seq: RcuSequence,
+    current_holdouts: ProgressCpuMask,
+    progress: &mut ActiveGpProgress,
+    mut candidate: StallCandidate,
+    now: u64,
+) -> Option<StallCandidate> {
+    if candidate.seq != current_seq || progress.seq() != current_seq {
+        return None;
+    }
+    candidate.holdouts.intersect(&current_holdouts);
+    if candidate.holdouts.is_empty() {
+        return None;
+    }
+    candidate.last_progress_at = progress.last_progress_at();
+    progress
+        .commit_stall_report(candidate.seq, candidate.report_number, now)
+        .then_some(candidate)
+}
+
+#[inline]
+fn remaining(now: u64, origin: u64, interval: u64) -> u64 {
+    let elapsed = now.wrapping_sub(origin);
+    if elapsed >= interval && elapsed < HALF_RANGE {
+        0
+    } else {
+        interval.wrapping_sub(elapsed)
+    }
+}
+
+pub(super) fn run_progress_selftests() -> Result<(), &'static str> {
+    run_escalation_selftest()?;
+    run_stall_repeat_selftest()?;
+    run_partial_progress_selftest()?;
+    run_deadline_wrap_selftest()?;
+    run_stall_validation_selftest()?;
+    Ok(())
+}
+
+#[inline(never)]
+fn run_stall_validation_selftest() -> Result<(), &'static str> {
+    let seq = RcuSequence::from_raw(11);
+    let old_seq = RcuSequence::from_raw(9);
+    let cpu0 = ProcessorId::new(0);
+    let cpu1 = ProcessorId::new(1);
+    let mut original = ProgressCpuMask::from_cpu(cpu0);
+    original.set(cpu1, true);
+
+    let mut stale_progress = ActiveGpProgress::new(seq, 0);
+    let stale = stale_progress
+        .actions(STALL_TIMEOUT_NS, original)
+        .stall
+        .unwrap();
+    if validate_and_commit_stall(
+        old_seq,
+        original,
+        &mut stale_progress,
+        stale,
+        STALL_TIMEOUT_NS,
+    )
+    .is_some()
+    {
+        return Err("RCU stall validation accepted a stale GP sequence");
+    }
+
+    let mut empty_progress = ActiveGpProgress::new(seq, 0);
+    let empty = empty_progress
+        .actions(STALL_TIMEOUT_NS, original)
+        .stall
+        .unwrap();
+    if validate_and_commit_stall(
+        seq,
+        ProgressCpuMask::new(),
+        &mut empty_progress,
+        empty,
+        STALL_TIMEOUT_NS,
+    )
+    .is_some()
+    {
+        return Err("RCU stall validation accepted an empty holdout set");
+    }
+
+    let mut valid_progress = ActiveGpProgress::new(seq, 0);
+    valid_progress.note_progress(STALL_TIMEOUT_NS - 1);
+    let valid = valid_progress
+        .actions(STALL_TIMEOUT_NS, original)
+        .stall
+        .unwrap();
+    let current = ProgressCpuMask::from_cpu(cpu1);
+    let committed =
+        validate_and_commit_stall(seq, current, &mut valid_progress, valid, STALL_TIMEOUT_NS)
+            .ok_or("RCU stall validation rejected a current candidate")?;
+    if committed.holdouts != current
+        || committed.last_progress_at != STALL_TIMEOUT_NS - 1
+        || committed.report_number != 1
+    {
+        return Err("RCU stall validation did not refresh and filter its candidate");
+    }
+    if valid_progress
+        .actions(STALL_TIMEOUT_NS + STALL_REPEAT_NS - 1, current)
+        .stall
+        .is_some()
+    {
+        return Err("RCU stall validation did not commit report rate limiting");
+    }
+    Ok(())
+}
+
+#[inline(never)]
+fn run_deadline_wrap_selftest() -> Result<(), &'static str> {
+    let seq = RcuSequence::from_raw(9);
+    let started_at = 0u64.wrapping_sub(SOFT_REQUEST_NS);
+    let holdout = ProgressCpuMask::from_cpu(ProcessorId::new(0));
+    let mut progress = ActiveGpProgress::new(seq, started_at);
+    if progress.next_deadline(started_at) != 0 {
+        return Err("RCU progress selftest did not construct a zero wrapping deadline");
+    }
+    let actions = progress.actions(0, holdout);
+    if actions.soft != holdout {
+        return Err("RCU progress policy lost a valid zero wrapping deadline");
+    }
+    Ok(())
+}
+
+#[inline(never)]
+fn run_escalation_selftest() -> Result<(), &'static str> {
+    let seq = RcuSequence::from_raw(7);
+    let mut holdouts = ProgressCpuMask::from_cpu(ProcessorId::new(0));
+    holdouts.set(ProcessorId::new(1), true);
+    let mut progress = ActiveGpProgress::new(seq, 100);
+
+    let before = progress.actions(100 + SOFT_REQUEST_NS - 1, holdouts);
+    if !before.soft.is_empty() || !before.resched.is_empty() || before.stall.is_some() {
+        return Err("RCU progress policy escalated before its deadline");
+    }
+    let soft = progress.actions(100 + SOFT_REQUEST_NS, holdouts);
+    if soft.soft != holdouts || !soft.resched.is_empty() || soft.stall.is_some() {
+        return Err("RCU progress policy did not issue the soft request exactly on time");
+    }
+    let hard = progress.actions(100 + RESCHED_DELAY_NS, holdouts);
+    if hard.resched != holdouts || hard.stall.is_some() {
+        return Err("RCU progress policy did not issue the reschedule action");
+    }
+    Ok(())
+}
+
+#[inline(never)]
+fn run_stall_repeat_selftest() -> Result<(), &'static str> {
+    // Force both independent actions due in one evaluation. A mutually
+    // exclusive implementation would silently starve the stall report.
+    let seq = RcuSequence::from_raw(7);
+    let mut holdouts = ProgressCpuMask::from_cpu(ProcessorId::new(0));
+    holdouts.set(ProcessorId::new(1), true);
+    let mut simultaneous = ActiveGpProgress::new(seq, 0);
+    simultaneous.last_resched_at = Some(STALL_TIMEOUT_NS - RESCHED_REPEAT_NS);
+    let both = simultaneous.actions(STALL_TIMEOUT_NS, holdouts);
+    if both.resched != holdouts || both.stall.is_none() {
+        return Err("RCU hard escalation starved a simultaneous stall report");
+    }
+    let report_number = both.stall.as_ref().unwrap().report_number;
+    if !simultaneous.commit_stall_report(seq, report_number, STALL_TIMEOUT_NS) {
+        return Err("RCU progress policy rejected a valid stall report commit");
+    }
+    let before_repeat = simultaneous.actions(STALL_TIMEOUT_NS + STALL_REPEAT_NS - 1, holdouts);
+    if before_repeat.stall.is_some() {
+        return Err("RCU progress policy repeated a stall report too early");
+    }
+    let repeat = simultaneous.actions(STALL_TIMEOUT_NS + STALL_REPEAT_NS, holdouts);
+    if repeat
+        .stall
+        .as_ref()
+        .map(|candidate| candidate.report_number)
+        != Some(2)
+    {
+        return Err("RCU progress policy did not repeat a persistent stall");
+    }
+
+    let mut retry = ActiveGpProgress::new(seq, 0);
+    let first_attempt = retry.actions(STALL_TIMEOUT_NS, holdouts);
+    let expected_report = first_attempt.stall.as_ref().unwrap().report_number;
+    if retry
+        .actions(STALL_TIMEOUT_NS + STALL_RETRY_NS - 1, holdouts)
+        .stall
+        .is_some()
+    {
+        return Err("RCU progress policy retried a dropped stall report too early");
+    }
+    let retried = retry.actions(STALL_TIMEOUT_NS + STALL_RETRY_NS, holdouts);
+    if retried
+        .stall
+        .as_ref()
+        .map(|candidate| candidate.report_number)
+        != Some(expected_report)
+    {
+        return Err("RCU progress policy did not retry a dropped stall report");
+    }
+    Ok(())
+}
+
+#[inline(never)]
+fn run_partial_progress_selftest() -> Result<(), &'static str> {
+    let seq = RcuSequence::from_raw(7);
+    let mut progress = ActiveGpProgress::new(seq, 100);
+    let initial = ProgressCpuMask::from_cpu(ProcessorId::new(1));
+    let _ = progress.actions(100 + RESCHED_DELAY_NS, initial);
+    let mut remaining_holdout = ProgressCpuMask::from_cpu(ProcessorId::new(1));
+    progress.note_progress(100 + RESCHED_DELAY_NS + 1);
+    let repeated = progress.actions(
+        100 + RESCHED_DELAY_NS + RESCHED_REPEAT_NS,
+        remaining_holdout,
+    );
+    if repeated.resched != remaining_holdout {
+        return Err("RCU progress policy retained a CPU that already reported QS");
+    }
+    remaining_holdout.set(ProcessorId::new(1), false);
+    if !remaining_holdout.is_empty() {
+        return Err("RCU progress selftest constructed an invalid empty mask");
+    }
+
+    Ok(())
+}

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -16,6 +16,7 @@ use crate::{
     },
     process::{
         kthread::{KernelThreadClosure, KernelThreadMechanism},
+        preempt::PreemptGuard,
         ProcessManager,
     },
     sched::completion::Completion,
@@ -153,6 +154,123 @@ fn run_callback_flood_selftest() -> Result<(), &'static str> {
     rcu_barrier();
     if hits.load(Ordering::SeqCst) != callbacks {
         return Err("RCU callback flood did not drain across bounded batches");
+    }
+    Ok(())
+}
+
+#[repr(C)]
+struct RcuSlowCallbackProbe {
+    head: RcuHead,
+    hits: Arc<AtomicUsize>,
+}
+
+unsafe fn rcu_slow_selftest_callback(head: NonNull<RcuHead>) {
+    // SAFETY: the callback owns the Box allocated below and consumes it once.
+    let probe = unsafe { Box::from_raw(head.as_ptr() as *mut RcuSlowCallbackProbe) };
+    let started = rcu_now();
+    while !progress::elapsed_at_least(rcu_now(), started, RCU_SLOW_CALLBACK_NS + 1_000_000) {
+        core::hint::spin_loop();
+    }
+    probe.hits.fetch_add(1, Ordering::SeqCst);
+}
+
+fn run_slow_callback_budget_selftest() -> Result<(), &'static str> {
+    let slow_before = RCU_STATE.stats.slow_callbacks.load(Ordering::Acquire);
+    let budget_before = RCU_STATE
+        .stats
+        .callback_time_budget_hits
+        .load(Ordering::Acquire);
+    let hits = Arc::new(AtomicUsize::new(0));
+    let probe = Box::into_raw(Box::new(RcuSlowCallbackProbe {
+        head: RcuHead::new(),
+        hits: hits.clone(),
+    }));
+    // SAFETY: ownership of the stable Box transfers to the callback.
+    unsafe {
+        call_rcu_raw(
+            NonNull::new_unchecked(ptr::addr_of_mut!((*probe).head)),
+            rcu_slow_selftest_callback,
+        );
+    }
+    rcu_barrier();
+
+    if hits.load(Ordering::SeqCst) != 1
+        || RCU_STATE.stats.slow_callbacks.load(Ordering::Acquire) <= slow_before
+        || RCU_STATE
+            .stats
+            .callback_time_budget_hits
+            .load(Ordering::Acquire)
+            <= budget_before
+        || RCU_STATE.stats.max_callback_ns.load(Ordering::Acquire) < RCU_SLOW_CALLBACK_NS
+    {
+        return Err("RCU slow callback did not trigger time-budget diagnostics");
+    }
+    Ok(())
+}
+
+fn run_reschedule_escalation_selftest() -> Result<(), &'static str> {
+    let current_cpu = crate::smp::core::smp_get_processor_id();
+    let Some(target_cpu) = smp_cpu_manager()
+        .present_cpus()
+        .iter_cpu()
+        .find(|cpu| *cpu != current_cpu && smp_cpu_manager().is_online_cpu(*cpu))
+    else {
+        // UP configurations cannot exercise a remote reschedule IPI.
+        return Ok(());
+    };
+
+    // Finish any pre-existing GP before constructing the target holdout. The
+    // success condition below is per target CPU, so unrelated GP traffic on a
+    // different CPU cannot satisfy this test.
+    synchronize_rcu();
+    let submitted_before = RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis();
+    let ready = Arc::new(Completion::new());
+    let done = Arc::new(Completion::new());
+    let saw_escalation = Arc::new(AtomicBool::new(false));
+    let thread_ready = ready.clone();
+    let thread_done = done.clone();
+    let thread_saw = saw_escalation.clone();
+    let closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let preempt_guard = PreemptGuard::new();
+            let started = rcu_now();
+            thread_ready.complete();
+            while RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis() == submitted_before
+                && !progress::elapsed_at_least(rcu_now(), started, 3_000_000_000)
+            {
+                core::hint::spin_loop();
+            }
+            let escalated =
+                RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis() > submitted_before;
+            thread_saw.store(escalated, Ordering::Release);
+            drop(preempt_guard);
+            crate::sched::sched_yield();
+            thread_done.complete();
+            i32::from(!escalated)
+        }),
+        (),
+    ));
+    let Some(worker) = KernelThreadMechanism::create_on_cpu(
+        closure,
+        "rcu-resched-holdout".to_string(),
+        target_cpu,
+    ) else {
+        return Err("RCU reschedule selftest could not create its holdout task");
+    };
+    if ProcessManager::wakeup(&worker).is_err() {
+        let _ = KernelThreadMechanism::stop(&worker);
+        return Err("RCU reschedule selftest could not wake its holdout task");
+    }
+    if ready.wait_for_completion().is_err() {
+        let _ = KernelThreadMechanism::stop(&worker);
+        return Err("RCU reschedule selftest holdout did not start");
+    }
+
+    synchronize_rcu();
+    let done_result = done.wait_for_completion();
+    let stop_result = KernelThreadMechanism::stop(&worker);
+    if done_result.is_err() || stop_result.is_err() || !saw_escalation.load(Ordering::Acquire) {
+        return Err("RCU holdout did not recover through reschedule escalation");
     }
     Ok(())
 }
@@ -426,13 +544,36 @@ fn run_duplicate_claim_selftest() -> Result<(), &'static str> {
 
 fn run_pr1_selftest() -> Result<(), &'static str> {
     gp::run_state_machine_selftests()?;
+    progress::run_progress_selftests()?;
+    if callback_duration_ns(100, 100 + RCU_SLOW_CALLBACK_NS) != Some(RCU_SLOW_CALLBACK_NS)
+        || callback_duration_ns(0, 10).is_some()
+        || callback_duration_ns(100, 99).is_some()
+        || callback_duration_ns(100, 200) != Some(100)
+    {
+        return Err("RCU callback duration validation accepted an invalid clock sample");
+    }
+    if RCU_SLOW_CALLBACK_NS < RCU_CALLBACK_TIME_BUDGET_NS {
+        return Err("RCU slow callback threshold is below the batch time budget");
+    }
+    #[cfg(target_arch = "x86_64")]
+    {
+        let cycles = usize::MAX / 1_000_000 + 1;
+        let khz = 3_000_000;
+        let expected = ((cycles as u128 * 1_000_000u128) / khz as u128) as usize;
+        if crate::arch::time::cycles_to_ns(cycles, khz) != expected {
+            return Err("x86 cycles-to-nanoseconds conversion overflowed");
+        }
+    }
     context::run_context_selftests()?;
     callback::run_segmented_callback_selftests()?;
     run_callback_generation_selftest()?;
     run_duplicate_claim_selftest()?;
     run_cpu_hotplug_lifecycle_selftest()?;
     run_cpu_hotplug_concurrent_selftest()?;
+    run_immediate_gp_accounting_selftest()?;
     run_callback_flood_selftest()?;
+    run_slow_callback_budget_selftest()?;
+    run_reschedule_escalation_selftest()?;
     run_smp_callback_barrier_selftest()?;
     run_concurrent_barrier_selftest()?;
 
@@ -482,7 +623,7 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
         if blocked_hits.load(Ordering::SeqCst) != 0 {
             Err("rcu_defer callback ran before leaving the read-side critical section")
         } else {
-            note_context_switch();
+            note_context_switch(&ProcessManager::current_pcb());
             let (_, completed_gp_mid, completed_cb_mid, queued_mid, ready_mid) = debug_snapshot();
 
             if blocked_hits.load(Ordering::SeqCst) != 0 {
@@ -499,7 +640,7 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
         }
     };
 
-    note_context_switch();
+    note_context_switch(&ProcessManager::current_pcb());
     rcu_barrier();
     blocked_result?;
 
@@ -698,12 +839,37 @@ fn run_callback_generation_selftest() -> Result<(), &'static str> {
 fn pump_cpu_lifecycle_model(inner: &mut RcuStateInner) -> bool {
     RcuState::pump_grace_periods_with(
         inner,
+        1,
         |participants| (participants.clone(), [0; PerCpu::MAX_CPU_NUM as usize]),
-        |_| {},
+        |_| false,
         |_| {},
         |_| false,
         |_| {},
+        |_| {},
+        |_| {},
     )
+}
+
+fn run_immediate_gp_accounting_selftest() -> Result<(), &'static str> {
+    let mut inner = RcuStateInner::new();
+    inner.gp.request_future();
+    let mut starts = 0usize;
+    let mut completions = 0usize;
+    RcuState::pump_grace_periods_with(
+        &mut inner,
+        42,
+        |_| (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
+        |_| false,
+        |_| {},
+        |_| false,
+        |_| {},
+        |_| starts += 1,
+        |_| completions += 1,
+    );
+    if starts != 1 || completions != 1 || inner.gp.is_active() || inner.progress.is_some() {
+        return Err("immediately completed RCU GP was not accounted exactly once");
+    }
+    Ok(())
 }
 
 fn run_cpu_hotplug_lifecycle_selftest() -> Result<(), &'static str> {

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -230,7 +230,6 @@ fn run_reschedule_escalation_selftest() -> Result<(), &'static str> {
     // success condition below is per target CPU, so unrelated GP traffic on a
     // different CPU cannot satisfy this test.
     synchronize_rcu();
-    let submitted_before = RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis();
     let ready = Arc::new(Completion::new());
     let done = Arc::new(Completion::new());
     let saw_escalation = Arc::new(AtomicBool::new(false));
@@ -240,15 +239,20 @@ fn run_reschedule_escalation_selftest() -> Result<(), &'static str> {
     let closure = KernelThreadClosure::EmptyClosure((
         Box::new(move || {
             let preempt_guard = PreemptGuard::new();
+            let submitted_before = RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis();
+            let received_before = crate::smp::kick_cpu_received(target_cpu);
             let started = rcu_now();
             thread_ready.complete();
-            while RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis() == submitted_before
-                && !progress::elapsed_at_least(rcu_now(), started, 3_000_000_000)
+            while !(progress::elapsed_at_least(rcu_now(), started, 3_000_000_000)
+                || RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis()
+                    != submitted_before
+                    && crate::smp::kick_cpu_received(target_cpu) != received_before)
             {
                 core::hint::spin_loop();
             }
-            let escalated =
-                RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis() > submitted_before;
+            let escalated = RCU_STATE.contexts[target_cpu.data() as usize].resched_ipis()
+                != submitted_before
+                && crate::smp::kick_cpu_received(target_cpu) != received_before;
             thread_saw.store(escalated, Ordering::Release);
             drop(preempt_guard);
             crate::sched::sched_yield();
@@ -562,6 +566,7 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
     if RCU_SLOW_CALLBACK_NS < RCU_CALLBACK_TIME_BUDGET_NS {
         return Err("RCU slow callback threshold is below the batch time budget");
     }
+    crate::sched::clock::run_sched_clock_selftests()?;
     #[cfg(target_arch = "x86_64")]
     {
         let cycles = usize::MAX / 1_000_000 + 1;

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -209,6 +209,13 @@ fn run_slow_callback_budget_selftest() -> Result<(), &'static str> {
 }
 
 fn run_reschedule_escalation_selftest() -> Result<(), &'static str> {
+    if !crate::smp::kick_cpu_supported() {
+        // The policy and failure accounting remain covered on every
+        // architecture. This production-path test requires an implemented
+        // generic KickCpu IPI receiver.
+        return Ok(());
+    }
+
     let current_cpu = crate::smp::core::smp_get_processor_id();
     let Some(target_cpu) = smp_cpu_manager()
         .present_cpus()
@@ -840,13 +847,17 @@ fn pump_cpu_lifecycle_model(inner: &mut RcuStateInner) -> bool {
     RcuState::pump_grace_periods_with(
         inner,
         1,
-        |participants| (participants.clone(), [0; PerCpu::MAX_CPU_NUM as usize]),
-        |_| false,
-        |_| {},
-        |_| false,
-        |_| {},
-        |_| {},
-        |_| {},
+        GracePeriodPumpHooks {
+            waiting_snapshot: |participants: &CpuMask| {
+                (participants.clone(), [0; PerCpu::MAX_CPU_NUM as usize])
+            },
+            credit_context: |_: &mut GracePeriodState| false,
+            publish_active: |_| {},
+            complete_callbacks: |_| false,
+            prepare_callbacks: |_| {},
+            note_gp_start: |_| {},
+            note_gp_complete: |_| {},
+        },
     )
 }
 
@@ -858,13 +869,15 @@ fn run_immediate_gp_accounting_selftest() -> Result<(), &'static str> {
     RcuState::pump_grace_periods_with(
         &mut inner,
         42,
-        |_| (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
-        |_| false,
-        |_| {},
-        |_| false,
-        |_| {},
-        |_| starts += 1,
-        |_| completions += 1,
+        GracePeriodPumpHooks {
+            waiting_snapshot: |_: &CpuMask| (CpuMask::new(), [0; PerCpu::MAX_CPU_NUM as usize]),
+            credit_context: |_: &mut GracePeriodState| false,
+            publish_active: |_| {},
+            complete_callbacks: |_| false,
+            prepare_callbacks: |_| {},
+            note_gp_start: |_| starts += 1,
+            note_gp_complete: |_| completions += 1,
+        },
     );
     if starts != 1 || completions != 1 || inner.gp.is_active() || inner.progress.is_some() {
         return Err("immediately completed RCU GP was not accounted exactly once");

--- a/kernel/src/sched/clock.rs
+++ b/kernel/src/sched/clock.rs
@@ -1,19 +1,181 @@
 //! 这个文件实现的是调度过程中涉及到的时钟
 //!
+#[cfg(target_arch = "x86_64")]
+use core::sync::atomic::{AtomicU64, AtomicU8, Ordering};
+
 use crate::{arch::CurrentTimeArch, smp::cpu::ProcessorId, time::TimeArch};
+
+#[cfg(target_arch = "x86_64")]
+const HALF_RANGE: u64 = 1_u64 << 63;
+#[cfg(target_arch = "x86_64")]
+const CLOCK_UNINITIALIZED: u8 = 0;
+#[cfg(target_arch = "x86_64")]
+const CLOCK_INITIALIZING: u8 = 1;
+#[cfg(target_arch = "x86_64")]
+const CLOCK_INITIALIZED: u8 = 2;
+
+#[cfg(target_arch = "x86_64")]
+#[repr(align(64))]
+struct SchedClockData {
+    tick_raw: AtomicU64,
+    tick_clock: AtomicU64,
+    clock: AtomicU64,
+    state: AtomicU8,
+}
+
+#[cfg(target_arch = "x86_64")]
+impl SchedClockData {
+    const fn new() -> Self {
+        Self {
+            tick_raw: AtomicU64::new(0),
+            tick_clock: AtomicU64::new(0),
+            clock: AtomicU64::new(0),
+            state: AtomicU8::new(CLOCK_UNINITIALIZED),
+        }
+    }
+
+    fn initialize(&self, raw: u64, global: u64) -> bool {
+        match self.state.compare_exchange(
+            CLOCK_UNINITIALIZED,
+            CLOCK_INITIALIZING,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        ) {
+            Ok(_) => {}
+            Err(CLOCK_INITIALIZED) => return true,
+            Err(_) => return false,
+        }
+        let old = self.clock.load(Ordering::Acquire);
+        let anchor = advance_clock(self, later_clock(global, old));
+        self.tick_raw.store(raw, Ordering::Relaxed);
+        self.tick_clock.store(anchor, Ordering::Relaxed);
+        self.state.store(CLOCK_INITIALIZED, Ordering::Release);
+        true
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+static SCHED_CLOCK_DATA: [SchedClockData; crate::mm::percpu::PerCpu::MAX_CPU_NUM as usize] =
+    [const { SchedClockData::new() }; crate::mm::percpu::PerCpu::MAX_CPU_NUM as usize];
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn clock_after(candidate: u64, reference: u64) -> bool {
+    candidate != reference && candidate.wrapping_sub(reference) < HALF_RANGE
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn later_clock(candidate: u64, reference: u64) -> u64 {
+    if clock_after(candidate, reference) {
+        candidate
+    } else {
+        reference
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+const fn corrected_clock_value(raw: u64, tick_raw: u64, tick_clock: u64, old: u64) -> u64 {
+    let raw_delta = raw.wrapping_sub(tick_raw);
+    let delta = if raw_delta < HALF_RANGE { raw_delta } else { 0 };
+    let candidate = tick_clock.wrapping_add(delta);
+    if clock_after(candidate, old) {
+        candidate
+    } else {
+        old
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn raw_sched_clock() -> u64 {
+    if crate::arch::driver::tsc::TSCManager::cpu_khz() == 0 {
+        0
+    } else {
+        CurrentTimeArch::cycles2ns(CurrentTimeArch::get_cycles()) as u64
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+#[inline]
+fn global_tick_clock() -> u64 {
+    crate::time::timer::clock().wrapping_mul(crate::time::jiffies::NSEC_PER_JIFFY as u64)
+}
 
 pub struct SchedClock;
 
 impl SchedClock {
+    /// Couples the current CPU's raw clock to the global tick epoch.
+    ///
+    /// If CPU0 later stops ticking, the last raw anchor remains in place and
+    /// healthy CPUs continue advancing from their invariant local counters.
     #[inline]
-    pub fn sched_clock_cpu(_cpu: ProcessorId) -> u64 {
+    pub fn tick(cpu: ProcessorId) {
         #[cfg(target_arch = "x86_64")]
         {
-            if crate::arch::driver::tsc::TSCManager::cpu_khz() == 0 {
-                // TSC not calibrated yet
+            let raw = raw_sched_clock();
+            if raw == 0 {
+                return;
+            }
+            let global = global_tick_clock();
+            let data = &SCHED_CLOCK_DATA[cpu.data() as usize];
+            if !data.initialize(raw, global) {
+                return;
+            }
+            let local = update_local_clock(data, raw);
+            let anchor = if clock_after(global, local) {
+                advance_clock(data, global)
+            } else {
+                local
+            };
+            // Never re-anchor to a lagging global tick. This preserves the
+            // progress accumulated from the local counter while CPU0 was not
+            // ticking.
+            data.tick_raw.store(raw, Ordering::Relaxed);
+            data.tick_clock.store(anchor, Ordering::Release);
+        }
+
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = cpu;
+    }
+
+    pub fn reset_cpu(cpu: ProcessorId) {
+        #[cfg(target_arch = "x86_64")]
+        SCHED_CLOCK_DATA[cpu.data() as usize]
+            .state
+            .store(CLOCK_UNINITIALIZED, Ordering::Release);
+
+        #[cfg(not(target_arch = "x86_64"))]
+        let _ = cpu;
+    }
+
+    #[inline]
+    pub fn sched_clock_cpu(cpu: ProcessorId) -> u64 {
+        #[cfg(target_arch = "x86_64")]
+        {
+            let raw = raw_sched_clock();
+            if raw == 0 {
                 return 0;
             }
-            return CurrentTimeArch::cycles2ns(CurrentTimeArch::get_cycles()) as u64;
+            let current_cpu = crate::smp::core::smp_get_processor_id();
+            let local_data = &SCHED_CLOCK_DATA[current_cpu.data() as usize];
+            if !local_data.initialize(raw, global_tick_clock()) {
+                return local_data.clock.load(Ordering::Acquire);
+            }
+            let local = update_local_clock(local_data, raw);
+            if cpu == current_cpu {
+                return local;
+            }
+
+            // A remote CPU's raw counter cannot be sampled here: it may have
+            // a different TSC offset. Couple its already-corrected clock to
+            // this CPU's comparable local value instead.
+            let remote = &SCHED_CLOCK_DATA[cpu.data() as usize];
+            if remote.state.load(Ordering::Acquire) != CLOCK_INITIALIZED {
+                return local;
+            }
+            return advance_clock(remote, local);
         }
 
         #[cfg(any(target_arch = "riscv64", target_arch = "loongarch64"))]
@@ -21,6 +183,62 @@ impl SchedClock {
             return CurrentTimeArch::cycles2ns(CurrentTimeArch::get_cycles()) as u64;
         }
     }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn advance_clock(data: &SchedClockData, candidate: u64) -> u64 {
+    let mut old = data.clock.load(Ordering::Acquire);
+    while clock_after(candidate, old) {
+        match data
+            .clock
+            .compare_exchange_weak(old, candidate, Ordering::AcqRel, Ordering::Acquire)
+        {
+            Ok(_) => return candidate,
+            Err(actual) => old = actual,
+        }
+    }
+    old
+}
+
+#[cfg(target_arch = "x86_64")]
+fn update_local_clock(data: &SchedClockData, raw: u64) -> u64 {
+    let tick_clock = data.tick_clock.load(Ordering::Acquire);
+    let tick_raw = data.tick_raw.load(Ordering::Relaxed);
+    let old = data.clock.load(Ordering::Acquire);
+    advance_clock(data, corrected_clock_value(raw, tick_raw, tick_clock, old))
+}
+
+pub(crate) fn run_sched_clock_selftests() -> Result<(), &'static str> {
+    #[cfg(target_arch = "x86_64")]
+    {
+        let global = 5_000_000;
+        let cpu0 = corrected_clock_value(1_020_000, 1_000_000, global, global);
+        let cpu1 = corrected_clock_value(9_020_000, 9_000_000, global, global);
+        if cpu0 != global + 20_000 || cpu1 != cpu0 {
+            return Err("sched clock did not normalize per-CPU counter offsets");
+        }
+        if corrected_clock_value(2_020_000, 1_000_000, global, cpu0) != global + 1_020_000 {
+            return Err("sched clock stopped without a newer global tick anchor");
+        }
+        let advanced = global + 1_020_000;
+        if later_clock(global + 10_000, advanced) != advanced {
+            return Err("sched clock reset discarded monotonic progress");
+        }
+        let resumed_anchor = later_clock(global + 10_000, advanced);
+        if corrected_clock_value(2_030_000, 2_020_000, resumed_anchor, advanced)
+            != advanced + 10_000
+        {
+            return Err("sched clock froze after a lagging global tick resumed");
+        }
+        if corrected_clock_value(999_000, 1_000_000, global, cpu0) != cpu0 {
+            return Err("sched clock accepted backward local-counter motion");
+        }
+        let wrapped = corrected_clock_value(5, u64::MAX - 10, u64::MAX - 20, u64::MAX - 20);
+        if wrapped != u64::MAX - 4 {
+            return Err("sched clock lost a valid wrapping delta");
+        }
+    }
+    Ok(())
 }
 
 bitflags! {

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -104,6 +104,10 @@ pub fn cpu_is_online(cpu: ProcessorId) -> bool {
     smp_cpu_manager().is_online_cpu(cpu)
 }
 
+pub(crate) fn try_current_task(cpu: ProcessorId) -> Option<Arc<ProcessControlBlock>> {
+    cpu_rq(cpu.data() as usize).try_current_task()
+}
+
 pub fn nr_iowait() -> u32 {
     smp_cpu_manager()
         .present_cpus()
@@ -573,6 +577,17 @@ impl CpuRunQueue {
             core::hint::spin_loop();
         };
         (self.force_mut_locked(), guard)
+    }
+
+    /// Best-effort current-task snapshot for lockup diagnostics.
+    ///
+    /// The caller must tolerate `None`: a stalled CPU may itself hold the
+    /// runqueue lock, so diagnostic code must never spin waiting for it.
+    pub(crate) fn try_current_task(&self) -> Option<Arc<ProcessControlBlock>> {
+        let guard = self.lock.try_lock_irqsave().ok()?;
+        let current = self.current();
+        drop(guard);
+        Some(current)
     }
 
     #[allow(clippy::mut_from_ref)]
@@ -1112,7 +1127,6 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
         }
     }
 
-    crate::rcu::note_context_switch();
     let cpu = smp_get_processor_id().data() as usize;
     let rq = cpu_rq(cpu);
     let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
@@ -1128,6 +1142,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
             }
         }
     };
+    crate::rcu::note_context_switch(&prev);
 
     // TODO: hrtick_clear(rq);
 

--- a/kernel/src/smp/cpu/mod.rs
+++ b/kernel/src/smp/cpu/mod.rs
@@ -312,6 +312,7 @@ impl SmpCpuManager {
         if !rcu::prepare_cpu_starting(cpu_id) {
             return Err(SystemError::EBUSY);
         }
+        crate::sched::clock::SchedClock::reset_cpu(cpu_id);
         unsafe { cpu_state.configure_bringup(target_state, true) };
         cpu_state.publish_state(CpuHpState::Starting);
 

--- a/kernel/src/smp/mod.rs
+++ b/kernel/src/smp/mod.rs
@@ -1,5 +1,7 @@
 use system_error::SystemError;
 
+use ::core::sync::atomic::{AtomicU64, Ordering};
+
 use crate::{
     arch::{interrupt::ipi::send_ipi, CurrentSMPArch},
     exception::ipi::{IpiKind, IpiTarget},
@@ -18,12 +20,33 @@ pub mod cpu;
 pub mod init;
 mod syscall;
 
+#[repr(align(64))]
+struct KickCpuReceiveCounter(AtomicU64);
+
+static KICK_CPU_RECEIVED: [KickCpuReceiveCounter; crate::mm::percpu::PerCpu::MAX_CPU_NUM as usize] =
+    [const { KickCpuReceiveCounter(AtomicU64::new(0)) };
+        crate::mm::percpu::PerCpu::MAX_CPU_NUM as usize];
+
 /// Returns whether this build has a working generic KickCpu IPI path.
 ///
 /// Keep this capability next to `kick_cpu()` so architecture bring-up cannot
 /// accidentally make callers infer support from CPU count alone.
 pub const fn kick_cpu_supported() -> bool {
     cfg!(target_arch = "x86_64")
+}
+
+/// Records completed delivery of the generic reschedule IPI on this CPU.
+pub(crate) fn note_kick_cpu_received() {
+    let cpu = smp_get_processor_id();
+    KICK_CPU_RECEIVED[cpu.data() as usize]
+        .0
+        .fetch_add(1, Ordering::Relaxed);
+}
+
+pub(crate) fn kick_cpu_received(cpu: ProcessorId) -> u64 {
+    KICK_CPU_RECEIVED[cpu.data() as usize]
+        .0
+        .load(Ordering::Relaxed)
 }
 
 pub fn kick_cpu(cpu_id: ProcessorId) -> Result<(), SystemError> {

--- a/kernel/src/smp/mod.rs
+++ b/kernel/src/smp/mod.rs
@@ -18,6 +18,14 @@ pub mod cpu;
 pub mod init;
 mod syscall;
 
+/// Returns whether this build has a working generic KickCpu IPI path.
+///
+/// Keep this capability next to `kick_cpu()` so architecture bring-up cannot
+/// accidentally make callers infer support from CPU count alone.
+pub const fn kick_cpu_supported() -> bool {
+    cfg!(target_arch = "x86_64")
+}
+
 pub fn kick_cpu(cpu_id: ProcessorId) -> Result<(), SystemError> {
     if !smp_cpu_manager_initialized()
         || smp_cpu_manager().possible_cpus().get(cpu_id) != Some(true)

--- a/kernel/src/smp/mod.rs
+++ b/kernel/src/smp/mod.rs
@@ -7,7 +7,10 @@ use crate::{
 
 use self::{
     core::smp_get_processor_id,
-    cpu::{smp_cpu_manager, smp_cpu_manager_init, CpuHpCpuState, ProcessorId},
+    cpu::{
+        smp_cpu_manager, smp_cpu_manager_init, smp_cpu_manager_initialized, CpuHpCpuState,
+        ProcessorId,
+    },
 };
 
 pub mod core;
@@ -16,10 +19,24 @@ pub mod init;
 mod syscall;
 
 pub fn kick_cpu(cpu_id: ProcessorId) -> Result<(), SystemError> {
-    // todo: 增加对cpu_id的有效性检查
+    if !smp_cpu_manager_initialized()
+        || smp_cpu_manager().possible_cpus().get(cpu_id) != Some(true)
+        || !smp_cpu_manager().is_online_cpu(cpu_id)
+    {
+        return Err(SystemError::ENODEV);
+    }
 
-    send_ipi(IpiKind::KickCpu, IpiTarget::Specified(cpu_id));
-    return Ok(());
+    #[cfg(target_arch = "x86_64")]
+    {
+        send_ipi(IpiKind::KickCpu, IpiTarget::Specified(cpu_id));
+        Ok(())
+    }
+
+    #[cfg(not(target_arch = "x86_64"))]
+    {
+        let _ = cpu_id;
+        Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+    }
 }
 
 pub trait SMPArch {

--- a/kernel/src/time/tick_common.rs
+++ b/kernel/src/time/tick_common.rs
@@ -23,6 +23,7 @@ fn tick_periodic(cpu_id: ProcessorId, trap_frame: &TrapFrame) {
         run_local_timer();
     }
 
+    crate::sched::clock::SchedClock::tick(cpu_id);
     crate::rcu::scheduler_tick();
     ProcessManager::update_process_times(trap_frame.is_from_user());
 }

--- a/kernel/src/time/tick_common.rs
+++ b/kernel/src/time/tick_common.rs
@@ -23,5 +23,6 @@ fn tick_periodic(cpu_id: ProcessorId, trap_frame: &TrapFrame) {
         run_local_timer();
     }
 
+    crate::rcu::scheduler_tick();
     ProcessManager::update_process_times(trap_frame.is_from_user());
 }

--- a/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
@@ -11,6 +11,8 @@ namespace {
 
 constexpr const char* kRcuSelftestPath = "/sys/kernel/debug/rcu/selftest";
 constexpr const char* kRcuCallbacksPath = "/sys/kernel/debug/rcu/callbacks";
+constexpr const char* kRcuStatePath = "/sys/kernel/debug/rcu/state";
+constexpr const char* kRcuStatsPath = "/sys/kernel/debug/rcu/stats";
 
 std::string ReadAll(const char* path) {
     int fd = open(path, O_RDONLY);
@@ -78,6 +80,25 @@ TEST(RcuSelftest, CallbackQueueSnapshotIsPresentAndStablePerOpen) {
     EXPECT_NE(std::string::npos, report.find(" next=")) << report;
     EXPECT_NE(std::string::npos, report.find(" executing=")) << report;
     EXPECT_NE(std::string::npos, report.find("cpu=0 total=")) << report;
+}
+
+TEST(RcuSelftest, ProgressStateSnapshotIsPresent) {
+    const std::string report = ReadAll(kRcuStatePath);
+    ASSERT_FALSE(report.empty());
+    EXPECT_NE(std::string::npos, report.find("active=")) << report;
+    EXPECT_NE(std::string::npos, report.find("current_seq=")) << report;
+    EXPECT_NE(std::string::npos, report.find("completed_seq=")) << report;
+    EXPECT_NE(std::string::npos, report.find("next_progress_ns=")) << report;
+}
+
+TEST(RcuSelftest, ProgressStatisticsArePresent) {
+    const std::string report = ReadAll(kRcuStatsPath);
+    ASSERT_FALSE(report.empty());
+    EXPECT_NE(std::string::npos, report.find("gp_started=")) << report;
+    EXPECT_NE(std::string::npos, report.find("gp_completed=")) << report;
+    EXPECT_NE(std::string::npos, report.find("ipi_attempted=")) << report;
+    EXPECT_NE(std::string::npos, report.find("callback_time_budget_hits=")) << report;
+    EXPECT_NE(std::string::npos, report.find("slow_callbacks=")) << report;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Summary

- track active RCU grace-period progress with deterministic soft-request, reschedule-IPI, and stall-report deadlines
- allow any healthy scheduler tick to drive escalation without depending on CPU0 jiffies or a bound worker
- keep timer hardirq work allocation-free by deferring waitqueue wakeups to an RCU softirq and diagnostics to worker context
- bound callback batches by count and elapsed time, expose read-only state/statistics, and fix x86 cycle conversion overflow
- add deterministic policy coverage, production-path two-CPU escalation coverage, slow-callback coverage, and debugfs dunitests

## Concurrency and safety

- holdout, sequence, deadline, and stall-candidate transitions remain under the RCU coordinator lock
- IPIs are sent after releasing the coordinator lock and never clear holdouts directly
- stall candidates are revalidated against the active sequence and current holdouts before rate-limit state is committed
- debug snapshots use fixed-size lock-domain copies and do not expose callback addresses
- the owner-only selftest runs once under serialization and serves a cached report afterward

## Validation

- `make kernel`
- 2-vCPU KVM QEMU boot to userspace
- `/opt/tests/dunitest/bin/normal/rcu_selftest_test`: 5/5 passed
- final run: 136 grace periods started and completed, one soft request, one submitted reschedule IPI, no stall reports, and no queued callbacks
- repeated guest regression runs completed without panic or general-protection faults

Fixes #2214