### PR TITLE
perf(smp): reduce maximum CPU count to 16

### DIFF
--- a/kernel/src/arch/x86_64/asm/head.S
+++ b/kernel/src/arch/x86_64/asm/head.S
@@ -638,8 +638,8 @@ GDT_Table:
     .quad 0x00affb000000ffff // 6 用户64位代码段描述符 0x30
     .quad 0x00cf9a000000ffff // 7 内核32位代码段描述符 0x38
     .quad 0x00cf92000000ffff // 8 内核32位数据段描述符 0x40
-    // Entry 9 is reserved. Entries 10..265 hold 128 per-CPU TSS descriptors.
-    .fill 257, 8, 0
+    // Entry 9 is reserved. Entries 10..41 hold 16 per-CPU TSS descriptors.
+    .fill 33, 8, 0
 .global GDT_END
 GDT_END:
 

--- a/kernel/src/mm/percpu.rs
+++ b/kernel/src/mm/percpu.rs
@@ -20,13 +20,7 @@ static CPU_NUM_ATOMIC: AtomicU32 = AtomicU32::new(PerCpu::MAX_CPU_NUM);
 pub struct PerCpu;
 
 impl PerCpu {
-    #[cfg(target_arch = "x86_64")]
-    pub const MAX_CPU_NUM: u32 = 128;
-    #[cfg(target_arch = "riscv64")]
-    pub const MAX_CPU_NUM: u32 = 64;
-
-    #[cfg(target_arch = "loongarch64")]
-    pub const MAX_CPU_NUM: u32 = 128;
+    pub const MAX_CPU_NUM: u32 = 16;
 
     /// # 初始化PerCpu
     ///


### PR DESCRIPTION
## Summary

- reduce the global maximum CPU count to 16 for lightweight agent-oriented workloads
- shrink the x86_64 GDT per-CPU TSS descriptor area to match the new limit
- preserve the early-boot invariant between the assembly GDT and the Rust TSS table

## Memory impact

Measured after booting the same rootfs with 2 GiB RAM and 2 vCPUs:

- `free -k` used memory: 65,976 kB -> 54,944 kB (11,032 kB / about 10.77 MiB lower)
- kernel ELF section total: 23,227,232 bytes -> 21,807,392 bytes (about 1.35 MiB lower)

## Testing

- `make kernel`
- `make qemu-nographic`
  - booted both vCPUs
  - reached the DragonOS userspace shell