### PR TITLE
fix(net): enforce capabilities for rtnetlink mutations

### DIFF
--- a/kernel/src/net/socket/netlink/common/bound.rs
+++ b/kernel/src/net/socket/netlink/common/bound.rs
@@ -5,7 +5,7 @@ use crate::{
         receiver::MessageQueue,
         table::BoundHandle,
     },
-    process::namespace::net_namespace::NetNamespace,
+    process::{cred::Cred, namespace::net_namespace::NetNamespace},
 };
 use alloc::fmt::Debug;
 use alloc::sync::Arc;
@@ -17,6 +17,7 @@ pub struct BoundNetlink<Message: 'static + Debug> {
     pub(in crate::net::socket::netlink) remote_addr: NetlinkSocketAddr,
     pub(in crate::net::socket::netlink) receive_queue: MessageQueue<Message>,
     pub(in crate::net::socket::netlink) netns: Arc<NetNamespace>,
+    pub(in crate::net::socket::netlink) opener_cred: Arc<Cred>,
 }
 
 impl<Message: 'static + Debug> BoundNetlink<Message> {
@@ -24,12 +25,14 @@ impl<Message: 'static + Debug> BoundNetlink<Message> {
         handle: BoundHandle<Message>,
         message_queue: MessageQueue<Message>,
         netns: Arc<NetNamespace>,
+        opener_cred: Arc<Cred>,
     ) -> Self {
         Self {
             handle,
             remote_addr: NetlinkSocketAddr::new_unspecified(),
             receive_queue: message_queue,
             netns,
+            opener_cred,
         }
     }
 
@@ -64,5 +67,9 @@ impl<Message: 'static + Debug> BoundNetlink<Message> {
 
     pub fn netns(&self) -> Arc<NetNamespace> {
         self.netns.clone()
+    }
+
+    pub fn opener_cred(&self) -> Arc<Cred> {
+        self.opener_cred.clone()
     }
 }

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -82,7 +82,8 @@ where
         let wait_queue = Arc::new(WaitQueue::default());
         let epoll_items = Arc::new(EPollItems::default());
         let fasync_items = Arc::new(FAsyncItems::default());
-        let unbound = UnboundNetlink::new(epoll_items.clone(), fasync_items.clone());
+        let opener_cred = ProcessManager::current_pcb().cred();
+        let unbound = UnboundNetlink::new(epoll_items.clone(), fasync_items.clone(), opener_cred);
         Arc::new(Self {
             inner: RwSem::new(Inner::Unbound(unbound)),
             is_nonblocking: AtomicBool::new(is_nonblocking),
@@ -107,6 +108,7 @@ where
         to: Option<NetlinkSocketAddr>,
         flags: crate::net::socket::PMSG,
     ) -> Result<usize, SystemError> {
+        let destination_is_explicit = to.is_some();
         let send_bytes = select_remote_and_bind(
             &self.inner,
             to,
@@ -117,7 +119,7 @@ where
                     self.netns(),
                 )
             },
-            |bound, remote| bound.try_send(buf, &remote, flags),
+            |bound, remote| bound.try_send(buf, &remote, flags, destination_is_explicit),
         )?;
         // todo pollee invalidate??
 
@@ -130,6 +132,7 @@ where
         to: Option<NetlinkSocketAddr>,
         flags: crate::net::socket::PMSG,
     ) -> Result<usize, SystemError> {
+        let destination_is_explicit = to.is_some();
         let send_bytes = select_remote_and_bind(
             &self.inner,
             to,
@@ -140,7 +143,7 @@ where
                     self.netns(),
                 )
             },
-            |bound, remote| bound.try_send_vec(buf, &remote, flags),
+            |bound, remote| bound.try_send_vec(buf, &remote, flags, destination_is_explicit),
         )?;
 
         Ok(send_bytes)

--- a/kernel/src/net/socket/netlink/common/unbound.rs
+++ b/kernel/src/net/socket/netlink/common/unbound.rs
@@ -12,7 +12,7 @@ use crate::{
         },
         utils::datagram_common,
     },
-    process::namespace::net_namespace::NetNamespace,
+    process::{cred::Cred, namespace::net_namespace::NetNamespace},
 };
 use alloc::sync::Arc;
 use core::marker::PhantomData;
