### PR TITLE
test(rcu): add reproducible regression validation

### DIFF
--- a/kernel/src/debug/rcu.rs
+++ b/kernel/src/debug/rcu.rs
@@ -1,4 +1,8 @@
 use alloc::string::{String, ToString};
+use core::{
+    str,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use crate::debug::sysfs::debugfs_kobj;
 use crate::driver::base::kobject::KObject;
@@ -11,6 +15,19 @@ lazy_static! {
     /// The production-path selftest intentionally holds a remote CPU until
     /// escalation. Run it once and serve immutable snapshots thereafter.
     static ref RCU_SELFTEST_REPORT: Mutex<Option<String>> = Mutex::new(None);
+    static ref RCU_TORTURE_REPORT: Mutex<String> =
+        Mutex::new("status=never-run\n".to_string());
+}
+
+static RCU_TORTURE_RUNNING: AtomicBool = AtomicBool::new(false);
+static RCU_TORTURE_POISONED: AtomicBool = AtomicBool::new(false);
+
+struct RcuTortureRunGuard;
+
+impl Drop for RcuTortureRunGuard {
+    fn drop(&mut self) {
+        RCU_TORTURE_RUNNING.store(false, Ordering::Release);
+    }
 }
 
 #[derive(Debug)]
@@ -55,6 +72,9 @@ struct RcuStateCallBack;
 
 #[derive(Debug)]
 struct RcuStatsCallBack;
+
+#[derive(Debug)]
+struct RcuTortureCallBack;
 
 fn read_debug_text(
     data: KernCallbackData,
@@ -118,6 +138,100 @@ impl KernFSCallback for RcuSelftestCallBack {
 
     fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
         Ok(PollStatus::READ)
+    }
+}
+
+fn parse_u64(value: &str) -> Result<u64, SystemError> {
+    if let Some(hex) = value
+        .strip_prefix("0x")
+        .or_else(|| value.strip_prefix("0X"))
+    {
+        u64::from_str_radix(hex, 16).map_err(|_| SystemError::EINVAL)
+    } else {
+        value.parse::<u64>().map_err(|_| SystemError::EINVAL)
+    }
+}
+
+fn parse_torture_config(buf: &[u8]) -> Result<crate::rcu::RcuTortureConfig, SystemError> {
+    if buf.is_empty() || buf.len() > 128 {
+        return Err(if buf.len() > 128 {
+            SystemError::E2BIG
+        } else {
+            SystemError::EINVAL
+        });
+    }
+    let input = str::from_utf8(buf).map_err(|_| SystemError::EINVAL)?.trim();
+    let mut seed = None;
+    let mut rounds = None;
+    for token in input.split_whitespace() {
+        let (key, value) = token.split_once('=').ok_or(SystemError::EINVAL)?;
+        if value.is_empty() {
+            return Err(SystemError::EINVAL);
+        }
+        match key {
+            "seed" if seed.is_none() => seed = Some(parse_u64(value)?),
+            "rounds" if rounds.is_none() => {
+                rounds = Some(value.parse::<usize>().map_err(|_| SystemError::EINVAL)?)
+            }
+            _ => return Err(SystemError::EINVAL),
+        }
+    }
+    let config = crate::rcu::RcuTortureConfig {
+        seed: seed.ok_or(SystemError::EINVAL)?,
+        rounds: rounds.ok_or(SystemError::EINVAL)?,
+    };
+    config.validate()
+}
+
+impl KernFSCallback for RcuTortureCallBack {
+    fn open(&self, mut data: KernCallbackData) -> Result<(), SystemError> {
+        data.file_private_data_mut()
+            .replace(KernFilePrivateData::DebugTextSnapshot(
+                RCU_TORTURE_REPORT.lock().clone(),
+            ));
+        Ok(())
+    }
+
+    fn read(
+        &self,
+        data: KernCallbackData,
+        buf: &mut [u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        read_debug_text(data, buf, offset)
+    }
+
+    fn write(
+        &self,
+        _data: KernCallbackData,
+        buf: &[u8],
+        offset: usize,
+    ) -> Result<usize, SystemError> {
+        if offset != 0 {
+            return Err(SystemError::EINVAL);
+        }
+        let config = parse_torture_config(buf)?;
+        if RCU_TORTURE_POISONED.load(Ordering::Acquire) {
+            return Err(SystemError::EIO);
+        }
+        RCU_TORTURE_RUNNING
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map_err(|_| SystemError::EBUSY)?;
+        let _guard = RcuTortureRunGuard;
+        let result = crate::rcu::run_torture(config)?;
+        if result.reboot_required {
+            RCU_TORTURE_POISONED.store(true, Ordering::Release);
+        }
+        *RCU_TORTURE_REPORT.lock() = result.report;
+        if result.passed {
+            Ok(buf.len())
+        } else {
+            Err(SystemError::EIO)
+        }
+    }
+
+    fn poll(&self, _data: KernCallbackData) -> Result<PollStatus, SystemError> {
+        Ok(PollStatus::READ | PollStatus::WRITE)
     }
 }
 
@@ -227,6 +341,13 @@ pub fn init_debugfs_rcu() -> Result<(), SystemError> {
         Some(4096),
         None,
         Some(&RcuStatsCallBack),
+    )?;
+    rcu_root.add_file(
+        "torture".to_string(),
+        InodeMode::S_IRUSR | InodeMode::S_IWUSR,
+        Some(4096),
+        None,
+        Some(&RcuTortureCallBack),
     )?;
 
     Ok(())

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -51,6 +51,7 @@ mod context;
 mod gp;
 mod progress;
 mod selftest;
+mod torture;
 pub use callback::RcuHead;
 use callback::{RcuCallbackQueueDepth, RcuSegmentedCallbacks};
 use context::{
@@ -62,6 +63,7 @@ use progress::{
     validate_and_commit_stall, ActiveGpProgress, ProgressActions, ProgressCpuMask, StallCandidate,
 };
 pub use selftest::run_debug_selftests;
+pub(crate) use torture::{run_torture, RcuTortureConfig};
 
 pub(crate) type RcuRawCallback = unsafe fn(NonNull<RcuHead>);
 

--- a/kernel/src/rcu/selftest.rs
+++ b/kernel/src/rcu/selftest.rs
@@ -2,7 +2,7 @@ use alloc::{boxed::Box, format, string::String, sync::Arc, vec::Vec};
 use core::{
     fmt::Debug,
     ptr::{self, NonNull},
-    sync::atomic::{AtomicBool, AtomicUsize, Ordering},
+    sync::atomic::{fence, AtomicBool, AtomicPtr, AtomicUsize, Ordering},
 };
 
 use crate::{
@@ -553,6 +553,448 @@ fn run_duplicate_claim_selftest() -> Result<(), &'static str> {
     Ok(())
 }
 
+fn request_selftest_gp() -> gp::RcuSequence {
+    let target = {
+        let mut inner = RCU_STATE.inner.lock_irqsave();
+        let target = inner.gp.request_future();
+        RcuState::pump_grace_periods(&mut inner);
+        target
+    };
+    RCU_STATE.wake_state_waiters();
+    RCU_STATE.wake_worker();
+    target
+}
+
+fn wait_for_selftest_gp_active(target: gp::RcuSequence, required_cpu: ProcessorId) -> bool {
+    let started = rcu_now();
+    loop {
+        let inner = RCU_STATE.inner.lock_irqsave();
+        if inner.gp.current() == target
+            && !inner.gp.has_completed(target)
+            && inner.gp.is_waiting_for(required_cpu)
+        {
+            return true;
+        }
+        drop(inner);
+        if progress::elapsed_at_least(rcu_now(), started, 1_000_000_000) {
+            return false;
+        }
+        sched_yield();
+    }
+}
+
+fn wait_for_selftest_gp(target: gp::RcuSequence) {
+    RCU_STATE.state_wait.wait_until(|| {
+        RCU_STATE
+            .inner
+            .lock_irqsave()
+            .gp
+            .has_completed(target)
+            .then_some(())
+    });
+    fence(Ordering::SeqCst);
+}
+
+fn selftest_gp_completed(target: gp::RcuSequence) -> bool {
+    RCU_STATE.inner.lock_irqsave().gp.has_completed(target)
+}
+
+fn selftest_remote_cpu() -> Option<ProcessorId> {
+    let current = crate::smp::core::smp_get_processor_id();
+    smp_cpu_manager()
+        .present_cpus()
+        .iter_cpu()
+        .find(|cpu| *cpu != current && smp_cpu_manager().is_online_cpu(*cpu))
+}
+
+fn run_sync_read_litmus_selftest() -> Result<(), &'static str> {
+    let Some(reader_cpu) = selftest_remote_cpu() else {
+        // The fixed schedule needs a reader to remain non-preemptible while
+        // the updater and coordinator make progress on another CPU.
+        return Ok(());
+    };
+    synchronize_rcu();
+
+    let current_cpu = crate::smp::core::smp_get_processor_id();
+    let x = Arc::new(AtomicUsize::new(0));
+    let y = Arc::new(AtomicUsize::new(0));
+    let allow_y = Arc::new(AtomicBool::new(false));
+    let reader_entered = Arc::new(Completion::new());
+    let releaser_done = Arc::new(Completion::new());
+    let saw_active_gp = Arc::new(AtomicBool::new(false));
+    let target_gp = Arc::new(SpinLock::new(None));
+
+    let reader_x = x.clone();
+    let reader_y = y.clone();
+    let reader_allow_y = allow_y.clone();
+    let reader_entered_worker = reader_entered.clone();
+    let reader_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let _guard = rcu_read_lock();
+            reader_x.store(1, Ordering::Release);
+            reader_entered_worker.complete();
+            while !reader_allow_y.load(Ordering::Acquire) {
+                core::hint::spin_loop();
+            }
+            reader_y.store(1, Ordering::Relaxed);
+            0
+        }),
+        (),
+    ));
+    let Some(reader) = KernelThreadMechanism::create_on_cpu(
+        reader_closure,
+        "rcu-sync-read-reader".to_string(),
+        reader_cpu,
+    ) else {
+        return Err("RCU+sync+read could not create its reader");
+    };
+    let releaser_allow_y = allow_y.clone();
+    let releaser_done_worker = releaser_done.clone();
+    let releaser_saw_active_gp = saw_active_gp.clone();
+    let releaser_target_gp = target_gp.clone();
+    let releaser_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let target = releaser_target_gp
+                .lock_irqsave()
+                .expect("RCU+sync+read target GP was not published");
+            let active = wait_for_selftest_gp_active(target, reader_cpu);
+            releaser_saw_active_gp.store(active, Ordering::Release);
+            releaser_allow_y.store(true, Ordering::Release);
+            releaser_done_worker.complete();
+            i32::from(!active)
+        }),
+        (),
+    ));
+    let Some(releaser) = KernelThreadMechanism::create_on_cpu(
+        releaser_closure,
+        "rcu-sync-read-releaser".to_string(),
+        current_cpu,
+    ) else {
+        allow_y.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        return Err("RCU+sync+read could not create its GP releaser");
+    };
+    if ProcessManager::wakeup(&reader).is_err() || reader_entered.wait_for_completion().is_err() {
+        allow_y.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        let _ = KernelThreadMechanism::stop(&releaser);
+        return Err("RCU+sync+read reader did not enter");
+    }
+    let target = request_selftest_gp();
+    *target_gp.lock_irqsave() = Some(target);
+    if ProcessManager::wakeup(&releaser).is_err() {
+        allow_y.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        let _ = KernelThreadMechanism::stop(&releaser);
+        return Err("RCU+sync+read GP releaser did not start");
+    }
+
+    let x_before_gp = x.load(Ordering::Acquire);
+    wait_for_selftest_gp(target);
+    let y_after_gp = y.load(Ordering::Relaxed);
+    let completed = releaser_done.wait_for_completion().is_ok();
+    let reader_stopped = KernelThreadMechanism::stop(&reader).is_ok();
+    let releaser_stopped = KernelThreadMechanism::stop(&releaser).is_ok();
+    if !saw_active_gp.load(Ordering::Acquire) || !completed || !reader_stopped || !releaser_stopped
+    {
+        return Err("RCU+sync+read fixed schedule did not complete");
+    }
+    if x_before_gp != 1 || y_after_gp != 1 {
+        return Err("RCU+sync+read observed x=1 after y remained zero across a GP");
+    }
+    Ok(())
+}
+
+#[derive(Debug)]
+struct RcuSyncFreeNode {
+    value: AtomicUsize,
+}
+
+fn run_sync_free_litmus_selftest() -> Result<(), &'static str> {
+    let Some(reader_cpu) = selftest_remote_cpu() else {
+        return Ok(());
+    };
+    synchronize_rcu();
+
+    let current_cpu = crate::smp::core::smp_get_processor_id();
+    let old = Arc::new(RcuSyncFreeNode {
+        value: AtomicUsize::new(1),
+    });
+    let new = Arc::new(RcuSyncFreeNode {
+        value: AtomicUsize::new(1),
+    });
+    let published = Arc::new(AtomicPtr::new(Arc::as_ptr(&old) as *mut RcuSyncFreeNode));
+    let allow_read = Arc::new(AtomicBool::new(false));
+    let reader_loaded = Arc::new(Completion::new());
+    let releaser_done = Arc::new(Completion::new());
+    let saw_active_gp = Arc::new(AtomicBool::new(false));
+    let target_gp = Arc::new(SpinLock::new(None));
+    let observed = Arc::new(AtomicUsize::new(usize::MAX));
+
+    let reader_published = published.clone();
+    let reader_allow = allow_read.clone();
+    let reader_loaded_worker = reader_loaded.clone();
+    let reader_observed = observed.clone();
+    let reader_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let _guard = rcu_read_lock();
+            let object = rcu_dereference(&reader_published);
+            reader_loaded_worker.complete();
+            while !reader_allow.load(Ordering::Acquire) {
+                core::hint::spin_loop();
+            }
+            if object.is_null() {
+                reader_observed.store(usize::MAX - 1, Ordering::Release);
+                return 1;
+            }
+            // SAFETY: the old Arc is retained by the coordinator and RCU
+            // additionally protects this dereference in the tested schedule.
+            reader_observed.store(
+                unsafe { &*object }.value.load(Ordering::Relaxed),
+                Ordering::Release,
+            );
+            0
+        }),
+        (),
+    ));
+    let Some(reader) = KernelThreadMechanism::create_on_cpu(
+        reader_closure,
+        "rcu-sync-free-reader".to_string(),
+        reader_cpu,
+    ) else {
+        return Err("RCU+sync+free could not create its reader");
+    };
+    let releaser_allow_read = allow_read.clone();
+    let releaser_done_worker = releaser_done.clone();
+    let releaser_saw_active_gp = saw_active_gp.clone();
+    let releaser_target_gp = target_gp.clone();
+    let releaser_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let target = releaser_target_gp
+                .lock_irqsave()
+                .expect("RCU+sync+free target GP was not published");
+            let active = wait_for_selftest_gp_active(target, reader_cpu);
+            releaser_saw_active_gp.store(active, Ordering::Release);
+            releaser_allow_read.store(true, Ordering::Release);
+            releaser_done_worker.complete();
+            i32::from(!active)
+        }),
+        (),
+    ));
+    let Some(releaser) = KernelThreadMechanism::create_on_cpu(
+        releaser_closure,
+        "rcu-sync-free-releaser".to_string(),
+        current_cpu,
+    ) else {
+        allow_read.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        return Err("RCU+sync+free could not create its GP releaser");
+    };
+    if ProcessManager::wakeup(&reader).is_err() || reader_loaded.wait_for_completion().is_err() {
+        allow_read.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        let _ = KernelThreadMechanism::stop(&releaser);
+        return Err("RCU+sync+free reader did not load the old pointer");
+    }
+    rcu_assign_pointer(&published, Arc::as_ptr(&new) as *mut RcuSyncFreeNode);
+    let target = request_selftest_gp();
+    *target_gp.lock_irqsave() = Some(target);
+    if ProcessManager::wakeup(&releaser).is_err() {
+        allow_read.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        let _ = KernelThreadMechanism::stop(&releaser);
+        return Err("RCU+sync+free GP releaser did not start");
+    }
+
+    wait_for_selftest_gp(target);
+    old.value.store(0, Ordering::Relaxed);
+    let completed = releaser_done.wait_for_completion().is_ok();
+    let reader_stopped = KernelThreadMechanism::stop(&reader).is_ok();
+    let releaser_stopped = KernelThreadMechanism::stop(&releaser).is_ok();
+    if !saw_active_gp.load(Ordering::Acquire) || !completed || !reader_stopped || !releaser_stopped
+    {
+        return Err("RCU+sync+free fixed schedule did not complete");
+    }
+    if observed.load(Ordering::Acquire) != 1 {
+        return Err("RCU+sync+free reader observed the GP-after destruction write");
+    }
+    Ok(())
+}
+
+fn run_reader_handoff_selftest() -> Result<(), &'static str> {
+    let Some(first_cpu) = selftest_remote_cpu() else {
+        return Ok(());
+    };
+    synchronize_rcu();
+
+    let coordinator_cpu = crate::smp::core::smp_get_processor_id();
+    let release_first = Arc::new(AtomicBool::new(false));
+    let first_entered = Arc::new(Completion::new());
+    let successor_done = Arc::new(Completion::new());
+    let target_gp = Arc::new(SpinLock::new(None));
+    let completed_during_successor = Arc::new(AtomicBool::new(false));
+
+    let first_release = release_first.clone();
+    let first_entered_worker = first_entered.clone();
+    let first_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let _guard = rcu_read_lock();
+            first_entered_worker.complete();
+            while !first_release.load(Ordering::Acquire) {
+                core::hint::spin_loop();
+            }
+            0
+        }),
+        (),
+    ));
+    let Some(first) = KernelThreadMechanism::create_on_cpu(
+        first_closure,
+        "rcu-reader-handoff-first".to_string(),
+        first_cpu,
+    ) else {
+        return Err("RCU reader handoff could not create its first reader");
+    };
+
+    let successor_release = release_first.clone();
+    let successor_done_worker = successor_done.clone();
+    let successor_target = target_gp.clone();
+    let successor_completed = completed_during_successor.clone();
+    let successor_closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let _guard = rcu_read_lock();
+            let target = successor_target
+                .lock_irqsave()
+                .expect("RCU reader handoff target GP was not published");
+            // The readers overlap: the successor enters before it releases
+            // the reader that was present at target-GP start.
+            successor_release.store(true, Ordering::Release);
+            let started = rcu_now();
+            while !selftest_gp_completed(target)
+                && !progress::elapsed_at_least(rcu_now(), started, 1_000_000_000)
+            {
+                core::hint::spin_loop();
+            }
+            successor_completed.store(selftest_gp_completed(target), Ordering::Release);
+            successor_done_worker.complete();
+            0
+        }),
+        (),
+    ));
+    let Some(successor) = KernelThreadMechanism::create_on_cpu(
+        successor_closure,
+        "rcu-reader-handoff-successor".to_string(),
+        coordinator_cpu,
+    ) else {
+        release_first.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&first);
+        return Err("RCU reader handoff could not create its successor");
+    };
+
+    if ProcessManager::wakeup(&first).is_err() || first_entered.wait_for_completion().is_err() {
+        release_first.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&first);
+        let _ = KernelThreadMechanism::stop(&successor);
+        return Err("RCU reader handoff first reader did not enter");
+    }
+    let target = request_selftest_gp();
+    if !wait_for_selftest_gp_active(target, first_cpu) {
+        release_first.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&first);
+        let _ = KernelThreadMechanism::stop(&successor);
+        return Err("RCU reader handoff target GP did not start");
+    }
+    *target_gp.lock_irqsave() = Some(target);
+    if ProcessManager::wakeup(&successor).is_err() || successor_done.wait_for_completion().is_err()
+    {
+        release_first.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&first);
+        let _ = KernelThreadMechanism::stop(&successor);
+        return Err("RCU reader handoff successor did not finish");
+    }
+
+    let first_stopped = KernelThreadMechanism::stop(&first).is_ok();
+    let successor_stopped = KernelThreadMechanism::stop(&successor).is_ok();
+    wait_for_selftest_gp(target);
+    if !first_stopped || !successor_stopped || !completed_during_successor.load(Ordering::Acquire) {
+        return Err("RCU target GP did not progress across overlapping reader handoff");
+    }
+    Ok(())
+}
+
+fn run_arc_slot_cross_thread_selftest() -> Result<(), &'static str> {
+    const REPLACEMENTS: usize = 64;
+    let initial_drops = Arc::new(AtomicUsize::new(0));
+    let replacement_drops = Arc::new(AtomicUsize::new(0));
+    let slot = Arc::new(RcuArcSlot::new(Arc::new(RcuSelftestDropProbe {
+        id: 40,
+        drops: initial_drops.clone(),
+    })));
+    let reader_loaded = Arc::new(Completion::new());
+    let allow_drop = Arc::new(AtomicBool::new(false));
+    let reader_ok = Arc::new(AtomicBool::new(false));
+
+    let reader_slot = slot.clone();
+    let reader_loaded_worker = reader_loaded.clone();
+    let reader_allow_drop = allow_drop.clone();
+    let reader_ok_worker = reader_ok.clone();
+    let closure = KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            let pinned = reader_slot.load();
+            reader_loaded_worker.complete();
+            while !reader_allow_drop.load(Ordering::Acquire) {
+                sched_yield();
+            }
+            reader_ok_worker.store(pinned.id == 40, Ordering::Release);
+            drop(pinned);
+            0
+        }),
+        (),
+    ));
+    let Some(reader) =
+        KernelThreadMechanism::create_and_run(closure, "rcu-arc-slot-cross-thread".to_string())
+    else {
+        return Err("RcuArcSlot cross-thread test could not create its reader");
+    };
+    if reader_loaded.wait_for_completion().is_err() {
+        allow_drop.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        return Err("RcuArcSlot cross-thread reader did not pin the initial object");
+    }
+
+    for index in 0..REPLACEMENTS {
+        slot.store_deferred(Arc::new(RcuSelftestDropProbe {
+            id: 41 + index,
+            drops: replacement_drops.clone(),
+        }));
+    }
+    rcu_barrier();
+    if initial_drops.load(Ordering::Acquire) != 0 {
+        allow_drop.store(true, Ordering::Release);
+        let _ = KernelThreadMechanism::stop(&reader);
+        drop(slot);
+        rcu_barrier();
+        return Err("RcuArcSlot dropped a cross-thread pinned snapshot early");
+    }
+
+    allow_drop.store(true, Ordering::Release);
+    if KernelThreadMechanism::stop(&reader).is_err() || !reader_ok.load(Ordering::Acquire) {
+        drop(slot);
+        rcu_barrier();
+        return Err("RcuArcSlot cross-thread reader did not retain its snapshot");
+    }
+    if initial_drops.load(Ordering::Acquire) != 1 {
+        drop(slot);
+        rcu_barrier();
+        return Err("RcuArcSlot initial snapshot was not dropped after the final pin");
+    }
+    drop(slot);
+    rcu_barrier();
+    if replacement_drops.load(Ordering::Acquire) != REPLACEMENTS {
+        return Err("RcuArcSlot replacements were not dropped exactly once");
+    }
+    Ok(())
+}
+
 fn run_pr1_selftest() -> Result<(), &'static str> {
     gp::run_state_machine_selftests()?;
     progress::run_progress_selftests()?;
