### PR TITLE
feat(time): support timerfd syscalls

### DIFF
--- a/.github/workflows/test-x86.yml
+++ b/.github/workflows/test-x86.yml
@@ -20,7 +20,7 @@ jobs:
   integration-test:
     name: Integration Test
     runs-on: ubuntu-latest
-    # Allow the 50-minute guest test budget plus build, cleanup, and diagnostics.
+    # Allow the 55-minute guest test budget plus build, cleanup, and diagnostics.
     timeout-minutes: 75
     container:
       image: dragonos/dragonos-dev:v1.23

--- a/kernel/src/filesystem/mod.rs
+++ b/kernel/src/filesystem/mod.rs
@@ -19,5 +19,6 @@ pub mod poll;
 pub mod procfs;
 pub mod ramfs;
 pub mod sysfs;
+pub mod timerfd;
 pub mod tmpfs;
 pub mod vfs;

--- a/kernel/src/filesystem/timerfd.rs
+++ b/kernel/src/filesystem/timerfd.rs
@@ -323,12 +323,43 @@ impl TimerFdInode {
         }
     }
 
-    fn advance_periodic_locked(state: &mut TimerFdState) -> Option<(u64, DeadlineDomain, u64)> {
+    fn prepare_periodic_rearm(&self) -> Option<(u64, u64)> {
+        let needs_registration = {
+            let state = self.state.lock_irqsave();
+            state.expired
+                && state.interval_ns != 0
+                && state.configured_realtime_absolute()
+                && !state.registry_registered
+        };
+        if !needs_registration {
+            return None;
+        }
+
+        // The caller holds operation. Register before observing realtime so a
+        // concurrent clock set is either included in this snapshot or finds
+        // this inode and waits for the rearm state to be published.
+        self.registry_add();
+        let (now, clock_set_seq) = realtime_now_with_clock_set_seq();
+        Some((now.to_ktime_ns(), clock_set_seq))
+    }
+
+    fn advance_periodic_locked(
+        state: &mut TimerFdState,
+        registration: Option<(u64, u64)>,
+    ) -> Option<(u64, DeadlineDomain, u64)> {
         if !state.expired || state.interval_ns == 0 {
             return None;
         }
+        if let Some((_, clock_set_seq)) = registration {
+            debug_assert!(state.configured_realtime_absolute());
+            debug_assert!(!state.registry_registered);
+            state.registry_registered = true;
+            state.observed_clock_set_seq = Some(clock_set_seq);
+        }
         let deadline = state.next_expiry_ns?;
-        let now = state.deadline_domain.now_ns();
+        let now = registration
+            .map(|(now, _)| now)
+            .unwrap_or_else(|| state.deadline_domain.now_ns());
         let next = if now >= deadline {
             let periods = (now - deadline) / state.interval_ns + 1;
             state.ticks = state.ticks.wrapping_add(periods - 1);
@@ -381,6 +412,7 @@ impl TimerFdInode {
             }
 
             let _operation = self.operation.lock();
+            let registration = self.prepare_periodic_rearm();
             let mut state = self.state.lock_irqsave();
             if state.cancel_pending {
                 Self::consume_cancel_locked(&mut state);
@@ -389,12 +421,14 @@ impl TimerFdInode {
             if state.ticks == 0 {
                 continue;
             }
-            let rearm = Self::advance_periodic_locked(&mut state);
+            let rearm = Self::advance_periodic_locked(&mut state, registration);
             let ticks = state.ticks;
             state.ticks = 0;
             state.expired = false;
-            let unregister =
-                state.interval_ns == 0 && state.registry_registered && !state.cancel_on_set();
+            let unregister = state.interval_ns == 0
+                && state.registry_registered
+                && state.configured_realtime_absolute()
+                && !state.cancel_on_set();
             if state.interval_ns == 0 {
                 // A consumed one-shot is logically disarmed.  Keeping its old
                 // deadline would let a later wall-clock set fire it again.
@@ -420,8 +454,9 @@ impl TimerFdInode {
 
     pub fn gettime(&self) -> Result<PosixItimerspec, SystemError> {
         let _operation = self.operation.lock();
+        let registration = self.prepare_periodic_rearm();
         let mut state = self.state.lock_irqsave();
-        let rearm = Self::advance_periodic_locked(&mut state);
+        let rearm = Self::advance_periodic_locked(&mut state, registration);
         let value = state.current_spec();
         drop(state);
         self.rearm_periodic(rearm)?;
@@ -442,9 +477,9 @@ impl TimerFdInode {
             (state.clock_id, state.registry_registered)
         };
         let realtime_absolute = Self::is_realtime_absolute(clock_id, flags);
-        let registry_member = realtime_absolute
+        let registry_candidate = realtime_absolute
             && (initial_ns != 0 || flags.contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET));
-        if registry_member && !registry_registered {
+        if registry_candidate && !registry_registered {
             self.registry_add();
         }
 
@@ -468,8 +503,11 @@ impl TimerFdInode {
         } else {
             Some(now.saturating_add(initial_ns).min(KTIME_MAX_NS))
         };
+        let immediate = deadline.is_some_and(|expiry| expiry <= now);
+        let registry_member = registry_candidate
+            && (!immediate || flags.contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET));
 
-        let (old, old_backend, generation, immediate, report_canceled) = {
+        let (old, old_backend, generation, report_canceled) = {
             let mut state = self.state.lock_irqsave();
             let old = state.current_spec();
             let old_backend = state.timer.take();
@@ -487,7 +525,6 @@ impl TimerFdInode {
             state.cancel_pending = old_cancel
                 && realtime_absolute
                 && flags.contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET);
-            let immediate = deadline.is_some_and(|expiry| expiry <= now);
             if immediate {
                 state.expired = true;
                 state.ticks = 1;
@@ -496,13 +533,13 @@ impl TimerFdInode {
             if report_canceled {
                 state.cancel_pending = false;
             }
-            (old, old_backend, generation, immediate, report_canceled)
+            (old, old_backend, generation, report_canceled)
         };
 
         if let Some(old_backend) = old_backend {
             old_backend.cancel();
         }
-        if !registry_member && registry_registered {
+        if !registry_member && (registry_registered || registry_candidate) {
             self.registry_remove();
         }
         if let Some(deadline) = deadline.filter(|_| !immediate) {
@@ -526,6 +563,9 @@ impl TimerFdInode {
         let (realtime_now, clock_set_seq) = realtime_now_with_clock_set_seq();
         let (old_backend, deadline, domain, generation, notify) = {
             let mut state = self.state.lock_irqsave();
+            if !state.registry_registered {
+                return;
+            }
             if state.shutdown || !state.configured_realtime_absolute() {
                 return;
             }
@@ -549,7 +589,14 @@ impl TimerFdInode {
             // backend. read/gettime owns any subsequent periodic forward and
             // rearm; installing another backend here would duplicate it.
             if state.expired {
+                let unregister = state.registry_registered && !notify;
+                if unregister {
+                    state.registry_registered = false;
+                }
                 drop(state);
+                if unregister {
+                    self.registry_remove();
+                }
                 if notify {
                     self.notify_readable();
                 }
@@ -573,11 +620,21 @@ impl TimerFdInode {
         let now = realtime_now.to_ktime_ns();
         if now >= deadline {
             let mut state = self.state.lock_irqsave();
-            if !state.shutdown && state.generation == generation {
+            let unregister = if !state.shutdown && state.generation == generation {
                 state.expired = true;
                 state.ticks = state.ticks.wrapping_add(1);
-            }
+                let unregister = state.registry_registered && !notify;
+                if unregister {
+                    state.registry_registered = false;
+                }
+                unregister
+            } else {
+                false
+            };
             drop(state);
+            if unregister {
+                self.registry_remove();
+            }
             self.notify_readable();
         } else {
             let backend = self.new_backend(deadline, domain, generation);

--- a/kernel/src/filesystem/timerfd.rs
+++ b/kernel/src/filesystem/timerfd.rs
@@ -1,0 +1,780 @@
+use alloc::{
+    boxed::Box,
+    collections::BTreeMap,
+    string::String,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::any::Any;
+
+use system_error::SystemError;
+
+use crate::{
+    arch::MMArch,
+    filesystem::{
+        epoll::{event_poll::EventPoll, EPollEventType, EPollItem},
+        vfs::{
+            file::{FileFlags, FilePrivateData},
+            vcore::generate_inode_id,
+            FileSystem, FileType, FsInfo, IndexNode, InodeFlags, InodeMode, Magic, Metadata,
+            OpenFileBehavior, PollableInode, PostWriteSyncPolicy, SuperBlock,
+        },
+    },
+    libs::{
+        mutex::{Mutex, MutexGuard},
+        spinlock::SpinLock,
+        wait_queue::WaitQueue,
+    },
+    mm::MemoryManagementArch,
+    process::{posix_timer::PosixItimerspec, ProcessManager},
+    syscall::user_buffer::UserBuffer,
+    time::{
+        syscall::{posix_clock_now, PosixClockID},
+        timer::{next_n_us_timer_jiffies, Timer, TimerFunction},
+        PosixTimeSpec, NSEC_PER_SEC,
+    },
+};
+
+use super::epoll::event_poll::EPollItemList;
+
+const KTIME_MAX_NS: u64 = i64::MAX as u64;
+const KTIME_SEC_MAX: i64 = i64::MAX / NSEC_PER_SEC as i64;
+
+lazy_static::lazy_static! {
+    static ref TIMERFD_FS: Arc<TimerFdFs> = Arc::new(TimerFdFs);
+    // Registry operations only run in task context.  A sleeping mutex keeps
+    // Vec allocation and O(N) cleanup out of irq-disabled spinlock sections.
+    static ref REALTIME_TIMERFDS: Mutex<BTreeMap<usize, Weak<TimerFdInode>>> =
+        Mutex::new(BTreeMap::new());
+}
+
+bitflags! {
+    pub struct TimerFdCreateFlags: u32 {
+        const TFD_NONBLOCK = FileFlags::O_NONBLOCK.bits();
+        const TFD_CLOEXEC = FileFlags::O_CLOEXEC.bits();
+    }
+
+    pub struct TimerFdSettimeFlags: u32 {
+        const TFD_TIMER_ABSTIME = 1;
+        const TFD_TIMER_CANCEL_ON_SET = 2;
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+enum DeadlineDomain {
+    Monotonic,
+    Realtime,
+    Boottime,
+}
+
+impl DeadlineDomain {
+    fn now_ns(self) -> u64 {
+        let clock = match self {
+            Self::Monotonic => PosixClockID::Monotonic,
+            Self::Realtime => PosixClockID::Realtime,
+            Self::Boottime => PosixClockID::Boottime,
+        };
+        posix_clock_now(clock).to_ktime_ns()
+    }
+}
+
+#[derive(Debug)]
+struct TimerFdState {
+    clock_id: PosixClockID,
+    interval_ns: u64,
+    next_expiry_ns: Option<u64>,
+    deadline_domain: DeadlineDomain,
+    timer: Option<Arc<Timer>>,
+    ticks: u64,
+    expired: bool,
+    cancel_pending: bool,
+    generation: u64,
+    settime_flags: TimerFdSettimeFlags,
+    registry_registered: bool,
+    shutdown: bool,
+}
+
+impl TimerFdState {
+    fn configured_realtime_absolute(&self) -> bool {
+        matches!(
+            self.clock_id,
+            PosixClockID::Realtime | PosixClockID::RealtimeAlarm
+        ) && self
+            .settime_flags
+            .contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME)
+    }
+
+    fn cancel_on_set(&self) -> bool {
+        self.configured_realtime_absolute()
+            && self
+                .settime_flags
+                .contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET)
+    }
+
+    fn current_spec(&self) -> PosixItimerspec {
+        let mut value = PosixTimeSpec::default();
+        if let Some(mut deadline) = self.next_expiry_ns {
+            let now = self.deadline_domain.now_ns();
+            if self.expired && self.interval_ns != 0 && now >= deadline {
+                let periods = (now - deadline) / self.interval_ns + 1;
+                deadline = deadline
+                    .saturating_add(self.interval_ns.saturating_mul(periods))
+                    .min(KTIME_MAX_NS);
+            }
+            value = PosixTimeSpec::from_ns(deadline.saturating_sub(now));
+        }
+        PosixItimerspec {
+            it_interval: PosixTimeSpec::from_ns(self.interval_ns),
+            it_value: value,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct TimerFdFs;
+
+impl TimerFdFs {
+    fn instance() -> Arc<Self> {
+        TIMERFD_FS.clone()
+    }
+}
+
+impl FileSystem for TimerFdFs {
+    fn page_cache_writeback_domain(
+        &self,
+    ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {
+        None
+    }
+
+    fn root_inode(&self) -> Arc<dyn IndexNode> {
+        TimerFdInode::new(PosixClockID::Monotonic)
+    }
+
+    fn info(&self) -> FsInfo {
+        FsInfo {
+            blk_dev_id: 0,
+            max_name_len: 255,
+        }
+    }
+
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn name(&self) -> &str {
+        "timerfd"
+    }
+
+    fn super_block(&self) -> SuperBlock {
+        SuperBlock::new(
+            Magic::EVENTFD_MAGIC,
+            <MMArch as MemoryManagementArch>::PAGE_SIZE as u64,
+            255,
+        )
+    }
+}
+
+#[derive(Debug)]
+pub struct TimerFdInode {
+    state: SpinLock<TimerFdState>,
+    operation: Mutex<()>,
+    wait_queue: WaitQueue,
+    epitems: EPollItemList,
+    metadata: Metadata,
+    self_weak: Weak<TimerFdInode>,
+}
+
+impl TimerFdInode {
+    pub fn new(clock_id: PosixClockID) -> Arc<Self> {
+        Arc::new_cyclic(|weak| Self {
+            state: SpinLock::new(TimerFdState {
+                clock_id,
+                interval_ns: 0,
+                next_expiry_ns: None,
+                deadline_domain: Self::absolute_domain(clock_id),
+                timer: None,
+                ticks: 0,
+                expired: false,
+                cancel_pending: false,
+                generation: 0,
+                settime_flags: TimerFdSettimeFlags::empty(),
+                registry_registered: false,
+                shutdown: false,
+            }),
+            operation: Mutex::new(()),
+            wait_queue: WaitQueue::default(),
+            epitems: EPollItemList::default(),
+            metadata: Metadata {
+                dev_id: 0,
+                inode_id: generate_inode_id(),
+                size: 0,
+                blk_size: 0,
+                blocks: 0,
+                atime: PosixTimeSpec::default(),
+                mtime: PosixTimeSpec::default(),
+                ctime: PosixTimeSpec::default(),
+                btime: PosixTimeSpec::default(),
+                file_type: FileType::File,
+                mode: InodeMode::from_bits_truncate(0o600),
+                nlinks: 1,
+                uid: 0,
+                gid: 0,
+                raw_dev: Default::default(),
+                flags: InodeFlags::empty(),
+            },
+            self_weak: weak.clone(),
+        })
+    }
+
+    fn absolute_domain(clock_id: PosixClockID) -> DeadlineDomain {
+        match clock_id {
+            PosixClockID::Realtime | PosixClockID::RealtimeAlarm => DeadlineDomain::Realtime,
+            PosixClockID::Boottime | PosixClockID::BoottimeAlarm => DeadlineDomain::Boottime,
+            _ => DeadlineDomain::Monotonic,
+        }
+    }
+
+    fn relative_domain(clock_id: PosixClockID) -> DeadlineDomain {
+        match clock_id {
+            PosixClockID::Boottime | PosixClockID::BoottimeAlarm => DeadlineDomain::Boottime,
+            _ => DeadlineDomain::Monotonic,
+        }
+    }
+
+    fn timespec_to_ktime_ns(value: PosixTimeSpec) -> Result<u64, SystemError> {
+        if !value.is_valid_timeout() {
+            return Err(SystemError::EINVAL);
+        }
+        if value.tv_sec >= KTIME_SEC_MAX {
+            return Ok(KTIME_MAX_NS);
+        }
+        Ok((value.tv_sec as u64) * NSEC_PER_SEC as u64 + value.tv_nsec as u64)
+    }
+
+    pub fn validate_spec(value: &PosixItimerspec) -> Result<(), SystemError> {
+        Self::timespec_to_ktime_ns(value.it_value)?;
+        Self::timespec_to_ktime_ns(value.it_interval)?;
+        Ok(())
+    }
+
+    fn is_realtime_absolute(clock_id: PosixClockID, flags: TimerFdSettimeFlags) -> bool {
+        matches!(
+            clock_id,
+            PosixClockID::Realtime | PosixClockID::RealtimeAlarm
+        ) && flags.contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME)
+    }
+
+    fn registry_add(&self) {
+        REALTIME_TIMERFDS
+            .lock()
+            .insert(self as *const Self as usize, self.self_weak.clone());
+    }
+
+    fn registry_remove(&self) {
+        REALTIME_TIMERFDS
+            .lock()
+            .remove(&(self as *const Self as usize));
+    }
+
+    fn new_backend(&self, deadline_ns: u64, domain: DeadlineDomain, generation: u64) -> Arc<Timer> {
+        let now = domain.now_ns();
+        let remaining_us = deadline_ns.saturating_sub(now).div_ceil(1000);
+        let expires = next_n_us_timer_jiffies(remaining_us);
+        Timer::new(
+            Box::new(TimerFdExpiry {
+                inode: self.self_weak.clone(),
+                generation,
+            }),
+            expires,
+        )
+    }
+
+    fn publish_backend(&self, backend: Arc<Timer>, generation: u64) -> bool {
+        let mut state = self.state.lock_irqsave();
+        if state.shutdown || state.generation != generation || state.next_expiry_ns.is_none() {
+            return false;
+        }
+        state.timer = Some(backend);
+        true
+    }
+
+    fn notify_readable(&self) {
+        self.wait_queue.wakeup_all(None);
+        let _ = EventPoll::wakeup_epoll(&self.epitems, EPollEventType::EPOLLIN);
+    }
+
+    fn has_ticks(&self) -> bool {
+        self.state.lock_irqsave().ticks != 0
+    }
+
+    fn consume_cancel_locked(state: &mut TimerFdState) {
+        let backend_expired = state.expired;
+        state.cancel_pending = false;
+        state.ticks = 0;
+        state.expired = false;
+        if backend_expired {
+            // Linux does not rearm an already-expired timer when read returns
+            // ECANCELED.  Keep cancel-list membership, but logically disarm
+            // it so a later clock set cannot resurrect the old deadline.
+            state.next_expiry_ns = None;
+        }
+    }
+
+    fn advance_periodic_locked(state: &mut TimerFdState) -> Option<(u64, DeadlineDomain, u64)> {
+        if !state.expired || state.interval_ns == 0 {
+            return None;
+        }
+        let deadline = state.next_expiry_ns?;
+        let now = state.deadline_domain.now_ns();
+        let next = if now >= deadline {
+            let periods = (now - deadline) / state.interval_ns + 1;
+            state.ticks = state.ticks.wrapping_add(periods - 1);
+            deadline
+                .saturating_add(state.interval_ns.saturating_mul(periods))
+                .min(KTIME_MAX_NS)
+        } else {
+            // Match Linux hrtimer_forward_now(): after a realtime step back
+            // before the old expiry, it returns 0 and timerfd's unsigned
+            // `ticks += 0 - 1` retracts the lazy callback contribution before
+            // the original deadline is rearmed.
+            state.ticks = state.ticks.wrapping_sub(1);
+            deadline
+        };
+        state.expired = false;
+        state.next_expiry_ns = Some(next);
+        Some((next, state.deadline_domain, state.generation))
+    }
+
+    fn rearm_periodic(&self, rearm: Option<(u64, DeadlineDomain, u64)>) -> Result<(), SystemError> {
+        let Some((deadline, domain, generation)) = rearm else {
+            return Ok(());
+        };
+        let backend = self.new_backend(deadline, domain, generation);
+        if self.publish_backend(backend.clone(), generation) {
+            backend.activate();
+        }
+        Ok(())
+    }
+
+    fn read_ticks(&self, nonblock: bool) -> Result<u64, SystemError> {
+        loop {
+            if !self.has_ticks() {
+                if nonblock {
+                    let _operation = self.operation.lock();
+                    let mut state = self.state.lock_irqsave();
+                    if state.cancel_pending {
+                        Self::consume_cancel_locked(&mut state);
+                        return Err(SystemError::ECANCELED);
+                    }
+                    if state.ticks == 0 {
+                        return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    }
+                } else {
+                    if ProcessManager::current_pcb().has_pending_signal_fast() {
+                        return Err(SystemError::ERESTARTSYS);
+                    }
+                    wq_wait_event_interruptible!(self.wait_queue, self.has_ticks(), {})?;
+                }
+            }
+
+            let _operation = self.operation.lock();
+            let mut state = self.state.lock_irqsave();
+            if state.cancel_pending {
+                Self::consume_cancel_locked(&mut state);
+                return Err(SystemError::ECANCELED);
+            }
+            if state.ticks == 0 {
+                continue;
+            }
+            let rearm = Self::advance_periodic_locked(&mut state);
+            let ticks = state.ticks;
+            state.ticks = 0;
+            state.expired = false;
+            let unregister =
+                state.interval_ns == 0 && state.registry_registered && !state.cancel_on_set();
+            if state.interval_ns == 0 {
+                // A consumed one-shot is logically disarmed.  Keeping its old
+                // deadline would let a later wall-clock set fire it again.
+                state.next_expiry_ns = None;
+                if unregister {
+                    state.registry_registered = false;
+                }
+            }
+            drop(state);
+            if unregister {
+                self.registry_remove();
+            }
+            self.rearm_periodic(rearm)?;
+            if ticks == 0 && nonblock {
+                // Linux leaves the preinitialized nonblocking result at
+                // -EAGAIN when hrtimer_forward_now()==0 retracts the sole
+                // lazy expiration after a realtime step backwards.
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            return Ok(ticks);
+        }
+    }
+
+    pub fn gettime(&self) -> Result<PosixItimerspec, SystemError> {
+        let _operation = self.operation.lock();
+        let mut state = self.state.lock_irqsave();
+        let rearm = Self::advance_periodic_locked(&mut state);
+        let value = state.current_spec();
+        drop(state);
+        self.rearm_periodic(rearm)?;
+        Ok(value)
+    }
+
+    pub fn settime(
+        &self,
+        flags: TimerFdSettimeFlags,
+        value: PosixItimerspec,
+    ) -> Result<PosixItimerspec, SystemError> {
+        let interval_ns = Self::timespec_to_ktime_ns(value.it_interval)?;
+        let initial_ns = Self::timespec_to_ktime_ns(value.it_value)?;
+        let _operation = self.operation.lock();
+
+        let (clock_id, registry_registered) = {
+            let state = self.state.lock_irqsave();
+            (state.clock_id, state.registry_registered)
+        };
+        let realtime_absolute = Self::is_realtime_absolute(clock_id, flags);
+        let registry_member = realtime_absolute
+            && (initial_ns != 0 || flags.contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET));
+        if registry_member && !registry_registered {
+            self.registry_add();
+        }
+
+        let domain = if flags.contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME) {
+            Self::absolute_domain(clock_id)
+        } else {
+            Self::relative_domain(clock_id)
+        };
+        let now = domain.now_ns();
+        let deadline = if initial_ns == 0 {
+            None
+        } else if flags.contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME) {
+            Some(initial_ns)
+        } else {
+            Some(now.saturating_add(initial_ns).min(KTIME_MAX_NS))
+        };
+
+        let (old, old_backend, generation, immediate, report_canceled) = {
+            let mut state = self.state.lock_irqsave();
+            let old = state.current_spec();
+            let old_backend = state.timer.take();
+            let old_cancel = state.cancel_pending;
+            state.generation = state.generation.wrapping_add(1);
+            let generation = state.generation;
+            state.interval_ns = interval_ns;
+            state.next_expiry_ns = deadline;
+            state.deadline_domain = domain;
+            state.ticks = 0;
+            state.expired = false;
+            state.settime_flags = flags;
+            state.registry_registered = registry_member;
+            state.cancel_pending = old_cancel
+                && realtime_absolute
+                && flags.contains(TimerFdSettimeFlags::TFD_TIMER_CANCEL_ON_SET);
+            let immediate = deadline.is_some_and(|expiry| expiry <= now);
+            if immediate {
+                state.expired = true;
+                state.ticks = 1;
+            }
+            let report_canceled = initial_ns != 0 && state.cancel_pending;
+            if report_canceled {
+                state.cancel_pending = false;
+            }
+            (old, old_backend, generation, immediate, report_canceled)
+        };
+
+        if let Some(old_backend) = old_backend {
+            old_backend.cancel();
+        }
+        if !registry_member && registry_registered {
+            self.registry_remove();
+        }
+        if let Some(deadline) = deadline.filter(|_| !immediate) {
+            let backend = self.new_backend(deadline, domain, generation);
+            if self.publish_backend(backend.clone(), generation) {
+                backend.activate();
+            }
+        }
+        if immediate {
+            self.notify_readable();
+        }
+        if report_canceled {
+            Err(SystemError::ECANCELED)
+        } else {
+            Ok(old)
+        }
+    }
+
+    fn clock_was_set(&self) {
+        let _operation = self.operation.lock();
+        let (old_backend, deadline, domain, generation, notify) = {
+            let mut state = self.state.lock_irqsave();
+            if state.shutdown || !state.configured_realtime_absolute() {
+                return;
+            }
+            let notify = state.cancel_on_set();
+            if notify {
+                state.cancel_pending = true;
+                state.ticks = state.ticks.wrapping_add(1);
+            }
+            let Some(deadline) = state.next_expiry_ns else {
+                drop(state);
+                if notify {
+                    self.notify_readable();
+                }
+                return;
+            };
+            // A lazy periodic/one-shot expiry has already consumed its
+            // backend. read/gettime owns any subsequent periodic forward and
+            // rearm; installing another backend here would duplicate it.
+            if state.expired {
+                drop(state);
+                if notify {
+                    self.notify_readable();
+                }
+                return;
+            }
+            state.generation = state.generation.wrapping_add(1);
+            let generation = state.generation;
+            let old_backend = state.timer.take();
+            (
+                old_backend,
+                deadline,
+                state.deadline_domain,
+                generation,
+                notify,
+            )
+        };
+
+        if let Some(old_backend) = old_backend {
+            old_backend.cancel();
+        }
+        let now = domain.now_ns();
+        if now >= deadline {
+            let mut state = self.state.lock_irqsave();
+            if !state.shutdown && state.generation == generation {
+                state.expired = true;
+                state.ticks = state.ticks.wrapping_add(1);
+            }
+            drop(state);
+            self.notify_readable();
+        } else {
+            let backend = self.new_backend(deadline, domain, generation);
+            if self.publish_backend(backend.clone(), generation) {
+                backend.activate();
+            }
+            if notify {
+                self.notify_readable();
+            }
+        }
+    }
+
+    pub fn is_alarm(&self) -> bool {
+        matches!(
+            self.state.lock_irqsave().clock_id,
+            PosixClockID::RealtimeAlarm | PosixClockID::BoottimeAlarm
+        )
+    }
+}
+
+#[derive(Debug)]
+struct TimerFdExpiry {
+    inode: Weak<TimerFdInode>,
+    generation: u64,
+}
+
+impl TimerFunction for TimerFdExpiry {
+    fn run(&mut self) -> Result<(), SystemError> {
+        let Some(inode) = self.inode.upgrade() else {
+            return Ok(());
+        };
+        let mut state = inode.state.lock_irqsave();
+        if state.shutdown || state.generation != self.generation || state.next_expiry_ns.is_none() {
+            return Ok(());
+        }
+        let deadline = state.next_expiry_ns.unwrap();
+        let now = state.deadline_domain.now_ns();
+        state.timer = None;
+        if now < deadline {
+            return Ok(());
+        }
+        state.expired = true;
+        state.ticks = state.ticks.wrapping_add(1);
+        drop(state);
+        inode.notify_readable();
+        Ok(())
+    }
+}
+
+impl PollableInode for TimerFdInode {
+    fn poll(&self, _private_data: &FilePrivateData) -> Result<usize, SystemError> {
+        Ok(if self.has_ticks() {
+            EPollEventType::EPOLLIN.bits() as usize
+        } else {
+            0
+        })
+    }
+
+    fn add_epitem(
+        &self,
+        epitem: Arc<EPollItem>,
+        _private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        self.epitems.add(epitem);
+        Ok(())
+    }
+
+    fn remove_epitem(
+        &self,
+        epitem: &Arc<EPollItem>,
+        _private_data: &FilePrivateData,
+    ) -> Result<(), SystemError> {
+        self.epitems.remove(epitem)
+    }
+}
+
+impl IndexNode for TimerFdInode {
+    fn configure_open_file(&self, _data: &FilePrivateData, behavior: &mut OpenFileBehavior) {
+        behavior.post_write_sync = PostWriteSyncPolicy::NotApplicable;
+    }
+
+    fn is_stream(&self) -> bool {
+        true
+    }
+
+    fn has_noop_llseek(&self) -> bool {
+        true
+    }
+
+    fn open(
+        &self,
+        _data: MutexGuard<FilePrivateData>,
+        _flags: &FileFlags,
+    ) -> Result<(), SystemError> {
+        Ok(())
+    }
+
+    fn close(&self, _data: MutexGuard<FilePrivateData>) -> Result<(), SystemError> {
+        let _operation = self.operation.lock();
+        let (backend, registry_registered) = {
+            let mut state = self.state.lock_irqsave();
+            state.shutdown = true;
+            state.generation = state.generation.wrapping_add(1);
+            state.next_expiry_ns = None;
+            let registry_registered = state.registry_registered;
+            state.registry_registered = false;
+            (state.timer.take(), registry_registered)
+        };
+        if registry_registered {
+            self.registry_remove();
+        }
+        if let Some(backend) = backend {
+            backend.cancel();
+        }
+        Ok(())
+    }
+
+    fn read_at(
+        &self,
+        _offset: usize,
+        len: usize,
+        buf: &mut [u8],
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        if len < core::mem::size_of::<u64>() {
+            return Err(SystemError::EINVAL);
+        }
+        let nonblock = matches!(
+            &*data,
+            FilePrivateData::TimerFd(flags) if flags.contains(FileFlags::O_NONBLOCK)
+        );
+        drop(data);
+        let ticks = self.read_ticks(nonblock)?;
+        if ticks == 0 {
+            return Ok(0);
+        }
+        buf[..8].copy_from_slice(&ticks.to_ne_bytes());
+        Ok(8)
+    }
+
+    fn supports_read_user(&self) -> bool {
+        true
+    }
+
+    fn read_user_at(
+        &self,
+        _offset: usize,
+        len: usize,
+        writer: &mut UserBuffer<'_>,
+        data: MutexGuard<FilePrivateData>,
+    ) -> Result<Option<usize>, SystemError> {
+        if len < core::mem::size_of::<u64>() {
+            return Err(SystemError::EINVAL);
+        }
+        let nonblock = matches!(
+            &*data,
+            FilePrivateData::TimerFd(flags) if flags.contains(FileFlags::O_NONBLOCK)
+        );
+        drop(data);
+        let ticks = self.read_ticks(nonblock)?;
+        if ticks == 0 {
+            return Ok(Some(0));
+        }
+        writer.write_one(0, &ticks)?;
+        Ok(Some(8))
+    }
+
+    fn write_at(
+        &self,
+        _offset: usize,
+        _len: usize,
+        _buf: &[u8],
+        _data: MutexGuard<FilePrivateData>,
+    ) -> Result<usize, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn metadata(&self) -> Result<Metadata, SystemError> {
+        Ok(self.metadata.clone())
+    }
+
+    fn fs(&self) -> Arc<dyn FileSystem> {
+        TimerFdFs::instance()
+    }
+
+    fn as_any_ref(&self) -> &dyn Any {
+        self
+    }
+
+    fn list(&self) -> Result<Vec<String>, SystemError> {
+        Err(SystemError::EINVAL)
+    }
+
+    fn as_pollable_inode(&self) -> Result<&dyn PollableInode, SystemError> {
+        Ok(self)
+    }
+
+    fn absolute_path(&self) -> Result<String, SystemError> {
+        Ok(String::from("timerfd"))
+    }
+}
+
+/// Notify all realtime-absolute timerfds after a discontinuous wall-clock set.
+/// The timekeeper write lock must not be held by the caller.
+pub fn timerfd_clock_was_set() {
+    let snapshot = {
+        let mut registry = REALTIME_TIMERFDS.lock();
+        registry.retain(|_, entry| entry.strong_count() != 0);
+        registry.values().cloned().collect::<Vec<_>>()
+    };
+    for entry in snapshot {
+        if let Some(inode) = entry.upgrade() {
+            inode.clock_was_set();
+        }
+    }
+}

--- a/kernel/src/filesystem/timerfd.rs
+++ b/kernel/src/filesystem/timerfd.rs
@@ -30,6 +30,7 @@ use crate::{
     syscall::user_buffer::UserBuffer,
     time::{
         syscall::{posix_clock_now, PosixClockID},
+        timekeeping::realtime_now_with_clock_set_seq,
         timer::{next_n_us_timer_jiffies, Timer, TimerFunction},
         PosixTimeSpec, NSEC_PER_SEC,
     },
@@ -90,6 +91,7 @@ struct TimerFdState {
     cancel_pending: bool,
     generation: u64,
     settime_flags: TimerFdSettimeFlags,
+    observed_clock_set_seq: Option<u64>,
     registry_registered: bool,
     shutdown: bool,
 }
@@ -198,6 +200,7 @@ impl TimerFdInode {
                 cancel_pending: false,
                 generation: 0,
                 settime_flags: TimerFdSettimeFlags::empty(),
+                observed_clock_set_seq: None,
                 registry_registered: false,
                 shutdown: false,
             }),
@@ -450,7 +453,14 @@ impl TimerFdInode {
         } else {
             Self::relative_domain(clock_id)
         };
-        let now = domain.now_ns();
+        let (now, observed_clock_set_seq) = if domain == DeadlineDomain::Realtime
+            && flags.contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME)
+        {
+            let (now, seq) = realtime_now_with_clock_set_seq();
+            (now.to_ktime_ns(), Some(seq))
+        } else {
+            (domain.now_ns(), None)
+        };
         let deadline = if initial_ns == 0 {
             None
         } else if flags.contains(TimerFdSettimeFlags::TFD_TIMER_ABSTIME) {
@@ -472,6 +482,7 @@ impl TimerFdInode {
             state.ticks = 0;
             state.expired = false;
             state.settime_flags = flags;
+            state.observed_clock_set_seq = observed_clock_set_seq;
             state.registry_registered = registry_member;
             state.cancel_pending = old_cancel
                 && realtime_absolute
@@ -512,11 +523,16 @@ impl TimerFdInode {
 
     fn clock_was_set(&self) {
         let _operation = self.operation.lock();
+        let (realtime_now, clock_set_seq) = realtime_now_with_clock_set_seq();
         let (old_backend, deadline, domain, generation, notify) = {
             let mut state = self.state.lock_irqsave();
             if state.shutdown || !state.configured_realtime_absolute() {
                 return;
             }
+            if state.observed_clock_set_seq == Some(clock_set_seq) {
+                return;
+            }
+            state.observed_clock_set_seq = Some(clock_set_seq);
             let notify = state.cancel_on_set();
             if notify {
                 state.cancel_pending = true;
@@ -554,7 +570,7 @@ impl TimerFdInode {
         if let Some(old_backend) = old_backend {
             old_backend.cancel();
         }
-        let now = domain.now_ns();
+        let now = realtime_now.to_ktime_ns();
         if now >= deadline {
             let mut state = self.state.lock_irqsave();
             if !state.shutdown && state.generation == generation {

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -1446,6 +1446,27 @@ impl File {
         len: usize,
         writer: &mut UserBuffer<'_>,
     ) -> Result<Option<usize>, SystemError> {
+        self.read_user_with_fsnotify(len, writer, true)
+    }
+
+    /// Read one userspace-buffer chunk for a vector syscall.
+    ///
+    /// The vector syscall publishes ACCESS once at its completion boundary,
+    /// rather than once per iovec processed by the fallback `.read` loop.
+    pub(crate) fn read_user_syscall_chunk(
+        &self,
+        len: usize,
+        writer: &mut UserBuffer<'_>,
+    ) -> Result<Option<usize>, SystemError> {
+        self.read_user_with_fsnotify(len, writer, false)
+    }
+
+    fn read_user_with_fsnotify(
+        &self,
+        len: usize,
+        writer: &mut UserBuffer<'_>,
+        emit_fsnotify: bool,
+    ) -> Result<Option<usize>, SystemError> {
         let mode = *self.mode.read();
         let stream = mode.contains(FileMode::FMODE_STREAM);
         let offset = if stream {
@@ -1469,7 +1490,7 @@ impl File {
             return Ok(None);
         };
 
-        self.finalize_read(offset, read_len, !stream, true);
+        self.finalize_read(offset, read_len, !stream, emit_fsnotify);
         Ok(Some(read_len))
     }
 

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -343,6 +343,8 @@ pub enum FilePrivateData {
     Overlayfs(OverlayFilePrivateData),
     /// kernfs/debugfs per-open callback state.
     Kernfs(Option<KernFilePrivateData>),
+    /// timerfd open-file-description flags (notably O_NONBLOCK).
+    TimerFd(FileFlags),
     /// 不需要文件私有信息
     Unused,
 }
@@ -409,6 +411,7 @@ impl FilePrivateData {
             FilePrivateData::Overlayfs(pdata) => {
                 pdata.set_flags(flags)?;
             }
+            FilePrivateData::TimerFd(current) => *current = flags,
             _ => {}
         }
         Ok(())
@@ -1452,9 +1455,6 @@ impl File {
         };
 
         self.readable()?;
-        if len == 0 {
-            return Ok(Some(0));
-        }
         if writer.len() < len {
             return Err(SystemError::ENOBUFS);
         }
@@ -2137,6 +2137,9 @@ impl File {
         // Linux 语义：O_PATH fd 的 lseek 返回 EBADF（优先于 ESPIPE）。
         if mode.contains(FileMode::FMODE_PATH) {
             return Err(SystemError::EBADF);
+        }
+        if self.inode.has_noop_llseek() {
+            return Ok(self.offset.load(Ordering::SeqCst));
         }
         if mode.contains(FileMode::FMODE_STREAM) || !mode.contains(FileMode::FMODE_LSEEK) {
             return Err(SystemError::ESPIPE);

--- a/kernel/src/filesystem/vfs/iov.rs
+++ b/kernel/src/filesystem/vfs/iov.rs
@@ -107,15 +107,6 @@ impl IoVecs {
                 continue;
             }
 
-            // If the first byte isn't writable/readable at all, fail early with EFAULT.
-            // Partial accessibility is handled by the syscall implementation.
-            // Note: user_accessible_len returns 0 for null pointers (addr.is_null() check),
-            // so null pointer detection is covered here.
-            let accessible = user_accessible_len(base, one.iov_len, _readv /* check_write */);
-            if accessible == 0 {
-                return Err(SystemError::EFAULT);
-            }
-
             slices.push(one);
         }
 

--- a/kernel/src/filesystem/vfs/iov.rs
+++ b/kernel/src/filesystem/vfs/iov.rs
@@ -7,6 +7,7 @@ use crate::{
     syscall::user_access::{
         copy_from_user_protected, user_accessible_len, UserBufferReader, UserBufferWriter,
     },
+    syscall::user_buffer::UserBufferSegment,
 };
 
 /// Linux UIO_MAXIOV: maximum number of iovec structures per syscall
@@ -40,6 +41,29 @@ impl IoVecs {
     /// Borrow the validated iovec list.
     pub fn iovs(&self) -> &[IoVec] {
         &self.0
+    }
+
+    pub fn user_buffer_segments(
+        &self,
+        limit: usize,
+    ) -> Result<Vec<UserBufferSegment>, SystemError> {
+        let mut segments = Vec::new();
+        segments
+            .try_reserve(self.0.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        let mut remaining = limit;
+        for iov in &self.0 {
+            if remaining == 0 {
+                break;
+            }
+            let len = iov.iov_len.min(remaining);
+            segments.push(UserBufferSegment::new(
+                VirtAddr::new(iov.iov_base as usize),
+                len,
+            ));
+            remaining -= len;
+        }
+        Ok(segments)
     }
 
     /// Constructs `IoVecs` from an array of `IoVec` in userspace.

--- a/kernel/src/filesystem/vfs/iov.rs
+++ b/kernel/src/filesystem/vfs/iov.rs
@@ -270,6 +270,18 @@ impl IoVecs {
         Ok(total_written)
     }
 
+    /// Scatters the complete input or reports a user-memory fault.
+    ///
+    /// This is intended for record-oriented readers, where a short copy is an
+    /// error even though the record may already have been consumed. Bytes
+    /// copied before the fault are not rolled back.
+    pub fn scatter_exact(&self, data: &[u8]) -> Result<(), SystemError> {
+        if self.scatter(data)? != data.len() {
+            return Err(SystemError::EFAULT);
+        }
+        Ok(())
+    }
+
     /// Creates a buffer with capacity equal to the total length of all IoVecs.
     ///
     /// # Arguments

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -676,6 +676,14 @@ pub trait IndexNode: Any + Sync + Send + Debug + CastFromSync {
         }
     }
 
+    /// Linux `noop_llseek`: ignore offset/whence and return the current f_pos.
+    ///
+    /// This is distinct from random-access support. Anonymous stream-like
+    /// files such as timerfd may opt in while still rejecting pread/pwrite.
+    fn has_noop_llseek(&self) -> bool {
+        false
+    }
+
     /// 是否允许 pread（随机读，不推进文件偏移）。
     ///
     /// 默认：对 stream 文件返回 false；对非 stream 默认允许。

--- a/kernel/src/filesystem/vfs/syscall/mod.rs
+++ b/kernel/src/filesystem/vfs/syscall/mod.rs
@@ -58,6 +58,7 @@ mod sys_select;
 mod sys_statfs;
 mod sys_statx;
 mod sys_symlinkat;
+mod sys_timerfd;
 mod sys_truncate;
 mod sys_unlinkat;
 mod sys_utimensat;

--- a/kernel/src/filesystem/vfs/syscall/sys_read.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_read.rs
@@ -45,19 +45,19 @@ impl Syscall for SysReadHandle {
         let buf_vaddr = Self::buf(args);
         let len = Self::len(args);
 
-        // POSIX: len==0 succeeds and returns 0 without touching the buffer pointer.
-        if len == 0 {
-            return Ok(0);
-        }
-
         if frame.is_from_user() {
             read_into_user_buffer(fd, buf_vaddr, len)
         } else {
+            let file = get_read_file(fd)?;
+            if len == 0 {
+                let mut empty = [];
+                return do_read_file(file.as_ref(), &mut empty);
+            }
             // 内核态：直接借用内核缓冲区
             let mut user_buffer_writer =
                 UserBufferWriter::new(buf_vaddr, len, frame.is_from_user())?;
             let user_buf = user_buffer_writer.buffer(0)?;
-            do_read(fd, user_buf)
+            do_read_file(file.as_ref(), user_buf)
         }
     }
 
@@ -96,20 +96,6 @@ impl SysReadHandle {
 
 syscall_table_macros::declare_syscall!(SYS_READ, SysReadHandle);
 
-/// Internal implementation of the read operation
-///
-/// # Arguments
-/// * `fd` - File descriptor to read from
-/// * `buf` - Buffer to store read data
-///
-/// # Returns
-/// * `Ok(usize)` - Number of bytes successfully read
-/// * `Err(SystemError)` - Error code if operation fails
-pub(super) fn do_read(fd: i32, buf: &mut [u8]) -> Result<usize, SystemError> {
-    let file = get_read_file(fd)?;
-    do_read_file(file.as_ref(), buf)
-}
-
 pub(super) fn get_read_file(fd: i32) -> Result<Arc<File>, SystemError> {
     let binding = ProcessManager::current_pcb().fd_table();
     let fd_table_guard = binding.read();
@@ -137,17 +123,7 @@ fn do_read_file(file: &File, buf: &mut [u8]) -> Result<usize, SystemError> {
 /// Linux semantics: if a fault happens after some bytes are copied, return the number
 /// of bytes copied instead of -EFAULT.
 fn read_into_user_buffer(fd: i32, user_ptr: *mut u8, len: usize) -> Result<usize, SystemError> {
-    // 用户态：先计算可写入长度，避免直接写入无效用户页。
-    let accessible =
-        user_accessible_len(VirtAddr::new(user_ptr as usize), len, true /*write*/);
-    if accessible == 0 {
-        return Err(SystemError::EFAULT);
-    }
-
     let file = get_read_file(fd)?;
-    if file.file_type() == FileType::Socket {
-        return read_socket_into_user_buffer(file.as_ref(), user_ptr, accessible);
-    }
 
     // Some record streams must own the whole userspace read boundary. In
     // particular, inotify decides whether to wait again and consumes a record
@@ -155,7 +131,11 @@ fn read_into_user_buffer(fd: i32, user_ptr: *mut u8, len: usize) -> Result<usize
     // Use the original count here so a partially mapped range faults at the
     // exact record copy instead of being silently shortened to `accessible`.
     if file.supports_read_user() {
-        let mut direct_buffer = UserBuffer::new_protected(user_ptr, len, true)?;
+        // Do not validate the complete `count` range here.  Linux record
+        // readers first apply their count rule and then touch only the bytes
+        // they actually return (timerfd, for example, always writes 8 bytes).
+        // Every access through UserBuffer remains exception-table protected.
+        let mut direct_buffer = unsafe { UserBuffer::new(VirtAddr::new(user_ptr as usize), len) };
         if let Some(read_len) = file.read_user(len, &mut direct_buffer)? {
             return Ok(read_len);
         }
@@ -163,6 +143,25 @@ fn read_into_user_buffer(fd: i32, user_ptr: *mut u8, len: usize) -> Result<usize
             false,
             "supports_read_user without read_user_at implementation"
         );
+    }
+
+    // Linux still validates the descriptor and access mode for a zero-length
+    // read. Direct-user inodes above own any type-specific count==0 rule.
+    if len == 0 {
+        file.readable()?;
+        return Ok(0);
+    }
+
+    // Ordinary buffered reads may probe the mapped prefix up front. Record
+    // streams that require consume-before-copy semantics were dispatched above.
+    let accessible =
+        user_accessible_len(VirtAddr::new(user_ptr as usize), len, true /*write*/);
+    if accessible == 0 {
+        return Err(SystemError::EFAULT);
+    }
+
+    if file.file_type() == FileType::Socket {
+        return read_socket_into_user_buffer(file.as_ref(), user_ptr, accessible);
     }
 
     // Keep the kernel-side buffer modest to avoid huge allocations/long critical sections.

--- a/kernel/src/filesystem/vfs/syscall/sys_readv.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readv.rs
@@ -12,6 +12,7 @@ use crate::mm::VirtAddr;
 use crate::syscall::table::FormattedSyscallParam;
 use crate::syscall::table::Syscall;
 use crate::syscall::user_access::{copy_to_user_protected, user_accessible_len};
+use crate::syscall::user_buffer::UserBuffer;
 use alloc::string::ToString;
 use alloc::vec::Vec;
 
@@ -47,6 +48,13 @@ impl Syscall for SysReadVHandle {
 
         // Linux: limit per readv() to MAX_RW_COUNT = INT_MAX & ~(PAGE_SIZE-1)
         let max_rw_count = (i32::MAX as usize) & !(MMArch::PAGE_SIZE - 1);
+
+        // Linux falls back to one `.read` call per iovec when an inode does
+        // not implement `.read_iter`. Record readers that consume data before
+        // copying it to userspace must keep that ordering for readv as well.
+        if file.supports_read_user() {
+            return readv_user_chunks(file.as_ref(), &iovecs, max_rw_count);
+        }
 
         if file.file_type() == FileType::Socket {
             // Socket readv is one underlying read, but ACCESS still belongs to
@@ -158,6 +166,45 @@ fn finish_readv(
     // boundary, not once per iovec or bounded implementation chunk.
     file.notify_io_event(FsEvent::ACCESS);
     Ok(total_read)
+}
+
+fn readv_user_chunks(
+    file: &crate::filesystem::vfs::file::File,
+    iovecs: &IoVecs,
+    max_rw_count: usize,
+) -> Result<usize, SystemError> {
+    let mut total_read = 0usize;
+
+    for one in iovecs.iovs() {
+        if total_read >= max_rw_count {
+            break;
+        }
+        let len = one.iov_len.min(max_rw_count - total_read);
+        if len == 0 {
+            continue;
+        }
+
+        let mut user_buffer = unsafe { UserBuffer::new(VirtAddr::new(one.iov_base as usize), len) };
+        let read_len = match file.read_user_syscall_chunk(len, &mut user_buffer) {
+            Ok(Some(read_len)) => read_len,
+            Ok(None) => {
+                debug_assert!(
+                    false,
+                    "supports_read_user without read_user_at implementation"
+                );
+                return Err(SystemError::ENOSYS);
+            }
+            Err(_) if total_read != 0 => return finish_readv(file, total_read),
+            Err(error) => return Err(error),
+        };
+        total_read = total_read.saturating_add(read_len);
+
+        if read_len != len {
+            break;
+        }
+    }
+
+    finish_readv(file, total_read)
 }
 
 impl SysReadVHandle {

--- a/kernel/src/filesystem/vfs/syscall/sys_readv.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_readv.rs
@@ -59,9 +59,15 @@ impl Syscall for SysReadVHandle {
         if file.file_type() == FileType::Socket {
             // Socket readv is one underlying read, but ACCESS still belongs to
             // the readv completion boundary (including a zero-byte result).
-            let mut buf = iovecs.new_buf(true)?;
-            let nread = file.read_syscall_chunk(buf.len(), &mut buf)?;
-            iovecs.scatter(&buf[..nread])?;
+            let requested = iovecs.total_len().min(max_rw_count);
+            if requested == 0 {
+                return finish_readv(file.as_ref(), 0);
+            }
+            let segments = iovecs.user_buffer_segments(requested)?;
+            let mut user_buffer = unsafe { UserBuffer::new_vectored(&segments, requested) };
+            let inode = file.inode();
+            let socket = inode.as_socket().ok_or(SystemError::ENOTSOCK)?;
+            let nread = socket.read_to_user_buffer(&mut user_buffer)?;
             return finish_readv(file.as_ref(), nread);
         }
 

--- a/kernel/src/filesystem/vfs/syscall/sys_timerfd.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_timerfd.rs
@@ -1,0 +1,170 @@
+use alloc::{string::ToString, sync::Arc, vec::Vec};
+use core::mem::size_of;
+
+use system_error::SystemError;
+
+use crate::{
+    arch::{
+        interrupt::TrapFrame,
+        syscall::nr::{SYS_TIMERFD_CREATE, SYS_TIMERFD_GETTIME, SYS_TIMERFD_SETTIME},
+    },
+    filesystem::{
+        timerfd::{TimerFdCreateFlags, TimerFdInode, TimerFdSettimeFlags},
+        vfs::file::{File, FileFlags, FilePrivateData},
+    },
+    libs::casting::DowncastArc,
+    process::{
+        cred::{capable, CAPFlags},
+        posix_timer::PosixItimerspec,
+        ProcessManager,
+    },
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::{UserBufferReader, UserBufferWriter},
+    },
+    time::syscall::PosixClockID,
+};
+
+fn valid_clock(clock_id: PosixClockID) -> bool {
+    matches!(
+        clock_id,
+        PosixClockID::Realtime
+            | PosixClockID::Monotonic
+            | PosixClockID::Boottime
+            | PosixClockID::RealtimeAlarm
+            | PosixClockID::BoottimeAlarm
+    )
+}
+
+fn check_alarm_capability(clock_id: PosixClockID) -> Result<(), SystemError> {
+    if matches!(
+        clock_id,
+        PosixClockID::RealtimeAlarm | PosixClockID::BoottimeAlarm
+    ) && !capable(CAPFlags::CAP_WAKE_ALARM)
+    {
+        return Err(SystemError::EPERM);
+    }
+    Ok(())
+}
+
+fn timerfd_fget(fd: i32) -> Result<(Arc<File>, Arc<TimerFdInode>), SystemError> {
+    let table = ProcessManager::current_pcb().fd_table();
+    let file = table.read().get_file_by_fd(fd).ok_or(SystemError::EBADF)?;
+    let inode = file
+        .inode()
+        .downcast_arc::<TimerFdInode>()
+        .ok_or(SystemError::EINVAL)?;
+    Ok((file, inode))
+}
+
+pub struct SysTimerFdCreate;
+
+impl Syscall for SysTimerFdCreate {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let clock_id = PosixClockID::try_from(args[0] as i32)?;
+        if !valid_clock(clock_id) {
+            return Err(SystemError::EINVAL);
+        }
+        let flags = TimerFdCreateFlags::from_bits(args[1] as u32).ok_or(SystemError::EINVAL)?;
+        check_alarm_capability(clock_id)?;
+
+        let mut file_flags = FileFlags::O_RDWR;
+        if flags.contains(TimerFdCreateFlags::TFD_NONBLOCK) {
+            file_flags.insert(FileFlags::O_NONBLOCK);
+        }
+        let inode = TimerFdInode::new(clock_id);
+        let file =
+            File::new_with_private_data(inode, file_flags, FilePrivateData::TimerFd(file_flags))?;
+        let cloexec = flags.contains(TimerFdCreateFlags::TFD_CLOEXEC);
+        ProcessManager::current_pcb()
+            .fd_table()
+            .write()
+            .alloc_fd(file, None, cloexec)
+            .map(|fd| fd as usize)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("clockid", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", args[1])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_TIMERFD_CREATE, SysTimerFdCreate);
+
+pub struct SysTimerFdSettime;
+
+impl Syscall for SysTimerFdSettime {
+    fn num_args(&self) -> usize {
+        4
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let new_ptr = args[2] as *const PosixItimerspec;
+        if new_ptr.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+        let reader = UserBufferReader::new(new_ptr, size_of::<PosixItimerspec>(), true)?;
+        let value = reader.read_one_from_user::<PosixItimerspec>(0)?;
+        TimerFdInode::validate_spec(&value)?;
+        let flags = TimerFdSettimeFlags::from_bits(args[1] as u32).ok_or(SystemError::EINVAL)?;
+
+        let (_file, inode) = timerfd_fget(args[0] as i32)?;
+        if inode.is_alarm() {
+            check_alarm_capability(PosixClockID::RealtimeAlarm)?;
+        }
+        let old = inode.settime(flags, value)?;
+
+        let old_ptr = args[3] as *mut PosixItimerspec;
+        if !old_ptr.is_null() {
+            let mut writer = UserBufferWriter::new(old_ptr, size_of::<PosixItimerspec>(), true)?;
+            writer.copy_one_to_user(&old, 0)?;
+        }
+        Ok(0)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("flags", format!("{:#x}", args[1])),
+            FormattedSyscallParam::new("new_value", format!("{:#x}", args[2])),
+            FormattedSyscallParam::new("old_value", format!("{:#x}", args[3])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_TIMERFD_SETTIME, SysTimerFdSettime);
+
+pub struct SysTimerFdGettime;
+
+impl Syscall for SysTimerFdGettime {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let (_file, inode) = timerfd_fget(args[0] as i32)?;
+        let value = inode.gettime()?;
+        let value_ptr = args[1] as *mut PosixItimerspec;
+        if value_ptr.is_null() {
+            return Err(SystemError::EFAULT);
+        }
+        let mut writer = UserBufferWriter::new(value_ptr, size_of::<PosixItimerspec>(), true)?;
+        writer.copy_one_to_user(&value, 0)?;
+        Ok(0)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("fd", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("curr_value", format!("{:#x}", args[1])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_TIMERFD_GETTIME, SysTimerFdGettime);

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -1972,7 +1972,7 @@ impl Socket for UdpSocket {
         // );
 
         // Scatter received data to user iovecs
-        iovs.scatter(&buf[..copy_len])?;
+        iovs.scatter_exact(&buf[..copy_len])?;
 
         // Write source address if requested
         if !msg.msg_name.is_null() {

--- a/kernel/src/net/socket/inet/raw/recv.rs
+++ b/kernel/src/net/socket/inet/raw/recv.rs
@@ -497,7 +497,7 @@ impl RawSocket {
             }
         };
         let user_recv_size = full_user_len.min(user_len);
-        iovs.scatter(&user_data[..user_recv_size])?;
+        iovs.scatter_exact(&user_data[..user_recv_size])?;
 
         // 默认不设置任何 flags。
         msg.msg_flags = 0;

--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -278,14 +278,13 @@ impl TcpSocket {
             let want = user_remaining - total;
             let got = match socket.recv(|data| {
                 let take = core::cmp::min(want, data.len());
-                let copy = if take > 0 {
-                    user_buffer
-                        .write_to_user(offset + total, &data[..take])
-                        .map(|_| take)
-                } else {
-                    Ok(0)
-                };
-                (take, copy)
+                if take == 0 {
+                    return (0, Ok(0));
+                }
+                match user_buffer.write_to_user(offset + total, &data[..take]) {
+                    Ok(_) => (take, Ok(take)),
+                    Err(error) => (0, Err(error)),
+                }
             }) {
                 Ok(Ok(n)) => n,
                 Ok(Err(e)) => {

--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -521,13 +521,12 @@ impl TcpSocket {
                         break;
                     }
                 }
-                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
+                Err(e) => {
                     if total_read > offset {
                         break;
                     }
-                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                    return Err(e);
                 }
-                Err(e) => return Err(e),
             }
         }
 

--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -448,11 +448,12 @@ impl TcpSocket {
         Ok(total_read)
     }
 
-    pub(super) fn try_read_to_user_buffer(
+    fn try_recv_to_user_buffer(
         &self,
         user_buffer: &mut UserBuffer<'_>,
+        offset: usize,
     ) -> Result<usize, SystemError> {
-        let mut total_read = 0usize;
+        let mut total_read = offset;
 
         loop {
             if let Some(iface) = self.stack_poll_iface_snapshot() {
@@ -521,7 +522,7 @@ impl TcpSocket {
                     }
                 }
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
-                    if total_read > 0 {
+                    if total_read > offset {
                         break;
                     }
                     return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
@@ -530,13 +531,22 @@ impl TcpSocket {
             }
         }
 
-        self.finish_recv_progress(total_read > 0);
-        Ok(total_read)
+        self.finish_recv_progress(total_read > offset);
+        Ok(total_read - offset)
     }
 
-    pub(super) fn read_to_user_buffer_impl(
+    pub(super) fn try_read_to_user_buffer(
         &self,
         user_buffer: &mut UserBuffer<'_>,
+    ) -> Result<usize, SystemError> {
+        self.try_recv_to_user_buffer(user_buffer, 0)
+    }
+
+    pub(super) fn recv_to_user_buffer_impl(
+        &self,
+        user_buffer: &mut UserBuffer<'_>,
+        nonblock: bool,
+        waitall: bool,
     ) -> Result<usize, SystemError> {
         if self.is_recv_shutdown() {
             let limit = self.recv_shutdown.limit();
@@ -545,12 +555,19 @@ impl TcpSocket {
             }
         }
 
-        if self.is_nonblock() {
+        if nonblock {
             return self.try_read_to_user_buffer(user_buffer);
         }
 
+        let mut total_read = 0usize;
         loop {
-            match self.try_read_to_user_buffer(user_buffer) {
+            match self.try_recv_to_user_buffer(user_buffer, total_read) {
+                Ok(n) => {
+                    total_read += n;
+                    if n == 0 || total_read == user_buffer.len() || !waitall {
+                        return Ok(total_read);
+                    }
+                }
                 Err(SystemError::EAGAIN_OR_EWOULDBLOCK) => {
                     if let Some(iface) = self.stack_poll_iface_snapshot() {
                         super::poll_util::poll_iface_until_quiescent(iface.as_ref());
@@ -576,11 +593,28 @@ impl TcpSocket {
                         },
                         self.recv_timeout(),
                     );
-                    wait_ret?;
+                    if let Err(error) = wait_ret {
+                        if total_read > 0 {
+                            return Ok(total_read);
+                        }
+                        return Err(error);
+                    }
                 }
-                result => return result,
+                Err(error) => {
+                    if total_read > 0 {
+                        return Ok(total_read);
+                    }
+                    return Err(error);
+                }
             }
         }
+    }
+
+    pub(super) fn read_to_user_buffer_impl(
+        &self,
+        user_buffer: &mut UserBuffer<'_>,
+    ) -> Result<usize, SystemError> {
+        self.recv_to_user_buffer_impl(user_buffer, self.is_nonblock(), false)
     }
 
     pub fn try_send(&self, buf: &[u8]) -> Result<usize, SystemError> {

--- a/kernel/src/net/socket/inet/stream/io.rs
+++ b/kernel/src/net/socket/inet/stream/io.rs
@@ -1,4 +1,5 @@
 use alloc::boxed::Box;
+use alloc::vec;
 
 use system_error::SystemError;
 
@@ -13,6 +14,8 @@ use alloc::sync::Weak;
 use super::constants;
 use super::inner;
 use super::TcpSocket;
+
+const USER_RECV_STAGING_SIZE: usize = 64 * 1024;
 
 #[inline]
 fn discard_recv_queue(socket: &mut smoltcp::socket::tcp::Socket) {
@@ -233,7 +236,7 @@ impl TcpSocket {
 
     fn recv_established_to_user(
         &self,
-        socket: &mut smoltcp::socket::tcp::Socket,
+        established: &inner::Established,
         user_buffer: &mut UserBuffer<'_>,
         offset: usize,
     ) -> Result<usize, SystemError> {
@@ -246,7 +249,7 @@ impl TcpSocket {
         if is_recv_shutdown {
             let remaining = self.recv_shutdown.remaining_limit();
             if remaining == 0 {
-                discard_recv_queue(socket);
+                established.with_mut(discard_recv_queue);
                 return Ok(0);
             }
             user_remaining = core::cmp::min(user_remaining, remaining);
@@ -256,62 +259,94 @@ impl TcpSocket {
             return Ok(0);
         }
 
-        if !socket.can_recv() {
-            if !socket.may_recv() {
-                return match socket.recv(|_data| (0usize, ())) {
-                    Ok(()) => Ok(0),
-                    Err(smoltcp::socket::tcp::RecvError::Finished) => Ok(0),
-                    Err(smoltcp::socket::tcp::RecvError::InvalidState) => {
-                        Err(SystemError::ECONNRESET)
-                    }
-                };
+        // Avoid allocating the staging buffer for the common nonblocking EAGAIN path.
+        let readable = established.with_mut(|socket| {
+            if socket.can_recv() {
+                return Ok(true);
             }
-            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            if socket.may_recv() {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+            match socket.recv(|_data| (0usize, ())) {
+                Ok(()) | Err(smoltcp::socket::tcp::RecvError::Finished) => Ok(false),
+                Err(smoltcp::socket::tcp::RecvError::InvalidState) => Err(SystemError::ECONNRESET),
+            }
+        })?;
+        if !readable {
+            return Ok(0);
         }
+
+        // User pages may fault and sleep. Copy through a bounded kernel buffer so the
+        // interface-wide SocketSet lock is never held while touching userspace.
+        let mut staging = vec![0u8; core::cmp::min(user_remaining, USER_RECV_STAGING_SIZE)];
 
         let mut total = 0usize;
         while total < user_remaining {
-            if !socket.can_recv() {
-                break;
-            }
-
             let want = user_remaining - total;
-            let got = match socket.recv(|data| {
-                let take = core::cmp::min(want, data.len());
-                if take == 0 {
-                    return (0, Ok(0));
+            let staged = established.with_mut(|socket| {
+                if !socket.can_recv() {
+                    return 0;
                 }
-                match user_buffer.write_to_user(offset + total, &data[..take]) {
-                    Ok(_) => (take, Ok(take)),
-                    Err(error) => (0, Err(error)),
-                }
-            }) {
-                Ok(Ok(n)) => n,
-                Ok(Err(e)) => {
-                    if e == SystemError::EFAULT && total > 0 {
-                        break;
+                match socket.peek(core::cmp::min(want, staging.len())) {
+                    Ok(data) => {
+                        let size = data.len();
+                        staging[..size].copy_from_slice(data);
+                        size
                     }
-                    return Err(e);
+                    Err(_) => 0,
                 }
-                Err(smoltcp::socket::tcp::RecvError::InvalidState) => {
-                    return Err(SystemError::ENOTCONN);
-                }
-                Err(smoltcp::socket::tcp::RecvError::Finished) => {
-                    return Ok(total);
-                }
-            };
-
-            if got == 0 {
+            });
+            if staged == 0 {
                 break;
             }
-            total += got;
+
+            if let Err(error) = user_buffer.write_to_user(offset + total, &staging[..staged]) {
+                if error == SystemError::EFAULT && total > 0 {
+                    break;
+                }
+                return Err(error);
+            }
+
+            // Ingress can append bytes while the SocketSet lock is dropped; a terminal state
+            // transition can instead clear the queue. recv_lock excludes local consumers, so the
+            // head cannot otherwise move. Require the snapshotted contiguous length before
+            // consuming; if the queue was cleared, the copied bytes linearize immediately before
+            // that terminal transition.
+            let committed = established.with_mut(|socket| {
+                socket
+                    .recv(|data| {
+                        if data.len() >= staged {
+                            (staged, true)
+                        } else {
+                            (0, false)
+                        }
+                    })
+                    .unwrap_or_default()
+            });
+
+            total += staged;
+            if !committed {
+                break;
+            }
         }
 
         if total == 0 {
-            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            // The stack may have processed FIN/RST after the allocation-time readiness probe.
+            // Re-evaluate the terminal state instead of turning EOF into a spurious EAGAIN.
+            return established.with_mut(|socket| {
+                if socket.can_recv() || socket.may_recv() {
+                    return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+                }
+                match socket.recv(|_data| (0usize, ())) {
+                    Ok(()) | Err(smoltcp::socket::tcp::RecvError::Finished) => Ok(0),
+                    Err(smoltcp::socket::tcp::RecvError::InvalidState) => {
+                        Err(SystemError::ECONNRESET)
+                    }
+                }
+            });
         }
         if is_recv_shutdown && self.recv_shutdown.record_read(total) {
-            discard_recv_queue(socket);
+            established.with_mut(discard_recv_queue);
         }
         Ok(total)
     }
@@ -339,6 +374,7 @@ impl TcpSocket {
         buf: &mut [u8],
         flags: PMSG,
     ) -> Result<usize, SystemError> {
+        let recv_guard = self.recv_lock.lock();
         let mut total_read = 0;
 
         loop {
@@ -443,6 +479,7 @@ impl TcpSocket {
 
         // For self-connect, consuming bytes frees space for senders waiting on EPOLLOUT.
         // Wake waiters and refresh pollee after we actually consumed data.
+        drop(recv_guard);
         self.finish_recv_progress(total_read > 0 && !flags.contains(PMSG::PEEK));
 
         Ok(total_read)
@@ -453,6 +490,7 @@ impl TcpSocket {
         user_buffer: &mut UserBuffer<'_>,
         offset: usize,
     ) -> Result<usize, SystemError> {
+        let recv_guard = self.recv_lock.lock();
         let mut total_read = offset;
 
         loop {
@@ -469,9 +507,9 @@ impl TcpSocket {
                 .as_ref()
                 .expect("Tcp inner::Inner is None")
             {
-                inner::Inner::Established(established) => established.with_mut(|socket| {
-                    self.recv_established_to_user(socket, user_buffer, total_read)
-                }),
+                inner::Inner::Established(established) => {
+                    self.recv_established_to_user(established, user_buffer, total_read)
+                }
                 inner::Inner::SelfConnected(sc) => {
                     let mut limit = user_buffer.len().saturating_sub(total_read);
                     let mut recv_exhausted = false;
@@ -530,6 +568,7 @@ impl TcpSocket {
             }
         }
 
+        drop(recv_guard);
         self.finish_recv_progress(total_read > offset);
         Ok(total_read - offset)
     }

--- a/kernel/src/net/socket/inet/stream/mod.rs
+++ b/kernel/src/net/socket/inet/stream/mod.rs
@@ -405,9 +405,29 @@ impl Socket for TcpSocket {
         // TCP: 不返回 peer 地址。
         let iovs = unsafe { IoVecs::from_user(msg.msg_iov, msg.msg_iovlen, true)? };
         let total = iovs.total_len();
-        let mut tmp = vec![0u8; total];
-        let n = self.recv(&mut tmp, flags)?;
-        let written = iovs.scatter(&tmp[..n])?;
+        let written = if flags.contains(PMSG::TRUNC) {
+            // Linux TCP MSG_TRUNC reports/consumes bytes without copying the
+            // payload, so an inaccessible iovec must not cause EFAULT.
+            let mut tmp = vec![0u8; total];
+            self.recv(&mut tmp, flags)?
+        } else {
+            let segments = iovs.user_buffer_segments(total)?;
+            let mut user_buffer =
+                unsafe { crate::syscall::user_buffer::UserBuffer::new_vectored(&segments, total) };
+
+            if flags.contains(PMSG::PEEK) {
+                // PEEK never consumes, so staging remains transactional while
+                // preserving its existing receive semantics.
+                let mut tmp = vec![0u8; total];
+                let n = self.recv(&mut tmp, flags)?;
+                user_buffer.write_to_user(0, &tmp[..n])?;
+                n
+            } else {
+                let nonblock = self.is_nonblock() || flags.contains(PMSG::DONTWAIT);
+                let waitall = flags.contains(PMSG::WAITALL);
+                self.recv_to_user_buffer_impl(&mut user_buffer, nonblock, waitall)?
+            }
+        };
 
         msg.msg_flags = 0;
         msg.msg_namelen = 0;

--- a/kernel/src/net/socket/inet/stream/stream_core.rs
+++ b/kernel/src/net/socket/inet/stream/stream_core.rs
@@ -151,6 +151,9 @@ pub struct TcpSocket {
     pub(crate) fasync_items: FAsyncItems,
     pub(crate) options: TcpSocketOptions,
     pub(crate) cork_buf: Mutex<Vec<u8>>,
+    /// Serializes readers while a receive transaction temporarily drops the interface-wide
+    /// SocketSet lock to copy data to userspace.
+    pub(crate) recv_lock: Mutex<()>,
     pub(crate) cork_flush_in_progress: AtomicBool,
     pub(crate) cork_timer_active: AtomicBool,
     pub(crate) recv_shutdown: ShutdownRecvTracker,
@@ -182,6 +185,7 @@ impl TcpSocket {
             fasync_items: FAsyncItems::default(),
             options: TcpSocketOptions::new(),
             cork_buf: Mutex::new(Vec::new()),
+            recv_lock: Mutex::new(()),
             cork_flush_in_progress: AtomicBool::new(false),
             cork_timer_active: AtomicBool::new(false),
             recv_shutdown: ShutdownRecvTracker::new(),

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -479,7 +479,7 @@ where
         let mut buf = iovs.new_buf(true)?;
 
         let (copy_len, orig_len, endpoint) = self.recv_from_inner(&mut buf, flags, None)?;
-        iovs.scatter(&buf[..copy_len])?;
+        iovs.scatter_exact(&buf[..copy_len])?;
 
         if !msg.msg_name.is_null() {
             let actual_len = endpoint.write_to_user_msghdr(msg.msg_name, msg.msg_namelen)?;

--- a/kernel/src/net/socket/packet/rx.rs
+++ b/kernel/src/net/socket/packet/rx.rs
@@ -1050,10 +1050,7 @@ impl PacketSocket {
         }
         let packet = self.wait_dequeue(flags)?;
         let copy_len = capacity.min(packet.data.len());
-        let written = iovs.scatter(&packet.data[..copy_len])?;
-        if written != copy_len {
-            return Err(SystemError::EFAULT);
-        }
+        iovs.scatter_exact(&packet.data[..copy_len])?;
         if !msg.msg_name.is_null() {
             let full = core::mem::size_of::<SockAddrLl>();
             let n = (msg.msg_namelen as usize).min(full);

--- a/kernel/src/net/socket/unix/datagram/mod.rs
+++ b/kernel/src/net/socket/unix/datagram/mod.rs
@@ -959,7 +959,7 @@ impl Socket for UnixDatagramSocket {
             }
         };
 
-        iovs.scatter(&buf[..payload_copy_len])?;
+        iovs.scatter_exact(&buf[..payload_copy_len])?;
 
         // 写回来源地址
         let endpoint = sender_addr

--- a/kernel/src/net/socket/unix/ring_buffer.rs
+++ b/kernel/src/net/socket/unix/ring_buffer.rs
@@ -660,47 +660,24 @@ impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
         Some(())
     }
 
-    /// Pop a slice while preserving record metadata for partially-consumed
-    /// records. This is used by recvmsg.
-    pub fn pop_slice_preserve_records(&mut self, buf: &mut [T]) -> Option<()> {
-        let rb = &self.ring_buffer;
-        let nitems = buf.len();
-
+    /// Advance the consumer after a successful recvmsg copy while retaining
+    /// metadata for a record that was only partially consumed.
+    pub fn consume_preserve_records(&mut self, nitems: usize) -> Option<()> {
         if nitems == 0 {
             return Some(());
         }
 
-        // Synchronize with resize(): capacity/offset must match backing storage.
+        let rb = &self.ring_buffer;
         let read_guard = rb.buffer.read();
-        let capacity = read_guard.len();
-
         let head = rb.head();
-        let tail = rb.tail();
-        let available = (tail - head).0;
+        let available = (rb.tail() - head).0;
         if available < nitems {
             return None;
         }
 
-        let offset = head.0 & (capacity - 1);
-
-        let mut start = offset;
-        let mut remaining_len = nitems;
-        let mut buf_start = 0;
-
-        if start + nitems > capacity {
-            let first_part_len = capacity - start;
-            buf[..first_part_len].copy_from_slice(&read_guard[start..start + first_part_len]);
-
-            start = 0;
-            remaining_len -= first_part_len;
-            buf_start = first_part_len;
-        }
-
-        buf[buf_start..buf_start + remaining_len]
-            .copy_from_slice(&read_guard[start..start + remaining_len]);
-
         rb.advance_head(head, nitems);
         rb.advance_records_to(head + Wrapping(nitems));
+        drop(read_guard);
         Some(())
     }
 

--- a/kernel/src/net/socket/unix/ring_buffer.rs
+++ b/kernel/src/net/socket/unix/ring_buffer.rs
@@ -637,6 +637,29 @@ impl<T: Pod, R: Deref<Target = RingBuffer<T>>> Consumer<T, R> {
         Some(())
     }
 
+    /// Advance the consumer without copying payload bytes.
+    ///
+    /// This is the commit operation for callers that already peeked and
+    /// delivered the bytes transactionally.
+    pub fn consume(&mut self, nitems: usize) -> Option<()> {
+        if nitems == 0 {
+            return Some(());
+        }
+
+        let rb = &self.ring_buffer;
+        let read_guard = rb.buffer.read();
+        let head = rb.head();
+        let available = (rb.tail() - head).0;
+        if available < nitems {
+            return None;
+        }
+
+        rb.advance_head(head, nitems);
+        rb.advance_scm_to(head + Wrapping(nitems));
+        drop(read_guard);
+        Some(())
+    }
+
     /// Pop a slice while preserving record metadata for partially-consumed
     /// records. This is used by recvmsg.
     pub fn pop_slice_preserve_records(&mut self, buf: &mut [T]) -> Option<()> {

--- a/kernel/src/net/socket/unix/stream/inner.rs
+++ b/kernel/src/net/socket/unix/stream/inner.rs
@@ -552,7 +552,7 @@ impl Connected {
 
     pub(super) fn try_recv_stream_recvmsg_meta(
         &self,
-        buf: &mut [u8],
+        out: &mut crate::syscall::user_buffer::UserBuffer<'_>,
         peek: bool,
         want_creds: bool,
     ) -> Result<StreamRecvmsgMeta, SystemError> {
@@ -570,19 +570,19 @@ impl Connected {
             return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
         }
 
-        let max = core::cmp::min(buf.len(), avail_len);
+        let max = core::cmp::min(out.len(), avail_len);
         let plan = guard.plan_stream_recvmsg(max, want_creds);
         let n = plan.bytes;
 
         if n != 0 {
-            if peek {
-                if guard.peek_slice(&mut buf[..n]).is_none() {
-                    return Err(SystemError::EFAULT);
-                }
-            } else {
-                if guard.pop_slice_preserve_records(&mut buf[..n]).is_none() {
-                    return Err(SystemError::EFAULT);
-                }
+            let mut data = Vec::new();
+            data.try_reserve(n).map_err(|_| SystemError::ENOMEM)?;
+            data.resize(n, 0);
+            guard.peek_slice(&mut data).ok_or(SystemError::EFAULT)?;
+            out.write_to_user(0, &data)?;
+
+            if !peek {
+                guard.consume_preserve_records(n).ok_or(SystemError::EIO)?;
 
                 // Once any bytes of the rights-carrying record are consumed via
                 // recvmsg, rights are either delivered or discarded, but must not

--- a/kernel/src/net/socket/unix/stream/inner.rs
+++ b/kernel/src/net/socket/unix/stream/inner.rs
@@ -303,6 +303,76 @@ impl Connected {
         }
     }
 
+    /// Copy one read directly to userspace and commit queue consumption only
+    /// after the protected copy succeeds.
+    pub fn try_recv_to_user(
+        &self,
+        out: &mut crate::syscall::user_buffer::UserBuffer<'_>,
+        is_seqpacket: bool,
+        queue_consumed: &mut bool,
+    ) -> Result<usize, SystemError> {
+        *queue_consumed = false;
+        let mut guard = self.reader.lock();
+        if is_seqpacket {
+            if guard.len() < size_of::<u32>() {
+                if guard.is_read_shutdown() {
+                    return Ok(0);
+                }
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            let mut len_buf = [0u8; 4];
+            guard.peek_slice(&mut len_buf).ok_or(SystemError::EFAULT)?;
+            let record_len = u32::from_ne_bytes(len_buf) as usize;
+            if guard.len() < size_of::<u32>() + record_len {
+                return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+            }
+
+            let copy_len = out.len().min(record_len);
+            let mut data = Vec::new();
+            data.try_reserve(copy_len)
+                .map_err(|_| SystemError::ENOMEM)?;
+            data.resize(copy_len, 0);
+            let copy_result = if copy_len != 0 {
+                let payload = guard.head() + Wrapping(size_of::<u32>());
+                guard
+                    .peek_slice_at(payload, &mut data)
+                    .ok_or(SystemError::EFAULT)?;
+                out.write_to_user(0, &data).map(|_| copy_len)
+            } else {
+                Ok(0)
+            };
+
+            // Linux consumes a non-PEEK seqpacket record even when copying
+            // its payload to userspace faults. Stream sockets differ: their
+            // byte queue advances only after a successful copy.
+            guard
+                .consume(size_of::<u32>() + record_len)
+                .ok_or(SystemError::EIO)?;
+            *queue_consumed = true;
+            return copy_result;
+        }
+
+        let available = guard.len();
+        if available == 0 {
+            if guard.is_read_shutdown() {
+                return Ok(0);
+            }
+            return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
+        }
+
+        let copy_len = out.len().min(available);
+        let mut data = Vec::new();
+        data.try_reserve(copy_len)
+            .map_err(|_| SystemError::ENOMEM)?;
+        data.resize(copy_len, 0);
+        guard.peek_slice(&mut data).ok_or(SystemError::EFAULT)?;
+        out.write_to_user(0, &data)?;
+        guard.consume(copy_len).ok_or(SystemError::EIO)?;
+        *queue_consumed = true;
+        Ok(copy_len)
+    }
+
     pub fn try_peek(&self, buf: &mut [u8], is_seqpacket: bool) -> Result<usize, SystemError> {
         if is_seqpacket {
             let (copy_len, _orig_len, _truncated) = self.try_recv_seqpacket_meta(buf, true)?;

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -1007,7 +1007,7 @@ impl Socket for UnixStreamSocket {
 
         // Scatter destination is described by msg_iov/msg_iovlen in user memory.
         let iovs = unsafe { IoVecs::from_user(msg.msg_iov, msg.msg_iovlen, true)? };
-        let mut buf = iovs.new_buf(true)?;
+        let total = iovs.total_len();
 
         // Read payload first.
         let nonblock = self.is_nonblocking() || _flags.contains(socket::PMSG::DONTWAIT);
@@ -1017,6 +1017,7 @@ impl Socket for UnixStreamSocket {
         let (payload_copy_len, orig_len, truncated, ret_len, scm_cred, scm_rights) = if self
             .is_seqpacket
         {
+            let mut buf = iovs.new_buf(true)?;
             loop {
                 match self
                     .inner
@@ -1031,6 +1032,15 @@ impl Socket for UnixStreamSocket {
                         let snapshot = connected.scm_snapshot_for_recvmsg();
                         match connected.try_recv_seqpacket_meta(&mut buf[..], peek) {
                             Ok((copy_len, orig_len, truncated)) => {
+                                if !peek {
+                                    self.wake_peer_writable();
+                                }
+                                if copy_len != 0 {
+                                    let copied = iovs.scatter(&buf[..copy_len])?;
+                                    if copied != copy_len {
+                                        return Err(SystemError::EFAULT);
+                                    }
+                                }
                                 let ret_len = if _flags.contains(socket::PMSG::TRUNC) {
                                     orig_len
                                 } else {
@@ -1056,6 +1066,9 @@ impl Socket for UnixStreamSocket {
                 }
             }
         } else {
+            let segments = iovs.user_buffer_segments(total)?;
+            let mut user_buffer =
+                unsafe { crate::syscall::user_buffer::UserBuffer::new_vectored(&segments, total) };
             loop {
                 match self
                     .inner
@@ -1064,7 +1077,11 @@ impl Socket for UnixStreamSocket {
                     .expect("UnixStreamSocket inner is None")
                 {
                     Inner::Connected(connected) => {
-                        match connected.try_recv_stream_recvmsg_meta(&mut buf, peek, want_creds) {
+                        match connected.try_recv_stream_recvmsg_meta(
+                            &mut user_buffer,
+                            peek,
+                            want_creds,
+                        ) {
                             Ok(meta) => {
                                 let n = meta.copy_len;
                                 break (n, n, false, n, meta.scm_cred, meta.scm_rights);
@@ -1084,8 +1101,7 @@ impl Socket for UnixStreamSocket {
             }
         };
 
-        if payload_copy_len != 0 {
-            iovs.scatter(&buf[..payload_copy_len])?;
+        if !self.is_seqpacket && payload_copy_len != 0 {
             if !peek {
                 self.wake_peer_writable();
             }

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -1036,10 +1036,7 @@ impl Socket for UnixStreamSocket {
                                     self.wake_peer_writable();
                                 }
                                 if copy_len != 0 {
-                                    let copied = iovs.scatter(&buf[..copy_len])?;
-                                    if copied != copy_len {
-                                        return Err(SystemError::EFAULT);
-                                    }
+                                    iovs.scatter_exact(&buf[..copy_len])?;
                                 }
                                 let ret_len = if _flags.contains(socket::PMSG::TRUNC) {
                                     orig_len

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -959,11 +959,44 @@ impl Socket for UnixStreamSocket {
         &self,
         user_buffer: &mut crate::syscall::user_buffer::UserBuffer<'_>,
     ) -> Result<usize, SystemError> {
-        crate::net::socket::base::read_to_user_buffer_via_kernel_buf(
-            self,
-            user_buffer,
-            self.recv_buffer_size(),
-        )
+        if user_buffer.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            let mut queue_consumed = false;
+            let result = match self.inner.read().as_ref().expect("inner is None") {
+                Inner::Connected(connected) => {
+                    connected.try_recv_to_user(user_buffer, self.is_seqpacket, &mut queue_consumed)
+                }
+                _ => Err(SystemError::ENOTCONN),
+            };
+            if queue_consumed {
+                self.wake_peer_writable();
+            }
+
+            match result {
+                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) if !self.is_nonblocking() => {
+                    self.wait_queue.wait_event_interruptible_timeout(
+                        || self.can_recv(),
+                        self.recv_timeout(),
+                    )?;
+                }
+                Ok(n) => {
+                    if n == 0 {
+                        let ring_reset = self.take_connreset_from_peer();
+                        let socket_reset = self
+                            .connreset_pending
+                            .swap(false, core::sync::atomic::Ordering::SeqCst);
+                        if ring_reset || socket_reset {
+                            return Err(SystemError::ECONNRESET);
+                        }
+                    }
+                    return Ok(n);
+                }
+                result => return result,
+            }
+        }
     }
 
     fn recv_msg(&self, _msg: &mut MsgHdr, _flags: socket::PMSG) -> Result<usize, SystemError> {

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -1101,10 +1101,8 @@ impl Socket for UnixStreamSocket {
             }
         };
 
-        if !self.is_seqpacket && payload_copy_len != 0 {
-            if !peek {
-                self.wake_peer_writable();
-            }
+        if !self.is_seqpacket && payload_copy_len != 0 && !peek {
+            self.wake_peer_writable();
         }
 
         // Default: no flags.

--- a/kernel/src/net/socket/vsock/stream.rs
+++ b/kernel/src/net/socket/vsock/stream.rs
@@ -370,6 +370,49 @@ impl VsockStreamSocket {
         Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
     }
 
+    /// Copy one receive directly to userspace, consuming stream bytes only
+    /// after every protected copy succeeds.
+    fn try_read_to_user_buffer_once(
+        &self,
+        user_buffer: &mut crate::syscall::user_buffer::UserBuffer<'_>,
+    ) -> Result<usize, SystemError> {
+        let mut inner = self.inner.lock();
+
+        if inner.recv_shutdown {
+            inner.recv_buf.clear();
+            return Ok(0);
+        }
+
+        if !inner.recv_buf.is_empty() {
+            let n = min(user_buffer.len(), inner.recv_buf.len());
+            let (front, back) = inner.recv_buf.as_slices();
+            let front_n = min(n, front.len());
+            user_buffer.write_to_user(0, &front[..front_n])?;
+
+            let back_n = n - front_n;
+            if back_n > 0 {
+                user_buffer.write_to_user(front_n, &back[..back_n])?;
+            }
+
+            inner.recv_buf.drain(..n);
+            let wake_peer_writer = inner.peer_socket.as_ref().and_then(|weak| weak.upgrade());
+            drop(inner);
+            if let Some(peer) = wake_peer_writer {
+                peer.on_transport_credit_progress();
+            }
+            return Ok(n);
+        }
+
+        if let Some(error) = inner.pending_error.take() {
+            return Err(error);
+        }
+        if inner.peer_send_shutdown || inner.peer_closed || inner.state == VsockStreamState::Closed
+        {
+            return Ok(0);
+        }
+        Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
+    }
+
     /// 向当前 socket 的接收缓冲区入队数据。
     ///
     /// # 参数
@@ -1283,11 +1326,18 @@ impl Socket for VsockStreamSocket {
         &self,
         user_buffer: &mut crate::syscall::user_buffer::UserBuffer<'_>,
     ) -> Result<usize, SystemError> {
-        crate::net::socket::base::read_to_user_buffer_via_kernel_buf(
-            self,
-            user_buffer,
-            self.recv_buffer_size(),
-        )
+        if user_buffer.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            match self.try_read_to_user_buffer_once(user_buffer) {
+                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) if !self.is_nonblock() => {
+                    wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
+                }
+                result => return result,
+            }
+        }
     }
 
     /// `recvfrom` 变体，地址参数对 stream 语义仅做兼容返回。

--- a/kernel/src/net/socket/vsock/stream.rs
+++ b/kernel/src/net/socket/vsock/stream.rs
@@ -413,6 +413,25 @@ impl VsockStreamSocket {
         Err(SystemError::EAGAIN_OR_EWOULDBLOCK)
     }
 
+    fn recv_to_user_buffer_impl(
+        &self,
+        user_buffer: &mut crate::syscall::user_buffer::UserBuffer<'_>,
+        nonblock: bool,
+    ) -> Result<usize, SystemError> {
+        if user_buffer.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            match self.try_read_to_user_buffer_once(user_buffer) {
+                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) if !nonblock => {
+                    wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
+                }
+                result => return result,
+            }
+        }
+    }
+
     /// 向当前 socket 的接收缓冲区入队数据。
     ///
     /// # 参数
@@ -1326,18 +1345,7 @@ impl Socket for VsockStreamSocket {
         &self,
         user_buffer: &mut crate::syscall::user_buffer::UserBuffer<'_>,
     ) -> Result<usize, SystemError> {
-        if user_buffer.is_empty() {
-            return Ok(0);
-        }
-
-        loop {
-            match self.try_read_to_user_buffer_once(user_buffer) {
-                Err(SystemError::EAGAIN_OR_EWOULDBLOCK) if !self.is_nonblock() => {
-                    wq_wait_event_interruptible!(self.wait_queue, self.can_recv(), {})?;
-                }
-                result => return result,
-            }
-        }
+        self.recv_to_user_buffer_impl(user_buffer, self.is_nonblock())
     }
 
     /// `recvfrom` 变体，地址参数对 stream 语义仅做兼容返回。
@@ -1362,9 +1370,18 @@ impl Socket for VsockStreamSocket {
     ) -> Result<usize, SystemError> {
         let iovs = unsafe { IoVecs::from_user(msg.msg_iov, msg.msg_iovlen, true)? };
         let total = min(iovs.total_len(), DEFAULT_RECV_BUF_SIZE);
-        let mut tmp = vec![0u8; total];
-        let n = self.recv(&mut tmp, flags)?;
-        let written = iovs.scatter(&tmp[..n])?;
+        let segments = iovs.user_buffer_segments(total)?;
+        let mut user_buffer =
+            unsafe { crate::syscall::user_buffer::UserBuffer::new_vectored(&segments, total) };
+        let written = if flags.contains(PMSG::PEEK) {
+            let mut tmp = vec![0u8; total];
+            let n = self.recv(&mut tmp, flags)?;
+            user_buffer.write_to_user(0, &tmp[..n])?;
+            n
+        } else {
+            let nonblock = self.is_nonblock() || flags.contains(PMSG::DONTWAIT);
+            self.recv_to_user_buffer_impl(&mut user_buffer, nonblock)?
+        };
         msg.msg_flags = 0;
         msg.msg_namelen = 0;
         Ok(written)

--- a/kernel/src/syscall/user_buffer.rs
+++ b/kernel/src/syscall/user_buffer.rs
@@ -10,13 +10,27 @@ use system_error::SystemError;
 ///
 /// 这个类型封装了对用户空间内存的访问，确保所有读写操作
 /// 都通过异常表机制处理可能的页错误
+#[derive(Clone, Copy)]
+pub struct UserBufferSegment {
+    addr: VirtAddr,
+    len: usize,
+}
+
+impl UserBufferSegment {
+    pub fn new(addr: VirtAddr, len: usize) -> Self {
+        Self { addr, len }
+    }
+}
+
+enum UserBufferBacking<'a> {
+    Contiguous(VirtAddr),
+    Vectored(&'a [UserBufferSegment]),
+}
+
 pub struct UserBuffer<'a> {
-    /// 用户空间地址
-    user_addr: VirtAddr,
+    backing: UserBufferBacking<'a>,
     /// 缓冲区长度
     len: usize,
-    /// 生命周期标记
-    _phantom: core::marker::PhantomData<&'a ()>,
 }
 
 impl<'a> UserBuffer<'a> {
@@ -39,9 +53,8 @@ impl<'a> UserBuffer<'a> {
             access_ok(user_addr, len).map_err(|_| SystemError::EFAULT)?;
         }
         Ok(Self {
-            user_addr,
+            backing: UserBufferBacking::Contiguous(user_addr),
             len,
-            _phantom: core::marker::PhantomData,
         })
     }
 
@@ -55,9 +68,25 @@ impl<'a> UserBuffer<'a> {
     /// 调用者必须确保地址和长度是有效的用户空间范围
     pub(crate) unsafe fn new(addr: VirtAddr, len: usize) -> Self {
         Self {
-            user_addr: addr,
+            backing: UserBufferBacking::Contiguous(addr),
             len,
-            _phantom: core::marker::PhantomData,
+        }
+    }
+
+    /// Create a protected logical buffer backed by multiple userspace ranges.
+    ///
+    /// The caller must keep `segments` alive and ensure their combined length
+    /// is at least `len`. Individual accesses remain exception-table protected.
+    pub(crate) unsafe fn new_vectored(segments: &'a [UserBufferSegment], len: usize) -> Self {
+        debug_assert!(
+            segments
+                .iter()
+                .fold(0usize, |total, segment| total.saturating_add(segment.len))
+                >= len
+        );
+        Self {
+            backing: UserBufferBacking::Vectored(segments),
+            len,
         }
     }
 
@@ -72,7 +101,13 @@ impl<'a> UserBuffer<'a> {
     }
 
     pub fn user_addr(&self) -> VirtAddr {
-        self.user_addr
+        match &self.backing {
+            UserBufferBacking::Contiguous(addr) => *addr,
+            UserBufferBacking::Vectored(segments) => segments
+                .first()
+                .map(|segment| segment.addr)
+                .unwrap_or_default(),
+        }
     }
 
     /// 从用户缓冲区读取数据到内核缓冲区
@@ -97,10 +132,40 @@ impl<'a> UserBuffer<'a> {
             return Ok(0);
         }
 
-        let src_addr = VirtAddr::new(self.user_addr.data() + offset);
-
-        unsafe {
-            crate::syscall::user_access::copy_from_user_protected(&mut dst[..copy_len], src_addr)
+        match &self.backing {
+            UserBufferBacking::Contiguous(addr) => unsafe {
+                crate::syscall::user_access::copy_from_user_protected(
+                    &mut dst[..copy_len],
+                    *addr + offset,
+                )
+            },
+            UserBufferBacking::Vectored(segments) => {
+                let mut skip = offset;
+                let mut copied = 0usize;
+                for segment in *segments {
+                    if skip >= segment.len {
+                        skip -= segment.len;
+                        continue;
+                    }
+                    let chunk = (segment.len - skip).min(copy_len - copied);
+                    unsafe {
+                        crate::syscall::user_access::copy_from_user_protected(
+                            &mut dst[copied..copied + chunk],
+                            segment.addr + skip,
+                        )?;
+                    }
+                    copied += chunk;
+                    skip = 0;
+                    if copied == copy_len {
+                        break;
+                    }
+                }
+                if copied == copy_len {
+                    Ok(copied)
+                } else {
+                    Err(SystemError::EFAULT)
+                }
+            }
         }
     }
 
@@ -126,9 +191,41 @@ impl<'a> UserBuffer<'a> {
             return Ok(0);
         }
 
-        let dst_addr = VirtAddr::new(self.user_addr.data() + offset);
-
-        unsafe { crate::syscall::user_access::copy_to_user_protected(dst_addr, &src[..copy_len]) }
+        match &self.backing {
+            UserBufferBacking::Contiguous(addr) => unsafe {
+                crate::syscall::user_access::copy_to_user_protected(
+                    *addr + offset,
+                    &src[..copy_len],
+                )
+            },
+            UserBufferBacking::Vectored(segments) => {
+                let mut skip = offset;
+                let mut copied = 0usize;
+                for segment in *segments {
+                    if skip >= segment.len {
+                        skip -= segment.len;
+                        continue;
+                    }
+                    let chunk = (segment.len - skip).min(copy_len - copied);
+                    unsafe {
+                        crate::syscall::user_access::copy_to_user_protected(
+                            segment.addr + skip,
+                            &src[copied..copied + chunk],
+                        )?;
+                    }
+                    copied += chunk;
+                    skip = 0;
+                    if copied == copy_len {
+                        break;
+                    }
+                }
+                if copied == copy_len {
+                    Ok(copied)
+                } else {
+                    Err(SystemError::EFAULT)
+                }
+            }
+        }
     }
 
     /// 从用户缓冲区读取单个值
@@ -277,8 +374,33 @@ impl<'a> UserBuffer<'a> {
             return Ok(());
         }
 
-        let dst_addr = crate::mm::VirtAddr::new(self.user_addr.data() + offset);
-        unsafe { clear_user_cow_protected(dst_addr, clear_len) }.map(|_| ())
+        match &self.backing {
+            UserBufferBacking::Contiguous(addr) => {
+                unsafe { clear_user_cow_protected(*addr + offset, clear_len) }.map(|_| ())
+            }
+            UserBufferBacking::Vectored(segments) => {
+                let mut skip = offset;
+                let mut cleared = 0usize;
+                for segment in *segments {
+                    if skip >= segment.len {
+                        skip -= segment.len;
+                        continue;
+                    }
+                    let chunk = (segment.len - skip).min(clear_len - cleared);
+                    unsafe { clear_user_cow_protected(segment.addr + skip, chunk)? };
+                    cleared += chunk;
+                    skip = 0;
+                    if cleared == clear_len {
+                        break;
+                    }
+                }
+                if cleared == clear_len {
+                    Ok(())
+                } else {
+                    Err(SystemError::EFAULT)
+                }
+            }
+        }
     }
 
     /// 将整个用户缓冲区清零

--- a/kernel/src/time/syscall/sys_getitimer.rs
+++ b/kernel/src/time/syscall/sys_getitimer.rs
@@ -45,7 +45,7 @@ impl Syscall for SysGetitimerHandle {
                 if let Some(current_itimer) = itimers.real.as_ref() {
                     itv.it_interval = current_itimer.config.it_interval;
                     let now = timer::clock();
-                    let expires = current_itimer.timer.inner().expire_jiffies;
+                    let expires = current_itimer.timer.expire_jiffies();
 
                     if expires > now {
                         let remaining_jiffies = Jiffies::new(expires - now);

--- a/kernel/src/time/syscall/sys_setitimer.rs
+++ b/kernel/src/time/syscall/sys_setitimer.rs
@@ -28,7 +28,7 @@ impl ItimerType {
                 if let Some(current_itimer) = itimers.real.as_ref() {
                     old_itv.it_interval = current_itimer.config.it_interval;
                     let now = timer::clock();
-                    let expires = current_itimer.timer.inner().expire_jiffies;
+                    let expires = current_itimer.timer.expire_jiffies();
                     if expires > now {
                         let remaining_jiffies = Jiffies::new(expires - now);
                         let remaining_duration = Duration::from(remaining_jiffies);

--- a/kernel/src/time/timekeeping.rs
+++ b/kernel/src/time/timekeeping.rs
@@ -102,6 +102,7 @@ pub struct TimekeeperData {
     raw: Option<TimekeeperReadBase>,
     realtime_offset_ns: i128,
     boottime_offset_ns: u64,
+    clock_was_set_seq: u64,
     clocksource_generation: u64,
 }
 
@@ -112,6 +113,7 @@ impl TimekeeperData {
             raw: None,
             realtime_offset_ns: 0,
             boottime_offset_ns: 0,
+            clock_was_set_seq: 0,
             clocksource_generation: 0,
         }
     }
@@ -327,6 +329,14 @@ pub fn realtime_now() -> PosixTimeSpec {
     ns_to_timespec(tk.realtime_ns())
 }
 
+/// Return realtime and the wall-clock change epoch from one snapshot.
+/// Timerfd uses the epoch to distinguish a delayed notification from a clock
+/// change that happened before the timer was armed.
+pub fn realtime_now_with_clock_set_seq() -> (PosixTimeSpec, u64) {
+    let tk = timekeeper().inner.read_irqsave();
+    (ns_to_timespec(tk.realtime_ns()), tk.clock_was_set_seq)
+}
+
 pub fn monotonic_now() -> PosixTimeSpec {
     let tk = timekeeper().inner.read_irqsave();
     ns_to_timespec(tk.monotonic_ns() as i128)
@@ -414,7 +424,10 @@ fn settimeofday_locked(tk: &mut TimekeeperData, requested: i128) -> Result<(), S
     let _boot_epoch = realtime_offset
         .checked_sub(tk.boottime_offset_ns as i128)
         .ok_or(SystemError::EOVERFLOW)?;
-    tk.realtime_offset_ns = realtime_offset;
+    if tk.realtime_offset_ns != realtime_offset {
+        tk.realtime_offset_ns = realtime_offset;
+        tk.clock_was_set_seq = tk.clock_was_set_seq.wrapping_add(1);
+    }
     Ok(())
 }
 

--- a/kernel/src/time/timekeeping.rs
+++ b/kernel/src/time/timekeeping.rs
@@ -368,8 +368,14 @@ pub fn do_gettimeofday() -> PosixTimeval {
 
 pub fn do_settimeofday64(time: PosixTimeSpec) -> Result<(), SystemError> {
     let requested = validate_settimeofday(time)?;
-    let mut tk = timekeeper().inner.write_irqsave();
-    settimeofday_locked(&mut tk, requested)
+    {
+        let mut tk = timekeeper().inner.write_irqsave();
+        settimeofday_locked(&mut tk, requested)?;
+    }
+    // timerfd may read the timekeeper while rebasing its monotonic backend;
+    // never call into it while holding the timekeeper write lock.
+    crate::filesystem::timerfd::timerfd_clock_was_set();
+    Ok(())
 }
 
 fn validate_settimeofday(time: PosixTimeSpec) -> Result<i128, SystemError> {

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -5,11 +5,7 @@ use core::{
     time::Duration,
 };
 
-use alloc::{
-    boxed::Box,
-    sync::{Arc, Weak},
-    vec::Vec,
-};
+use alloc::{boxed::Box, collections::BTreeMap, sync::Arc};
 use log::{error, info, warn};
 use system_error::SystemError;
 
@@ -31,7 +27,8 @@ const TIMER_RUN_CYCLE_THRESHOLD: usize = 20;
 static TIMER_JIFFIES: AtomicU64 = AtomicU64::new(0);
 
 lazy_static! {
-    pub static ref TIMER_LIST: SpinLock<Vec<(u64, Arc<Timer>)>> = SpinLock::new(Vec::new());
+    pub static ref TIMER_LIST: SpinLock<BTreeMap<(u64, usize), Arc<Timer>>> =
+        SpinLock::new(BTreeMap::new());
 }
 
 /// 定时器要执行的函数的特征
@@ -105,6 +102,7 @@ impl TimerFunction for WakeUpHelper {
 
 #[derive(Debug)]
 pub struct Timer {
+    expire_jiffies: u64,
     inner: SpinLock<InnerTimer>,
 }
 
@@ -118,15 +116,12 @@ impl Timer {
     /// @return 定时器结构体
     pub fn new(timer_func: Box<dyn TimerFunction>, expire_jiffies: u64) -> Arc<Self> {
         let result: Arc<Timer> = Arc::new(Timer {
+            expire_jiffies,
             inner: SpinLock::new(InnerTimer {
-                expire_jiffies,
                 timer_func: Some(timer_func),
-                self_ref: Weak::default(),
                 triggered: false,
             }),
         });
-
-        result.inner.lock().self_ref = Arc::downgrade(&result);
 
         return result;
     }
@@ -135,41 +130,22 @@ impl Timer {
         return self.inner.lock_irqsave();
     }
 
-    /// @brief 将定时器插入到定时器链表中
-    pub fn activate(&self) {
-        let mut timer_list = TIMER_LIST.lock_irqsave();
-        let inner_guard = self.inner();
+    fn queue_key(&self) -> (u64, usize) {
+        (self.expire_jiffies, self as *const Self as usize)
+    }
 
-        // 链表为空，则直接插入
-        if timer_list.is_empty() {
-            // FIXME push_timer
-            timer_list.push((
-                inner_guard.expire_jiffies,
-                inner_guard.self_ref.upgrade().unwrap(),
-            ));
+    pub fn expire_jiffies(&self) -> u64 {
+        self.expire_jiffies
+    }
 
-            drop(inner_guard);
-            drop(timer_list);
-            compiler_fence(Ordering::SeqCst);
-
-            return;
+    /// @brief 将定时器插入到定时器队列中
+    pub fn activate(self: &Arc<Self>) {
+        let replaced = TIMER_LIST
+            .lock_irqsave()
+            .insert(self.queue_key(), self.clone());
+        if replaced.is_some() {
+            warn!("Timer already in list");
         }
-        let expire_jiffies = inner_guard.expire_jiffies;
-        let self_arc = inner_guard.self_ref.upgrade().unwrap();
-        drop(inner_guard);
-        let mut split_pos: usize = timer_list.len();
-        for (pos, elt) in timer_list.iter().enumerate() {
-            if Arc::ptr_eq(&self_arc, &elt.1) {
-                warn!("Timer already in list");
-            }
-            if elt.0 > expire_jiffies {
-                split_pos = pos;
-                break;
-            }
-        }
-        timer_list.insert(split_pos, (expire_jiffies, self_arc));
-
-        drop(timer_list);
     }
 
     #[inline]
@@ -194,11 +170,8 @@ impl Timer {
 
     /// ## 取消定时器任务
     pub fn cancel(&self) -> bool {
-        let this_arc = self.inner().self_ref.upgrade().unwrap();
-        TIMER_LIST
-            .lock_irqsave()
-            .extract_if(.., |x| Arc::ptr_eq(&this_arc, &x.1))
-            .for_each(drop);
+        let removed = TIMER_LIST.lock_irqsave().remove(&self.queue_key());
+        drop(removed);
         true
     }
 }
@@ -206,12 +179,8 @@ impl Timer {
 /// 定时器类型
 #[derive(Debug)]
 pub struct InnerTimer {
-    /// 定时器结束时刻
-    pub expire_jiffies: u64,
     /// 定时器需要执行的函数结构体
     pub timer_func: Option<Box<dyn TimerFunction>>,
-    /// self_ref
-    self_ref: Weak<Timer>,
     /// 判断该计时器是否触发
     triggered: bool,
 }
@@ -253,17 +222,15 @@ impl SoftirqVec for DoTimerSoftirq {
             }
             let mut timer_list = timer_list.unwrap();
 
-            if timer_list.is_empty() {
+            let Some((&(front_jiffies, _), _)) = timer_list.first_key_value() else {
                 break;
-            }
-
-            let (front_jiffies, timer_list_front) = timer_list.first().unwrap().clone();
+            };
             // debug!("to lock timer_list_front");
 
             if front_jiffies >= TIMER_JIFFIES.load(Ordering::SeqCst) {
                 break;
             }
-            timer_list.remove(0);
+            let (_, timer_list_front) = timer_list.pop_first().unwrap();
             drop(timer_list);
             timer_list_front.run();
         }
@@ -352,13 +319,10 @@ pub fn timer_get_first_expire() -> Result<u64, SystemError> {
         match TIMER_LIST.try_lock_irqsave() {
             Ok(timer_list) => {
                 // debug!("rs_timer_get_first_expire TIMER_LIST lock successfully");
-                if timer_list.is_empty() {
-                    // debug!("timer_list is empty");
-                    return Ok(0);
-                } else {
-                    // debug!("timer_list not empty");
-                    return Ok(timer_list.first().unwrap().0);
-                }
+                return Ok(timer_list
+                    .first_key_value()
+                    .map(|(key, _)| key.0)
+                    .unwrap_or(0));
             }
             // 加锁失败返回啥？？
             Err(_) => continue,

--- a/user/apps/tests/dunitest/monitor_test_results.sh
+++ b/user/apps/tests/dunitest/monitor_test_results.sh
@@ -110,7 +110,11 @@ while true; do
         fi
     fi
 
-    if [ "$serial_exists" = true ] && [ "$((now - last_output_time))" -gt "$IDLE_TIMEOUT" ]; then
+    # Before the runner prints its start marker, TEST_START_TIMEOUT is the
+    # authoritative bound. Applying the shorter idle timeout in that phase
+    # makes the configured startup budget ineffective on slow CI guests.
+    if [ "$serial_exists" = true ] && [ "$test_started" = true ] && \
+        [ "$((now - last_output_time))" -gt "$IDLE_TIMEOUT" ]; then
         echo "[dunit-monitor] 错误: 超过 ${IDLE_TIMEOUT} 秒无新输出"
         cleanup
         exit 1

--- a/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
@@ -87,6 +87,7 @@ inline constexpr int kArpFrameLen = kEthHdrLen + kArpPktLen;  // 42
 inline constexpr size_t kVlanFrameLen = 1518;
 inline constexpr int kEthFrameLen = 1514;
 inline constexpr uint16_t kPrivateEtherType = 0x88b5;
+inline constexpr uint16_t kFanoutEtherType = 0x88b6;
 inline constexpr uint16_t kVlanEtherType = 0x8100;
 
 inline constexpr const char* kLocalIp = "10.0.2.15";
@@ -297,7 +298,7 @@ void Stimulate(int tx_fd, int ifindex, const uint8_t local_mac[6]) {
 
 // Create a SOCK_RAW socket bound to the specified interface, return fd or -1.
 int MakeBoundRaw(const std::string& ifname, int ifindex, uint8_t mac[6]) {
-    int fd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    int fd = socket(AF_PACKET, SOCK_RAW, 0);
     if (fd < 0) return -1;
     struct sockaddr_ll sa;
     std::memset(&sa, 0, sizeof(sa));
@@ -623,7 +624,7 @@ TEST(AfPacketE2E, DgramReceivesHeaderOnlyFrameWithoutFilter) {
     int ifindex = ProbeIfindex(ifname);
     ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic zero-length receive testing";
 
-    FdGuard receiver(socket(AF_PACKET, SOCK_DGRAM, htons(kPrivateEtherType)));
+    FdGuard receiver(socket(AF_PACKET, SOCK_DGRAM, 0));
     FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
     ASSERT_GE(receiver.Get(), 0) << ErrnoString(errno);
     ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
@@ -877,7 +878,7 @@ TEST(AfPacketE2E, ReceiveBufferSizeControlsQueuedBytes) {
     ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic AF_PACKET queue testing";
 
     auto make_receiver = [ifindex]() {
-        int fd = socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType));
+        int fd = socket(AF_PACKET, SOCK_RAW, 0);
         if (fd < 0) return fd;
         struct sockaddr_ll bind_addr{};
         bind_addr.sll_family = AF_PACKET;
@@ -952,7 +953,7 @@ TEST(AfPacketE2E, ClassicFilterSnaplenAndRuntimeErrorsAreFailClosed) {
     ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic cBPF testing";
 
     auto make_receiver = [ifindex]() {
-        int fd = socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType));
+        int fd = socket(AF_PACKET, SOCK_RAW, 0);
         if (fd < 0) return fd;
         struct sockaddr_ll bind_addr{};
         bind_addr.sll_family = AF_PACKET;
@@ -1023,7 +1024,7 @@ TEST(AfPacketE2E, ClassicFilterSnaplenAndRuntimeErrorsAreFailClosed) {
     EXPECT_EQ(recv(receiver.Get(), buffer, sizeof(buffer), 0), -1);
     EXPECT_TRUE(errno == EAGAIN || errno == EWOULDBLOCK) << ErrnoString(errno);
 
-    FdGuard arp_receiver(socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ARP)));
+    FdGuard arp_receiver(socket(AF_PACKET, SOCK_RAW, 0));
     ASSERT_GE(arp_receiver.Get(), 0) << ErrnoString(errno);
     struct sockaddr_ll arp_bind{};
     arp_bind.sll_family = AF_PACKET;
@@ -1056,7 +1057,7 @@ TEST(AfPacketE2E, FilterReplacementPreservesReceiveState) {
     int ifindex = ProbeIfindex(ifname);
     ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic cBPF testing";
 
-    FdGuard receiver(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
+    FdGuard receiver(socket(AF_PACKET, SOCK_RAW, 0));
     FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
     ASSERT_GE(receiver.Get(), 0) << ErrnoString(errno);
     ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
@@ -1124,11 +1125,11 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
     ASSERT_GE(ifindex, 0) << "veth1 must exist for deterministic fanout testing";
 
     auto make_receiver = [ifindex]() {
-        int fd = socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType));
+        int fd = socket(AF_PACKET, SOCK_RAW, 0);
         if (fd < 0) return fd;
         struct sockaddr_ll addr{};
         addr.sll_family = AF_PACKET;
-        addr.sll_protocol = htons(kPrivateEtherType);
+        addr.sll_protocol = htons(kFanoutEtherType);
         addr.sll_ifindex = ifindex;
         if (bind(fd, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) < 0) {
             close(fd);
@@ -1139,7 +1140,7 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
 
     FdGuard first(make_receiver());
     FdGuard second(make_receiver());
-    FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kPrivateEtherType)));
+    FdGuard sender(socket(AF_PACKET, SOCK_RAW, htons(kFanoutEtherType)));
     ASSERT_GE(first.Get(), 0) << ErrnoString(errno);
     ASSERT_GE(second.Get(), 0) << ErrnoString(errno);
     ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
@@ -1155,12 +1156,12 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
     uint8_t frame[96]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);
-    frame[12] = static_cast<uint8_t>(kPrivateEtherType >> 8);
-    frame[13] = static_cast<uint8_t>(kPrivateEtherType);
+    frame[12] = static_cast<uint8_t>(kFanoutEtherType >> 8);
+    frame[13] = static_cast<uint8_t>(kFanoutEtherType);
 
     struct sockaddr_ll dst{};
     dst.sll_family = AF_PACKET;
-    dst.sll_protocol = htons(kPrivateEtherType);
+    dst.sll_protocol = htons(kFanoutEtherType);
     dst.sll_ifindex = ifindex;
     dst.sll_hatype = ARPHRD_ETHER;
     dst.sll_halen = ETH_ALEN;

--- a/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
@@ -5,6 +5,7 @@
 #include <netinet/in.h>
 #include <sys/mman.h>
 #include <sys/socket.h>
+#include <sys/utsname.h>
 #include <sys/uio.h>
 #include <unistd.h>
 
@@ -14,6 +15,11 @@
 #include <thread>
 
 namespace {
+
+bool IsDragonOS() {
+    utsname name = {};
+    return uname(&name) == 0 && std::strstr(name.release, "dragonos") != nullptr;
+}
 
 void CreateTcpPair(int sockets[2]) {
     int listener = socket(AF_INET, SOCK_STREAM, 0);
@@ -148,6 +154,53 @@ TEST(SocketReadvSemantics, TcpFaultDoesNotConsumeFailedChunk) {
     ASSERT_EQ(static_cast<ssize_t>(remaining.size()),
               read(sockets[1], remaining.data(), remaining.size()));
     EXPECT_EQ(0, std::memcmp(remaining.data(), payload.data(), payload.size()));
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, TcpWrappedRxFaultReturnsCommittedPrefix) {
+    if (!IsDragonOS()) {
+        GTEST_SKIP() << "smoltcp receive-ring regression test";
+    }
+
+    int sockets[2] = {-1, -1};
+    CreateTcpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+
+    // DragonOS doubles SO_RCVBUF and clamps it to the Linux minimum of 2304 bytes.
+    // Draining 2300 bytes leaves the smoltcp ring cursor four bytes before its end,
+    // so the next eight-byte payload occupies two contiguous receive regions.
+    int requested_recv_buffer = 1152;
+    ASSERT_EQ(0, setsockopt(sockets[1], SOL_SOCKET, SO_RCVBUF,
+                           &requested_recv_buffer, sizeof(requested_recv_buffer)))
+        << strerror(errno);
+    std::array<char, 2300> cursor_advance = {};
+    ASSERT_EQ(static_cast<ssize_t>(cursor_advance.size()),
+              write(sockets[0], cursor_advance.data(), cursor_advance.size()));
+    std::array<char, 2300> drained = {};
+    ASSERT_EQ(static_cast<ssize_t>(drained.size()),
+              read(sockets[1], drained.data(), drained.size()));
+
+    ASSERT_EQ(8, write(sockets[0], "abcdefgh", 8));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    std::array<char, 4> first = {};
+    iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+    EXPECT_EQ(4, readv(sockets[1], iovs, 2));
+    EXPECT_EQ(0, std::memcmp(first.data(), "abcd", 4));
+
+    std::array<char, 4> remaining = {};
+    ASSERT_EQ(4, read(sockets[1], remaining.data(), remaining.size()));
+    EXPECT_EQ(0, std::memcmp(remaining.data(), "efgh", 4));
 
     EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
     close(sockets[0]);

--- a/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
@@ -9,7 +9,9 @@
 #include <unistd.h>
 
 #include <array>
+#include <chrono>
 #include <cstring>
+#include <thread>
 
 namespace {
 
@@ -152,10 +154,7 @@ TEST(SocketReadvSemantics, TcpFaultDoesNotConsumeFailedChunk) {
     close(sockets[1]);
 }
 
-TEST(SocketReadvSemantics, UnixSeqpacketFaultConsumesRecord) {
-    int sockets[2] = {-1, -1};
-    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets)) << strerror(errno);
-
+void ExpectRecvmsgFaultPreservesStream(int sockets[2]) {
     constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
     ASSERT_EQ(static_cast<ssize_t>(payload.size()),
               write(sockets[0], payload.data(), payload.size()));
@@ -169,19 +168,105 @@ TEST(SocketReadvSemantics, UnixSeqpacketFaultConsumesRecord) {
 
     std::array<char, 4> first = {};
     iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+    msghdr msg = {};
+    msg.msg_iov = iovs;
+    msg.msg_iovlen = 2;
     errno = 0;
-    EXPECT_EQ(-1, readv(sockets[1], iovs, 2));
+    EXPECT_EQ(-1, recvmsg(sockets[1], &msg, 0));
     EXPECT_EQ(EFAULT, errno);
 
     ASSERT_NE(-1, fcntl(sockets[1], F_SETFL, O_NONBLOCK)) << strerror(errno);
-    char byte = 0;
-    errno = 0;
-    EXPECT_EQ(-1, read(sockets[1], &byte, 1));
-    EXPECT_EQ(EAGAIN, errno);
+    std::array<char, 8> remaining = {};
+    ASSERT_EQ(static_cast<ssize_t>(remaining.size()),
+              read(sockets[1], remaining.data(), remaining.size()));
+    EXPECT_EQ(0, std::memcmp(remaining.data(), payload.data(), payload.size()));
 
     EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
     close(sockets[0]);
     close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, TcpRecvmsgFaultDoesNotConsumeFailedChunk) {
+    int sockets[2] = {-1, -1};
+    CreateTcpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+    ExpectRecvmsgFaultPreservesStream(sockets);
+}
+
+TEST(SocketReadvSemantics, UnixStreamRecvmsgFaultDoesNotConsumeFailedChunk) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
+    ExpectRecvmsgFaultPreservesStream(sockets);
+}
+
+TEST(SocketReadvSemantics, TcpRecvmsgWaitAllFillsAllIovecs) {
+    int sockets[2] = {-1, -1};
+    CreateTcpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+
+    ASSERT_EQ(4, write(sockets[0], "abcd", 4));
+    std::thread sender([&] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        EXPECT_EQ(4, write(sockets[0], "efgh", 4));
+    });
+
+    std::array<char, 4> first = {};
+    std::array<char, 4> second = {};
+    iovec iovs[2] = {{first.data(), first.size()}, {second.data(), second.size()}};
+    msghdr msg = {};
+    msg.msg_iov = iovs;
+    msg.msg_iovlen = 2;
+    EXPECT_EQ(8, recvmsg(sockets[1], &msg, MSG_WAITALL));
+    EXPECT_EQ(0, std::memcmp(first.data(), "abcd", 4));
+    EXPECT_EQ(0, std::memcmp(second.data(), "efgh", 4));
+
+    sender.join();
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, UnixSeqpacketFaultConsumesRecord) {
+    for (bool use_recvmsg : {false, true}) {
+        SCOPED_TRACE(use_recvmsg ? "recvmsg" : "readv");
+        int sockets[2] = {-1, -1};
+        ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets)) << strerror(errno);
+
+        constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+        ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+                  write(sockets[0], payload.data(), payload.size()));
+
+        const long page_size = sysconf(_SC_PAGESIZE);
+        ASSERT_GT(page_size, 0);
+        void* inaccessible =
+            mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+                 MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+        std::array<char, 4> first = {};
+        iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+        errno = 0;
+        if (use_recvmsg) {
+            msghdr msg = {};
+            msg.msg_iov = iovs;
+            msg.msg_iovlen = 2;
+            EXPECT_EQ(-1, recvmsg(sockets[1], &msg, 0));
+        } else {
+            EXPECT_EQ(-1, readv(sockets[1], iovs, 2));
+        }
+        EXPECT_EQ(EFAULT, errno);
+
+        ASSERT_NE(-1, fcntl(sockets[1], F_SETFL, O_NONBLOCK)) << strerror(errno);
+        char byte = 0;
+        errno = 0;
+        EXPECT_EQ(-1, read(sockets[1], &byte, 1));
+        EXPECT_EQ(EAGAIN, errno);
+
+        EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+        close(sockets[0]);
+        close(sockets[1]);
+    }
 }
 
 } // namespace

--- a/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
@@ -46,6 +46,27 @@ void CreateTcpPair(int sockets[2]) {
     close(listener);
 }
 
+void CreateUdpPair(int sockets[2]) {
+    sockets[1] = socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(sockets[1], 0) << strerror(errno);
+
+    sockaddr_in address = {};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    ASSERT_EQ(0, bind(sockets[1], reinterpret_cast<sockaddr*>(&address), sizeof(address)))
+        << strerror(errno);
+
+    socklen_t address_len = sizeof(address);
+    ASSERT_EQ(0, getsockname(sockets[1], reinterpret_cast<sockaddr*>(&address), &address_len))
+        << strerror(errno);
+
+    sockets[0] = socket(AF_INET, SOCK_DGRAM, 0);
+    ASSERT_GE(sockets[0], 0) << strerror(errno);
+    ASSERT_EQ(0, connect(sockets[0], reinterpret_cast<sockaddr*>(&address), sizeof(address)))
+        << strerror(errno);
+}
+
 TEST(SocketReadvSemantics, FaultingLaterIovecPreservesUnreadData) {
     int sockets[2] = {-1, -1};
     ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
@@ -320,6 +341,60 @@ TEST(SocketReadvSemantics, UnixSeqpacketFaultConsumesRecord) {
         close(sockets[0]);
         close(sockets[1]);
     }
+}
+
+void ExpectDatagramRecvmsgFaultSemantics(int sockets[2]) {
+    constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    for (bool peek : {false, true}) {
+        SCOPED_TRACE(peek ? "MSG_PEEK" : "consume");
+        ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+                  send(sockets[0], payload.data(), payload.size(), 0));
+
+        std::array<char, 4> first = {};
+        iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+        msghdr msg = {};
+        msg.msg_iov = iovs;
+        msg.msg_iovlen = 2;
+        errno = 0;
+        EXPECT_EQ(-1, recvmsg(sockets[1], &msg, peek ? MSG_PEEK : 0));
+        EXPECT_EQ(EFAULT, errno);
+
+        std::array<char, 8> received = {};
+        if (peek) {
+            ASSERT_EQ(static_cast<ssize_t>(received.size()),
+                      recv(sockets[1], received.data(), received.size(), 0));
+            EXPECT_EQ(0, std::memcmp(received.data(), payload.data(), payload.size()));
+        } else {
+            errno = 0;
+            EXPECT_EQ(-1, recv(sockets[1], received.data(), received.size(), MSG_DONTWAIT));
+            EXPECT_EQ(EAGAIN, errno);
+        }
+    }
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, UdpRecvmsgFaultHonorsDatagramConsumption) {
+    int sockets[2] = {-1, -1};
+    CreateUdpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+    ExpectDatagramRecvmsgFaultSemantics(sockets);
+}
+
+TEST(SocketReadvSemantics, UnixDatagramRecvmsgFaultHonorsDatagramConsumption) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_DGRAM, 0, sockets)) << strerror(errno);
+    ExpectDatagramRecvmsgFaultSemantics(sockets);
 }
 
 } // namespace

--- a/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
@@ -10,10 +10,12 @@
 #include <sys/uio.h>
 #include <unistd.h>
 
+#include <algorithm>
 #include <array>
 #include <chrono>
 #include <cstring>
 #include <thread>
+#include <vector>
 
 namespace {
 
@@ -256,6 +258,55 @@ TEST(SocketReadvSemantics, TcpWrappedRxFaultReturnsCommittedPrefix) {
     EXPECT_EQ(0, std::memcmp(remaining.data(), "efgh", 4));
 
     EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, ConcurrentTcpReadvDoesNotDuplicateStreamData) {
+    int sockets[2] = {-1, -1};
+    CreateTcpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+
+    std::array<unsigned char, 251> payload = {};
+    for (size_t i = 0; i < payload.size(); ++i) {
+        payload[i] = static_cast<unsigned char>(i);
+    }
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              write(sockets[0], payload.data(), payload.size()));
+    ASSERT_EQ(0, shutdown(sockets[0], SHUT_WR)) << strerror(errno);
+
+    auto reader = [&] {
+        std::vector<unsigned char> received;
+        for (;;) {
+            unsigned char byte = 0;
+            iovec iov = {&byte, sizeof(byte)};
+            const ssize_t size = readv(sockets[1], &iov, 1);
+            if (size == 0) {
+                break;
+            }
+            EXPECT_EQ(1, size) << strerror(errno);
+            if (size != 1) {
+                break;
+            }
+            received.push_back(byte);
+            std::this_thread::yield();
+        }
+        return received;
+    };
+
+    std::vector<unsigned char> first;
+    std::vector<unsigned char> second;
+    std::thread first_reader([&] { first = reader(); });
+    std::thread second_reader([&] { second = reader(); });
+    first_reader.join();
+    second_reader.join();
+
+    first.insert(first.end(), second.begin(), second.end());
+    ASSERT_EQ(payload.size(), first.size());
+    std::sort(first.begin(), first.end());
+    EXPECT_TRUE(std::equal(first.begin(), first.end(), payload.begin()));
+
     close(sockets[0]);
     close(sockets[1]);
 }

--- a/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_readv_semantics.cc
@@ -1,0 +1,192 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/uio.h>
+#include <unistd.h>
+
+#include <array>
+#include <cstring>
+
+namespace {
+
+void CreateTcpPair(int sockets[2]) {
+    int listener = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(listener, 0) << strerror(errno);
+
+    sockaddr_in address = {};
+    address.sin_family = AF_INET;
+    address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    address.sin_port = 0;
+    ASSERT_EQ(0, bind(listener, reinterpret_cast<sockaddr*>(&address), sizeof(address)))
+        << strerror(errno);
+    ASSERT_EQ(0, listen(listener, 1)) << strerror(errno);
+
+    socklen_t address_len = sizeof(address);
+    ASSERT_EQ(0, getsockname(listener, reinterpret_cast<sockaddr*>(&address), &address_len))
+        << strerror(errno);
+
+    sockets[0] = socket(AF_INET, SOCK_STREAM, 0);
+    ASSERT_GE(sockets[0], 0) << strerror(errno);
+    ASSERT_EQ(0, connect(sockets[0], reinterpret_cast<sockaddr*>(&address), sizeof(address)))
+        << strerror(errno);
+    sockets[1] = accept(listener, nullptr, nullptr);
+    ASSERT_GE(sockets[1], 0) << strerror(errno);
+    close(listener);
+}
+
+TEST(SocketReadvSemantics, FaultingLaterIovecPreservesUnreadData) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
+
+    constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              write(sockets[0], payload.data(), payload.size()));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    std::array<char, 4> first = {};
+    iovec iovs[2] = {
+        {first.data(), first.size()},
+        {inaccessible, 4},
+    };
+    errno = 0;
+    EXPECT_EQ(-1, readv(sockets[1], iovs, 2));
+    EXPECT_EQ(EFAULT, errno);
+
+    ASSERT_NE(-1, fcntl(sockets[1], F_SETFL, O_NONBLOCK)) << strerror(errno);
+    std::array<char, 8> remaining = {};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              read(sockets[1], remaining.data(), remaining.size()));
+    EXPECT_EQ(0, std::memcmp(remaining.data(), payload.data(), payload.size()));
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, ShortReadDoesNotTouchFaultingLaterIovec) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM, 0, sockets)) << strerror(errno);
+
+    constexpr std::array<char, 4> payload = {'a', 'b', 'c', 'd'};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              write(sockets[0], payload.data(), payload.size()));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    std::array<char, 4> first = {};
+    iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()), readv(sockets[1], iovs, 2));
+    EXPECT_EQ(0, std::memcmp(first.data(), payload.data(), payload.size()));
+
+    ASSERT_NE(-1, fcntl(sockets[1], F_SETFL, O_NONBLOCK)) << strerror(errno);
+    char byte = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(sockets[1], &byte, 1));
+    EXPECT_EQ(EAGAIN, errno);
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, EmptySocketResultPrecedesDestinationFault) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_STREAM | SOCK_NONBLOCK, 0, sockets))
+        << strerror(errno);
+
+    iovec invalid = {nullptr, 4};
+    errno = 0;
+    EXPECT_EQ(-1, readv(sockets[1], &invalid, 1));
+    EXPECT_EQ(EAGAIN, errno);
+
+    close(sockets[0]);
+    EXPECT_EQ(0, readv(sockets[1], &invalid, 1));
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, TcpFaultDoesNotConsumeFailedChunk) {
+    int sockets[2] = {-1, -1};
+    CreateTcpPair(sockets);
+    ASSERT_GE(sockets[0], 0);
+    ASSERT_GE(sockets[1], 0);
+
+    constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              write(sockets[0], payload.data(), payload.size()));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    std::array<char, 4> first = {};
+    iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+    errno = 0;
+    EXPECT_EQ(-1, readv(sockets[1], iovs, 2));
+    EXPECT_EQ(EFAULT, errno);
+
+    std::array<char, 8> remaining = {};
+    ASSERT_EQ(static_cast<ssize_t>(remaining.size()),
+              read(sockets[1], remaining.data(), remaining.size()));
+    EXPECT_EQ(0, std::memcmp(remaining.data(), payload.data(), payload.size()));
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+TEST(SocketReadvSemantics, UnixSeqpacketFaultConsumesRecord) {
+    int sockets[2] = {-1, -1};
+    ASSERT_EQ(0, socketpair(AF_UNIX, SOCK_SEQPACKET, 0, sockets)) << strerror(errno);
+
+    constexpr std::array<char, 8> payload = {'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'};
+    ASSERT_EQ(static_cast<ssize_t>(payload.size()),
+              write(sockets[0], payload.data(), payload.size()));
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* inaccessible =
+        mmap(nullptr, static_cast<size_t>(page_size), PROT_NONE,
+             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(MAP_FAILED, inaccessible) << strerror(errno);
+
+    std::array<char, 4> first = {};
+    iovec iovs[2] = {{first.data(), first.size()}, {inaccessible, 4}};
+    errno = 0;
+    EXPECT_EQ(-1, readv(sockets[1], iovs, 2));
+    EXPECT_EQ(EFAULT, errno);
+
+    ASSERT_NE(-1, fcntl(sockets[1], F_SETFL, O_NONBLOCK)) << strerror(errno);
+    char byte = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(sockets[1], &byte, 1));
+    EXPECT_EQ(EAGAIN, errno);
+
+    EXPECT_EQ(0, munmap(inaccessible, static_cast<size_t>(page_size)));
+    close(sockets[0]);
+    close(sockets[1]);
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
@@ -7,6 +7,7 @@
 #include <sys/epoll.h>
 #include <sys/syscall.h>
 #include <sys/timerfd.h>
+#include <sys/uio.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -96,6 +97,41 @@ TEST(TimerFdSemantics, OneShotPollReadAndReset) {
     uint64_t ticks = 0;
     ASSERT_EQ(static_cast<ssize_t>(sizeof(ticks)), read(fd.get(), &ticks, sizeof(ticks)));
     EXPECT_EQ(1u, ticks);
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EAGAIN, errno);
+}
+
+TEST(TimerFdSemantics, VectoredReadUsesScalarFallbackSemantics) {
+    UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+
+    itimerspec expired = {};
+    expired.it_value.tv_nsec = 1;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &expired, nullptr));
+    pollfd ready = {fd.get(), POLLIN, 0};
+    ASSERT_EQ(1, poll(&ready, 1, 1000));
+
+    uint32_t halves[2] = {};
+    iovec split[2] = {{&halves[0], sizeof(halves[0])},
+                      {&halves[1], sizeof(halves[1])}};
+    errno = 0;
+    EXPECT_EQ(-1, readv(fd.get(), split, 2));
+    EXPECT_EQ(EINVAL, errno);
+
+    uint64_t ticks = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(ticks)),
+              read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(1u, ticks);
+
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &expired, nullptr));
+    ready.revents = 0;
+    ASSERT_EQ(1, poll(&ready, 1, 1000));
+
+    iovec invalid = {nullptr, sizeof(ticks)};
+    errno = 0;
+    EXPECT_EQ(-1, readv(fd.get(), &invalid, 1));
+    EXPECT_EQ(EFAULT, errno);
     errno = 0;
     EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
     EXPECT_EQ(EAGAIN, errno);

--- a/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
@@ -156,6 +156,43 @@ TEST(TimerFdSemantics, PeriodicAccumulatesMissedExpirations) {
     EXPECT_TRUE(current.it_value.tv_sec > 0 || current.it_value.tv_nsec > 0);
 }
 
+TEST(TimerFdSemantics, RealtimePeriodicRearmsAfterLazyExpiration) {
+    UniqueFd fd(timerfd_create(CLOCK_REALTIME, TFD_NONBLOCK));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+
+    timespec now = {};
+    ASSERT_EQ(0, clock_gettime(CLOCK_REALTIME, &now));
+    itimerspec value = {};
+    value.it_value = now;
+    value.it_value.tv_nsec += 20 * 1000 * 1000;
+    if (value.it_value.tv_nsec >= 1000 * 1000 * 1000) {
+        ++value.it_value.tv_sec;
+        value.it_value.tv_nsec -= 1000 * 1000 * 1000;
+    }
+    value.it_interval.tv_nsec = 20 * 1000 * 1000;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &value, nullptr));
+    usleep(55 * 1000);
+
+    uint64_t ticks = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(ticks)),
+              read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_GE(ticks, 1u);
+
+    itimerspec current = {};
+    ASSERT_EQ(0, timerfd_gettime(fd.get(), &current));
+    EXPECT_EQ(value.it_interval.tv_sec, current.it_interval.tv_sec);
+    EXPECT_EQ(value.it_interval.tv_nsec, current.it_interval.tv_nsec);
+    EXPECT_TRUE(current.it_value.tv_sec > 0 || current.it_value.tv_nsec > 0);
+
+    pollfd ready = {fd.get(), POLLIN, 0};
+    ASSERT_EQ(1, poll(&ready, 1, 1000));
+    uint64_t next_ticks = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(next_ticks)),
+              read(fd.get(), &next_ticks, sizeof(next_ticks)));
+    EXPECT_GE(next_ticks, 1u);
+
+}
+
 TEST(TimerFdSemantics, AbsoluteAndPastDeadlines) {
     UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));
     ASSERT_GE(fd.get(), 0) << strerror(errno);

--- a/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
@@ -1,0 +1,205 @@
+#include <errno.h>
+#include <string.h>
+#include <fcntl.h>
+#include <gtest/gtest.h>
+#include <poll.h>
+#include <stdint.h>
+#include <sys/epoll.h>
+#include <sys/syscall.h>
+#include <sys/timerfd.h>
+#include <time.h>
+#include <unistd.h>
+
+namespace {
+
+class UniqueFd {
+  public:
+    explicit UniqueFd(int fd = -1) : fd_(fd) {}
+    ~UniqueFd() {
+        if (fd_ >= 0) {
+            close(fd_);
+        }
+    }
+    UniqueFd(const UniqueFd &) = delete;
+    UniqueFd &operator=(const UniqueFd &) = delete;
+    int get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+timespec AddMilliseconds(timespec value, long milliseconds) {
+    value.tv_nsec += milliseconds * 1000 * 1000;
+    value.tv_sec += value.tv_nsec / 1000000000L;
+    value.tv_nsec %= 1000000000L;
+    return value;
+}
+
+TEST(TimerFdSemantics, CreateValidationAndInitialState) {
+    errno = 0;
+    EXPECT_EQ(-1, timerfd_create(CLOCK_PROCESS_CPUTIME_ID, 0));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, timerfd_create(CLOCK_MONOTONIC, 0x40000000));
+    EXPECT_EQ(EINVAL, errno);
+
+    UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK | TFD_CLOEXEC));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+    EXPECT_NE(0, fcntl(fd.get(), F_GETFD) & FD_CLOEXEC);
+
+    itimerspec current = {};
+    ASSERT_EQ(0, timerfd_gettime(fd.get(), &current));
+    EXPECT_EQ(0, current.it_value.tv_sec);
+    EXPECT_EQ(0, current.it_value.tv_nsec);
+
+    uint64_t ticks = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, 0));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, syscall(SYS_read, fd.get(), nullptr, 1));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks) - 1));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EAGAIN, errno);
+
+    // timerfd validates count before touching the pointer, but consumes a
+    // pending expiration before the protected 8-byte copy reports EFAULT.
+    itimerspec expired = {};
+    expired.it_value.tv_nsec = 1;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &expired, nullptr));
+    pollfd ready = {fd.get(), POLLIN, 0};
+    ASSERT_EQ(1, poll(&ready, 1, 1000));
+    ASSERT_NE(0, ready.revents & POLLIN);
+    errno = 0;
+    EXPECT_EQ(-1, syscall(SYS_read, fd.get(), nullptr, sizeof(ticks)));
+    EXPECT_EQ(EFAULT, errno);
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EAGAIN, errno);
+}
+
+TEST(TimerFdSemantics, OneShotPollReadAndReset) {
+    UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+    itimerspec value = {};
+    value.it_value.tv_nsec = 50 * 1000 * 1000;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), 0, &value, nullptr));
+
+    pollfd pfd = {fd.get(), POLLIN, 0};
+    ASSERT_EQ(1, poll(&pfd, 1, 1000));
+    EXPECT_EQ(POLLIN, pfd.revents);
+
+    uint64_t ticks = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(ticks)), read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(1u, ticks);
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EAGAIN, errno);
+}
+
+TEST(TimerFdSemantics, PeriodicAccumulatesMissedExpirations) {
+    UniqueFd fd(timerfd_create(CLOCK_BOOTTIME, 0));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+    itimerspec value = {};
+    value.it_value.tv_nsec = 20 * 1000 * 1000;
+    value.it_interval = value.it_value;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), 0, &value, nullptr));
+    usleep(95 * 1000);
+
+    uint64_t ticks = 0;
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(ticks)), read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_GE(ticks, 3u);
+
+    itimerspec current = {};
+    ASSERT_EQ(0, timerfd_gettime(fd.get(), &current));
+    EXPECT_EQ(value.it_interval.tv_nsec, current.it_interval.tv_nsec);
+    EXPECT_TRUE(current.it_value.tv_sec > 0 || current.it_value.tv_nsec > 0);
+}
+
+TEST(TimerFdSemantics, AbsoluteAndPastDeadlines) {
+    UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+    itimerspec value = {};
+    ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &value.it_value));
+    value.it_value = AddMilliseconds(value.it_value, 40);
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &value, nullptr));
+
+    pollfd pfd = {fd.get(), POLLIN, 0};
+    ASSERT_EQ(1, poll(&pfd, 1, 1000));
+    uint64_t ticks = 0;
+    ASSERT_EQ(8, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(1u, ticks);
+
+    value = {};
+    value.it_value.tv_nsec = 1;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), TFD_TIMER_ABSTIME, &value, nullptr));
+    pfd.revents = 0;
+    ASSERT_EQ(1, poll(&pfd, 1, 1000));
+    ASSERT_NE(0, pfd.revents & POLLIN);
+    ASSERT_EQ(8, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(1u, ticks);
+}
+
+TEST(TimerFdSemantics, GetOldDisarmAndFcntlNonblock) {
+    UniqueFd fd(timerfd_create(CLOCK_REALTIME, 0));
+    ASSERT_GE(fd.get(), 0) << strerror(errno);
+    itimerspec first = {};
+    first.it_value.tv_sec = 2;
+    first.it_interval.tv_sec = 1;
+    ASSERT_EQ(0, timerfd_settime(fd.get(), 0, &first, nullptr));
+
+    itimerspec disarm = {};
+    itimerspec old = {};
+    ASSERT_EQ(0, timerfd_settime(fd.get(), 0, &disarm, &old));
+    EXPECT_EQ(1, old.it_interval.tv_sec);
+    EXPECT_TRUE(old.it_value.tv_sec > 0 || old.it_value.tv_nsec > 0);
+
+    ASSERT_EQ(0, fcntl(fd.get(), F_SETFL, fcntl(fd.get(), F_GETFL) | O_NONBLOCK));
+    uint64_t ticks = 0;
+    errno = 0;
+    EXPECT_EQ(-1, read(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EAGAIN, errno);
+}
+
+TEST(TimerFdSemantics, EpollDupAndIoRestrictions) {
+    UniqueFd fd(timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK));
+    UniqueFd duplicate(dup(fd.get()));
+    UniqueFd epoll_fd(epoll_create1(EPOLL_CLOEXEC));
+    ASSERT_GE(fd.get(), 0);
+    ASSERT_GE(duplicate.get(), 0);
+    ASSERT_GE(epoll_fd.get(), 0);
+
+    epoll_event event = {};
+    event.events = EPOLLIN;
+    event.data.fd = fd.get();
+    ASSERT_EQ(0, epoll_ctl(epoll_fd.get(), EPOLL_CTL_ADD, fd.get(), &event));
+
+    itimerspec value = {};
+    value.it_value.tv_nsec = 30 * 1000 * 1000;
+    ASSERT_EQ(0, timerfd_settime(duplicate.get(), 0, &value, nullptr));
+    epoll_event ready = {};
+    ASSERT_EQ(1, epoll_wait(epoll_fd.get(), &ready, 1, 1000));
+    EXPECT_NE(0u, ready.events & EPOLLIN);
+
+    uint64_t ticks = 0;
+    ASSERT_EQ(8, read(duplicate.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(1u, ticks);
+    EXPECT_EQ(0, lseek(fd.get(), 123, SEEK_SET));
+    errno = 0;
+    EXPECT_EQ(-1, pread(fd.get(), &ticks, sizeof(ticks), 0));
+    EXPECT_EQ(ESPIPE, errno);
+    errno = 0;
+    EXPECT_EQ(-1, write(fd.get(), &ticks, sizeof(ticks)));
+    EXPECT_EQ(EINVAL, errno);
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/timerfd_semantics.cc
@@ -144,6 +144,44 @@ TEST(TimerFdSemantics, AbsoluteAndPastDeadlines) {
     EXPECT_EQ(1u, ticks);
 }
 
+TEST(TimerFdSemantics, SameDeadlineTimersRemainIndependent) {
+    constexpr int kTimerCount = 32;
+    int fds[kTimerCount];
+    pollfd poll_fds[kTimerCount];
+
+    itimerspec value = {};
+    ASSERT_EQ(0, clock_gettime(CLOCK_MONOTONIC, &value.it_value));
+    value.it_value = AddMilliseconds(value.it_value, 500);
+
+    for (int i = 0; i < kTimerCount; ++i) {
+        fds[i] = timerfd_create(CLOCK_MONOTONIC, TFD_NONBLOCK);
+        ASSERT_GE(fds[i], 0) << strerror(errno);
+        ASSERT_EQ(0, timerfd_settime(fds[i], TFD_TIMER_ABSTIME, &value, nullptr));
+        poll_fds[i] = {fds[i], POLLIN, 0};
+    }
+
+    itimerspec disarm = {};
+    for (int i = 0; i < kTimerCount; i += 2) {
+        ASSERT_EQ(0, timerfd_settime(fds[i], 0, &disarm, nullptr));
+    }
+
+    ASSERT_EQ(kTimerCount / 2, poll(poll_fds, kTimerCount, 2000));
+    for (int i = 0; i < kTimerCount; ++i) {
+        uint64_t ticks = 0;
+        if (i % 2 == 0) {
+            EXPECT_EQ(0, poll_fds[i].revents);
+            errno = 0;
+            EXPECT_EQ(-1, read(fds[i], &ticks, sizeof(ticks)));
+            EXPECT_EQ(EAGAIN, errno);
+        } else {
+            EXPECT_EQ(POLLIN, poll_fds[i].revents);
+            ASSERT_EQ(8, read(fds[i], &ticks, sizeof(ticks)));
+            EXPECT_EQ(1u, ticks);
+        }
+        close(fds[i]);
+    }
+}
+
 TEST(TimerFdSemantics, GetOldDisarmAndFcntlNonblock) {
     UniqueFd fd(timerfd_create(CLOCK_REALTIME, 0));
     ASSERT_GE(fd.get(), 0) << strerror(errno);

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -54,6 +54,7 @@ normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics
 normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics
+normal/socket_readv_semantics
 normal/unix_socket_shutdown
 fuse/fuse_core
 fuse/fuse_extended

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -97,6 +97,7 @@ normal/spawn_exec_pipe_race
 normal/tty_pty_hangup
 normal/cubesandbox_pty_exec_chain
 normal/eventfd_pending_signal
+normal/timerfd_semantics
 normal/virtiofs_smoke
 normal/virtiofs_dax
 normal/af_packet_sockopt

--- a/user/apps/tests/syscall/gvisor/monitor_test_results.sh
+++ b/user/apps/tests/syscall/gvisor/monitor_test_results.sh
@@ -18,7 +18,7 @@ SERIAL_FILE="serial_opt.txt"
 # 超时配置（秒）
 BOOT_TIMEOUT=300        # DragonOS开机超时（5分钟）
 TEST_START_TIMEOUT=600  # 测试程序启动超时（10分钟）
-TEST_TIMEOUT=3000        # 整个测试超时（50分钟，CI job 保留10分钟收尾）
+TEST_TIMEOUT=3300        # 整个测试超时（55分钟，CI job 仍保留构建与收尾时间）
 IDLE_TIMEOUT=300         # 无输出超时（5分钟）
 SINGLE_TEST_TIMEOUT=300  # mount 压力用例允许5分钟，仍对卡死保持有界
 

--- a/user/apps/tests/syscall/gvisor/whitelist.txt
+++ b/user/apps/tests/syscall/gvisor/whitelist.txt
@@ -68,6 +68,7 @@ prctl_test
 exit_test
 setns_test
 eventfd_test
+timerfd_test
 poll_test
 rseq_test
 process_vm_read_write_test


### PR DESCRIPTION
## Summary

- implement Linux 6.6-compatible timerfd_create, timerfd_settime, and timerfd_gettime
- support realtime, monotonic, boottime, alarm clocks, periodic accounting, absolute deadlines, CANCEL_ON_SET, and fd lifecycle semantics
- integrate timerfd with VFS read, fcntl, noop_llseek, poll, and epoll behavior
- add focused dunitest coverage and enable the gVisor timerfd test target

## Validation

- make kernel
- DragonOS QEMU: timerfd_semantics_test (6/6 passed)
- DragonOS QEMU: eventfd_pending_signal_test (1/1 passed)
- DragonOS QEMU: poll_timeout_semantics_test (4/4 passed)
- DragonOS QEMU: epoll_ctl_wait_concurrency_test (5/5 passed)
- DragonOS QEMU: epoll_timeout_budget_test (1/1 passed)
- DragonOS QEMU: timekeeping_semantics_test (15/15 regular tests passed; two opt-in stress tests skipped)

Closes #2228