### PR TITLE
refactor(net): serialize network control mutations with RTNL

### DIFF
--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -10,6 +10,7 @@ pub mod neighbor;
 pub mod net_core;
 pub mod posix;
 pub mod routing;
+mod rtnl;
 pub mod socket;
 pub mod syscall;
 pub mod tcp_close_defer;

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -10,6 +10,14 @@ use crate::{
     time::{sleep::nanosleep, PosixTimeSpec},
 };
 
+enum DhcpControlEvent {
+    Configured {
+        address: wire::Ipv4Cidr,
+        router: Option<wire::Ipv4Address>,
+    },
+    Deconfigured,
+}
+
 pub fn net_init() -> Result<(), SystemError> {
     KernelThreadMechanism::create_and_run(
         KernelThreadClosure::StaticEmptyClosure((&(dhcp_worker as fn() -> i32), ())),
@@ -64,22 +72,37 @@ fn dhcp_query() -> Result<(), SystemError> {
     for i in 0..DHCP_TRY_ROUND {
         log::debug!("DHCP try round: {}", i);
         net_face.poll();
-        let mut binding = sockets();
-        let event = binding.get_mut::<dhcpv4::Socket>(dhcp_handle).poll();
+        let event = {
+            let mut binding = sockets();
+            binding
+                .get_mut::<dhcpv4::Socket>(dhcp_handle)
+                .poll()
+                .map(|event| match event {
+                    dhcpv4::Event::Configured(config) => DhcpControlEvent::Configured {
+                        address: config.address,
+                        router: config.router,
+                    },
+                    dhcpv4::Event::Deconfigured => DhcpControlEvent::Deconfigured,
+                })
+        };
 
         match event {
             None => {}
 
-            Some(dhcpv4::Event::Configured(config)) => {
+            Some(DhcpControlEvent::Configured { address, router }) => {
+                // The DHCP socket guard is released before RTNL. Lease commits
+                // share the same global serialization domain as userspace
+                // rtnetlink mutations without extending it over DHCP polling.
+                let _rtnl_guard = crate::net::rtnl::lock();
                 // debug!("Find Config!! {config:?}");
                 // debug!("Find ip address: {}", config.address);
                 // debug!("iface.ip_addrs={:?}", net_face.inner_iface.ip_addrs());
 
                 net_face
-                    .update_ip_addrs(&[wire::IpCidr::Ipv4(config.address)])
+                    .update_ip_addrs(&[wire::IpCidr::Ipv4(address)])
                     .ok();
 
-                if let Some(router) = config.router {
+                if let Some(router) = router {
                     let mut smol_iface = net_face.smol_iface().lock();
                     smol_iface.routes_mut().update(|table| {
                         let _ = table.push(smoltcp::iface::Route {
@@ -115,7 +138,8 @@ fn dhcp_query() -> Result<(), SystemError> {
                 }
             }
 
-            Some(dhcpv4::Event::Deconfigured) => {
+            Some(DhcpControlEvent::Deconfigured) => {
+                let _rtnl_guard = crate::net::rtnl::lock();
                 log::debug!("Dhcp v4 deconfigured");
                 net_face
                     .update_ip_addrs(&[smoltcp::wire::IpCidr::Ipv4(wire::Ipv4Cidr::new(
@@ -130,9 +154,6 @@ fn dhcp_query() -> Result<(), SystemError> {
                     .remove_default_ipv4_route();
             }
         }
-        // 在睡眠前释放锁
-        drop(binding);
-
         let sleep_time = PosixTimeSpec {
             tv_sec: 0,
             tv_nsec: DHCP_RETRY_INTERVAL_NS,

--- a/kernel/src/net/rtnl.rs
+++ b/kernel/src/net/rtnl.rs
@@ -1,0 +1,26 @@
+//! Global serialization for the network control plane.
+//!
+//! RTNL is a sleeping lock. It may only be acquired from process-context
+//! control paths; hardirq, NAPI, and packet data paths must never acquire it.
+//!
+//! Lock ordering for control operations starts with RTNL, followed by netns
+//! topology, interface/control state, data-plane state, and finally netlink
+//! notification queues. Notification helpers must not acquire RTNL
+//! recursively.
+
+use crate::libs::mutex::{Mutex, MutexGuard};
+
+static RTNL_MUTEX: Mutex<()> = Mutex::new(());
+
+/// RAII proof that the global network control-plane lock is held.
+#[must_use = "the RTNL guard must be held for the complete control operation"]
+pub(in crate::net) struct RtnlGuard {
+    _guard: MutexGuard<'static, ()>,
+}
+
+/// Acquires the global network control-plane lock.
+pub(in crate::net) fn lock() -> RtnlGuard {
+    RtnlGuard {
+        _guard: RTNL_MUTEX.lock(),
+    }
+}

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -80,17 +80,20 @@ pub(super) fn do_new_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let (iface, cidr, changed) = add_addr(request_segment, netns.clone())?;
+    let iface = lookup_iface_by_index(request_segment, netns.clone())?;
+    let cidr = parse_cidr(request_segment)?;
+    let notification = addr_to_segment(
+        &kernel_notify_header(CSegmentType::NEWADDR),
+        &iface,
+        cidr,
+        CSegmentType::NEWADDR,
+    )?;
+    let changed = add_addr(request_segment, &iface, cidr)?;
     if changed {
         multicast_notify(
             netns,
             addr_notify_group(cidr.address()),
-            RouteNlSegment::NewAddr(addr_to_segment(
-                &kernel_notify_header(CSegmentType::NEWADDR),
-                &iface,
-                cidr,
-                CSegmentType::NEWADDR,
-            )?),
+            RouteNlSegment::NewAddr(notification),
         );
     }
     Ok(Vec::new())
@@ -100,26 +103,28 @@ pub(super) fn do_del_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let (iface, cidr) = del_addr(request_segment, netns.clone())?;
+    let iface = lookup_iface_by_index(request_segment, netns.clone())?;
+    let cidr = parse_cidr(request_segment)?;
+    let notification = addr_to_segment(
+        &kernel_notify_header(CSegmentType::DELADDR),
+        &iface,
+        cidr,
+        CSegmentType::DELADDR,
+    )?;
+    del_addr(&iface, cidr)?;
     multicast_notify(
         netns,
         addr_notify_group(cidr.address()),
-        RouteNlSegment::DelAddr(addr_to_segment(
-            &kernel_notify_header(CSegmentType::DELADDR),
-            &iface,
-            cidr,
-            CSegmentType::DELADDR,
-        )?),
+        RouteNlSegment::DelAddr(notification),
     );
     Ok(Vec::new())
 }
 
 fn add_addr(
     request_segment: &AddrSegment,
-    netns: Arc<NetNamespace>,
-) -> Result<(Arc<dyn Iface>, IpCidr, bool), SystemError> {
-    let iface = lookup_iface_by_index(request_segment, netns)?;
-    let cidr = parse_cidr(request_segment)?;
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+) -> Result<bool, SystemError> {
     let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
 
     let mut exists = false;
@@ -144,7 +149,7 @@ fn add_addr(
 
     if exists {
         if flags.contains(NewRequestFlags::REPLACE) {
-            return Ok((iface, cidr, false));
+            return Ok(false);
         }
         return Err(SystemError::EEXIST);
     }
@@ -153,23 +158,17 @@ fn add_addr(
         return Err(SystemError::ENOSPC);
     }
 
-    if let Err(err) = add_local_route(&iface, cidr) {
-        rollback_added_addr(&iface, cidr);
+    if let Err(err) = add_local_route(iface, cidr) {
+        rollback_added_addr(iface, cidr);
         return Err(err);
     }
 
-    sync_router_ip_addrs(&iface);
+    sync_router_ip_addrs(iface);
 
-    Ok((iface, cidr, true))
+    Ok(true)
 }
 
-fn del_addr(
-    request_segment: &AddrSegment,
-    netns: Arc<NetNamespace>,
-) -> Result<(Arc<dyn Iface>, IpCidr), SystemError> {
-    let iface = lookup_iface_by_index(request_segment, netns)?;
-    let cidr = parse_cidr(request_segment)?;
-
+fn del_addr(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemError> {
     let mut removed = false;
 
     iface.smol_iface().lock().update_ip_addrs(|ip_addrs| {
@@ -183,10 +182,10 @@ fn del_addr(
         return Err(SystemError::EADDRNOTAVAIL);
     }
 
-    remove_local_route(&iface, cidr);
-    sync_router_ip_addrs(&iface);
+    remove_local_route(iface, cidr);
+    sync_router_ip_addrs(iface);
 
-    Ok((iface, cidr))
+    Ok(())
 }
 
 fn lookup_iface_by_index(

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -4,7 +4,6 @@ use crate::{
         types::{InterfaceFlags, InterfaceType},
         Iface, Operstate,
     },
-    libs::mutex::Mutex,
     net::socket::{
         netlink::{
             message::segment::{
@@ -33,16 +32,6 @@ use alloc::sync::Arc;
 use alloc::vec::Vec;
 use core::num::NonZero;
 use system_error::SystemError;
-
-lazy_static! {
-    /// Serialize RTM_SETLINK transactions through flag publication, operstate,
-    /// timer rearm, rename/MTU updates, and notification.
-    ///
-    /// Linux provides this boundary with RTNL. DragonOS does not yet expose a
-    /// general RTNL lock, so link mutation owns the smallest equivalent
-    /// serialization point here.
-    static ref RTNL_LINK_LOCK: Mutex<()> = Mutex::new(());
-}
 
 pub(super) fn do_get_link(
     request_segment: &LinkSegment,
@@ -208,7 +197,6 @@ pub(super) fn do_set_link(
     request_segment: &LinkSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let _rtnl_guard = RTNL_LINK_LOCK.lock();
     let iface = find_iface_for_setlink(request_segment, netns.clone())?;
     let updates = validate_setlink_request(request_segment, iface.as_ref())?;
 

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -120,28 +120,13 @@ impl NetlinkRouteKernelSocket {
             let request_flags = SegHdrCommonFlags::from_bits_truncate(header.flags);
             let need_ack = request_flags.contains(SegHdrCommonFlags::ACK);
 
-            let response_segments = match segment {
-                RouteNlSegment::GetAddr(request) => addr::do_get_addr(request, netns.clone()),
-                RouteNlSegment::NewAddr(request) => addr::do_new_addr(request, netns.clone()),
-                RouteNlSegment::DelAddr(request) => addr::do_del_addr(request, netns.clone()),
-                RouteNlSegment::GetLink(request) => link::do_get_link(request, netns.clone()),
-                RouteNlSegment::SetLink(request) if seg_type == CSegmentType::DELLINK => {
-                    link::do_del_link(request, netns.clone())
-                }
-                RouteNlSegment::SetLink(request) => link::do_set_link(request, netns.clone()),
-                RouteNlSegment::GetRoute(request) if seg_type == CSegmentType::GETRULE => {
-                    route::do_get_rule(request, netns.clone())
-                }
-                RouteNlSegment::GetRoute(request) => route::do_get_route(request, netns.clone()),
-                RouteNlSegment::NewRoute(request) => route::do_new_route(request, netns.clone()),
-                RouteNlSegment::DelRoute(request) => route::do_del_route(request, netns.clone()),
-                RouteNlSegment::NewNeigh(request) => neigh::do_new_neigh(request, netns.clone()),
-                RouteNlSegment::GetNeigh(request) => neigh::do_get_neigh(request, netns.clone()),
-                RouteNlSegment::DelNeigh(request) => neigh::do_del_neigh(request, netns.clone()),
-                _ => {
-                    log::warn!("Unsupported route request segment type: {:?}", seg_type);
-                    Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
-                }
+            let response_segments = {
+                // Linux runs regular rtnetlink doit and dump handlers under
+                // RTNL unless a handler is explicitly registered as unlocked.
+                // Keep response delivery outside this scope so ACKs cannot
+                // extend the global control-plane critical section.
+                let _rtnl_guard = crate::net::rtnl::lock();
+                dispatch_request(segment, seg_type, netns.clone())
             };
 
             let response = match response_segments {
@@ -168,6 +153,36 @@ impl NetlinkRouteKernelSocket {
                     e
                 );
             }
+        }
+    }
+}
+
+fn dispatch_request(
+    segment: &RouteNlSegment,
+    seg_type: CSegmentType,
+    netns: Arc<NetNamespace>,
+) -> Result<alloc::vec::Vec<RouteNlSegment>, SystemError> {
+    match segment {
+        RouteNlSegment::GetAddr(request) => addr::do_get_addr(request, netns),
+        RouteNlSegment::NewAddr(request) => addr::do_new_addr(request, netns),
+        RouteNlSegment::DelAddr(request) => addr::do_del_addr(request, netns),
+        RouteNlSegment::GetLink(request) => link::do_get_link(request, netns),
+        RouteNlSegment::SetLink(request) if seg_type == CSegmentType::DELLINK => {
+            link::do_del_link(request, netns)
+        }
+        RouteNlSegment::SetLink(request) => link::do_set_link(request, netns),
+        RouteNlSegment::GetRoute(request) if seg_type == CSegmentType::GETRULE => {
+            route::do_get_rule(request, netns)
+        }
+        RouteNlSegment::GetRoute(request) => route::do_get_route(request, netns),
+        RouteNlSegment::NewRoute(request) => route::do_new_route(request, netns),
+        RouteNlSegment::DelRoute(request) => route::do_del_route(request, netns),
+        RouteNlSegment::NewNeigh(request) => neigh::do_new_neigh(request, netns),
+        RouteNlSegment::GetNeigh(request) => neigh::do_get_neigh(request, netns),
+        RouteNlSegment::DelNeigh(request) => neigh::do_del_neigh(request, netns),
+        _ => {
+            log::warn!("Unsupported route request segment type: {:?}", seg_type);
+            Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
         }
     }
 }

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -142,33 +142,30 @@ pub(super) fn do_new_route(
         return Err(SystemError::EEXIST);
     }
 
+    let notification = route_to_segment(
+        &kernel_notify_header(CSegmentType::NEWROUTE),
+        CSegmentType::NEWROUTE,
+        &iface,
+        RouteView {
+            destination: parsed.destination,
+            source: parsed.source,
+            gateway: parsed.gateway,
+            priority: parsed.priority,
+            table,
+            protocol: request_segment.body().protocol as u8,
+            scope: request_segment.body().scope as u8,
+            kind: request_segment.body().type_ as u8,
+            flags: RouteFlags::empty(),
+        },
+    )?;
+
+    sync_iface_route_table(&iface, &parsed)?;
     iface.common().upsert_netlink_route(entry);
 
-    if let Err(err) = sync_iface_route_table(&iface, &parsed) {
-        iface
-            .common()
-            .remove_netlink_route(parsed.destination, parsed.source, table);
-        return Err(err);
-    }
     multicast_notify(
         netns,
         route_notify_group(parsed.destination.address()),
-        RouteNlSegment::NewRoute(route_to_segment(
-            &kernel_notify_header(CSegmentType::NEWROUTE),
-            CSegmentType::NEWROUTE,
-            &iface,
-            RouteView {
-                destination: parsed.destination,
-                source: parsed.source,
-                gateway: parsed.gateway,
-                priority: parsed.priority,
-                table,
-                protocol: request_segment.body().protocol as u8,
-                scope: request_segment.body().scope as u8,
-                kind: request_segment.body().type_ as u8,
-                flags: RouteFlags::empty(),
-            },
-        )?),
+        RouteNlSegment::NewRoute(notification),
     );
     Ok(Vec::new())
 }
@@ -185,6 +182,22 @@ pub(super) fn do_del_route(
         .ok_or(SystemError::ENODEV)?;
 
     let table = effective_route_table(parsed.table);
+    let notification = route_to_segment(
+        &kernel_notify_header(CSegmentType::DELROUTE),
+        CSegmentType::DELROUTE,
+        &iface,
+        RouteView {
+            destination: parsed.destination,
+            source: parsed.source,
+            gateway: parsed.gateway,
+            priority: parsed.priority,
+            table,
+            protocol: request_segment.body().protocol as u8,
+            scope: request_segment.body().scope as u8,
+            kind: request_segment.body().type_ as u8,
+            flags: RouteFlags::empty(),
+        },
+    )?;
     if !iface
         .common()
         .remove_netlink_route(parsed.destination, parsed.source, table)
@@ -202,22 +215,7 @@ pub(super) fn do_del_route(
     multicast_notify(
         netns,
         route_notify_group(parsed.destination.address()),
-        RouteNlSegment::DelRoute(route_to_segment(
-            &kernel_notify_header(CSegmentType::DELROUTE),
-            CSegmentType::DELROUTE,
-            &iface,
-            RouteView {
-                destination: parsed.destination,
-                source: parsed.source,
-                gateway: parsed.gateway,
-                priority: parsed.priority,
-                table,
-                protocol: request_segment.body().protocol as u8,
-                scope: request_segment.body().scope as u8,
-                kind: request_segment.body().type_ as u8,
-                flags: RouteFlags::empty(),
-            },
-        )?),
+        RouteNlSegment::DelRoute(notification),
     );
     Ok(Vec::new())
 }
@@ -440,21 +438,36 @@ fn sync_iface_route_table(
     iface: &Arc<dyn Iface>,
     route: &ParsedRouteRequest,
 ) -> Result<(), SystemError> {
+    let new_route = smoltcp::iface::Route {
+        cidr: route.destination,
+        via_router: route.gateway,
+        preferred_until: None,
+        expires_at: None,
+    };
     let mut push_failed = false;
     iface.smol_iface().lock().routes_mut().update(|routes| {
-        routes.retain(|existing| {
-            existing.cidr != route.destination || is_local_connected_route(iface, existing)
-        });
+        // Replacing in place cannot fail when the fixed-capacity table is full.
+        // Canonicalize legacy duplicates while preserving connected routes.
+        let mut first_match = None;
+        let mut index = 0;
+        while index < routes.len() {
+            let replaceable = routes[index].cidr == route.destination
+                && !is_local_connected_route(iface, &routes[index]);
+            if !replaceable {
+                index += 1;
+                continue;
+            }
 
-        if routes
-            .push(smoltcp::iface::Route {
-                cidr: route.destination,
-                via_router: route.gateway,
-                preferred_until: None,
-                expires_at: None,
-            })
-            .is_err()
-        {
+            if first_match.is_none() {
+                routes[index] = new_route;
+                first_match = Some(index);
+                index += 1;
+            } else {
+                routes.remove(index);
+            }
+        }
+
+        if first_match.is_none() && routes.push(new_route).is_err() {
             push_failed = true;
         }
     });

--- a/kernel/src/net/socket/packet/binding.rs
+++ b/kernel/src/net/socket/packet/binding.rs
@@ -80,8 +80,11 @@ impl PacketSocket {
     }
 
     pub(super) fn close_binding(&self) -> Result<(), SystemError> {
+        let rtnl_guard = crate::net::rtnl::lock();
         let _guard = self.bind_lock.lock();
-        self.revert_all_memberships();
+        self.revert_all_memberships(&rtnl_guard);
+        drop(rtnl_guard);
+
         self.netns.unregister_packet_socket(&self.self_ref);
         *self.bound_iface.write() = None;
         self.binding.store(0, 0);

--- a/kernel/src/net/socket/packet/mreq.rs
+++ b/kernel/src/net/socket/packet/mreq.rs
@@ -28,6 +28,7 @@ fn mreq_match(a: &PacketMreq, b: &PacketMreq) -> bool {
 impl super::PacketSocket {
     pub(super) fn add_membership(&self, value: &[u8]) -> Result<(), SystemError> {
         let mreq = parse_mreq(value)?;
+        let _rtnl_guard = crate::net::rtnl::lock();
         let iface = self.find_iface(mreq.mr_ifindex as u32)?;
         validate_add_mreq(&mreq, iface.mac().as_bytes().len())?;
 
@@ -58,6 +59,7 @@ impl super::PacketSocket {
     pub(super) fn drop_membership(&self, value: &[u8]) -> Result<(), SystemError> {
         let mreq = parse_mreq(value)?;
 
+        let _rtnl_guard = crate::net::rtnl::lock();
         let mut state = self.memberships.lock();
         let Some(pos) = state
             .entries
@@ -83,7 +85,7 @@ impl super::PacketSocket {
         Ok(())
     }
 
-    pub(crate) fn revert_all_memberships(&self) {
+    pub(super) fn revert_all_memberships(&self, _rtnl_guard: &crate::net::rtnl::RtnlGuard) {
         let entries = {
             let mut state = self.memberships.lock();
             state.closed = true;

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -14,6 +14,7 @@ normal/mount_limit
 normal/open_dangling_symlink
 normal/rtnetlink_link_semantics
 normal/rtnetlink_permission_semantics
+normal/rtnetlink_serialization_semantics
 normal/socket_getsockopt_semantics
 normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_serialization_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_serialization_semantics.cc
@@ -1,0 +1,709 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <linux/if_addr.h>
+#include <linux/neighbour.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <sched.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <atomic>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <thread>
+#include <vector>
+
+namespace {
+
+constexpr int kWorkerIterations = 8;
+constexpr int kExclusiveRaceRounds = 8;
+constexpr int kExclusiveRaceWorkers = 4;
+constexpr int kMaxRouteFillAttempts = 32;
+constexpr int kCapacityNotReached = -2;
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+struct RouteSpec {
+    uint32_t dst;
+    uint8_t prefix_len;
+    uint32_t ifindex;
+    uint8_t table = RT_TABLE_MAIN;
+    uint32_t source = 0;
+    uint8_t source_prefix_len = 0;
+};
+
+struct ChildOutcome {
+    bool timed_out;
+    int exit_status;
+    int stage;
+};
+
+uint32_t Ipv4(const std::string& text) {
+    in_addr address{};
+    if (inet_pton(AF_INET, text.c_str(), &address) != 1) return 0;
+    return address.s_addr;
+}
+
+int OpenRouteSocket(uint32_t groups = 0) {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) return -1;
+
+    timeval timeout{};
+    timeout.tv_sec = 2;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+
+    sockaddr_nl local{};
+    local.nl_family = AF_NETLINK;
+    local.nl_groups = groups;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+void AddAttr(std::vector<uint8_t>* request, uint16_t type, const void* data, size_t len) {
+    auto* header = reinterpret_cast<nlmsghdr*>(request->data());
+    const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
+    const size_t attr_len = RTA_LENGTH(len);
+    const size_t end = offset + RTA_ALIGN(attr_len);
+    request->resize(end, 0);
+
+    header = reinterpret_cast<nlmsghdr*>(request->data());
+    auto* attr = reinterpret_cast<rtattr*>(request->data() + offset);
+    attr->rta_type = type;
+    attr->rta_len = attr_len;
+    std::memcpy(RTA_DATA(attr), data, len);
+    header->nlmsg_len = end;
+}
+
+template <typename Body>
+std::vector<uint8_t> NewRequest(uint16_t type, uint16_t flags, uint32_t seq) {
+    std::vector<uint8_t> request(NLMSG_SPACE(sizeof(Body)), 0);
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    header->nlmsg_len = NLMSG_LENGTH(sizeof(Body));
+    header->nlmsg_type = type;
+    header->nlmsg_flags = flags;
+    header->nlmsg_seq = seq;
+    request.resize(header->nlmsg_len);
+    return request;
+}
+
+int RecvAck(int fd, uint32_t seq) {
+    std::array<uint8_t, 8192> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq || header->nlmsg_type != NLMSG_ERROR) continue;
+            const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+            return error->error == 0 ? 0 : -error->error;
+        }
+    }
+}
+
+int SendAndRecvAck(int fd, const std::vector<uint8_t>& request) {
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+    return RecvAck(fd, reinterpret_cast<const nlmsghdr*>(request.data())->nlmsg_seq);
+}
+
+int SetLinkUp(int fd, uint32_t ifindex, uint32_t seq) {
+    auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, seq);
+    auto* link = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
+    link->ifi_family = AF_UNSPEC;
+    link->ifi_index = static_cast<int>(ifindex);
+    link->ifi_flags = IFF_UP;
+    link->ifi_change = IFF_UP;
+    return SendAndRecvAck(fd, request);
+}
+
+int RenameLink(int fd, uint32_t ifindex, const char* name, uint32_t seq) {
+    auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, seq);
+    auto* link = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
+    link->ifi_family = AF_UNSPEC;
+    link->ifi_index = static_cast<int>(ifindex);
+    AddAttr(&request, IFLA_IFNAME, name, std::strlen(name) + 1);
+    return SendAndRecvAck(fd, request);
+}
+
+int ChangeAddress(int fd, uint16_t type, uint16_t flags, uint32_t ifindex, uint32_t address,
+                  uint8_t prefix_len, uint32_t seq) {
+    auto request = NewRequest<ifaddrmsg>(type, flags, seq);
+    auto* addr = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()));
+    addr->ifa_family = AF_INET;
+    addr->ifa_prefixlen = prefix_len;
+    addr->ifa_scope = RT_SCOPE_HOST;
+    addr->ifa_index = ifindex;
+    AddAttr(&request, IFA_LOCAL, &address, sizeof(address));
+    AddAttr(&request, IFA_ADDRESS, &address, sizeof(address));
+    return SendAndRecvAck(fd, request);
+}
+
+int ChangeRoute(int fd, uint16_t type, uint16_t flags, const RouteSpec& route, uint32_t seq) {
+    auto request = NewRequest<rtmsg>(type, flags, seq);
+    auto* message = reinterpret_cast<rtmsg*>(NLMSG_DATA(request.data()));
+    message->rtm_family = AF_INET;
+    message->rtm_dst_len = route.prefix_len;
+    message->rtm_src_len = route.source_prefix_len;
+    message->rtm_table = route.table;
+    message->rtm_protocol = RTPROT_STATIC;
+    message->rtm_scope = RT_SCOPE_LINK;
+    message->rtm_type = RTN_UNICAST;
+    AddAttr(&request, RTA_DST, &route.dst, sizeof(route.dst));
+    AddAttr(&request, RTA_OIF, &route.ifindex, sizeof(route.ifindex));
+    if (route.source_prefix_len != 0) {
+        AddAttr(&request, RTA_SRC, &route.source, sizeof(route.source));
+    }
+    return SendAndRecvAck(fd, request);
+}
+
+int ReplaceNeighbour(int fd, uint32_t ifindex, uint32_t destination, uint32_t seq) {
+    auto request = NewRequest<ndmsg>(
+        RTM_NEWNEIGH, NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE, seq);
+    auto* neighbour = reinterpret_cast<ndmsg*>(NLMSG_DATA(request.data()));
+    neighbour->ndm_family = AF_INET;
+    neighbour->ndm_ifindex = static_cast<int>(ifindex);
+    neighbour->ndm_state = NUD_PERMANENT;
+    const uint8_t mac[6] = {0x02, 0x00, 0x00, 0x00, 0x02, 0x23};
+    AddAttr(&request, NDA_DST, &destination, sizeof(destination));
+    AddAttr(&request, NDA_LLADDR, mac, sizeof(mac));
+    return SendAndRecvAck(fd, request);
+}
+
+bool MessageContainsRoute(const nlmsghdr* header, const RouteSpec& route) {
+    if (header->nlmsg_type != RTM_NEWROUTE && header->nlmsg_type != RTM_DELROUTE) return false;
+    const auto* message = reinterpret_cast<const rtmsg*>(NLMSG_DATA(header));
+    if (message->rtm_family != AF_INET || message->rtm_dst_len != route.prefix_len ||
+        message->rtm_table != route.table || message->rtm_src_len != route.source_prefix_len) {
+        return false;
+    }
+
+    uint32_t destination = 0;
+    uint32_t ifindex = 0;
+    uint32_t source = 0;
+    int attr_len = RTM_PAYLOAD(header);
+    for (auto* attr = RTM_RTA(message); RTA_OK(attr, attr_len);
+         attr = RTA_NEXT(attr, attr_len)) {
+        if (attr->rta_type == RTA_DST && RTA_PAYLOAD(attr) >= sizeof(destination)) {
+            std::memcpy(&destination, RTA_DATA(attr), sizeof(destination));
+        } else if (attr->rta_type == RTA_OIF && RTA_PAYLOAD(attr) >= sizeof(ifindex)) {
+            std::memcpy(&ifindex, RTA_DATA(attr), sizeof(ifindex));
+        } else if (attr->rta_type == RTA_SRC && RTA_PAYLOAD(attr) >= sizeof(source)) {
+            std::memcpy(&source, RTA_DATA(attr), sizeof(source));
+        }
+    }
+    return destination == route.dst && ifindex == route.ifindex && source == route.source;
+}
+
+int DumpRoutes(int fd, uint32_t seq, const RouteSpec* probe = nullptr,
+               int* match_count = nullptr) {
+    auto request = NewRequest<rtmsg>(RTM_GETROUTE, NLM_F_REQUEST | NLM_F_DUMP, seq);
+    auto* message = reinterpret_cast<rtmsg*>(NLMSG_DATA(request.data()));
+    message->rtm_family = AF_INET;
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (probe != nullptr && MessageContainsRoute(header, *probe)) {
+                if (match_count == nullptr) return EEXIST;
+                ++(*match_count);
+            }
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? 0 : -error->error;
+            }
+        }
+    }
+}
+
+int DumpAddresses(int fd, uint32_t seq) {
+    auto request = NewRequest<ifaddrmsg>(RTM_GETADDR, NLM_F_REQUEST | NLM_F_DUMP, seq);
+    auto* message = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()));
+    message->ifa_family = AF_INET;
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? 0 : -error->error;
+            }
+        }
+    }
+}
+
+void RecordFailure(std::atomic<int>* first_failure, int stage, int error) {
+    const int encoded = stage * 1000 + error;
+    int expected = 0;
+    first_failure->compare_exchange_strong(expected, encoded);
+}
+
+void WaitForStart(std::atomic<int>* ready, std::atomic<bool>* start) {
+    ready->fetch_add(1, std::memory_order_release);
+    while (!start->load(std::memory_order_acquire)) std::this_thread::yield();
+}
+
+int RunExclusiveRouteRaces(int cleanup_fd, uint32_t ifindex) {
+    const RouteSpec route{Ipv4("198.22.0.0"), 24, ifindex};
+    uint32_t cleanup_seq = 1000;
+
+    for (int round = 0; round < kExclusiveRaceRounds; ++round) {
+        (void)ChangeRoute(cleanup_fd, RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                          cleanup_seq++);
+
+        std::atomic<int> ready{0};
+        std::atomic<bool> start{false};
+        std::array<int, kExclusiveRaceWorkers> results{};
+        std::vector<std::thread> workers;
+        workers.reserve(kExclusiveRaceWorkers);
+        for (int worker = 0; worker < kExclusiveRaceWorkers; ++worker) {
+            workers.emplace_back([&, worker] {
+                FdGuard fd(OpenRouteSocket());
+                if (fd.Get() < 0) {
+                    results[worker] = -errno;
+                    ready.fetch_add(1, std::memory_order_release);
+                    return;
+                }
+                WaitForStart(&ready, &start);
+                results[worker] = ChangeRoute(
+                    fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
+                    1100 + round * kExclusiveRaceWorkers + worker);
+            });
+        }
+
+        while (ready.load(std::memory_order_acquire) != kExclusiveRaceWorkers) {
+            std::this_thread::yield();
+        }
+        start.store(true, std::memory_order_release);
+        for (auto& worker : workers) worker.join();
+
+        int successes = 0;
+        int duplicates = 0;
+        for (const int result : results) {
+            if (result == 0) {
+                ++successes;
+            } else if (result == EEXIST) {
+                ++duplicates;
+            } else {
+                return 6000 + (result < 0 ? -result : result);
+            }
+        }
+        if (successes != 1 || duplicates != kExclusiveRaceWorkers - 1) return 7000;
+
+        int match_count = 0;
+        if (DumpRoutes(cleanup_fd, cleanup_seq++, &route, &match_count) != 0 ||
+            match_count != 1) {
+            return 8000 + match_count;
+        }
+        if (ChangeRoute(cleanup_fd, RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                        cleanup_seq++) != 0) {
+            return 9000;
+        }
+    }
+    return 0;
+}
+
+int RunConcurrentMutations() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 1000 + errno;
+    FdGuard setup(OpenRouteSocket());
+    if (setup.Get() < 0) return 2000 + errno;
+    const uint32_t ifindex = if_nametoindex("lo");
+    if (ifindex == 0) return 3000 + errno;
+    if (const int error = SetLinkUp(setup.Get(), ifindex, 1); error != 0) return 4000 + error;
+
+    const uint32_t address = Ipv4("198.19.0.1");
+    const RouteSpec route{Ipv4("198.20.0.0"), 24, ifindex};
+    const uint32_t neighbour = Ipv4("198.21.0.1");
+    std::atomic<int> ready{0};
+    std::atomic<bool> start{false};
+    std::atomic<int> first_failure{0};
+
+    std::thread link_worker([&] {
+        WaitForStart(&ready, &start);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) {
+            RecordFailure(&first_failure, 10, errno);
+            return;
+        }
+        for (int i = 0; i < kWorkerIterations; ++i) {
+            int error = RenameLink(fd.Get(), ifindex, "pr02lo", 100 + i * 2);
+            if (error == 0) error = RenameLink(fd.Get(), ifindex, "lo", 101 + i * 2);
+            if (error != 0) {
+                RecordFailure(&first_failure, 11, error);
+                return;
+            }
+        }
+    });
+
+    std::thread address_worker([&] {
+        WaitForStart(&ready, &start);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) {
+            RecordFailure(&first_failure, 20, errno);
+            return;
+        }
+        for (int i = 0; i < kWorkerIterations; ++i) {
+            int error = ChangeAddress(fd.Get(), RTM_NEWADDR,
+                                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                                      ifindex, address, 32, 200 + i * 2);
+            if (error == 0) {
+                error = ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ifindex,
+                                      address, 32, 201 + i * 2);
+            }
+            if (error != 0) {
+                RecordFailure(&first_failure, 21, error);
+                return;
+            }
+        }
+    });
+
+    std::thread route_worker([&] {
+        WaitForStart(&ready, &start);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) {
+            RecordFailure(&first_failure, 30, errno);
+            return;
+        }
+        for (int i = 0; i < kWorkerIterations; ++i) {
+            int error = ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                                    route, 300 + i * 2);
+            if (error == 0) {
+                error = ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                                    301 + i * 2);
+            }
+            if (error != 0) {
+                RecordFailure(&first_failure, 31, error);
+                return;
+            }
+        }
+    });
+
+    std::thread neighbour_worker([&] {
+        WaitForStart(&ready, &start);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) {
+            RecordFailure(&first_failure, 40, errno);
+            return;
+        }
+        for (int i = 0; i < kWorkerIterations; ++i) {
+            const int error = ReplaceNeighbour(fd.Get(), ifindex, neighbour, 400 + i);
+            if (error != 0) {
+                RecordFailure(&first_failure, 41, error);
+                return;
+            }
+        }
+    });
+
+    std::thread dump_worker([&] {
+        WaitForStart(&ready, &start);
+        FdGuard fd(OpenRouteSocket());
+        if (fd.Get() < 0) {
+            RecordFailure(&first_failure, 50, errno);
+            return;
+        }
+        for (int i = 0; i < kWorkerIterations; ++i) {
+            int error = DumpRoutes(fd.Get(), 500 + i * 2);
+            if (error == 0) error = DumpAddresses(fd.Get(), 501 + i * 2);
+            if (error != 0) {
+                RecordFailure(&first_failure, 51, error);
+                return;
+            }
+        }
+    });
+
+    while (ready.load(std::memory_order_acquire) != 5) std::this_thread::yield();
+    start.store(true, std::memory_order_release);
+    link_worker.join();
+    address_worker.join();
+    route_worker.join();
+    neighbour_worker.join();
+    dump_worker.join();
+
+    (void)RenameLink(setup.Get(), ifindex, "lo", 900);
+    (void)ChangeAddress(setup.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ifindex, address, 32,
+                        901);
+    (void)ChangeRoute(setup.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, 902);
+    if (const int failure = first_failure.load(); failure != 0) return failure;
+    return RunExclusiveRouteRaces(setup.Get(), ifindex);
+}
+
+void DrainNotifications(int fd) {
+    std::array<uint8_t, 16384> buffer{};
+    while (recv(fd, buffer.data(), buffer.size(), MSG_DONTWAIT) > 0) {
+    }
+}
+
+int HasRouteNotification(int fd, const RouteSpec& route) {
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), MSG_DONTWAIT);
+        if (received < 0) {
+            return errno == EAGAIN || errno == EWOULDBLOCK ? 0 : -errno;
+        }
+        if (received == 0) return 0;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_type == RTM_NEWROUTE && MessageContainsRoute(header, route)) {
+                return 1;
+            }
+        }
+    }
+}
+
+int RunFailedRouteAtomicity() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 1000 + errno;
+    FdGuard request_fd(OpenRouteSocket());
+    FdGuard notify_fd(OpenRouteSocket(RTMGRP_IPV4_ROUTE));
+    if (request_fd.Get() < 0 || notify_fd.Get() < 0) return 2000 + errno;
+    const uint32_t ifindex = if_nametoindex("lo");
+    if (ifindex == 0) return 3000 + errno;
+    if (const int error = SetLinkUp(request_fd.Get(), ifindex, 1); error != 0) {
+        return 4000 + error;
+    }
+    utsname host{};
+    if (uname(&host) != 0) return 4500 + errno;
+    if (std::strstr(host.release, "dragonos") == nullptr) return kCapacityNotReached;
+
+    const RouteSpec preserved{Ipv4("198.29.0.0"), 24, ifindex};
+    RouteSpec shadow = preserved;
+    shadow.source = Ipv4("198.28.0.1");
+    shadow.source_prefix_len = 32;
+    uint32_t seq = 100;
+    if (ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, preserved,
+                    seq++) != 0 ||
+        ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, shadow, seq++) != 0 ||
+        ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, shadow, seq++) !=
+            0) {
+        return 5000;
+    }
+    // DragonOS currently projects route keys with the same destination onto
+    // one smoltcp entry. Removing the source-specific shadow key leaves the
+    // source-agnostic control record present while removing that projection,
+    // exposing the historical replace rollback failure through public
+    // rtnetlink operations.
+    DrainNotifications(notify_fd.Get());
+
+    std::vector<RouteSpec> added;
+    int failure_error = 0;
+    for (int i = 0; i < kMaxRouteFillAttempts; ++i) {
+        RouteSpec candidate{Ipv4("198.30." + std::to_string(i) + ".0"), 24, ifindex};
+        const int error = ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
+                                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                                      candidate, seq++);
+        if (error == 0) {
+            added.push_back(candidate);
+            DrainNotifications(notify_fd.Get());
+            continue;
+        }
+        if (error == ENOSPC) {
+            failure_error = error;
+            break;
+        }
+        return 5000 + error;
+    }
+
+    if (failure_error != ENOSPC) {
+        for (const auto& route : added) {
+            (void)ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route,
+                              seq++);
+        }
+        (void)ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, preserved,
+                          seq++);
+        return kCapacityNotReached;
+    }
+
+    if (added.empty()) return 6000;
+
+    // A full table must still permit an in-place replace of an existing
+    // projection; this exercises the non-fallible first-match branch.
+    if (ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE, added.front(),
+                    seq++) != 0) {
+        return 7000;
+    }
+    int existing_count = 0;
+    if (DumpRoutes(request_fd.Get(), seq++, &added.front(), &existing_count) != 0 ||
+        existing_count != 1) {
+        return 8000 + existing_count;
+    }
+    DrainNotifications(notify_fd.Get());
+
+    // Replacing the preserved control record needs a new projection and must
+    // fail atomically when the data-plane table is full.
+    if (ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE, preserved,
+                    seq++) != ENOSPC) {
+        return 9000;
+    }
+    int preserved_count = 0;
+    if (DumpRoutes(request_fd.Get(), seq++, &preserved, &preserved_count) != 0 ||
+        preserved_count != 1) {
+        return 10000 + preserved_count;
+    }
+    const int notification = HasRouteNotification(notify_fd.Get(), preserved);
+    if (notification > 0) return 11000;
+    if (notification < 0) return 11000 - notification;
+
+    FdGuard udp(socket(AF_INET, SOCK_DGRAM, 0));
+    if (udp.Get() < 0) return 8000 + errno;
+    sockaddr_in destination{};
+    destination.sin_family = AF_INET;
+    destination.sin_port = htons(9);
+    destination.sin_addr.s_addr = preserved.dst | htonl(1);
+    const char payload = 'x';
+    errno = 0;
+    if (sendto(udp.Get(), &payload, sizeof(payload), 0,
+               reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) >= 0 ||
+        errno != ENETUNREACH) {
+        return 12000 + errno;
+    }
+
+    for (const auto& route : added) {
+        const int error =
+            ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, seq++);
+        if (error != 0) return 13000 + error;
+    }
+    if (ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, preserved,
+                    seq++) != 0) {
+        return 14000;
+    }
+    return 0;
+}
+
+template <typename Function>
+ChildOutcome RunWithWatchdog(Function function) {
+    int result_pipe[2];
+    if (pipe(result_pipe) != 0) return {false, -1, 11000 + errno};
+
+    const pid_t child = fork();
+    if (child < 0) {
+        const int saved = errno;
+        close(result_pipe[0]);
+        close(result_pipe[1]);
+        return {false, -1, 12000 + saved};
+    }
+    if (child == 0) {
+        close(result_pipe[0]);
+        const int stage = function();
+        const ssize_t ignored = write(result_pipe[1], &stage, sizeof(stage));
+        (void)ignored;
+        close(result_pipe[1]);
+        _exit(stage == 0 || stage == kCapacityNotReached ? 0 : 1);
+    }
+
+    close(result_pipe[1]);
+    int status = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(15);
+    for (;;) {
+        const pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) break;
+        if (waited < 0) {
+            close(result_pipe[0]);
+            return {false, -1, 13000 + errno};
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            (void)kill(child, SIGKILL);
+            (void)waitpid(child, &status, 0);
+            close(result_pipe[0]);
+            return {true, status, 0};
+        }
+        usleep(10 * 1000);
+    }
+
+    int stage = -1;
+    const ssize_t bytes = read(result_pipe[0], &stage, sizeof(stage));
+    close(result_pipe[0]);
+    if (bytes != static_cast<ssize_t>(sizeof(stage))) stage = 14000;
+    return {false, status, stage};
+}
+
+TEST(RtnetlinkSerializationSemantics, ConcurrentMutationsAndDumpsComplete) {
+    const ChildOutcome outcome = RunWithWatchdog(RunConcurrentMutations);
+    ASSERT_FALSE(outcome.timed_out) << "rtnetlink workers deadlocked in send/handler";
+    ASSERT_TRUE(WIFEXITED(outcome.exit_status));
+    EXPECT_EQ(outcome.stage, 0) << "encoded stage/error=" << outcome.stage;
+    EXPECT_EQ(WEXITSTATUS(outcome.exit_status), 0);
+}
+
+TEST(RtnetlinkSerializationSemantics, FailedRouteHasNoCommitOrSuccessNotification) {
+    const ChildOutcome outcome = RunWithWatchdog(RunFailedRouteAtomicity);
+    ASSERT_FALSE(outcome.timed_out) << "rtnetlink failure path deadlocked";
+    ASSERT_TRUE(WIFEXITED(outcome.exit_status));
+    if (outcome.stage == kCapacityNotReached) {
+        utsname name{};
+        ASSERT_EQ(uname(&name), 0);
+        if (std::strstr(name.release, "dragonos") == nullptr) {
+            GTEST_SKIP() << "Linux FIB has no DragonOS smoltcp fixed-capacity ENOSPC boundary";
+        }
+        FAIL() << "DragonOS route table did not reach ENOSPC within the bounded fill loop";
+    }
+    EXPECT_EQ(outcome.stage, 0) << "encoded stage/error=" << outcome.stage;
+    EXPECT_EQ(WEXITSTATUS(outcome.exit_status), 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -106,6 +106,7 @@ normal/af_packet_e2e
 normal/af_packet_mcast
 normal/rtnetlink_link_semantics
 normal/rtnetlink_permission_semantics
+normal/rtnetlink_serialization_semantics
 normal/tty_termios
 normal/inotify_dir_watch
 normal/inotify_events


### PR DESCRIPTION
## Summary

- introduce a network-owned RTNL guard as the shared serialization boundary for network control-plane mutations
- serialize rtnetlink handlers, DHCP lease commits, and AF_PACKET membership updates while keeping parsing, polling, registry rebuilds, and response delivery outside RTNL
- make fixed-capacity route replacement failure-atomic and add isolated concurrency, same-key linearization, and rollback coverage

This is PR-02 of #2233. It establishes the serialization primitive that later control-plane PRs can reuse without coupling them to the rtnetlink adapter.

## Design notes

- RTNL is owned by `net`, not by the netlink protocol implementation.
- The guard is crate-internal and RAII-based, with an explicit process-context and lock-order contract.
- The dispatcher provides a safe default for current and future rtnetlink handlers.
- DHCP polling and AF_PACKET registry snapshot rebuilding do not extend the global critical section.
- Notifications are prepared before mutation where allocation can fail, and route control/data-plane state is committed only after fallible projection updates succeed.

## Validation

- `make fmt`
- `make kernel`
- host Linux dunitest: concurrency and same-key linearization passed; DragonOS-only fixed-capacity case skipped as designed
- DragonOS QEMU `DUNITEST_PATTERN=rtnetlink_ make test-dunit`: 11/11 passed, 0 failures, 0 timeouts
- DragonOS QEMU AF_PACKET multicast regression: 14/14 passed
- DragonOS QEMU route semantics regression: 5/5 passed
- DragonOS boot DHCP smoke check: lease acquisition succeeded

Cube end-to-end testing was intentionally not repeated, as agreed in the #2233 roadmap.