@@ -23,15 +23,21 @@ pub struct UnboundNetlink<P: SupportedNetlinkProtocol> {
     groups: GroupIdSet,
     epoll_items: Arc<EPollItems>,
     fasync_items: Arc<FAsyncItems>,
+    opener_cred: Arc<Cred>,
     phantom: PhantomData<BoundNetlink<P::Message>>,
 }
 
 impl<P: SupportedNetlinkProtocol> UnboundNetlink<P> {
-    pub(super) fn new(epoll_items: Arc<EPollItems>, fasync_items: Arc<FAsyncItems>) -> Self {
+    pub(super) fn new(
+        epoll_items: Arc<EPollItems>,
+        fasync_items: Arc<FAsyncItems>,
+        opener_cred: Arc<Cred>,
+    ) -> Self {
         Self {
             groups: GroupIdSet::new_empty(),
             epoll_items,
             fasync_items,
+            opener_cred,
             phantom: PhantomData,
         }
     }
@@ -75,7 +81,12 @@ impl<P: SupportedNetlinkProtocol> datagram_common::Unbound for UnboundNetlink<P>
             <P as SupportedNetlinkProtocol>::bind(&endpoint, receiver, netns.clone())?
         };
 
-        Ok(BoundNetlink::new(bound_handle, message_queue, netns))
+        Ok(BoundNetlink::new(
+            bound_handle,
+            message_queue,
+            netns,
+            self.opener_cred.clone(),
+        ))
     }
 
     fn bind_ephemeral(
@@ -101,7 +112,12 @@ impl<P: SupportedNetlinkProtocol> datagram_common::Unbound for UnboundNetlink<P>
             <P as SupportedNetlinkProtocol>::bind(&endpoint, receiver, netns.clone())?
         };
 
-        Ok(BoundNetlink::new(bound_handle, message_queue, netns))
+        Ok(BoundNetlink::new(
+            bound_handle,
+            message_queue,
+            netns,
+            self.opener_cred.clone(),
+        ))
     }
 
     fn check_io_events(&self) -> EPollEventType {

--- a/kernel/src/net/socket/netlink/kobject/bound.rs
+++ b/kernel/src/net/socket/netlink/kobject/bound.rs
@@ -63,6 +63,7 @@ impl datagram_common::Bound for BoundNetlink<KobjectUeventMessage> {
         buf: &[u8],
         to: &Self::Endpoint,
         _flags: PMSG,
+        _destination_is_explicit: bool,
     ) -> Result<usize, SystemError> {
         let sent_len = buf.len();
         let message = KobjectUeventMessage::try_new(buf)?;
@@ -74,6 +75,7 @@ impl datagram_common::Bound for BoundNetlink<KobjectUeventMessage> {
         buf: Vec<u8>,
         to: &Self::Endpoint,
         _flags: PMSG,
+        _destination_is_explicit: bool,
     ) -> Result<usize, SystemError> {
         let sent_len = buf.len();
         let message = KobjectUeventMessage::from_vec(buf);

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -13,13 +13,16 @@ use crate::{
                 },
                 ProtocolSegment, NLMSG_ALIGN,
             },
-            route::{kern::NetlinkRouteKernelSocket, message::RouteNlMessage},
+            route::{
+                kern::{NetlinkRouteKernelSocket, RtnlRequestContext},
+                message::RouteNlMessage,
+            },
             table::{NetlinkRouteProtocol, SupportedNetlinkProtocol},
         },
         utils::datagram_common,
         PMSG,
     },
-    process::namespace::net_namespace::NetNamespace,
+    process::{namespace::net_namespace::NetNamespace, ProcessManager},
 };
 use alloc::sync::Arc;
 use core::mem::size_of;
@@ -49,6 +52,7 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
         buf: &[u8],
         to: &Self::Endpoint,
         _flags: crate::net::socket::PMSG,