@@ -588,6 +1030,10 @@ fn run_pr1_selftest() -> Result<(), &'static str> {
     run_reschedule_escalation_selftest()?;
     run_smp_callback_barrier_selftest()?;
     run_concurrent_barrier_selftest()?;
+    run_sync_read_litmus_selftest()?;
+    run_sync_free_litmus_selftest()?;
+    run_reader_handoff_selftest()?;
+    run_arc_slot_cross_thread_selftest()?;
 
     if ProcessManager::current_pcb().rcu_read_depth() != 0 {
         return Err("initial rcu_read_depth was not zero");
@@ -1676,6 +2122,7 @@ fn run_pr5_selftest() -> Result<(), &'static str> {
 }
 
 pub fn run_debug_selftests() -> String {
+    let has_remote_cpu = selftest_remote_cpu().is_some();
     let pr1 = run_pr1_selftest();
     let pr2 = run_pr2_selftest();
     let pr3 = run_pr3_selftest();
@@ -1689,10 +2136,17 @@ pub fn run_debug_selftests() -> String {
         "status=fail\n"
     });
 
-    match pr1 {
+    match &pr1 {
         Ok(()) => report.push_str("pr1=ok\n"),
         Err(reason) => report.push_str(&format!("pr1=fail:{reason}\n")),
     }
+    report.push_str(if pr1.is_err() {
+        "smp_litmus=not-completed\n"
+    } else if has_remote_cpu {
+        "smp_litmus=ok\n"
+    } else {
+        "smp_litmus=skip:no-remote-cpu\n"
+    });
 
     match pr2 {
         Ok(()) => report.push_str("pr2=ok\n"),

--- a/kernel/src/rcu/torture.rs
+++ b/kernel/src/rcu/torture.rs
@@ -1,0 +1,888 @@
+//! Reproducible SMP stress coverage for ordinary RCU.
+//!
+//! This module is debugfs-driven test code. It deliberately keeps every test
+//! object allocated until the final barrier, so a broken early callback can be
+//! diagnosed without turning the oracle itself into a use-after-free.
+
+use alloc::{
+    boxed::Box,
+    format,
+    string::{String, ToString},
+    sync::Arc,
+    vec::Vec,
+};
+use core::{
+    ptr::{self, NonNull},
+    sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicU8, AtomicUsize, Ordering},
+};
+
+use log::info;
+use system_error::SystemError;
+
+use crate::{
+    libs::spinlock::SpinLock,
+    process::{
+        kthread::{KernelThreadClosure, KernelThreadMechanism},
+        ProcessControlBlock, ProcessManager,
+    },
+    sched::{completion::Completion, cond_resched, sched_yield},
+    smp::cpu::{smp_cpu_manager, ProcessorId},
+};
+
+use super::*;
+
+pub(crate) const MAX_TORTURE_ROUNDS: usize = 4096;
+const PUBLISHER_COUNT: usize = 2;
+const MAX_READER_COUNT: usize = 4;
+const RECLAIM_NONE: u8 = 0;
+const RECLAIM_ASYNC: u8 = 1;
+const RECLAIM_SYNC: u8 = 2;
+
+const ERR_DUPLICATE_RECLAIM: usize = 1;
+const ERR_PREMATURE_RECLAIM: usize = 2;
+const ERR_CORRUPT_OBJECT: usize = 3;
+const ERR_WRONG_RECLAIM_MODE: usize = 4;
+const ERR_BARRIER_PREFIX: usize = 5;
+const ERR_OWNERSHIP_MISMATCH: usize = 6;
+const ERR_COMPLETION_WAIT: usize = 7;
+
+const REGISTRY_PREPARED: u8 = 0;
+const REGISTRY_EXPOSED: u8 = 1;
+const REGISTRY_DRAINED: u8 = 2;
+const REGISTRY_QUARANTINED: u8 = 3;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct RcuTortureConfig {
+    pub seed: u64,
+    pub rounds: usize,
+}
+
+impl RcuTortureConfig {
+    pub(crate) fn validate(self) -> Result<Self, SystemError> {
+        if self.rounds == 0 || self.rounds > MAX_TORTURE_ROUNDS {
+            return Err(SystemError::EINVAL);
+        }
+        self.rounds.checked_add(1).ok_or(SystemError::E2BIG)?;
+        Ok(self)
+    }
+}
+
+pub(crate) struct RcuTortureResult {
+    pub report: String,
+    pub passed: bool,
+    pub reboot_required: bool,
+}
+
+struct TortureShared {
+    seed: u64,
+    published: AtomicPtr<TortureObject>,
+    admission_lock: SpinLock<()>,
+    callback_completed: Vec<AtomicBool>,
+    start: Arc<Completion>,
+    ready: Arc<Completion>,
+    done: Arc<Completion>,
+    abort: AtomicBool,
+    readers_started: AtomicUsize,
+    expected_readers: usize,
+    next_work: AtomicUsize,
+    active_publishers: AtomicUsize,
+    reads: AtomicU64,
+    publishes: AtomicU64,
+    callbacks_admitted: AtomicU64,
+    callbacks_invoked: AtomicU64,
+    sync_reclaims: AtomicU64,
+    synchronize_calls: AtomicU64,
+    gp_total_ns: AtomicU64,
+    gp_max_ns: AtomicU64,
+    barrier_calls: AtomicU64,
+    max_observed_queue_depth: AtomicUsize,
+    publication_cas_retries: AtomicU64,
+    premature_reclaims: AtomicU64,
+    duplicate_reclaims: AtomicU64,
+    corrupt_reads: AtomicU64,
+    first_error: AtomicUsize,
+    first_error_worker: AtomicUsize,
+    first_error_iteration: AtomicUsize,
+}
+
+impl TortureShared {
+    fn new(seed: u64, callback_completed: Vec<AtomicBool>, expected_readers: usize) -> Self {
+        Self {
+            seed,
+            published: AtomicPtr::new(ptr::null_mut()),
+            admission_lock: SpinLock::new(()),
+            callback_completed,
+            readers_started: AtomicUsize::new(0),
+            expected_readers,
+            start: Arc::new(Completion::new()),
+            ready: Arc::new(Completion::new()),
+            done: Arc::new(Completion::new()),
+            abort: AtomicBool::new(false),
+            next_work: AtomicUsize::new(0),
+            active_publishers: AtomicUsize::new(PUBLISHER_COUNT),
+            reads: AtomicU64::new(0),
+            publishes: AtomicU64::new(0),
+            callbacks_admitted: AtomicU64::new(0),
+            callbacks_invoked: AtomicU64::new(0),
+            sync_reclaims: AtomicU64::new(0),
+            synchronize_calls: AtomicU64::new(0),
+            gp_total_ns: AtomicU64::new(0),
+            gp_max_ns: AtomicU64::new(0),
+            barrier_calls: AtomicU64::new(0),
+            max_observed_queue_depth: AtomicUsize::new(0),
+            publication_cas_retries: AtomicU64::new(0),
+            premature_reclaims: AtomicU64::new(0),
+            duplicate_reclaims: AtomicU64::new(0),
+            corrupt_reads: AtomicU64::new(0),
+            first_error: AtomicUsize::new(0),
+            first_error_worker: AtomicUsize::new(0),
+            first_error_iteration: AtomicUsize::new(0),
+        }
+    }
+
+    fn record_error(&self, error: usize, worker: usize, iteration: usize) {
+        if self
+            .first_error
+            .compare_exchange(0, error, Ordering::SeqCst, Ordering::SeqCst)
+            .is_ok()
+        {
+            self.first_error_worker.store(worker, Ordering::SeqCst);
+            self.first_error_iteration
+                .store(iteration, Ordering::SeqCst);
+        }
+    }
+
+    fn sample_queue_depth(&self) {
+        let (depth, _) = callback_queue_depth_snapshot();
+        self.max_observed_queue_depth
+            .fetch_max(depth.total(), Ordering::Relaxed);
+    }
+}
+
+#[repr(C)]
+struct TortureObject {
+    head: RcuHead,
+    generation: usize,
+    checksum: u64,
+    active_readers: AtomicUsize,
+    reclaim_started: AtomicBool,
+    async_admitted: AtomicBool,
+    reclaim_mode: AtomicU8,
+    shared: Arc<TortureShared>,
+}
+
+impl TortureObject {
+    fn new(generation: usize, seed: u64, shared: Arc<TortureShared>) -> Self {
+        Self {
+            head: RcuHead::new(),
+            generation,
+            checksum: object_checksum(seed, generation),
+            active_readers: AtomicUsize::new(0),
+            reclaim_started: AtomicBool::new(false),
+            async_admitted: AtomicBool::new(false),
+            reclaim_mode: AtomicU8::new(RECLAIM_NONE),
+            shared,
+        }
+    }
+}
+
+/// Owns every intrusive object and makes the fail-safe release policy part of
+/// the type. The boxed slice provides stable callback addresses without a
+/// raw-owner list or a separate allocation for every object.
+struct TortureRegistry {
+    objects: Box<[TortureObject]>,
+    state: AtomicU8,
+}
+
+impl TortureRegistry {
+    fn new(objects: Box<[TortureObject]>) -> Self {
+        Self {
+            objects,
+            state: AtomicU8::new(REGISTRY_PREPARED),
+        }
+    }
+
+    fn mark_exposed(&self) {
+        assert_eq!(
+            self.state.compare_exchange(
+                REGISTRY_PREPARED,
+                REGISTRY_EXPOSED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ),
+            Ok(REGISTRY_PREPARED),
+            "RCU torture registry exposed from an invalid phase"
+        );
+    }
+
+    fn mark_drained(&self) {
+        assert_eq!(
+            self.state.compare_exchange(
+                REGISTRY_EXPOSED,
+                REGISTRY_DRAINED,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ),
+            Ok(REGISTRY_EXPOSED),
+            "RCU torture registry drained from an invalid phase"
+        );
+    }
+
+    fn quarantine(&self) {
+        self.state.store(REGISTRY_QUARANTINED, Ordering::Release);
+    }
+}
+
+impl core::ops::Deref for TortureRegistry {
+    type Target = [TortureObject];
+
+    fn deref(&self) -> &Self::Target {
+        &self.objects
+    }
+}
+
+impl Drop for TortureRegistry {
+    fn drop(&mut self) {
+        let state = self.state.load(Ordering::Acquire);
+        if state == REGISTRY_EXPOSED || state == REGISTRY_QUARANTINED {
+            // Fail-safe quarantine: leaking is required because an RCU bug may
+            // have left an intrusive callback with this stable address.
+            core::mem::forget(core::mem::take(&mut self.objects));
+        }
+        // PREPARED and DRAINED use ordinary boxed-slice destruction.
+    }
+}
+
+struct SplitMix64 {
+    state: u64,
+}
+
+impl SplitMix64 {
+    fn new(seed: u64) -> Self {
+        Self {
+            state: seed ^ 0x9e37_79b9_7f4a_7c15,
+        }
+    }
+
+    fn next(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9e37_79b9_7f4a_7c15);
+        let mut value = self.state;
+        value = (value ^ (value >> 30)).wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94d0_49bb_1331_11eb);
+        value ^ (value >> 31)
+    }
+}
+
+fn object_checksum(seed: u64, generation: usize) -> u64 {
+    let mut random = SplitMix64::new(seed ^ generation as u64);
+    random.next() ^ 0xd4c3_b2a1_5a5a_c3c3
+}
+
+fn error_name(error: usize) -> &'static str {
+    match error {
+        ERR_DUPLICATE_RECLAIM => "duplicate_reclaim",
+        ERR_PREMATURE_RECLAIM => "premature_reclaim",
+        ERR_CORRUPT_OBJECT => "corrupt_object",
+        ERR_WRONG_RECLAIM_MODE => "wrong_reclaim_mode",
+        ERR_BARRIER_PREFIX => "broken_barrier_prefix",
+        ERR_OWNERSHIP_MISMATCH => "ownership_mismatch",
+        ERR_COMPLETION_WAIT => "completion_wait_error",
+        _ => "none",
+    }
+}
+
+unsafe fn mark_reclaimed(
+    object: NonNull<TortureObject>,
+    expected_mode: u8,
+    worker: usize,
+    iteration: usize,
+) {
+    // SAFETY: the coordinator-owned registry keeps every object alive until
+    // after the final barrier and worker join.
+    let object = unsafe { object.as_ref() };
+    let shared = &object.shared;
+    if object
+        .reclaim_started
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_err()
+    {
+        shared.duplicate_reclaims.fetch_add(1, Ordering::Relaxed);
+        shared.record_error(ERR_DUPLICATE_RECLAIM, worker, iteration);
+        return;
+    }
+
+    if object.reclaim_mode.load(Ordering::SeqCst) != expected_mode {
+        shared.record_error(ERR_WRONG_RECLAIM_MODE, worker, iteration);
+    }
+    if object.checksum != object_checksum(shared.seed, object.generation) {
+        shared.corrupt_reads.fetch_add(1, Ordering::Relaxed);
+        shared.record_error(ERR_CORRUPT_OBJECT, worker, iteration);
+    }
+    if object.active_readers.load(Ordering::SeqCst) != 0 {
+        shared.premature_reclaims.fetch_add(1, Ordering::Relaxed);
+        shared.record_error(ERR_PREMATURE_RECLAIM, worker, iteration);
+    }
+}
+
+unsafe fn torture_callback(head: NonNull<RcuHead>) {
+    // SAFETY: TortureObject is repr(C) and RcuHead is its first field. The
+    // coordinator registry keeps the allocation stable through this callback.
+    let object = head.cast::<TortureObject>();
+    let (shared, generation) = {
+        // SAFETY: callback admission keeps the embedded head stable, and a
+        // failed final ownership check quarantines rather than frees it.
+        let object_ref = unsafe { object.as_ref() };
+        let generation = object_ref.generation;
+        let shared = object_ref.shared.clone();
+        unsafe { mark_reclaimed(object, RECLAIM_ASYNC, usize::MAX, generation) };
+        (shared, generation)
+    };
+    // Publish completion only after the callback's last access through the
+    // object/head. A broken early barrier can then be diagnosed without the
+    // coordinator freeing storage still in use by this callback.
+    shared.callbacks_invoked.fetch_add(1, Ordering::Release);
+    shared.callback_completed[generation].store(true, Ordering::Release);
+}
+
+fn run_reader(shared: &Arc<TortureShared>, seed: u64, worker: usize) -> i32 {
+    let mut random = SplitMix64::new(seed ^ 0x1000_0000_0000_0000 ^ worker as u64);
+    let mut iteration = 0usize;
+    let mut announced = false;
+    while shared.active_publishers.load(Ordering::Acquire) != 0 {
+        let guard = rcu_read_lock();
+        let raw = rcu_dereference(&shared.published);
+        if !raw.is_null() {
+            // SAFETY: the read-side guard prevents legitimate reclamation and
+            // the registry keeps even a broken early-reclaimed node allocated.
+            let object = unsafe { &*raw };
+            object.active_readers.fetch_add(1, Ordering::SeqCst);
+            if object.reclaim_started.load(Ordering::SeqCst) {
+                shared.premature_reclaims.fetch_add(1, Ordering::Relaxed);
+                shared.record_error(ERR_PREMATURE_RECLAIM, worker, iteration);
+            }
+            if object.checksum != object_checksum(seed, object.generation) {
+                shared.corrupt_reads.fetch_add(1, Ordering::Relaxed);
+                shared.record_error(ERR_CORRUPT_OBJECT, worker, iteration);
+            }
+            for _ in 0..(random.next() as usize & 0x1f) {
+                core::hint::spin_loop();
+            }
+            if object.reclaim_started.load(Ordering::SeqCst) {
+                shared.premature_reclaims.fetch_add(1, Ordering::Relaxed);
+                shared.record_error(ERR_PREMATURE_RECLAIM, worker, iteration);
+            }
+            object.active_readers.fetch_sub(1, Ordering::SeqCst);
+            shared.reads.fetch_add(1, Ordering::Relaxed);
+            if !announced {
+                shared.readers_started.fetch_add(1, Ordering::Release);
+                announced = true;
+            }
+        }
+        drop(guard);
+        iteration = iteration.wrapping_add(1);
+        if iteration & 0x3f == 0 {
+            cond_resched();
+        }
+    }
+    0
+}
+
+fn run_publisher(
+    shared: &Arc<TortureShared>,
+    registry: &Arc<TortureRegistry>,
+    config: RcuTortureConfig,
+    worker: usize,
+) -> i32 {
+    let mut random = SplitMix64::new(config.seed ^ 0x2000_0000_0000_0000 ^ worker as u64);
+    while shared.readers_started.load(Ordering::Acquire) != shared.expected_readers {
+        sched_yield();
+    }
+    loop {
+        let iteration = shared.next_work.fetch_add(1, Ordering::Relaxed);
+        if iteration >= config.rounds {
+            break;
+        }
+
+        let new = NonNull::from(&registry[iteration + 1]).as_ptr();
+        let old = loop {
+            let current = shared.published.load(Ordering::Acquire);
+            match shared.published.compare_exchange_weak(
+                current,
+                new,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(old) => break old,
+                Err(_) => {
+                    shared
+                        .publication_cas_retries
+                        .fetch_add(1, Ordering::Relaxed);
+                    core::hint::spin_loop();
+                }
+            }
+        };
+        if old.is_null() {
+            shared.record_error(ERR_OWNERSHIP_MISMATCH, worker, iteration);
+            continue;
+        }
+        let old = NonNull::new(old).unwrap();
+        // Roughly one quarter of updates use synchronous reclamation. The
+        // choice is deterministic per logical iteration, while the SMP
+        // interleaving is intentionally left to the scheduler.
+        let reclaim_choice =
+            SplitMix64::new(config.seed ^ 0x3000_0000_0000_0000 ^ iteration as u64).next();
+        if iteration < PUBLISHER_COUNT || reclaim_choice & 3 == 0 {
+            // SAFETY: this publisher uniquely removed old from the slot.
+            unsafe { old.as_ref() }
+                .reclaim_mode
+                .store(RECLAIM_SYNC, Ordering::SeqCst);
+            let started = rcu_now();
+            synchronize_rcu();
+            let elapsed = rcu_now().wrapping_sub(started);
+            shared.synchronize_calls.fetch_add(1, Ordering::Relaxed);
+            shared.gp_total_ns.fetch_add(elapsed, Ordering::Relaxed);
+            shared.gp_max_ns.fetch_max(elapsed, Ordering::Relaxed);
+            // SAFETY: synchronize_rcu() covered the removed object.
+            unsafe { mark_reclaimed(old, RECLAIM_SYNC, worker, iteration) };
+            shared.sync_reclaims.fetch_add(1, Ordering::Release);
+        } else {
+            // SAFETY: this publisher uniquely removed old and the registry
+            // keeps its embedded head stable through callback start.
+            let object = unsafe { old.as_ref() };
+            object.reclaim_mode.store(RECLAIM_ASYNC, Ordering::SeqCst);
+            let _admission_guard = shared.admission_lock.lock_irqsave();
+            unsafe { call_rcu_raw(NonNull::from(&object.head), torture_callback) };
+            object.async_admitted.store(true, Ordering::Release);
+            shared.callbacks_admitted.fetch_add(1, Ordering::Relaxed);
+            drop(_admission_guard);
+            shared.sample_queue_depth();
+        }
+        shared.publishes.fetch_add(1, Ordering::Relaxed);
+        for _ in 0..(random.next() as usize & 0xf) {
+            core::hint::spin_loop();
+        }
+        if iteration & 0x1f == 0 {
+            sched_yield();
+        }
+    }
+
+    shared.active_publishers.fetch_sub(1, Ordering::Release);
+    0
+}
+
+fn check_barrier_prefix(
+    shared: &Arc<TortureShared>,
+    registry: &Arc<TortureRegistry>,
+    scratch: &mut Vec<usize>,
+    iteration: usize,
+) {
+    scratch.clear();
+    {
+        // Linearize the oracle snapshot against callback admission. This lock
+        // is dropped before rcu_barrier(), so callbacks never acquire it and
+        // it cannot enter production RCU lock ordering.
+        let _admission_guard = shared.admission_lock.lock_irqsave();
+        for object in registry.iter() {
+            if object.async_admitted.load(Ordering::Acquire) {
+                scratch.push(object.generation);
+            }
+        }
+    }
+    rcu_barrier();
+    shared.barrier_calls.fetch_add(1, Ordering::Relaxed);
+    for generation in scratch.iter().copied() {
+        if !shared.callback_completed[generation].load(Ordering::Acquire) {
+            shared.record_error(ERR_BARRIER_PREFIX, PUBLISHER_COUNT, iteration);
+            break;
+        }
+    }
+    shared.sample_queue_depth();
+}
+
+fn run_barrier(
+    shared: &Arc<TortureShared>,
+    registry: &Arc<TortureRegistry>,
+    mut scratch: Vec<usize>,
+) -> i32 {
+    let mut iteration = 0usize;
+    let mut last_admitted = 0;
+    while shared.active_publishers.load(Ordering::Acquire) != 0 {
+        let admitted = shared.callbacks_admitted.load(Ordering::Acquire);
+        if admitted != last_admitted {
+            check_barrier_prefix(shared, registry, &mut scratch, iteration);
+            last_admitted = admitted;
+            iteration = iteration.wrapping_add(1);
+        }
+        sched_yield();
+    }
+    check_barrier_prefix(shared, registry, &mut scratch, iteration);
+    0
+}
+
+fn online_cpus() -> Vec<ProcessorId> {
+    smp_cpu_manager()
+        .present_cpus()
+        .iter_cpu()
+        .filter(|cpu| smp_cpu_manager().is_online_cpu(*cpu))
+        .collect()
+}
+
+fn make_worker(
+    body: impl Fn() -> i32 + Send + Sync + 'static,
+    shared: Arc<TortureShared>,
+) -> KernelThreadClosure {
+    let ready = shared.ready.clone();
+    let start = shared.start.clone();
+    let done = shared.done.clone();
+    KernelThreadClosure::EmptyClosure((
+        Box::new(move || {
+            ready.complete();
+            let wait_error = wait_for_completions(&start, 1);
+            if wait_error.is_some() {
+                shared.record_error(ERR_COMPLETION_WAIT, usize::MAX, 0);
+            }
+            let result = if shared.abort.load(Ordering::Acquire) {
+                1
+            } else {
+                body()
+            };
+            done.complete();
+            result
+        }),
+        (),
+    ))
+}
+
+/// Owns only kthread lifecycle mechanics. RCU phase ordering, barriers and
+/// object recovery remain explicit in the coordinator below.
+struct TortureWorkers {
+    pcbs: Vec<Arc<ProcessControlBlock>>,
+    shared: Arc<TortureShared>,
+}
+
+impl TortureWorkers {
+    fn new(shared: Arc<TortureShared>, count: usize) -> Result<Self, SystemError> {
+        let mut pcbs = Vec::new();
+        pcbs.try_reserve_exact(count)
+            .map_err(|_| SystemError::ENOMEM)?;
+        Ok(Self { pcbs, shared })
+    }
+
+    fn push(&mut self, pcb: Arc<ProcessControlBlock>) {
+        self.pcbs.push(pcb);
+    }
+
+    fn abort_before_start(&self) {
+        self.shared.abort.store(true, Ordering::Release);
+        self.shared.start.complete_all();
+        for worker in &self.pcbs {
+            let _ = ProcessManager::wakeup(worker);
+            Self::stop_confirmed(worker);
+        }
+    }
+
+    fn wake_all(&self) -> Result<(), SystemError> {
+        for worker in &self.pcbs {
+            if ProcessManager::wakeup(worker).is_err() {
+                self.abort_before_start();
+                return Err(SystemError::EIO);
+            }
+        }
+        Ok(())
+    }
+
+    fn wait_ready(&self) -> Option<SystemError> {
+        wait_for_completions(&self.shared.ready, self.pcbs.len())
+    }
+
+    fn wait_done(&self) -> Option<SystemError> {
+        wait_for_completions(&self.shared.done, self.pcbs.len())
+    }
+
+    fn stop_all(&self) {
+        for worker in &self.pcbs {
+            if Self::stop_confirmed(worker) {
+                self.shared.record_error(ERR_COMPLETION_WAIT, usize::MAX, 0);
+            }
+        }
+    }
+
+    /// Returns whether a transient wait error occurred. Retrying is safe:
+    /// stop() first publishes SHOULD_STOP, and a subsequent call observes an
+    /// already exited task or waits on the same exit completion.
+    fn stop_confirmed(worker: &Arc<ProcessControlBlock>) -> bool {
+        let mut saw_error = false;
+        loop {
+            match KernelThreadMechanism::stop(worker) {
+                Ok(_) => return saw_error,
+                Err(_) => {
+                    saw_error = true;
+                    sched_yield();
+                }
+            }
+        }
+    }
+}
+
+fn wait_for_completions(completion: &Completion, count: usize) -> Option<SystemError> {
+    let mut completed = 0;
+    let mut first_error = None;
+    while completed < count {
+        match completion.wait_for_completion() {
+            Ok(_) => completed += 1,
+            Err(error) => {
+                first_error.get_or_insert(error);
+                sched_yield();
+            }
+        }
+    }
+    first_error
+}
+
+pub(crate) fn run_torture(config: RcuTortureConfig) -> Result<RcuTortureResult, SystemError> {
+    let config = config.validate()?;
+    let cpus = online_cpus();
+    if cpus.is_empty() {
+        return Err(SystemError::ENODEV);
+    }
+    let reader_count = cpus.len().min(MAX_READER_COUNT);
+    let worker_count = reader_count
+        .checked_add(PUBLISHER_COUNT)
+        .and_then(|count| count.checked_add(1))
+        .ok_or(SystemError::E2BIG)?;
+    let node_count = config.rounds.checked_add(1).ok_or(SystemError::E2BIG)?;
+    let mut callback_completed = Vec::new();
+    callback_completed
+        .try_reserve_exact(node_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+    callback_completed.resize_with(node_count, || AtomicBool::new(false));
+    let shared = Arc::new(TortureShared::new(
+        config.seed,
+        callback_completed,
+        reader_count,
+    ));
+
+    let mut objects = Vec::new();
+    objects
+        .try_reserve_exact(node_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+    for generation in 0..node_count {
+        objects.push(TortureObject::new(generation, config.seed, shared.clone()));
+    }
+    let registry = Arc::new(TortureRegistry::new(objects.into_boxed_slice()));
+    let mut barrier_scratch = Vec::new();
+    if barrier_scratch.try_reserve_exact(registry.len()).is_err() {
+        return Err(SystemError::ENOMEM);
+    }
+
+    info!(
+        "RCU torture start: seed={:#018x} rounds={} readers={} publishers={} cpus={}",
+        config.seed,
+        config.rounds,
+        reader_count,
+        PUBLISHER_COUNT,
+        cpus.len(),
+    );
+
+    let mut workers = TortureWorkers::new(shared.clone(), worker_count)?;
+
+    for worker in 0..reader_count {
+        let worker_shared = shared.clone();
+        let body_shared = shared.clone();
+        let body = move || run_reader(&body_shared, config.seed, worker);
+        let closure = make_worker(body, worker_shared);
+        let Some(pcb) = KernelThreadMechanism::create_on_cpu(
+            closure,
+            format!("rcu-torture-reader-{worker}"),
+            cpus[worker % cpus.len()],
+        ) else {
+            workers.abort_before_start();
+            return Err(SystemError::ENOMEM);
+        };
+        workers.push(pcb);
+    }
+
+    for publisher in 0..PUBLISHER_COUNT {
+        let worker_shared = shared.clone();
+        let body_shared = shared.clone();
+        let body_registry = registry.clone();
+        let body = move || run_publisher(&body_shared, &body_registry, config, publisher);
+        let closure = make_worker(body, worker_shared);
+        let Some(pcb) = KernelThreadMechanism::create_on_cpu(
+            closure,
+            format!("rcu-torture-publisher-{publisher}"),
+            cpus[(reader_count + publisher) % cpus.len()],
+        ) else {
+            workers.abort_before_start();
+            return Err(SystemError::ENOMEM);
+        };
+        workers.push(pcb);
+    }
+
+    let worker_shared = shared.clone();
+    let body_shared = shared.clone();
+    let body_registry = registry.clone();
+    let body_scratch = Arc::new(SpinLock::new(Some(barrier_scratch)));
+    let body = move || {
+        let scratch = body_scratch
+            .lock_irqsave()
+            .take()
+            .expect("RCU torture barrier worker invoked more than once");
+        run_barrier(&body_shared, &body_registry, scratch)
+    };
+    let closure = make_worker(body, worker_shared);
+    let Some(barrier) = KernelThreadMechanism::create_on_cpu(
+        closure,
+        "rcu-torture-barrier".to_string(),
+        cpus[(reader_count + PUBLISHER_COUNT) % cpus.len()],
+    ) else {
+        workers.abort_before_start();
+        return Err(SystemError::ENOMEM);
+    };
+    workers.push(barrier);
+
+    workers.wake_all()?;
+    let mut completion_error = workers.wait_ready();
+
+    registry.mark_exposed();
+    shared
+        .published
+        .store(NonNull::from(&registry[0]).as_ptr(), Ordering::Release);
+    let started_at = rcu_now();
+    shared.start.complete_all();
+
+    if let Some(error) = workers.wait_done() {
+        completion_error.get_or_insert(error);
+    }
+    if completion_error.is_some() {
+        shared.record_error(ERR_COMPLETION_WAIT, usize::MAX, 0);
+    }
+    workers.stop_all();
+
+    let final_object = shared.published.swap(ptr::null_mut(), Ordering::AcqRel);
+    if let Some(final_object) = NonNull::new(final_object) {
+        // SAFETY: all publishers have exited, so the coordinator uniquely
+        // removed the final published object.
+        let object = unsafe { final_object.as_ref() };
+        object.reclaim_mode.store(RECLAIM_ASYNC, Ordering::SeqCst);
+        let _admission_guard = shared.admission_lock.lock_irqsave();
+        unsafe { call_rcu_raw(NonNull::from(&object.head), torture_callback) };
+        object.async_admitted.store(true, Ordering::Release);
+        shared.callbacks_admitted.fetch_add(1, Ordering::Relaxed);
+    } else {
+        shared.record_error(ERR_OWNERSHIP_MISMATCH, usize::MAX, 0);
+    }
+    rcu_barrier();
+    shared.sample_queue_depth();
+    let elapsed_ns = rcu_now().wrapping_sub(started_at);
+
+    let mut every_object_reclaimed = true;
+    let mut every_async_callback_completed = true;
+    for object in registry.iter() {
+        if !object.reclaim_started.load(Ordering::Acquire) {
+            every_object_reclaimed = false;
+            shared.record_error(ERR_OWNERSHIP_MISMATCH, usize::MAX, object.generation);
+        }
+        if object.async_admitted.load(Ordering::Acquire)
+            && !shared.callback_completed[object.generation].load(Ordering::Acquire)
+        {
+            every_async_callback_completed = false;
+            shared.record_error(ERR_OWNERSHIP_MISMATCH, usize::MAX, object.generation);
+        }
+    }
+    let admitted = shared.callbacks_admitted.load(Ordering::Acquire);
+    let invoked = shared.callbacks_invoked.load(Ordering::Acquire);
+    let sync_reclaims = shared.sync_reclaims.load(Ordering::Acquire);
+    let ownership_matches = admitted == invoked
+        && invoked.checked_add(sync_reclaims) == Some(node_count as u64)
+        && every_object_reclaimed
+        && every_async_callback_completed;
+    if !ownership_matches {
+        shared.record_error(ERR_OWNERSHIP_MISMATCH, usize::MAX, 0);
+    }
+
+    let first_error = shared.first_error.load(Ordering::SeqCst);
+    let passed = first_error == 0;
+    let synchronize_calls = shared.synchronize_calls.load(Ordering::Relaxed);
+    let gp_total_ns = shared.gp_total_ns.load(Ordering::Relaxed);
+    let callback_throughput = invoked
+        .saturating_mul(1_000_000_000)
+        .checked_div(elapsed_ns)
+        .unwrap_or(0);
+    let report = format!(
+        concat!(
+            "status={}\n",
+            "seed={:#018x}\n",
+            "rounds={}\n",
+            "cpus={}\n",
+            "readers={}\n",
+            "reads={}\n",
+            "publishes={}\n",
+            "callbacks_admitted={}\n",
+            "callbacks_invoked={}\n",
+            "sync_reclaims={}\n",
+            "synchronize_calls={}\n",
+            "gp_average_ns={}\n",
+            "gp_max_ns={}\n",
+            "barrier_calls={}\n",
+            "callback_throughput_per_sec={}\n",
+            "max_observed_callback_queue_depth={}\n",
+            "publication_cas_retries={}\n",
+            "premature_reclaims={}\n",
+            "duplicate_reclaims={}\n",
+            "corrupt_reads={}\n",
+            "registry_quarantined={}\n",
+            "elapsed_ns={}\n",
+            "first_error={}\n",
+            "first_error_worker={}\n",
+            "first_error_iteration={}\n",
+        ),
+        if passed { "ok" } else { "fail" },
+        config.seed,
+        config.rounds,
+        cpus.len(),
+        reader_count,
+        shared.reads.load(Ordering::Relaxed),
+        shared.publishes.load(Ordering::Relaxed),
+        admitted,
+        invoked,
+        sync_reclaims,
+        synchronize_calls,
+        gp_total_ns.checked_div(synchronize_calls).unwrap_or(0),
+        shared.gp_max_ns.load(Ordering::Relaxed),
+        shared.barrier_calls.load(Ordering::Relaxed),
+        callback_throughput,
+        shared.max_observed_queue_depth.load(Ordering::Relaxed),
+        shared.publication_cas_retries.load(Ordering::Relaxed),
+        shared.premature_reclaims.load(Ordering::Relaxed),
+        shared.duplicate_reclaims.load(Ordering::Relaxed),
+        shared.corrupt_reads.load(Ordering::Relaxed),
+        usize::from(!ownership_matches),
+        elapsed_ns,
+        error_name(first_error),
+        shared.first_error_worker.load(Ordering::SeqCst),
+        shared.first_error_iteration.load(Ordering::SeqCst),
+    );
+
+    info!(
+        "RCU torture finish: seed={:#018x} status={} reads={} publishes={} callbacks={}/{} sync={}",
+        config.seed,
+        if passed { "ok" } else { "fail" },
+        shared.reads.load(Ordering::Relaxed),
+        shared.publishes.load(Ordering::Relaxed),
+        invoked,
+        admitted,
+        sync_reclaims,
+    );
+
+    if ownership_matches {
+        registry.mark_drained();
+    } else {
+        registry.quarantine();
+    }
+    Ok(RcuTortureResult {
+        report,
+        passed,
+        reboot_required: !ownership_matches,
+    })
+}

--- a/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
@@ -46,7 +46,14 @@ std::string ReadAll(const char* path) {
 void ExpectReportOk(const std::string& report) {
     EXPECT_NE(std::string::npos, report.find("status=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr1=ok\n")) << report;
-    EXPECT_NE(std::string::npos, report.find("smp_litmus=ok\n")) << report;
+    const long online_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    ASSERT_GT(online_cpus, 0) << "sysconf(_SC_NPROCESSORS_ONLN) failed: errno=" << errno << " ("
+                              << strerror(errno) << ")";
+    if (online_cpus == 1) {
+        EXPECT_NE(std::string::npos, report.find("smp_litmus=skip:no-remote-cpu\n")) << report;
+    } else {
+        EXPECT_NE(std::string::npos, report.find("smp_litmus=ok\n")) << report;
+    }
     EXPECT_NE(std::string::npos, report.find("pr2=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr3=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr5=ok\n")) << report;

--- a/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_selftest.cc
@@ -46,6 +46,7 @@ std::string ReadAll(const char* path) {
 void ExpectReportOk(const std::string& report) {
     EXPECT_NE(std::string::npos, report.find("status=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr1=ok\n")) << report;
+    EXPECT_NE(std::string::npos, report.find("smp_litmus=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr2=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr3=ok\n")) << report;
     EXPECT_NE(std::string::npos, report.find("pr5=ok\n")) << report;

--- a/user/apps/tests/dunitest/suites/normal/rcu_torture.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_torture.cc
@@ -78,8 +78,17 @@ void RunSeed(uint64_t seed) {
     EXPECT_EQ(seed, Field(report, "seed")) << report;
     EXPECT_EQ(kRounds, Field(report, "rounds")) << report;
     EXPECT_EQ(kRounds, Field(report, "publishes")) << report;
-    EXPECT_GT(Field(report, "cpus"), 1u) << report;
-    EXPECT_GT(Field(report, "readers"), 1u) << report;
+    const long online_cpus = sysconf(_SC_NPROCESSORS_ONLN);
+    ASSERT_GT(online_cpus, 0) << "sysconf(_SC_NPROCESSORS_ONLN) failed: errno=" << errno << " ("
+                              << strerror(errno) << ")";
+    const uint64_t reported_cpus = Field(report, "cpus");
+    const uint64_t readers = Field(report, "readers");
+    EXPECT_EQ(static_cast<uint64_t>(online_cpus), reported_cpus) << report;
+    EXPECT_GE(readers, 1u) << report;
+    EXPECT_LE(readers, reported_cpus) << report;
+    if (online_cpus > 1) {
+        EXPECT_GT(readers, 1u) << report;
+    }
     EXPECT_GT(Field(report, "reads"), 0u) << report;
     EXPECT_GT(Field(report, "synchronize_calls"), 0u) << report;
     EXPECT_GT(Field(report, "barrier_calls"), 0u) << report;

--- a/user/apps/tests/dunitest/suites/normal/rcu_torture.cc
+++ b/user/apps/tests/dunitest/suites/normal/rcu_torture.cc
@@ -1,0 +1,107 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <string>
+
+namespace {
+
+constexpr const char* kTorturePath = "/sys/kernel/debug/rcu/torture";
+constexpr size_t kRounds = 256;
+
+std::string ReadAll() {
+    int fd = open(kTorturePath, O_RDONLY);
+    EXPECT_GE(fd, 0) << strerror(errno);
+    if (fd < 0) {
+        return {};
+    }
+    std::string report;
+    char buf[512];
+    while (true) {
+        ssize_t n = read(fd, buf, sizeof(buf));
+        if (n == 0) {
+            break;
+        }
+        EXPECT_GT(n, 0) << strerror(errno);
+        if (n < 0) {
+            break;
+        }
+        report.append(buf, static_cast<size_t>(n));
+    }
+    EXPECT_EQ(0, close(fd));
+    return report;
+}
+
+uint64_t Field(const std::string& report, const char* name) {
+    const std::string prefix = std::string(name) + "=";
+    size_t start = report.find(prefix);
+    EXPECT_NE(std::string::npos, start) << report;
+    if (start == std::string::npos) {
+        return 0;
+    }
+    start += prefix.size();
+    size_t end = report.find('\n', start);
+    const std::string value = report.substr(start, end - start);
+    char* parse_end = nullptr;
+    errno = 0;
+    unsigned long long parsed = strtoull(value.c_str(), &parse_end, 0);
+    EXPECT_EQ(0, errno) << value;
+    EXPECT_NE(parse_end, value.c_str()) << value;
+    EXPECT_EQ('\0', *parse_end) << value;
+    return static_cast<uint64_t>(parsed);
+}
+
+void RunSeed(uint64_t seed) {
+    char command[96];
+    int length = snprintf(command, sizeof(command), "seed=0x%016llx rounds=%zu",
+                          static_cast<unsigned long long>(seed), kRounds);
+    ASSERT_GT(length, 0);
+    ASSERT_LT(static_cast<size_t>(length), sizeof(command));
+
+    int fd = open(kTorturePath, O_WRONLY);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ssize_t written = write(fd, command, static_cast<size_t>(length));
+    int write_errno = errno;
+    EXPECT_EQ(0, close(fd));
+
+    const std::string report = ReadAll();
+    ASSERT_FALSE(report.empty());
+    ASSERT_EQ(static_cast<ssize_t>(length), written)
+        << "write errno=" << write_errno << " (" << strerror(write_errno) << ")\n" << report;
+    EXPECT_NE(std::string::npos, report.find("status=ok\n")) << report;
+    EXPECT_EQ(seed, Field(report, "seed")) << report;
+    EXPECT_EQ(kRounds, Field(report, "rounds")) << report;
+    EXPECT_EQ(kRounds, Field(report, "publishes")) << report;
+    EXPECT_GT(Field(report, "cpus"), 1u) << report;
+    EXPECT_GT(Field(report, "readers"), 1u) << report;
+    EXPECT_GT(Field(report, "reads"), 0u) << report;
+    EXPECT_GT(Field(report, "synchronize_calls"), 0u) << report;
+    EXPECT_GT(Field(report, "barrier_calls"), 0u) << report;
+
+    const uint64_t admitted = Field(report, "callbacks_admitted");
+    const uint64_t invoked = Field(report, "callbacks_invoked");
+    const uint64_t sync_reclaims = Field(report, "sync_reclaims");
+    EXPECT_EQ(admitted, invoked) << report;
+    EXPECT_EQ(kRounds + 1, invoked + sync_reclaims) << report;
+    EXPECT_EQ(0u, Field(report, "premature_reclaims")) << report;
+    EXPECT_EQ(0u, Field(report, "duplicate_reclaims")) << report;
+    EXPECT_EQ(0u, Field(report, "corrupt_reads")) << report;
+}
+
+TEST(RcuTorture, ReproducibleBoundedSeeds) {
+    RunSeed(0x1);
+    RunSeed(0xdeadbeefcafebabeULL);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -38,6 +38,7 @@ normal/sched_affinity
 normal/sync_file_range
 normal/splice_concurrent_io
 normal/rcu_selftest
+normal/rcu_torture
 normal/kthread_selftest
 normal/restart_syscall_semantics
 normal/errseq_selftest


### PR DESCRIPTION
## Summary

- add deterministic RCU grace-period, sync/free, reader-handoff, and cross-thread Arc-slot regression coverage
- add a reproducible SMP RCU torture harness with seeded logical decisions, concurrent readers and publishers, and synchronous/callback reclamation
- expose bounded torture runs through debugfs and cover fixed SMP seeds with dunitest
- keep RCU-specific registry and worker lifecycle ownership instead of introducing a generic torture framework

## Correctness and safety

- linearize callback admission against barrier-prefix snapshots
- publish per-generation completion only after the callback final object access
- quarantine objects and poison further runs when callback ownership cannot be proven
- require deterministic target grace periods to include the held reader CPU
- store intrusive objects in one stable boxed slice, avoiding address movement and per-object allocations

## Validation

- make fmt
- make kernel ARCH=x86_64
- x86_64 QEMU: rcu_selftest_test (5/5 passed)
- x86_64 QEMU: rcu_torture_test (1/1 passed with two fixed seeds)
- make kernel ARCH=riscv64

Closes #2215