### PR TITLE
fix(tty): implement TCXONC flow control

### DIFF
--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -23,7 +23,7 @@ use crate::{
             console::ConsoleSwitch,
             kthread::{enqueue_tty_rx_byte_to_target_from_irq, TtyInputTarget},
             termios::{ControlMode, Termios, WindowSize},
-            tty_core::{TtyCore, TtyCoreData},
+            tty_core::{TtyCore, TtyCoreData, TtySleepLock},
             tty_driver::{TtyDriver, TtyDriverManager, TtyOperation},
             tty_port::TtyInputByteResult,
             virtual_terminal::{vc_manager, virtual_console::VirtualConsoleData, VirtConsole},
@@ -152,6 +152,8 @@ pub struct Serial8250PIOPort {
     rx_paused: AtomicBool,
     rx_state: SpinLock<Serial8250RxState>,
     tx_state: SpinLock<Serial8250TxState>,
+    open_close_lock: TtySleepLock,
+    tty_open: AtomicBool,
     /// Serializes the DLAB register-alias window against runtime UART I/O.
     hw_lock: SpinLock<()>,
     console_owner: AtomicUsize,
@@ -169,6 +171,8 @@ struct Serial8250RxState {
 #[derive(Debug)]
 struct Serial8250TxState {
     queue: Option<VecDeque<u8>>,
+    x_char: Option<u8>,
+    stopped: bool,
     tty: Weak<TtyCore>,
     console_active: bool,
     flush_generation: usize,
@@ -180,10 +184,25 @@ impl Serial8250TxState {
             // The PIO ports are constructed before the heap is available.
             // Allocate the process-context TX queue later during TTY install.
             queue: None,
+            x_char: None,
+            stopped: false,
             tty: Weak::new(),
             console_active: false,
             flush_generation: 0,
         }
+    }
+
+    fn irq_needed(&self) -> bool {
+        if self.console_active {
+            return false;
+        }
+        self.x_char.is_some()
+            || (!self.stopped
+                && self
+                    .queue
+                    .as_ref()
+                    .map(|queue| !queue.is_empty())
+                    .unwrap_or(false))
     }
 }
 
@@ -213,6 +232,8 @@ impl Serial8250PIOPort {
             rx_paused: AtomicBool::new(false),
             rx_state: SpinLock::new(Serial8250RxState::new()),
             tx_state: SpinLock::new(Serial8250TxState::new()),
+            open_close_lock: TtySleepLock::new(),
+            tty_open: AtomicBool::new(false),
             hw_lock: SpinLock::new(()),
             console_owner: AtomicUsize::new(SERIAL_8250_CONSOLE_OWNER_NONE),
             inner: RwSem::new(Serial8250PIOPortInner::new()),
@@ -346,10 +367,8 @@ impl Serial8250PIOPort {
             queue.extend(&buf[..accepted]);
             accepted
         };
-        if accepted != 0 {
-            self.pump_tx();
-        } else if self.tx_room() == 0 {
-            self.set_tx_interrupt_enabled(true);
+        if accepted != 0 || self.tx_room() == 0 {
+            self.pump_tx(true);
         }
         accepted
     }
@@ -372,45 +391,48 @@ impl Serial8250PIOPort {
             .unwrap_or(0)
     }
 
-    fn pump_tx(&self) {
+    fn pump_tx(&self, allow_wake: bool) {
         let (sent, should_wake, tty) = {
             let mut tx_state = self.tx_state.lock_irqsave();
             if tx_state.console_active {
                 return;
             }
             let tty = tx_state.tty.upgrade();
-            let Some(queue) = tx_state.queue.as_mut() else {
-                return;
-            };
-            let pending_before = queue.len();
+            let pending_before = tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0);
             let mut sent = 0;
             // THRE must be sampled after taking tx_state: both process and
             // IRQ contexts can pump this port, and a pre-lock sample becomes
             // stale as soon as another context fills the FIFO.
             let _hw_guard = self.hw_lock.lock_irqsave();
             if self.serial_in_raw(5) & 0x20 != 0 {
-                while sent < self.tx_fifo_size.load(Ordering::Acquire) {
-                    let Some(byte) = queue.pop_front() else {
-                        break;
-                    };
-                    self.serial_out_raw(0, byte.into());
-                    sent += 1;
+                if let Some(ch) = tx_state.x_char.take() {
+                    self.serial_out_raw(0, ch.into());
+                } else if !tx_state.stopped {
+                    let fifo_size = self.tx_fifo_size.load(Ordering::Acquire);
+                    if let Some(queue) = tx_state.queue.as_mut() {
+                        while sent < fifo_size {
+                            let Some(byte) = queue.pop_front() else {
+                                break;
+                            };
+                            self.serial_out_raw(0, byte.into());
+                            sent += 1;
+                        }
+                    }
                 }
             }
             drop(_hw_guard);
-            let pending = !queue.is_empty();
-            let pending_after = queue.len();
+            let pending_after = tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0);
             let should_wake = pending_before != 0
                 && (pending_after == 0
                     || (pending_before >= SERIAL_8250_TX_WAKEUP_CHARS
                         && pending_after < SERIAL_8250_TX_WAKEUP_CHARS));
             // Commit IER from the same queue snapshot before enqueue/clear can
             // mutate it, otherwise a stale disable can strand new bytes.
-            self.set_tx_interrupt_enabled(pending);
+            self.set_tx_interrupt_enabled(tx_state.irq_needed());
             (sent, should_wake, tty)
         };
 
-        if sent != 0 && should_wake {
+        if allow_wake && sent != 0 && should_wake {
             if let Some(tty) = tty {
                 tty.tty_wakeup();
             }
@@ -423,7 +445,7 @@ impl Serial8250PIOPort {
             queue.clear();
         }
         tx_state.flush_generation = tx_state.flush_generation.wrapping_add(1);
-        self.set_tx_interrupt_enabled(false);
+        self.set_tx_interrupt_enabled(tx_state.irq_needed());
     }
 
     fn abort_tx(&self) {
@@ -431,6 +453,8 @@ impl Serial8250PIOPort {
         if let Some(queue) = tx_state.queue.as_mut() {
             queue.clear();
         }
+        tx_state.x_char = None;
+        tx_state.stopped = false;
         tx_state.flush_generation = tx_state.flush_generation.wrapping_add(1);
         self.set_tx_interrupt_enabled(false);
 
@@ -527,7 +551,11 @@ impl Serial8250PIOPort {
         let (mut older_remaining, flush_generation, tty) = {
             let mut tx_state = self.tx_state.lock_irqsave();
             tx_state.console_active = true;
-            let pending = tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0);
+            let pending = if tx_state.stopped {
+                0
+            } else {
+                tx_state.queue.as_ref().map(VecDeque::len).unwrap_or(0)
+            };
             let flush_generation = tx_state.flush_generation;
             let tty = tx_state.tty.upgrade();
             self.set_tx_interrupt_enabled(false);
@@ -543,6 +571,13 @@ impl Serial8250PIOPort {
             }
             let mut tx_state = self.tx_state.lock_irqsave();
             if tx_state.flush_generation != flush_generation {
+                older_remaining = 0;
+                break;
+            }
+            // TCOOFF may race with a process-context console submission.
+            // Recheck on every batch so no ordinary TTY byte is dequeued
+            // after stop_tx() has committed the paused state.
+            if tx_state.stopped {
                 older_remaining = 0;
                 break;
             }
@@ -590,12 +625,7 @@ impl Serial8250PIOPort {
         {
             let mut tx_state = self.tx_state.lock_irqsave();
             tx_state.console_active = false;
-            let pending = tx_state
-                .queue
-                .as_ref()
-                .map(|queue| !queue.is_empty())
-                .unwrap_or(false);
-            self.set_tx_interrupt_enabled(pending);
+            self.set_tx_interrupt_enabled(tx_state.irq_needed());
         }
         if older_remaining == 0 {
             if let Some(tty) = tty {
@@ -603,7 +633,7 @@ impl Serial8250PIOPort {
             }
         }
         if healthy {
-            self.pump_tx();
+            self.pump_tx(true);
         }
         self.console_owner
             .store(SERIAL_8250_CONSOLE_OWNER_NONE, Ordering::Release);
@@ -649,12 +679,7 @@ impl Serial8250PIOPort {
         }
 
         tx_state.console_active = inherited_console_active;
-        let pending = tx_state
-            .queue
-            .as_ref()
-            .map(|queue| !queue.is_empty())
-            .unwrap_or(false);
-        if pending && !inherited_console_active {
+        if tx_state.irq_needed() && !inherited_console_active {
             rx_state.ier |= SERIAL_8250_IER_TX_EMPTY;
         } else {
             rx_state.ier &= !SERIAL_8250_IER_TX_EMPTY;
@@ -801,6 +826,33 @@ impl Serial8250PIOPort {
             tx_state.queue = Some(VecDeque::with_capacity(SERIAL_8250_TX_QUEUE_SIZE));
         }
         tx_state.tty = tty;
+    }
+
+    fn start_tx(&self) {
+        self.tx_state.lock_irqsave().stopped = false;
+        // This can run under the TTY flow lock. Advance the bounded hardware
+        // path immediately, but never re-enter the line discipline.
+        self.pump_tx(false);
+    }
+
+    fn stop_tx(&self) {
+        let mut tx_state = self.tx_state.lock_irqsave();
+        tx_state.stopped = true;
+        self.set_tx_interrupt_enabled(tx_state.irq_needed());
+    }
+
+    fn send_priority_char(&self, ch: u8) {
+        self.tx_state.lock_irqsave().x_char = Some(ch);
+        // A priority character must make progress even when TX is stopped or
+        // this port has no registered interrupt handler.
+        self.pump_tx(false);
+    }
+
+    fn reset_tx_flow(&self) {
+        let mut tx_state = self.tx_state.lock_irqsave();
+        tx_state.x_char = None;
+        tx_state.stopped = false;
+        self.set_tx_interrupt_enabled(tx_state.irq_needed());
     }
 
     fn line_control(control_mode: ControlMode) -> u8 {
@@ -1032,7 +1084,7 @@ impl UartPort for Serial8250PIOPort {
 
     fn handle_irq(&self) -> Result<(), SystemError> {
         self.pump_rx()?;
-        self.pump_tx();
+        self.pump_tx(true);
         Ok(())
     }
 
@@ -1126,7 +1178,16 @@ impl Serial8250PIOTtyDriverInner {
 }
 
 impl TtyOperation for Serial8250PIOTtyDriverInner {
-    fn open(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
+    fn open(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        let port = unsafe { PIO_PORTS.get(tty.index()).and_then(Option::as_ref) }
+            .ok_or(SystemError::ENODEV)?;
+        let _lifecycle_guard = port.open_close_lock.lock();
+        if !port.tty_open.load(Ordering::Acquire) {
+            // The TTY core resets generic flow under its non-PTY lifecycle
+            // lock; this callback resets only device-private TX state.
+            port.reset_tx_flow();
+            port.tty_open.store(true, Ordering::Release);
+        }
         Ok(())
     }
 
@@ -1199,6 +1260,30 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         self.write(tty, &[ch], 1).map(|_| ())
     }
 
+    fn send_xchar(&self, tty: &TtyCoreData, ch: u8) -> Result<(), SystemError> {
+        let index = tty.index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        port.send_priority_char(ch);
+        Ok(())
+    }
+
+    fn start(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        let index = tty.index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        port.start_tx();
+        Ok(())
+    }
+
+    fn stop(&self, tty: &TtyCoreData) -> Result<(), SystemError> {
+        let index = tty.index();
+        let port =
+            unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        port.stop_tx();
+        Ok(())
+    }
+
     fn ioctl(&self, _tty: Arc<TtyCore>, _cmd: u32, _arg: usize) -> Result<(), SystemError> {
         Err(SystemError::ENOIOCTLCMD)
     }
@@ -1207,6 +1292,7 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let index = tty.core().index();
         let port =
             unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
+        let _lifecycle_guard = port.open_close_lock.lock();
         let close_deadline = Instant::now() + SERIAL_8250_CLOSE_WAIT;
         let queue_drained = port
             .wait_for_tx_queue_empty_until(tty.core(), close_deadline)
@@ -1220,8 +1306,11 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
             // A failed/stalled UART must not leak bytes into the next open.
             port.abort_tx();
         }
-        tty.ldisc().flush_buffer(tty.clone())?;
-        Ok(())
+        // TTY objects are retained in the driver table across reopen. Never
+        // leak a priority byte or a paused driver state into the next open.
+        port.reset_tx_flow();
+        port.tty_open.store(false, Ordering::Release);
+        tty.ldisc().flush_buffer(tty.clone())
     }
 
     fn resize(&self, tty: Arc<TtyCore>, winsize: WindowSize) -> Result<(), SystemError> {

--- a/kernel/src/driver/serial/serial8250/serial8250_pio.rs
+++ b/kernel/src/driver/serial/serial8250/serial8250_pio.rs
@@ -1293,6 +1293,12 @@ impl TtyOperation for Serial8250PIOTtyDriverInner {
         let port =
             unsafe { PIO_PORTS.get(index).and_then(Option::as_ref) }.ok_or(SystemError::ENODEV)?;
         let _lifecycle_guard = port.open_close_lock.lock();
+        // Match Linux tty_port_close_start(): output stopped by TCOOFF cannot
+        // drain, so discard the software TX queue before waiting for bytes
+        // already submitted to the UART to leave the device.
+        if tty.core().flow_irqsave().tco_stopped {
+            port.clear_tx();
+        }
         let close_deadline = Instant::now() + SERIAL_8250_CLOSE_WAIT;
         let queue_drained = port
             .wait_for_tx_queue_empty_until(tty.core(), close_deadline)

--- a/kernel/src/driver/tty/pty/unix98pty.rs
+++ b/kernel/src/driver/tty/pty/unix98pty.rs
@@ -1009,9 +1009,14 @@ impl TtyOperation for Unix98PtyDriverInner {
 
         let link = core.checked_link()?;
 
+        if !link.core().contorl_info_irqsave().packet {
+            return Ok(());
+        }
+
         let mut ctrl = core.contorl_info_irqsave();
         ctrl.pktstatus.remove(TtyPacketStatus::TIOCPKT_STOP);
         ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_START);
+        drop(ctrl);
 
         let events =
             EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;
@@ -1028,9 +1033,14 @@ impl TtyOperation for Unix98PtyDriverInner {
 
         let link = core.checked_link()?;
 
+        if !link.core().contorl_info_irqsave().packet {
+            return Ok(());
+        }
+
         let mut ctrl = core.contorl_info_irqsave();
         ctrl.pktstatus.remove(TtyPacketStatus::TIOCPKT_START);
         ctrl.pktstatus.insert(TtyPacketStatus::TIOCPKT_STOP);
+        drop(ctrl);
 
         let events =
             EPollEventType::EPOLLPRI | EPollEventType::EPOLLIN | EPollEventType::EPOLLRDNORM;

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -239,6 +239,7 @@ impl TtyCore {
 
     pub fn tty_start(&self) {
         let mut flow = self.core.flow.lock_irqsave();
+        flow.transition_seq = flow.transition_seq.wrapping_add(1);
         if !self.tty_start_locked(&mut flow) {
             return;
         }
@@ -252,11 +253,13 @@ impl TtyCore {
     /// releasing any line-discipline locks it holds.
     pub(crate) fn tty_start_without_wakeup(&self) -> bool {
         let mut flow = self.core.flow.lock_irqsave();
+        flow.transition_seq = flow.transition_seq.wrapping_add(1);
         self.tty_start_locked(&mut flow)
     }
 
     pub fn tty_stop(&self) {
         let mut flow = self.core.flow.lock_irqsave();
+        flow.transition_seq = flow.transition_seq.wrapping_add(1);
         self.tty_stop_locked(&mut flow);
     }
 
@@ -266,6 +269,7 @@ impl TtyCore {
             return;
         }
         flow.tco_stopped = true;
+        flow.transition_seq = flow.transition_seq.wrapping_add(1);
         self.tty_stop_locked(&mut flow);
     }
 
@@ -275,6 +279,7 @@ impl TtyCore {
             return;
         }
         flow.tco_stopped = false;
+        flow.transition_seq = flow.transition_seq.wrapping_add(1);
         if !self.tty_start_locked(&mut flow) {
             return;
         }
@@ -297,18 +302,34 @@ impl TtyCore {
             return Ok(());
         }
 
-        let was_stopped = self.core.flow.lock_irqsave().stopped;
         let _write_guard = self.core.write_lock().lock_interruptible(false)?;
         let _termios_guard = self.core.termios_read_lock();
 
-        if was_stopped {
+        let (temporarily_started, transition_seq) = {
             let mut flow = self.core.flow.lock_irqsave();
-            self.tty_start_locked(&mut flow);
-        }
+            let transition_seq = flow.transition_seq;
+            let temporarily_started = self.tty_start_locked(&mut flow);
+            (temporarily_started, transition_seq)
+        };
         let _ = self.write(self.core(), &[ch], 1);
-        if was_stopped {
+        let mut should_wake = false;
+        if temporarily_started {
             let mut flow = self.core.flow.lock_irqsave();
-            self.tty_stop_locked(&mut flow);
+            // A concurrent flow-control request owns the final state. Restore
+            // the temporary stop only if no request raced with this fallback.
+            if flow.transition_seq == transition_seq && !flow.stopped {
+                self.tty_stop_locked(&mut flow);
+            } else if !flow.stopped {
+                // A start request can observe the temporary running state and
+                // skip its own wakeup. Complete that request after dropping
+                // every lock that write_wakeup may re-enter.
+                should_wake = true;
+            }
+        }
+        drop(_termios_guard);
+        drop(_write_guard);
+        if should_wake {
+            self.tty_wakeup();
         }
         Ok(())
     }
@@ -702,6 +723,9 @@ pub struct TtyFlowState {
     pub stopped: bool,
     /// 表示 TCO（Transmit Continuous Operation）流控是否被停止
     pub tco_stopped: bool,
+    /// Changes whenever an external start/stop request can supersede a
+    /// temporary state transition used by the xchar fallback.
+    transition_seq: usize,
 }
 
 #[derive(Debug)]

--- a/kernel/src/driver/tty/tty_core.rs
+++ b/kernel/src/driver/tty/tty_core.rs
@@ -141,6 +141,8 @@ impl TtyCore {
             read_wq: EventWaitQueue::new(),
             write_wq: EventWaitQueue::new(),
             write_lock: TtySleepLock::new(),
+            open_close_lock: TtySleepLock::new(),
+            open_files: AtomicUsize::new(0),
             job_control_lock: TtySleepLock::new(),
             port: RwLock::new(None),
             index,
@@ -225,12 +227,22 @@ impl TtyCore {
         true
     }
 
+    fn tty_stop_locked(&self, flow: &mut TtyFlowState) -> bool {
+        if flow.stopped {
+            return false;
+        }
+
+        flow.stopped = true;
+        let _ = self.stop(self.core());
+        true
+    }
+
     pub fn tty_start(&self) {
         let mut flow = self.core.flow.lock_irqsave();
         if !self.tty_start_locked(&mut flow) {
             return;
         }
-
+        drop(flow);
         self.tty_wakeup();
     }
 
@@ -245,12 +257,64 @@ impl TtyCore {
 
     pub fn tty_stop(&self) {
         let mut flow = self.core.flow.lock_irqsave();
-        if flow.stopped {
+        self.tty_stop_locked(&mut flow);
+    }
+
+    pub fn tty_stop_tco(&self) {
+        let mut flow = self.core.flow.lock_irqsave();
+        if flow.tco_stopped {
             return;
         }
-        flow.stopped = true;
+        flow.tco_stopped = true;
+        self.tty_stop_locked(&mut flow);
+    }
 
-        let _ = self.stop(self.core());
+    pub fn tty_start_tco(&self) {
+        let mut flow = self.core.flow.lock_irqsave();
+        if !flow.tco_stopped {
+            return;
+        }
+        flow.tco_stopped = false;
+        if !self.tty_start_locked(&mut flow) {
+            return;
+        }
+        drop(flow);
+        self.tty_wakeup();
+    }
+
+    /// Send a software flow-control character without output post-processing.
+    pub fn tty_send_xchar(&self, ch: u8) -> Result<(), SystemError> {
+        let hook_result = {
+            let _termios_guard = self.core.termios_read_lock();
+            self.core
+                .tty_driver
+                .driver_funcs()
+                .send_xchar(self.core(), ch)
+        };
+        if hook_result != Err(SystemError::ENOSYS) {
+            // Linux's send_xchar hook is void: an implemented driver path is
+            // best-effort and never exposes a device error to userspace.
+            return Ok(());
+        }
+
+        let was_stopped = self.core.flow.lock_irqsave().stopped;
+        let _write_guard = self.core.write_lock().lock_interruptible(false)?;
+        let _termios_guard = self.core.termios_read_lock();
+
+        if was_stopped {
+            let mut flow = self.core.flow.lock_irqsave();
+            self.tty_start_locked(&mut flow);
+        }
+        let _ = self.write(self.core(), &[ch], 1);
+        if was_stopped {
+            let mut flow = self.core.flow.lock_irqsave();
+            self.tty_stop_locked(&mut flow);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn reset_flow_state(&self) {
+        *self.core.flow.lock_irqsave() = TtyFlowState::default();
     }
 
     pub fn tty_wakeup(&self) {
@@ -660,6 +724,11 @@ pub struct TtyCoreData {
     write_wq: EventWaitQueue,
     /// 串行化整个 tty write 调用，等价于 Linux tty->atomic_write_lock。
     write_lock: TtySleepLock,
+    /// Serializes non-PTY first-open/last-close driver lifecycle callbacks.
+    open_close_lock: TtySleepLock,
+    /// User file descriptions; unlike `count`, this excludes the driver's
+    /// persistent table reference.
+    open_files: AtomicUsize,
     /// Serializes controlling-session changes with hangup.
     job_control_lock: TtySleepLock,
     /// 端口
@@ -871,6 +940,25 @@ impl TtyCoreData {
         &self.write_lock
     }
 
+    pub(crate) fn open_close_lock(&self) -> &TtySleepLock {
+        &self.open_close_lock
+    }
+
+    /// Caller must hold `open_close_lock`.
+    pub(crate) fn begin_file_open(&self) -> bool {
+        self.open_files.fetch_add(1, Ordering::SeqCst) == 0
+    }
+
+    /// Caller must hold `open_close_lock`.
+    pub(crate) fn end_file_open(&self) -> bool {
+        let count = self.open_files.load(Ordering::SeqCst);
+        if count == 0 {
+            return false;
+        }
+        self.open_files.store(count - 1, Ordering::SeqCst);
+        count == 1
+    }
+
     #[inline]
     pub fn job_control_lock(&self) -> &TtySleepLock {
         &self.job_control_lock
@@ -982,6 +1070,12 @@ impl TtyCoreData {
 
             while nr != 0 {
                 if !rescan {
+                    // Match Linux's `while (!stopped)` plus
+                    // `goto rescan_last_byte`: stop before consuming a new
+                    // byte, but always finish a byte already marked rescan.
+                    if self.flow.lock_irqsave().stopped {
+                        break;
+                    }
                     ch = buf[offset] as u32;
                     offset += 1;
                     nr -= 1;
@@ -1044,6 +1138,11 @@ impl TtyOperation for TtyCore {
     }
 
     #[inline]
+    fn send_xchar(&self, tty: &TtyCoreData, ch: u8) -> Result<(), SystemError> {
+        self.core().tty_driver.driver_funcs().send_xchar(tty, ch)
+    }
+
+    #[inline]
     fn install(&self, driver: Arc<TtyDriver>, tty: Arc<TtyCore>) -> Result<(), SystemError> {
         return self.core().tty_driver.driver_funcs().install(driver, tty);
     }
@@ -1083,6 +1182,9 @@ impl TtyOperation for TtyCore {
     }
 
     fn close(&self, tty: Arc<TtyCore>) -> Result<(), SystemError> {
+        let non_pty = tty.core().driver().tty_driver_type() != TtyDriverType::Pty;
+        let _open_close_guard = non_pty.then(|| tty.core().open_close_lock().lock());
+        let is_non_pty_last = non_pty && tty.core().end_file_open();
         self.core().dec_count();
         let cnt = self.core().count();
         // TODO: fix pty slave close issue
@@ -1090,7 +1192,7 @@ impl TtyOperation for TtyCore {
         let is_pty_slave_last = cnt == 1 && subtype == TtyDriverSubType::PtySlave;
         let is_pty_master_last = cnt == 1 && subtype == TtyDriverSubType::PtyMaster;
         let final_release = !self.core().count_valid();
-        if final_release || is_pty_slave_last || is_pty_master_last {
+        if final_release || is_pty_slave_last || is_pty_master_last || is_non_pty_last {
             // log::debug!(
             //     "TtyCore close: ref count: {}, tty: {}",
             //     cnt,
@@ -1101,6 +1203,9 @@ impl TtyOperation for TtyCore {
             // the peer keeps the tty structure count at one. The controlling
             // session remains attached in that case and may reopen /dev/tty;
             // only a true final structure release clears it here.
+            if final_release || is_non_pty_last {
+                self.reset_flow_state();
+            }
             if final_release {
                 let _ = TtyJobCtrlManager::remove_session_tty(&tty);
             }
@@ -1298,4 +1403,14 @@ impl TtyFlushArg {
     pub const TCOFLUSH: usize = 1;
     /// 丢弃所有待处理输入和输出数据
     pub const TCIOFLUSH: usize = 2;
+}
+
+pub struct TtyFlowArg;
+
+#[allow(dead_code)]
+impl TtyFlowArg {
+    pub const TCOOFF: usize = 0;
+    pub const TCOON: usize = 1;
+    pub const TCIOFF: usize = 2;
+    pub const TCION: usize = 3;
 }

--- a/kernel/src/driver/tty/tty_device.rs
+++ b/kernel/src/driver/tty/tty_device.rs
@@ -329,8 +329,17 @@ impl IndexNode for TtyDevice {
 
         tty.core().contorl_info_irqsave().clear_dead_session();
 
+        let non_pty = tty.core().driver().tty_driver_type() != TtyDriverType::Pty;
+        let open_close_guard = non_pty.then(|| tty.core().open_close_lock().lock());
+        let first_open = non_pty && tty.core().begin_file_open();
+        if first_open {
+            tty.reset_flow_state();
+        }
         let ret = tty.open(tty.core());
         if let Err(err) = ret {
+            if non_pty {
+                tty.core().end_file_open();
+            }
             tty.core().dec_count();
             *data = FilePrivateData::Unused;
             if err == SystemError::ENOSYS {
@@ -343,6 +352,7 @@ impl IndexNode for TtyDevice {
         // Linux. Do not clear a hangup which raced with this open: its
         // generation change marks this file as one of the hung-up instances.
         tty.core().finish_file_open(hangup_generation);
+        drop(open_close_guard);
 
         let driver = tty.core().driver();
         // 考虑 O_NOCTTY：显式指定则不设置控制终端；pty master 也不会成为控制终端。

--- a/kernel/src/driver/tty/tty_driver.rs
+++ b/kernel/src/driver/tty/tty_driver.rs
@@ -520,6 +520,14 @@ pub trait TtyOperation: Sync + Send + Debug {
         self.write(tty, &[ch], 1).map(|_| ())
     }
 
+    /// Send a high-priority software flow-control character.
+    ///
+    /// Drivers without a priority path return `ENOSYS` so the TTY core can
+    /// use Linux's write-serialized fallback.
+    fn send_xchar(&self, _tty: &TtyCoreData, _ch: u8) -> Result<(), SystemError> {
+        Err(SystemError::ENOSYS)
+    }
+
     fn start(&self, _tty: &TtyCoreData) -> Result<(), SystemError> {
         Err(SystemError::ENOSYS)
     }

--- a/kernel/src/driver/tty/tty_ldisc/ntty.rs
+++ b/kernel/src/driver/tty/tty_ldisc/ntty.rs
@@ -15,7 +15,7 @@ use crate::{
         },
         termios::{ControlCharIndex, InputMode, LocalMode, OutputMode, Termios},
         tty_core::{
-            EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyIoctlCmd, TtyPacketStatus,
+            EchoOperation, TtyCore, TtyCoreData, TtyFlag, TtyFlowArg, TtyIoctlCmd, TtyPacketStatus,
             TtySleepLock,
         },
         tty_driver::{TtyDriverFlag, TtyDriverSubType, TtyOperation},
@@ -108,7 +108,25 @@ impl NTtyLinediscipline {
     fn ioctl_helper(&self, tty: Arc<TtyCore>, cmd: u32, arg: usize) -> Result<usize, SystemError> {
         match cmd {
             TtyIoctlCmd::TCXONC => {
-                todo!()
+                TtyJobCtrlManager::tty_check_change(tty.clone(), Signal::SIGTTOU)?;
+                match arg {
+                    TtyFlowArg::TCOOFF => tty.tty_stop_tco(),
+                    TtyFlowArg::TCOON => tty.tty_start_tco(),
+                    TtyFlowArg::TCIOFF | TtyFlowArg::TCION => {
+                        let termios = tty.core().committed_termios_snapshot();
+                        let index = if arg == TtyFlowArg::TCIOFF {
+                            ControlCharIndex::VSTOP
+                        } else {
+                            ControlCharIndex::VSTART
+                        };
+                        let ch = termios.control_characters[index];
+                        if ch != ControlCharIndex::DISABLE_CHAR {
+                            tty.tty_send_xchar(ch)?;
+                        }
+                    }
+                    _ => return Err(SystemError::EINVAL),
+                }
+                Ok(0)
             }
             TtyIoctlCmd::TCFLSH => TtyCore::tty_perform_flush(tty, arg),
             _ => {

--- a/kernel/src/driver/tty/virtual_terminal/mod.rs
+++ b/kernel/src/driver/tty/virtual_terminal/mod.rs
@@ -433,13 +433,19 @@ impl TtyOperation for TtyConsoleDriverInner {
         Ok(())
     }
 
-    fn write_room(&self, _tty: &TtyCoreData) -> usize {
+    fn write_room(&self, tty: &TtyCoreData) -> usize {
+        if tty.flow_irqsave().stopped {
+            return 0;
+        }
         32768
     }
 
     /// 参考： https://code.dragonos.org.cn/xref/linux-6.1.9/drivers/tty/vt/vt.c#2894
     #[inline(never)]
     fn write(&self, tty: &TtyCoreData, buf: &[u8], nr: usize) -> Result<usize, SystemError> {
+        if tty.flow_irqsave().stopped {
+            return Ok(0);
+        }
         // if String::from_utf8_lossy(buf) == "Hello world!\n" {
         //     loop {}
         // }

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -9,12 +9,14 @@
 #include <atomic>
 #include <errno.h>
 #include <fcntl.h>
+#include <poll.h>
 #include <pthread.h>
 #include <pty.h>
+#include <stdint.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <poll.h>
 #include <termios.h>
+#include <time.h>
 #include <unistd.h>
 
 namespace {
@@ -841,6 +843,31 @@ TEST(TtyTermios, Serial8250AppliesModernAndLegacySettings) {
     EXPECT_EQ(cfgetospeed(&legacy_back), static_cast<speed_t>(B19200));
     EXPECT_EQ(legacy_back.c_cflag & CSIZE, static_cast<tcflag_t>(CS8));
     EXPECT_EQ(legacy_back.c_cflag & PARENB, 0u);
+}
+
+TEST(TtyTermios, Serial8250CloseDoesNotWaitOnTcoStoppedQueue) {
+    UniqueFd serial(open("/dev/ttyS0", O_RDWR | O_NOCTTY));
+    if (serial.get() < 0) {
+        GTEST_SKIP() << "cannot open /dev/ttyS0: " << strerror(errno);
+        return;
+    }
+
+    ASSERT_EQ(tcflow(serial.get(), TCOOFF), 0) << strerror(errno);
+    constexpr char marker[] = "discard-on-paused-close";
+    ASSERT_EQ(write(serial.get(), marker, sizeof(marker) - 1),
+              static_cast<ssize_t>(sizeof(marker) - 1));
+
+    struct timespec started = {};
+    struct timespec finished = {};
+    ASSERT_EQ(clock_gettime(CLOCK_MONOTONIC, &started), 0);
+    serial.reset();
+    ASSERT_EQ(clock_gettime(CLOCK_MONOTONIC, &finished), 0);
+
+    const int64_t elapsed_ms =
+        static_cast<int64_t>(finished.tv_sec - started.tv_sec) * 1000 +
+        (finished.tv_nsec - started.tv_nsec) / 1000000;
+    EXPECT_LT(elapsed_ms, 2000)
+        << "close waited for a software queue that TCOOFF cannot drain";
 }
 
 /* --------------------------------------------------------------------------

--- a/user/apps/tests/dunitest/suites/normal/tty_termios.cc
+++ b/user/apps/tests/dunitest/suites/normal/tty_termios.cc
@@ -13,6 +13,7 @@
 #include <pty.h>
 #include <string.h>
 #include <sys/ioctl.h>
+#include <poll.h>
 #include <termios.h>
 #include <unistd.h>
 
@@ -121,6 +122,219 @@ PtyPair OpenRawPty() {
     }
 
     return pair;
+}
+
+bool SetNonBlocking(int fd) {
+    int flags = fcntl(fd, F_GETFL, 0);
+    if (flags < 0 || fcntl(fd, F_SETFL, flags | O_NONBLOCK) < 0) {
+        return false;
+    }
+    int updated = fcntl(fd, F_GETFL, 0);
+    return updated >= 0 && (updated & O_NONBLOCK) != 0;
+}
+
+bool DrainNonBlocking(int fd) {
+    char buf[64];
+    while (read(fd, buf, sizeof(buf)) > 0) {
+    }
+    return errno == EAGAIN || errno == EWOULDBLOCK;
+}
+
+ssize_t ReadEventually(int fd, void* buf, size_t len, int timeout_ms = 1000) {
+    struct pollfd pfd = {fd, POLLIN | POLLPRI, 0};
+    int rc = poll(&pfd, 1, timeout_ms);
+    if (rc <= 0) {
+        errno = rc == 0 ? ETIMEDOUT : errno;
+        return -1;
+    }
+    return read(fd, buf, len);
+}
+
+struct BlockingWriterArgs {
+    int fd = -1;
+    std::atomic<bool> started{false};
+    std::atomic<bool> done{false};
+    ssize_t rc = -1;
+    int saved_errno = 0;
+};
+
+void* BlockingWrite(void* opaque) {
+    auto* args = static_cast<BlockingWriterArgs*>(opaque);
+    const char marker[] = "wake";
+    args->started.store(true, std::memory_order_release);
+    args->rc = write(args->fd, marker, sizeof(marker) - 1);
+    args->saved_errno = errno;
+    args->done.store(true, std::memory_order_release);
+    return nullptr;
+}
+
+bool WaitForAtomic(const std::atomic<bool>& flag, int timeout_ms) {
+    for (int elapsed = 0; elapsed < timeout_ms; ++elapsed) {
+        if (flag.load(std::memory_order_acquire)) {
+            return true;
+        }
+        usleep(1000);
+    }
+    return flag.load(std::memory_order_acquire);
+}
+
+TEST(TtyTermios, TcxoncActionsAndOutputFlow) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_GE(pty.slave.get(), 0);
+    ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+    ASSERT_TRUE(SetNonBlocking(pty.slave.get())) << strerror(errno);
+
+    EXPECT_EQ(tcflow(pty.slave.get(), TCOON), 0) << strerror(errno);
+    errno = 0;
+    EXPECT_EQ(ioctl(pty.slave.get(), TCXONC, 4), -1);
+    EXPECT_EQ(errno, EINVAL);
+
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOOFF), 0) << strerror(errno);
+    const char marker[] = "flow";
+    errno = 0;
+    EXPECT_EQ(write(pty.slave.get(), marker, sizeof(marker) - 1), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+    char buf[sizeof(marker)] = {};
+    errno = 0;
+    EXPECT_EQ(read(pty.master.get(), buf, sizeof(buf)), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOON), 0) << strerror(errno);
+    ASSERT_EQ(write(pty.slave.get(), marker, sizeof(marker) - 1),
+              static_cast<ssize_t>(sizeof(marker) - 1));
+    ASSERT_EQ(ReadEventually(pty.master.get(), buf, sizeof(marker) - 1),
+              static_cast<ssize_t>(sizeof(marker) - 1));
+    EXPECT_EQ(memcmp(buf, marker, sizeof(marker) - 1), 0);
+}
+
+TEST(TtyTermios, TcxoncStartWakesBlockedWriter) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_GE(pty.slave.get(), 0);
+    ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOOFF), 0) << strerror(errno);
+
+    BlockingWriterArgs args;
+    args.fd = pty.slave.get();
+    pthread_t writer;
+    ASSERT_EQ(pthread_create(&writer, nullptr, BlockingWrite, &args), 0);
+
+    // From this point onward every path restores flow and joins the thread.
+    const bool started = WaitForAtomic(args.started, 1000);
+    const bool remained_blocked = started && !WaitForAtomic(args.done, 20);
+    errno = 0;
+    const int start_rc = tcflow(pty.slave.get(), TCOON);
+    const int start_errno = errno;
+    const bool woke = WaitForAtomic(args.done, 1000);
+    if (!woke) {
+        // Closing the peer wakes the blocked slave writer with an error.
+        pty.master.reset();
+    }
+    const int join_rc = pthread_join(writer, nullptr);
+
+    EXPECT_TRUE(started);
+    EXPECT_TRUE(remained_blocked);
+    EXPECT_EQ(start_rc, 0) << strerror(start_errno);
+    EXPECT_TRUE(woke);
+    EXPECT_EQ(join_rc, 0);
+    EXPECT_EQ(args.rc, 4) << "errno=" << args.saved_errno << " ("
+                          << strerror(args.saved_errno) << ")";
+    if (woke && args.rc == 4 && pty.master.get() >= 0) {
+        char marker[4] = {};
+        ASSERT_EQ(ReadEventually(pty.master.get(), marker, sizeof(marker)), 4);
+        EXPECT_EQ(memcmp(marker, "wake", sizeof(marker)), 0);
+    }
+}
+
+TEST(TtyTermios, TcxoncSendsRawConfiguredCharacters) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+
+    struct termios term = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &term), 0);
+    term.c_cc[VSTOP] = 'X';
+    term.c_cc[VSTART] = 'Y';
+    ASSERT_EQ(tcsetattr(pty.slave.get(), TCSANOW, &term), 0);
+    ASSERT_TRUE(DrainNonBlocking(pty.master.get())) << strerror(errno);
+
+    char ch = 0;
+    ASSERT_EQ(tcflow(pty.slave.get(), TCIOFF), 0);
+    ASSERT_EQ(ReadEventually(pty.master.get(), &ch, 1), 1);
+    EXPECT_EQ(ch, 'X');
+    ASSERT_EQ(tcflow(pty.slave.get(), TCION), 0);
+    ASSERT_EQ(ReadEventually(pty.master.get(), &ch, 1), 1);
+    EXPECT_EQ(ch, 'Y');
+}
+
+TEST(TtyTermios, TcxoncPriorityCharacterBypassesOpost) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+
+    struct termios term = {};
+    ASSERT_EQ(tcgetattr(pty.slave.get(), &term), 0);
+    term.c_oflag = OPOST | ONLCR;
+    term.c_cc[VSTOP] = '\n';
+    ASSERT_EQ(tcsetattr(pty.slave.get(), TCSANOW, &term), 0);
+    ASSERT_TRUE(DrainNonBlocking(pty.master.get())) << strerror(errno);
+
+    char bytes[2] = {};
+    ASSERT_EQ(tcflow(pty.slave.get(), TCIOFF), 0);
+    ASSERT_EQ(ReadEventually(pty.master.get(), bytes, sizeof(bytes)), 1);
+    EXPECT_EQ(bytes[0], '\n');
+    usleep(20000);
+    errno = 0;
+    EXPECT_EQ(read(pty.master.get(), bytes, sizeof(bytes)), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+}
+
+TEST(TtyTermios, TcxoncDisabledCharactersAreSilent) {
+    for (int action : {TCIOFF, TCION}) {
+        auto pty = OpenRawPty();
+        ASSERT_GE(pty.master.get(), 0);
+        ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+        struct termios term = {};
+        ASSERT_EQ(tcgetattr(pty.slave.get(), &term), 0);
+        term.c_cc[action == TCIOFF ? VSTOP : VSTART] = _POSIX_VDISABLE;
+        ASSERT_EQ(tcsetattr(pty.slave.get(), TCSANOW, &term), 0);
+        ASSERT_TRUE(DrainNonBlocking(pty.master.get())) << strerror(errno);
+        ASSERT_EQ(tcflow(pty.slave.get(), action), 0);
+        for (int i = 0; i < 20; ++i) {
+            char ch = 0;
+            errno = 0;
+            ASSERT_EQ(read(pty.master.get(), &ch, 1), -1);
+            ASSERT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << strerror(errno);
+            usleep(1000);
+        }
+    }
+}
+
+TEST(TtyTermios, TcxoncPacketModeReportsIdempotentTransitions) {
+    auto pty = OpenRawPty();
+    ASSERT_GE(pty.master.get(), 0);
+    ASSERT_TRUE(SetNonBlocking(pty.master.get())) << strerror(errno);
+    int enabled = 1;
+    ASSERT_EQ(ioctl(pty.master.get(), TIOCPKT, &enabled), 0) << strerror(errno);
+    ASSERT_TRUE(DrainNonBlocking(pty.master.get())) << strerror(errno);
+
+    unsigned char status = 0;
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOOFF), 0);
+    ASSERT_EQ(ReadEventually(pty.master.get(), &status, 1), 1);
+    EXPECT_NE(status & TIOCPKT_STOP, 0);
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOOFF), 0);
+    errno = 0;
+    EXPECT_EQ(read(pty.master.get(), &status, 1), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
+
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOON), 0);
+    ASSERT_EQ(ReadEventually(pty.master.get(), &status, 1), 1);
+    EXPECT_NE(status & TIOCPKT_START, 0);
+    ASSERT_EQ(tcflow(pty.slave.get(), TCOON), 0);
+    errno = 0;
+    EXPECT_EQ(read(pty.master.get(), &status, 1), -1);
+    EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK);
 }
 
 struct TcsetattrThreadArgs {


### PR DESCRIPTION
## Summary

- implement Linux-compatible `TCXONC` handling for `TCOOFF`, `TCOON`, `TCIOFF`, and `TCION`
- centralize output-flow state transitions and provide a driver priority-character hook with a generic fallback
- add serial8250 pause/resume, priority xchar transmission, unified TX interrupt decisions, and first-open/last-close state reset
- preserve PTY packet-mode STOP/START notifications and gate virtual-terminal writes while output is stopped
- add dunitest coverage for validation, wakeups, custom and disabled control characters, output-postprocessing bypass, and PTY idempotence

## Root cause

Python Readline issues `TCXONC(TCOON)` while handling Ctrl+C. The N_TTY ioctl path reached an unimplemented branch, allowing a normal userspace action to trigger a caught kernel panic.

## Design

N_TTY owns ioctl validation and job-control ordering, TTY core owns shared flow-state transactions and the generic xchar fallback, and drivers implement only device-specific pause/resume and priority transmission. Wakeups occur outside flow and packet spinlocks, and serial TX paths derive interrupt state from one shared predicate.

## Validation

- `make fmt`
- `make kernel`
- DragonOS `tty_termios`: 20/20 passed
- DragonOS `tty_tcflush`: 6/6 passed
- DragonOS `tty_pty_hangup`: 36/36 passed
- `/dev/hvc0` Python Ctrl+C repeatedly produced `KeyboardInterrupt` without a kernel panic
- `/dev/ttyS0` pause, priority xchar ordering, resume, and close/reopen reset verified in QEMU