+        destination_is_explicit: bool,
     ) -> Result<usize, SystemError> {
         if *to != NetlinkSocketAddr::new_unspecified() {
             return Err(SystemError::ENOTCONN);
@@ -57,6 +61,13 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
         let sum_lens = buf.len();
         let local_port = self.handle.port();
         let netns = self.netns();
+        let context = RtnlRequestContext::new(
+            ProcessManager::current_pcb().cred(),
+            self.opener_cred(),
+            netns.clone(),
+            local_port,
+            destination_is_explicit,
+        );
 
         let Some(route_kernel) = netns.get_netlink_kernel_socket_by_protocol(
             crate::net::socket::netlink::table::StandardNetlinkProtocol::ROUTE.into(),
@@ -90,6 +101,14 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
             let flags = SegHdrCommonFlags::from_bits_truncate(header.flags);
             if !flags.contains(SegHdrCommonFlags::REQUEST) {
                 continue;
+            }
+
+            let payload_len = msg_len - size_of::<CMsgSegHdr>();
+            if rtnl_requires_net_admin(header.type_, payload_len) {
+                if let Err(error) = context.require_net_admin() {
+                    send_route_error_ack(&header, error, local_port, netns.clone());
+                    continue;
+                }
             }
 
             if CSegmentType::try_from(header.type_).is_err() {
@@ -126,7 +145,7 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
                 }
             }
 
-            route_kernel_socket.request(&nlmsg, local_port, netns.clone());
+            route_kernel_socket.request(&nlmsg, &context);
 
             // gVisor 测例常以 sizeof(req) 发送，nlmsg_len 之后多为结构体尾部零填充，勿当作下一条消息。
             if offset < buf.len() && buf[offset..].iter().all(|&b| b == 0) {
@@ -173,6 +192,21 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
     fn check_io_events(&self) -> EPollEventType {
         self.check_io_events_common()
     }
+}
+
+/// Mirrors Linux `rtnl_msgtype_kind()`: RTM message kinds repeat in groups of
+/// four as NEW, DEL, GET, SET. Every non-GET userspace request in Linux's RTM
+/// range requires CAP_NET_ADMIN, including message types DragonOS does not yet
+/// implement. A zero-length payload stays on the existing malformed-message
+/// path instead of changing its error ordering.
+fn rtnl_requires_net_admin(message_type: u16, payload_len: usize) -> bool {
+    const RTM_BASE: u16 = 16;
+    const RTM_MAX: u16 = 123;
+    const RTM_GET_KIND: u16 = 2;
+
+    payload_len != 0
+        && (RTM_BASE..=RTM_MAX).contains(&message_type)
+        && ((message_type - RTM_BASE) & 3) != RTM_GET_KIND
 }
 
 fn send_route_error_ack(

--- a/kernel/src/net/socket/netlink/route/bound.rs
+++ b/kernel/src/net/socket/netlink/route/bound.rs
@@ -104,17 +104,24 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
             }
 
             let payload_len = msg_len - size_of::<CMsgSegHdr>();
-            if rtnl_requires_net_admin(header.type_, payload_len) {
+            if payload_len == 0 && is_rtnl_message_type(header.type_) {
+                if flags.contains(SegHdrCommonFlags::ACK) {
+                    send_route_ack(&header, None, local_port, netns.clone());
+                }
+                continue;
+            }
+
+            if rtnl_requires_net_admin(header.type_) {
                 if let Err(error) = context.require_net_admin() {
-                    send_route_error_ack(&header, error, local_port, netns.clone());
+                    send_route_ack(&header, Some(error), local_port, netns.clone());
                     continue;
                 }
             }
 
             if CSegmentType::try_from(header.type_).is_err() {
-                send_route_error_ack(
+                send_route_ack(
                     &header,
-                    SystemError::EOPNOTSUPP_OR_ENOTSUP,
+                    Some(SystemError::EOPNOTSUPP_OR_ENOTSUP),
                     local_port,
                     netns.clone(),
                 );
@@ -197,31 +204,33 @@ impl datagram_common::Bound for BoundNetlink<RouteNlMessage> {
 /// Mirrors Linux `rtnl_msgtype_kind()`: RTM message kinds repeat in groups of
 /// four as NEW, DEL, GET, SET. Every non-GET userspace request in Linux's RTM
 /// range requires CAP_NET_ADMIN, including message types DragonOS does not yet
-/// implement. A zero-length payload stays on the existing malformed-message
-/// path instead of changing its error ordering.
-fn rtnl_requires_net_admin(message_type: u16, payload_len: usize) -> bool {
-    const RTM_BASE: u16 = 16;
-    const RTM_MAX: u16 = 123;
+/// implement. Linux's zero-payload success path is handled before this helper.
+fn rtnl_requires_net_admin(message_type: u16) -> bool {
     const RTM_GET_KIND: u16 = 2;
 
-    payload_len != 0
-        && (RTM_BASE..=RTM_MAX).contains(&message_type)
-        && ((message_type - RTM_BASE) & 3) != RTM_GET_KIND
+    is_rtnl_message_type(message_type) && ((message_type - RTM_BASE) & 3) != RTM_GET_KIND
 }
 
-fn send_route_error_ack(
+const RTM_BASE: u16 = 16;
+const RTM_MAX: u16 = 123;
+
+fn is_rtnl_message_type(message_type: u16) -> bool {
+    (RTM_BASE..=RTM_MAX).contains(&message_type)
+}
+
+fn send_route_ack(
     request_header: &CMsgSegHdr,
-    error: SystemError,
+    error: Option<SystemError>,
     dst_port: u32,
     netns: Arc<NetNamespace>,
 ) {
     use crate::net::socket::netlink::route::message::segment::RouteNlSegment;
 
-    let err_segment = ErrorSegment::new_from_request(request_header, Some(error));
+    let err_segment = ErrorSegment::new_from_request(request_header, error);
     let err_msg = RouteNlMessage::new(vec![RouteNlSegment::Error(err_segment)]);
     if let Err(e) = NetlinkRouteProtocol::unicast(dst_port, err_msg, netns) {
         log::warn!(
-            "netlink route: failed to deliver error ack to port {}: {:?}",
+            "netlink route: failed to deliver ack to port {}: {:?}",
             dst_port,
             e
         );

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -13,7 +13,10 @@ use crate::{
             SupportedNetlinkProtocol,
         },
     },
-    process::namespace::net_namespace::NetNamespace,
+    process::{
+        cred::{CAPFlags, Cred},
+        namespace::net_namespace::NetNamespace,
+    },
 };
 use alloc::sync::Arc;
 use core::marker::PhantomData;
@@ -26,6 +29,60 @@ mod route;
 mod utils;
 
 pub(crate) use link::notify_link_change;
+
+/// Per-send authorization and routing state for userspace rtnetlink requests.
+///
+/// Linux checks both the sending task's credentials and, unless an explicit
+/// destination was supplied, the credentials captured when the socket was
+/// opened. Both checks target the user namespace that owns the socket netns.
+pub(super) struct RtnlRequestContext {
+    sender_cred: Arc<Cred>,
+    opener_cred: Arc<Cred>,
+    netns: Arc<NetNamespace>,
+    port_id: u32,
+    destination_is_explicit: bool,
+}
+
+impl RtnlRequestContext {
+    pub(super) fn new(
+        sender_cred: Arc<Cred>,
+        opener_cred: Arc<Cred>,
+        netns: Arc<NetNamespace>,
+        port_id: u32,
+        destination_is_explicit: bool,
+    ) -> Self {
+        Self {
+            sender_cred,
+            opener_cred,
+            netns,
+            port_id,
+            destination_is_explicit,
+        }
+    }
+
+    pub(super) fn require_net_admin(&self) -> Result<(), SystemError> {
+        let target_user_ns = self.netns.user_ns();
+        if (!self.destination_is_explicit
+            && !self
+                .opener_cred
+                .has_capability_in_ns(target_user_ns, CAPFlags::CAP_NET_ADMIN))
+            || !self
+                .sender_cred
+                .has_capability_in_ns(target_user_ns, CAPFlags::CAP_NET_ADMIN)
+        {
+            return Err(SystemError::EPERM);
+        }
+        Ok(())
+    }
+
+    pub(super) fn netns(&self) -> Arc<NetNamespace> {
+        self.netns.clone()
+    }
+
+    pub(super) fn port_id(&self) -> u32 {
+        self.port_id
+    }
+}
 
 /// 负责处理 Netlink 路由相关的内核模块
 /// 每个 net namespace 都有一个独立的 NetlinkRouteKernelSocket
@@ -41,12 +98,9 @@ impl NetlinkRouteKernelSocket {
         }
     }
 
-    pub(super) fn request(
-        &self,
-        request: &RouteNlMessage,
-        dst_port: u32,
-        netns: Arc<NetNamespace>,
-    ) {
+    pub(super) fn request(&self, request: &RouteNlMessage, context: &RtnlRequestContext) {
+        let dst_port = context.port_id();
+        let netns = context.netns();
         for segment in request.segments() {
             let header = segment.header();
 

--- a/kernel/src/net/socket/utils/datagram_common.rs
+++ b/kernel/src/net/socket/utils/datagram_common.rs
@@ -54,15 +54,22 @@ pub trait Bound {
         flags: PMSG,
     ) -> Result<(usize, usize, Self::Endpoint), SystemError>;
 
-    fn try_send(&self, buf: &[u8], to: &Self::Endpoint, flags: PMSG) -> Result<usize, SystemError>;
+    fn try_send(
+        &self,
+        buf: &[u8],
+        to: &Self::Endpoint,
+        flags: PMSG,
+        destination_is_explicit: bool,
+    ) -> Result<usize, SystemError>;
 
     fn try_send_vec(
         &self,
         buf: Vec<u8>,
         to: &Self::Endpoint,
         flags: PMSG,
+        destination_is_explicit: bool,
     ) -> Result<usize, SystemError> {
-        self.try_send(&buf, to, flags)
+        self.try_send(&buf, to, flags, destination_is_explicit)
     }
 
     fn check_io_events(&self) -> EPollEventType;

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -13,6 +13,7 @@ normal/mount_object_topology
 normal/mount_limit
 normal/open_dangling_symlink
 normal/rtnetlink_link_semantics
+normal/rtnetlink_permission_semantics
 normal/socket_getsockopt_semantics
 normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_permission_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_permission_semantics.cc
@@ -199,6 +199,14 @@ std::vector<uint8_t> BuildRequest(uint16_t type, uint16_t flags, uint32_t seq) {
     return request;
 }
 
+std::vector<uint8_t> BuildZeroPayloadRequest(uint16_t type, uint16_t flags, uint32_t seq) {
+    auto request = BuildRequest(type, flags, seq);
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    header->nlmsg_len = NLMSG_LENGTH(0);
+    request.resize(header->nlmsg_len);
+    return request;
+}
+
 int RecvAck(int fd, uint32_t seq) {
     std::array<uint8_t, 8192> buffer{};
     for (;;) {
@@ -295,6 +303,23 @@ TEST(RtnetlinkPermissionSemantics, GetDumpsRemainAvailableWithoutNetAdmin) {
             if (actual != 0) return Failure(2000 + type, actual);
         }
         return Success();
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, ZeroPayloadMutationsAreAcknowledgedBeforeAuthorization) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        auto request =
+            BuildZeroPayloadRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 250);
+        int actual = SendAndRecvAck(fd.Get(), request, false);
+        if (actual != 0) return Failure(3, actual);
+
+        request = BuildZeroPayloadRequest(kRtmNewQdisc, NLM_F_REQUEST | NLM_F_ACK, 251);
+        actual = SendAndRecvAck(fd.Get(), request, false);
+        return actual == 0 ? Success() : Failure(4, actual);
     });
 }
 

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_permission_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_permission_semantics.cc
@@ -1,0 +1,403 @@
+#include <gtest/gtest.h>
+
+#include <linux/capability.h>
+#include <linux/if_addr.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <sched.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kInvalidIfindex = 0x3fffffff;
+constexpr uint16_t kRtmNewQdisc = 36;
+constexpr uint16_t kRtmGetQdisc = 38;
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+struct ChildResult {
+    int stage;
+    int actual;
+};
+
+ChildResult Success() { return {0, 0}; }
+ChildResult Failure(int stage, int actual) { return {stage, actual}; }
+
+void ExpectChildSuccess(const std::function<ChildResult()>& child_fn) {
+    int pipe_fds[2];
+    ASSERT_EQ(0, pipe(pipe_fds)) << std::strerror(errno);
+
+    pid_t child = fork();
+    ASSERT_GE(child, 0) << std::strerror(errno);
+    if (child == 0) {
+        close(pipe_fds[0]);
+        const ChildResult result = child_fn();
+        const ssize_t ignored = write(pipe_fds[1], &result, sizeof(result));
+        (void)ignored;
+        close(pipe_fds[1]);
+        _exit(result.stage == 0 ? 0 : 1);
+    }
+
+    close(pipe_fds[1]);
+    ChildResult result{-1, 0};
+    const ssize_t bytes = read(pipe_fds[0], &result, sizeof(result));
+    close(pipe_fds[0]);
+
+    int status = 0;
+    ASSERT_EQ(child, waitpid(child, &status, 0));
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(result)), bytes);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(0, WEXITSTATUS(status)) << "stage=" << result.stage
+                                      << " actual_errno=" << result.actual << " ("
+                                      << std::strerror(result.actual) << ")";
+}
+
+int OpenRouteSocket() {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) return -1;
+
+    timeval timeout{};
+    timeout.tv_sec = 3;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+
+    sockaddr_nl local{};
+    local.nl_family = AF_NETLINK;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+bool GetCaps(__user_cap_data_struct data[2]) {
+    __user_cap_header_struct header{};
+    header.version = _LINUX_CAPABILITY_VERSION_3;
+    header.pid = 0;
+    return syscall(SYS_capget, &header, data) == 0;
+}
+
+bool SetCaps(const __user_cap_data_struct data[2]) {
+    __user_cap_header_struct header{};
+    header.version = _LINUX_CAPABILITY_VERSION_3;
+    header.pid = 0;
+    return syscall(SYS_capset, &header, data) == 0;
+}
+
+bool DropAllCapabilities() {
+    __user_cap_data_struct data[2]{};
+    return SetCaps(data);
+}
+
+bool SetNetAdminEffective(bool enabled) {
+    __user_cap_data_struct data[2]{};
+    if (!GetCaps(data)) return false;
+
+    constexpr uint32_t bit = uint32_t{1} << CAP_NET_ADMIN;
+    if ((data[0].permitted & bit) == 0) return false;
+    if (enabled) {
+        data[0].effective |= bit;
+    } else {
+        data[0].effective &= ~bit;
+    }
+    return SetCaps(data);
+}
+
+void AddAttr(std::vector<uint8_t>* request, uint16_t type, const void* data, size_t len) {
+    auto* header = reinterpret_cast<nlmsghdr*>(request->data());
+    const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
+    const size_t attr_len = RTA_LENGTH(len);
+    const size_t end = offset + RTA_ALIGN(attr_len);
+    request->resize(end, 0);
+
+    header = reinterpret_cast<nlmsghdr*>(request->data());
+    auto* attr = reinterpret_cast<rtattr*>(request->data() + offset);
+    attr->rta_type = type;
+    attr->rta_len = attr_len;
+    std::memcpy(RTA_DATA(attr), data, len);
+    header->nlmsg_len = end;
+}
+
+std::vector<uint8_t> BuildRequest(uint16_t type, uint16_t flags, uint32_t seq) {
+    size_t payload_len = 1;
+    if (type >= RTM_NEWLINK && type <= RTM_SETLINK) {
+        payload_len = sizeof(ifinfomsg);
+    } else if (type >= RTM_NEWADDR && type <= RTM_GETADDR) {
+        payload_len = sizeof(ifaddrmsg);
+    } else if ((type >= RTM_NEWROUTE && type <= RTM_GETROUTE) || type == RTM_GETRULE) {
+        payload_len = sizeof(rtmsg);
+    } else if (type >= RTM_NEWNEIGH && type <= RTM_GETNEIGH) {
+        payload_len = sizeof(ndmsg);
+    }
+
+    std::vector<uint8_t> request(NLMSG_SPACE(payload_len), 0);
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    header->nlmsg_len = NLMSG_LENGTH(payload_len);
+    header->nlmsg_type = type;
+    header->nlmsg_flags = flags;
+    header->nlmsg_seq = seq;
+
+    if (payload_len == sizeof(ifinfomsg)) {
+        auto* msg = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(header));
+        msg->ifi_family = AF_UNSPEC;
+        if (type != RTM_GETLINK) msg->ifi_index = kInvalidIfindex;
+    } else if (payload_len == sizeof(ifaddrmsg)) {
+        auto* msg = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(header));
+        msg->ifa_family = AF_INET;
+        if (type != RTM_GETADDR) msg->ifa_index = kInvalidIfindex;
+    } else if (payload_len == sizeof(rtmsg)) {
+        auto* msg = reinterpret_cast<rtmsg*>(NLMSG_DATA(header));
+        msg->rtm_family = AF_INET;
+        msg->rtm_table = RT_TABLE_MAIN;
+        msg->rtm_protocol = RTPROT_STATIC;
+        msg->rtm_scope = RT_SCOPE_LINK;
+        msg->rtm_type = RTN_UNICAST;
+    } else if (payload_len == sizeof(ndmsg)) {
+        auto* msg = reinterpret_cast<ndmsg*>(NLMSG_DATA(header));
+        msg->ndm_family = AF_INET;
+        if (type != RTM_GETNEIGH) msg->ndm_ifindex = kInvalidIfindex;
+    } else {
+        *reinterpret_cast<uint8_t*>(NLMSG_DATA(header)) = AF_UNSPEC;
+    }
+
+    request.resize(header->nlmsg_len);
+    if (type == RTM_NEWROUTE || type == RTM_DELROUTE) {
+        const uint32_t oif = kInvalidIfindex;
+        AddAttr(&request, RTA_OIF, &oif, sizeof(oif));
+    }
+    return request;
+}
+
+int RecvAck(int fd, uint32_t seq) {
+    std::array<uint8_t, 8192> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq || header->nlmsg_type != NLMSG_ERROR) continue;
+            const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+            return error->error == 0 ? 0 : -error->error;
+        }
+    }
+}
+
+int SendAndRecvAck(int fd, const std::vector<uint8_t>& request, bool explicit_destination) {
+    ssize_t sent = -1;
+    if (explicit_destination) {
+        sockaddr_nl kernel{};
+        kernel.nl_family = AF_NETLINK;
+        iovec iov{};
+        iov.iov_base = const_cast<uint8_t*>(request.data());
+        iov.iov_len = request.size();
+        msghdr msg{};
+        msg.msg_name = &kernel;
+        msg.msg_namelen = sizeof(kernel);
+        msg.msg_iov = &iov;
+        msg.msg_iovlen = 1;
+        sent = sendmsg(fd, &msg, 0);
+    } else {
+        sent = send(fd, request.data(), request.size(), 0);
+    }
+    if (sent != static_cast<ssize_t>(request.size())) return errno;
+    return RecvAck(fd, reinterpret_cast<const nlmsghdr*>(request.data())->nlmsg_seq);
+}
+
+bool IsPostAuthorizationError(int error) { return error == EINVAL || error == EOPNOTSUPP; }
+
+int SendDumpAndWaitDone(int fd, uint16_t type, uint32_t seq) {
+    const auto request = BuildRequest(type, NLM_F_REQUEST | NLM_F_DUMP, seq);
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? 0 : -error->error;
+            }
+        }
+    }
+}
+
+TEST(RtnetlinkPermissionSemantics, AllSupportedMutationClassesRequireNetAdmin) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        constexpr uint16_t types[] = {RTM_NEWLINK,  RTM_DELLINK,  RTM_SETLINK,
+                                      RTM_NEWADDR,  RTM_DELADDR,  RTM_NEWROUTE,
+                                      RTM_DELROUTE, RTM_NEWNEIGH, RTM_DELNEIGH};
+        uint32_t seq = 100;
+        for (uint16_t type : types) {
+            const auto request = BuildRequest(type, NLM_F_REQUEST | NLM_F_ACK, seq++);
+            const int actual = SendAndRecvAck(fd.Get(), request, false);
+            if (actual != EPERM) return Failure(1000 + type, actual);
+        }
+        return Success();
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, GetDumpsRemainAvailableWithoutNetAdmin) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        constexpr uint16_t types[] = {RTM_GETLINK, RTM_GETADDR, RTM_GETROUTE, RTM_GETNEIGH,
+                                      RTM_GETRULE};
+        uint32_t seq = 200;
+        for (uint16_t type : types) {
+            const int actual = SendDumpAndWaitDone(fd.Get(), type, seq++);
+            if (actual != 0) return Failure(2000 + type, actual);
+        }
+        return Success();
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, PrivilegedOpenerDoesNotAuthorizeSenderAfterCapabilityDrop) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        const auto request = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 300);
+        const int actual = SendAndRecvAck(fd.Get(), request, false);
+        return actual == EPERM ? Success() : Failure(3, actual);
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, ExplicitDestinationBypassesOnlyOpenerCapabilityCheck) {
+    ExpectChildSuccess([] {
+        if (!SetNetAdminEffective(false)) return Failure(1, errno);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(2, errno);
+        if (!SetNetAdminEffective(true)) return Failure(3, errno);
+
+        const auto implicit = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 400);
+        int actual = SendAndRecvAck(fd.Get(), implicit, false);
+        if (actual != EPERM) return Failure(4, actual);
+
+        const auto explicit_request = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 401);
+        actual = SendAndRecvAck(fd.Get(), explicit_request, true);
+        if (actual != ENODEV) return Failure(5, actual);
+
+        if (!DropAllCapabilities()) return Failure(6, errno);
+        const auto unprivileged_explicit =
+            BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 402);
+        actual = SendAndRecvAck(fd.Get(), unprivileged_explicit, true);
+        return actual == EPERM ? Success() : Failure(7, actual);
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, UsesOwningUserNamespaceOfSocketNetns) {
+    ExpectChildSuccess([] {
+        if (unshare(CLONE_NEWUSER) != 0) return Failure(1, errno);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(2, errno);
+        const auto request = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 500);
+        const int actual = SendAndRecvAck(fd.Get(), request, false);
+        return actual == EPERM ? Success() : Failure(3, actual);
+    });
+
+    ExpectChildSuccess([] {
+        if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return Failure(1, errno);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(2, errno);
+        const auto request = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 501);
+        const int actual = SendAndRecvAck(fd.Get(), request, false);
+        return actual == ENODEV ? Success() : Failure(3, actual);
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, UnsupportedRtmTypesUseLinuxPermissionOrdering) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+
+        auto request = BuildRequest(kRtmNewQdisc, NLM_F_REQUEST | NLM_F_ACK, 600);
+        int actual = SendAndRecvAck(fd.Get(), request, false);
+        if (!IsPostAuthorizationError(actual)) return Failure(2, actual);
+
+        if (!DropAllCapabilities()) return Failure(3, errno);
+        request = BuildRequest(kRtmNewQdisc, NLM_F_REQUEST | NLM_F_ACK, 601);
+        actual = SendAndRecvAck(fd.Get(), request, false);
+        if (actual != EPERM) return Failure(4, actual);
+
+        request = BuildRequest(kRtmGetQdisc, NLM_F_REQUEST | NLM_F_ACK, 602);
+        actual = SendAndRecvAck(fd.Get(), request, false);
+        return IsPostAuthorizationError(actual) ? Success() : Failure(5, actual);
+    });
+}
+
+TEST(RtnetlinkPermissionSemantics, BatchedMutationsAreIndependentlyRejected) {
+    ExpectChildSuccess([] {
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        auto first = BuildRequest(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, 700);
+        auto second = BuildRequest(RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, 701);
+        std::vector<uint8_t> batch(NLMSG_ALIGN(first.size()) + second.size(), 0);
+        std::memcpy(batch.data(), first.data(), first.size());
+        std::memcpy(batch.data() + NLMSG_ALIGN(first.size()), second.data(), second.size());
+
+        if (send(fd.Get(), batch.data(), batch.size(), 0) != static_cast<ssize_t>(batch.size())) {
+            return Failure(3, errno);
+        }
+        int actual = RecvAck(fd.Get(), 700);
+        if (actual != EPERM) return Failure(4, actual);
+        actual = RecvAck(fd.Get(), 701);
+        return actual == EPERM ? Success() : Failure(5, actual);
+    });
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -105,6 +105,7 @@ normal/perf_bpf_mmap
 normal/af_packet_e2e
 normal/af_packet_mcast
 normal/rtnetlink_link_semantics
+normal/rtnetlink_permission_semantics
 normal/tty_termios
 normal/inotify_dir_watch
 normal/inotify_events


### PR DESCRIPTION
## Summary

- capture immutable netlink socket opener credentials and per-send sender credentials
- propagate explicit-destination metadata to match Linux `NETLINK_SKB_DST` semantics
- require `CAP_NET_ADMIN` for every non-GET message in the Linux rtnetlink range
- authorize against the user namespace owning the socket network namespace
- return per-message `EPERM` acknowledgements before handler or attribute parsing
- add regression coverage for mutation classes, GET dumps, credential changes, user/network namespaces, unsupported RTM types, and batched requests

Part of #2233 (PR-01).

## Validation

- `make kernel`
- Linux host: `rtnetlink_permission_semantics_test` — 7/7 passed
- DragonOS QEMU: `rtnetlink_permission_semantics_test` — 7/7 passed
- DragonOS QEMU: `rtnetlink_link_semantics_test` — 1/1 passed
- DragonOS QEMU: `rtnetlink_route_semantics_test` — 5/5 passed
- DragonOS QEMU existing C rtnetlink tests: link, address, route, and neighbor passed
- normal boot smoke check completed; existing kernel DHCP startup remained functional