### PR TITLE
feat(net): support Linux network device query ioctls

### DIFF
--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -465,6 +465,10 @@ impl Iface for E1000EInterface {
         self.inner().netdevice_common.state |= state;
     }
 
+    fn clear_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state &= !state;
+    }
+
     fn operstate(&self) -> Operstate {
         return self.inner().netdevice_common.operstate;
     }

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -624,6 +624,10 @@ impl Iface for LoopbackInterface {
         self.inner().netdevice_common.state |= state;
     }
 
+    fn clear_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state &= !state;
+    }
+
     fn operstate(&self) -> Operstate {
         return self.inner().netdevice_common.operstate;
     }

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -168,6 +168,9 @@ pub trait Iface: crate::driver::base::device::Device {
 
     fn set_net_state(&self, state: NetDeivceState);
 
+    /// Clear lifecycle state bits previously set with `set_net_state`.
+    fn clear_net_state(&self, state: NetDeivceState);
+
     fn operstate(&self) -> Operstate;
 
     fn set_operstate(&self, state: Operstate);
@@ -182,6 +185,39 @@ pub trait Iface: crate::driver::base::device::Device {
 
     fn flags(&self) -> InterfaceFlags {
         self.common().flags()
+    }
+
+    /// Flags exported through Linux network-device user APIs.
+    ///
+    /// Like Linux `dev_get_flags()`, runtime flags are derived from the
+    /// device lifecycle, operational state, and carrier state instead of
+    /// exposing their cached initialization values.
+    fn user_visible_flags(&self) -> InterfaceFlags {
+        self.project_user_visible_flags(self.common().configured_flags())
+    }
+
+    /// Project one configured-flags snapshot into the Linux userspace view.
+    fn project_user_visible_flags(&self, mut flags: InterfaceFlags) -> InterfaceFlags {
+        flags.remove(InterfaceFlags::RUNNING | InterfaceFlags::LOWER_UP | InterfaceFlags::DORMANT);
+
+        let state = self.net_state();
+        if !state.contains(NetDeivceState::__LINK_STATE_START) {
+            return flags;
+        }
+
+        if matches!(
+            self.operstate(),
+            Operstate::IF_OPER_UP | Operstate::IF_OPER_UNKNOWN
+        ) {
+            flags.insert(InterfaceFlags::RUNNING);
+        }
+        if !state.contains(NetDeivceState::__LINK_STATE_NOCARRIER) {
+            flags.insert(InterfaceFlags::LOWER_UP);
+        }
+        if state.contains(NetDeivceState::__LINK_STATE_DORMANT) {
+            flags.insert(InterfaceFlags::DORMANT);
+        }
+        flags
     }
 
     fn type_(&self) -> InterfaceType {
@@ -707,6 +743,10 @@ impl IfaceCommon {
                 configured.contains(InterfaceFlags::ALLMULTI),
             )?,
         })
+    }
+
+    pub fn configured_flags(&self) -> InterfaceFlags {
+        InterfaceFlags::from_bits_truncate(self.receive_mode.lock().configured_flags)
     }
 
     pub fn type_(&self) -> InterfaceType {

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -697,6 +697,10 @@ impl Iface for VethInterface {
         self.inner().netdevice_common.state |= state;
     }
 
+    fn clear_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state &= !state;
+    }
+
     fn operstate(&self) -> Operstate {
         self.inner().netdevice_common.operstate
     }

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -1299,6 +1299,10 @@ impl Iface for VirtioInterface {
         self.inner().netdevice_common.state |= state;
     }
 
+    fn clear_net_state(&self, state: NetDeivceState) {
+        self.inner().netdevice_common.state &= !state;
+    }
+
     fn operstate(&self) -> Operstate {
         return self.inner().netdevice_common.operstate;
     }

--- a/kernel/src/net/socket/base.rs
+++ b/kernel/src/net/socket/base.rs
@@ -11,6 +11,7 @@ use crate::{
         posix::{MsgHdr, SockAddr},
         socket::common::{EPollItems, ShutdownBit},
     },
+    process::namespace::net_namespace::NetNamespace,
 };
 // use crate::filesystem::epoll::event_poll::EventPoll;
 use alloc::{sync::Arc, vec::Vec};
@@ -38,6 +39,12 @@ pub struct SocketMmapLayout {
 /// ## Reference
 /// - [Posix standard](https://pubs.opengion.org/onlinepubs/9699919799/)
 pub trait Socket: PollableInode + IndexNode {
+    /// Network namespace captured when this socket was created.
+    ///
+    /// Generic socket ioctls must use this stable namespace rather than the
+    /// calling task's current namespace, matching Linux `sock_net(sk)`.
+    fn netns(&self) -> Arc<NetNamespace>;
+
     /// Number of fsnotify marks attached to this anonymous socket inode.
     fn fsnotify_watch_counter(&self) -> &AtomicUsize;
 

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -1310,6 +1310,10 @@ impl UdpSocket {
 }
 
 impl Socket for UdpSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        UdpSocket::netns(self)
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/inet/raw/ops.rs
+++ b/kernel/src/net/socket/inet/raw/ops.rs
@@ -13,6 +13,10 @@ use super::{InetSocket, RawSocket};
 type EP = crate::filesystem::epoll::EPollEventType;
 
 impl crate::net::socket::Socket for RawSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        RawSocket::netns(self)
+    }
+
     fn fsnotify_watch_counter(&self) -> &core::sync::atomic::AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/inet/stream/mod.rs
+++ b/kernel/src/net/socket/inet/stream/mod.rs
@@ -33,6 +33,10 @@ mod stream_core;
 pub use stream_core::TcpSocket;
 
 impl Socket for TcpSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        TcpSocket::netns(self)
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -1,286 +1,26 @@
 use crate::{
-    driver::net::Iface,
     filesystem::vfs::{
         fasync::FAsyncItem, file::File, FilePrivateData, FileType, IndexNode, InodeMode, Metadata,
         PollableInode,
     },
     libs::mutex::MutexGuard,
-    net::posix::SockAddrIn,
-    process::ProcessManager,
     syscall::user_access::{UserBufferReader, UserBufferWriter},
 };
 use alloc::{string::String, sync::Arc, vec::Vec};
 use core::sync::atomic::Ordering;
 use system_error::SystemError;
 
-use super::Socket;
-use crate::net::socket::IFNAMSIZ;
+use super::{
+    ioctl::{
+        handle_netdev_query, handle_siocgifconf, SIOCGIFCONF, SIOCGIFFLAGS, SIOCGIFHWADDR,
+        SIOCGIFINDEX, SIOCGIFMTU,
+    },
+    Socket,
+};
 
 // Socket ioctl commands
-const SIOCGIFCONF: u32 = 0x8912; // Get interface list
-const SIOCGIFINDEX: u32 = 0x8933; // name -> if_index mapping
 const FIONREAD: u32 = 0x541B; // Get number of bytes available to read
 const TIOCOUTQ: u32 = 0x5411; // Get output queue size
-
-/// ## ifreq - Interface request structure
-/// Used for socket ioctls. Must match C struct layout.
-/// On Linux x86_64: sizeof(ifreq) = 40 bytes
-/// - ifr_name: 16 bytes (IFNAMSIZ)
-/// - ifr_ifru: 24 bytes (union, largest member is struct ifmap)
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-struct IfReq {
-    ifr_name: [u8; IFNAMSIZ], // Interface name (16 bytes)
-    ifr_ifru: [u8; 24],       // Union for various data (24 bytes to match Linux)
-}
-
-impl Default for IfReq {
-    fn default() -> Self {
-        Self {
-            ifr_name: [0u8; IFNAMSIZ],
-            ifr_ifru: [0u8; 24],
-        }
-    }
-}
-
-impl IfReq {
-    /// Set the sockaddr_in in ifr_ifru
-    fn set_sockaddr_in(&mut self, addr: &SockAddrIn) {
-        // Copy sockaddr_in into the first 16 bytes of ifr_ifru
-        let addr_bytes: &[u8] =
-            unsafe { core::slice::from_raw_parts(addr as *const SockAddrIn as *const u8, 16) };
-        self.ifr_ifru[..16].copy_from_slice(addr_bytes);
-    }
-
-    fn name_str(&self) -> &str {
-        let end = self
-            .ifr_name
-            .iter()
-            .position(|&b| b == 0)
-            .unwrap_or(IFNAMSIZ);
-        core::str::from_utf8(&self.ifr_name[..end]).unwrap_or("")
-    }
-
-    fn set_ifindex(&mut self, ifindex: i32) {
-        self.ifr_ifru[..4].copy_from_slice(&ifindex.to_ne_bytes());
-    }
-}
-
-fn handle_siocgifindex(data: usize) -> Result<usize, SystemError> {
-    if data == 0 {
-        return Err(SystemError::EFAULT);
-    }
-
-    // Read ifreq from user space.
-    let user_reader =
-        UserBufferReader::new(data as *const IfReq, core::mem::size_of::<IfReq>(), true)?;
-    let mut ifreq: IfReq = user_reader.buffer_protected(0)?.read_one::<IfReq>(0)?;
-
-    let name = ifreq.name_str();
-    if name.is_empty() {
-        return Err(SystemError::ENODEV);
-    }
-
-    let netns = ProcessManager::current_netns();
-
-    // Prefer exact name match.
-    let mut ifindex: Option<i32> = netns.device_list().iter().find_map(|(_, iface)| {
-        if iface.iface_name() == name {
-            Some(iface.nic_id() as i32)
-        } else {
-            None
-        }
-    });
-
-    // Fallback for lo if not present in device_list (early init) but loopback is configured.
-    if ifindex.is_none() && name == "lo" {
-        if let Some(lo) = netns.loopback_iface() {
-            ifindex = Some(lo.nic_id() as i32);
-        }
-    }
-
-    let ifindex = ifindex.ok_or(SystemError::ENODEV)?;
-    ifreq.set_ifindex(ifindex);
-
-    // Write back.
-    let mut user_writer =
-        UserBufferWriter::new(data as *mut IfReq, core::mem::size_of::<IfReq>(), true)?;
-    user_writer.buffer_protected(0)?.write_one(0, &ifreq)?;
-
-    Ok(0)
-}
-
-/// ## ifconf - Interface configuration structure
-/// Used by SIOCGIFCONF. Must match C struct layout.
-#[repr(C)]
-#[derive(Debug, Clone, Copy)]
-struct IfConf {
-    ifc_len: i32,   // Size of buffer or number of bytes returned
-    ifc_buf: usize, // Pointer to buffer (union with ifc_req)
-}
-
-/// Handle SIOCGIFCONF ioctl
-/// This ioctl returns a list of interface (network layer) addresses.
-fn handle_siocgifconf(data: usize) -> Result<usize, SystemError> {
-    if data == 0 {
-        return Err(SystemError::EFAULT);
-    }
-
-    // Read ifconf structure from user space
-    let user_reader =
-        UserBufferReader::new(data as *const IfConf, core::mem::size_of::<IfConf>(), true)?;
-    let ifconf = user_reader.buffer_protected(0)?.read_one::<IfConf>(0)?;
-
-    let ifc_len = ifconf.ifc_len;
-    let ifc_buf = ifconf.ifc_buf;
-
-    // Get current network namespace and enumerate interfaces
-    let netns = ProcessManager::current_netns();
-    let device_list = netns.device_list();
-
-    // Calculate how many ifreq structures we can fit
-    let ifreq_size = core::mem::size_of::<IfReq>();
-
-    // Collect interface information
-    let mut ifreqs: Vec<IfReq> = Vec::new();
-
-    for (_, iface) in device_list.iter() {
-        // Get interface name
-        let iface_name = iface.iface_name();
-
-        // Get IPv4 address if available
-        if let Some(ipv4_addr) = iface.common().ipv4_addr() {
-            let mut ifreq = IfReq::default();
-
-            // Copy interface name
-            let name_bytes = iface_name.as_bytes();
-            let copy_len = core::cmp::min(name_bytes.len(), IFNAMSIZ - 1);
-            ifreq.ifr_name[..copy_len].copy_from_slice(&name_bytes[..copy_len]);
-
-            // Set up sockaddr_in for IPv4
-            let addr = SockAddrIn {
-                sin_family: 2, // AF_INET
-                sin_port: 0,
-                sin_addr: u32::from_ne_bytes(ipv4_addr.octets()),
-                sin_zero: [0u8; 8],
-            };
-            ifreq.set_sockaddr_in(&addr);
-
-            ifreqs.push(ifreq);
-        }
-    }
-
-    // Linux 语义：SIOCGIFCONF 至少应该能看到 lo（loopback）。
-    // 在 DragonOS 的某些启动/配置场景下，loopback 设备可能尚未被注册到 netns，
-    // 但用户态仍期望能通过该 ioctl 观察到 127.0.0.1。
-    let lo_name = "lo";
-    let already_added = ifreqs.iter().any(|req| {
-        // ifr_name 是以 NUL 结尾的 C 字符串。
-        let end = req
-            .ifr_name
-            .iter()
-            .position(|&b| b == 0)
-            .unwrap_or(IFNAMSIZ);
-        &req.ifr_name[..end] == lo_name.as_bytes()
-    });
-
-    if !already_added {
-        let ipv4_addr = netns
-            .loopback_iface()
-            .and_then(|lo| lo.as_ref().common().ipv4_addr())
-            .unwrap_or(core::net::Ipv4Addr::new(127, 0, 0, 1));
-
-        let mut ifreq = IfReq::default();
-        ifreq.ifr_name[..2].copy_from_slice(lo_name.as_bytes());
-
-        let addr = SockAddrIn {
-            sin_family: 2, // AF_INET
-            sin_port: 0,
-            sin_addr: u32::from_ne_bytes(ipv4_addr.octets()),
-            sin_zero: [0u8; 8],
-        };
-        ifreq.set_sockaddr_in(&addr);
-        ifreqs.push(ifreq);
-    }
-
-    // Move "lo" to the front if it exists (some tests expect loopback first)
-    if let Some(lo_idx) = ifreqs.iter().position(|req| {
-        let name_str = core::str::from_utf8(&req.ifr_name)
-            .unwrap_or("")
-            .trim_end_matches('\0');
-        name_str == "lo"
-    }) {
-        if lo_idx > 0 {
-            let lo_ifreq = ifreqs.remove(lo_idx);
-            ifreqs.insert(0, lo_ifreq);
-        }
-    }
-
-    // If ifc_buf is NULL (0), just return the total size needed
-    if ifc_buf == 0 {
-        let total_size = ifreqs.len() * ifreq_size;
-        // Write back the required size
-        let mut user_writer =
-            UserBufferWriter::new(data as *mut IfConf, core::mem::size_of::<IfConf>(), true)?;
-        let result_ifconf = IfConf {
-            ifc_len: total_size as i32,
-            ifc_buf: 0,
-        };
-        user_writer
-            .buffer_protected(0)?
-            .write_one(0, &result_ifconf)?;
-        return Ok(0);
-    }
-
-    // Calculate how many complete ifreq structures fit in the buffer
-    let max_ifreqs = if ifc_len >= 0 {
-        (ifc_len as usize) / ifreq_size
-    } else {
-        0
-    };
-
-    // Don't return partial ifreq structures
-    let num_to_copy = core::cmp::min(ifreqs.len(), max_ifreqs);
-    let bytes_to_copy = num_to_copy * ifreq_size;
-
-    // Validate the user buffer pointer before writing
-    // If the buffer pointer is invalid, return EFAULT
-    if num_to_copy > 0 {
-        // Try to create a user buffer writer to validate the pointer
-        let user_buf_writer_result = UserBufferWriter::new(ifc_buf as *mut u8, bytes_to_copy, true);
-        if user_buf_writer_result.is_err() {
-            return Err(SystemError::EFAULT);
-        }
-        let mut user_buf_writer = user_buf_writer_result.unwrap();
-
-        // Build a contiguous buffer with all ifreq structures
-        let mut all_data: Vec<u8> = Vec::with_capacity(bytes_to_copy);
-        for ifreq in ifreqs.iter().take(num_to_copy) {
-            let ifreq_bytes: &[u8] = unsafe {
-                core::slice::from_raw_parts(ifreq as *const IfReq as *const u8, ifreq_size)
-            };
-            all_data.extend_from_slice(ifreq_bytes);
-        }
-
-        // Write all data at once
-        user_buf_writer
-            .buffer_protected(0)?
-            .write_to_user(0, &all_data)?;
-    }
-
-    // Write back the actual size returned
-    let mut user_writer =
-        UserBufferWriter::new(data as *mut IfConf, core::mem::size_of::<IfConf>(), true)?;
-    let result_ifconf = IfConf {
-        ifc_len: bytes_to_copy as i32,
-        ifc_buf,
-    };
-    user_writer
-        .buffer_protected(0)?
-        .write_one(0, &result_ifconf)?;
-
-    Ok(0)
-}
 
 impl<T: Socket + 'static> IndexNode for T {
     fn fsnotify_watch_count(&self) -> Option<&core::sync::atomic::AtomicUsize> {
@@ -413,8 +153,10 @@ impl<T: Socket + 'static> IndexNode for T {
         private_data: MutexGuard<FilePrivateData>,
     ) -> Result<usize, SystemError> {
         match cmd {
-            SIOCGIFCONF => handle_siocgifconf(data),
-            SIOCGIFINDEX => handle_siocgifindex(data),
+            SIOCGIFCONF => handle_siocgifconf(self.netns(), data),
+            SIOCGIFINDEX | SIOCGIFFLAGS | SIOCGIFMTU | SIOCGIFHWADDR => {
+                handle_netdev_query(self.netns(), cmd, data)
+            }
             FIONREAD /* TIOCINQ */ => {
                 // Get number of bytes available to read
                 let bytes_available = self.recv_bytes_available();

--- a/kernel/src/net/socket/ioctl.rs
+++ b/kernel/src/net/socket/ioctl.rs
@@ -1,0 +1,208 @@
+//! Linux-compatible network-device query ioctls shared by all socket families.
+//!
+//! Query commands read the namespace captured by the socket at creation time,
+//! matching Linux `sock_net(sk)`. They intentionally do not acquire RTNL: each
+//! command returns one device property through the `ifreq` union. Mutation
+//! ioctls belong to the RTNL control core and must not be added here as direct
+//! `Iface` writes.
+
+use alloc::{sync::Arc, vec::Vec};
+use core::mem::size_of;
+
+use system_error::SystemError;
+
+use crate::{
+    driver::net::Iface,
+    net::{posix::SockAddrIn, socket::IFNAMSIZ},
+    process::namespace::net_namespace::NetNamespace,
+    syscall::user_access::{UserBufferReader, UserBufferWriter},
+};
+
+pub(super) const SIOCGIFCONF: u32 = 0x8912;
+pub(super) const SIOCGIFFLAGS: u32 = 0x8913;
+pub(super) const SIOCGIFMTU: u32 = 0x8921;
+pub(super) const SIOCGIFHWADDR: u32 = 0x8927;
+pub(super) const SIOCGIFINDEX: u32 = 0x8933;
+
+/// Native x86_64 Linux `struct ifreq` layout.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IfReq {
+    ifr_name: [u8; IFNAMSIZ],
+    ifr_ifru: [u8; 24],
+}
+
+const _: () = assert!(size_of::<IfReq>() == 40);
+
+impl Default for IfReq {
+    fn default() -> Self {
+        Self {
+            ifr_name: [0; IFNAMSIZ],
+            ifr_ifru: [0; 24],
+        }
+    }
+}
+
+impl IfReq {
+    fn lookup_name(&mut self) -> Result<&str, SystemError> {
+        self.ifr_name[IFNAMSIZ - 1] = 0;
+        let nul = self
+            .ifr_name
+            .iter()
+            .position(|byte| *byte == 0)
+            .unwrap_or(IFNAMSIZ);
+        let name = &self.ifr_name[..nul];
+        let alias = name.iter().position(|byte| *byte == b':').unwrap_or(nul);
+        let name = core::str::from_utf8(&name[..alias]).map_err(|_| SystemError::ENODEV)?;
+        if name.is_empty() {
+            return Err(SystemError::ENODEV);
+        }
+        Ok(name)
+    }
+
+    fn set_i32(&mut self, value: i32) {
+        self.ifr_ifru[..size_of::<i32>()].copy_from_slice(&value.to_ne_bytes());
+    }
+
+    fn set_flags(&mut self, flags: u32) {
+        let flags = flags as i16;
+        self.ifr_ifru[..size_of::<i16>()].copy_from_slice(&flags.to_ne_bytes());
+    }
+
+    fn set_hwaddr(&mut self, iface: &Arc<dyn Iface>) {
+        let family = iface.type_() as u16;
+        self.ifr_ifru[..size_of::<u16>()].copy_from_slice(&family.to_ne_bytes());
+        self.ifr_ifru[size_of::<u16>()..size_of::<u16>() + 6]
+            .copy_from_slice(iface.mac().as_bytes());
+    }
+
+    fn set_name(&mut self, name: &str) {
+        let bytes = name.as_bytes();
+        let len = bytes.len().min(IFNAMSIZ - 1);
+        self.ifr_name[..len].copy_from_slice(&bytes[..len]);
+    }
+
+    fn set_sockaddr_in(&mut self, addr: &SockAddrIn) {
+        let bytes = unsafe {
+            core::slice::from_raw_parts(
+                addr as *const SockAddrIn as *const u8,
+                size_of::<SockAddrIn>(),
+            )
+        };
+        self.ifr_ifru[..size_of::<SockAddrIn>()].copy_from_slice(bytes);
+    }
+}
+
+fn read_ifreq(data: usize) -> Result<IfReq, SystemError> {
+    let reader = UserBufferReader::new(data as *const IfReq, size_of::<IfReq>(), true)?;
+    reader.buffer_protected(0)?.read_one(0)
+}
+
+fn write_ifreq(data: usize, ifreq: &IfReq) -> Result<(), SystemError> {
+    let mut writer = UserBufferWriter::new(data as *mut IfReq, size_of::<IfReq>(), true)?;
+    writer.buffer_protected(0)?.write_one(0, ifreq)
+}
+
+fn find_iface(netns: &Arc<NetNamespace>, name: &str) -> Result<Arc<dyn Iface>, SystemError> {
+    netns
+        .device_list()
+        .iter()
+        .find_map(|(_, iface)| (iface.iface_name() == name).then(|| iface.clone()))
+        .ok_or(SystemError::ENODEV)
+}
+
+pub(super) fn handle_netdev_query(
+    netns: Arc<NetNamespace>,
+    cmd: u32,
+    data: usize,
+) -> Result<usize, SystemError> {
+    let mut ifreq = read_ifreq(data)?;
+    let iface = find_iface(&netns, ifreq.lookup_name()?)?;
+
+    match cmd {
+        SIOCGIFINDEX => ifreq.set_i32(iface.nic_id() as i32),
+        SIOCGIFFLAGS => ifreq.set_flags(iface.flags().bits()),
+        SIOCGIFMTU => ifreq.set_i32(iface.mtu() as i32),
+        SIOCGIFHWADDR => ifreq.set_hwaddr(&iface),
+        _ => return Err(SystemError::ENOTTY),
+    }
+
+    write_ifreq(data, &ifreq)?;
+    Ok(0)
+}
+
+/// Native x86_64 Linux `struct ifconf` layout.
+#[repr(C)]
+#[derive(Debug, Clone, Copy)]
+struct IfConf {
+    ifc_len: i32,
+    ifc_buf: usize,
+}
+
+const _: () = assert!(size_of::<IfConf>() == 16);
+
+fn read_ifconf(data: usize) -> Result<IfConf, SystemError> {
+    let reader = UserBufferReader::new(data as *const IfConf, size_of::<IfConf>(), true)?;
+    reader.buffer_protected(0)?.read_one(0)
+}
+
+fn write_ifconf_len(data: usize, len: i32) -> Result<(), SystemError> {
+    let mut writer = UserBufferWriter::new(data as *mut i32, size_of::<i32>(), true)?;
+    writer.buffer_protected(0)?.write_one(0, &len)
+}
+
+fn snapshot_ifconf(netns: &Arc<NetNamespace>) -> Result<Vec<IfReq>, SystemError> {
+    let _rtnl_guard = crate::net::rtnl::lock();
+    let devices = netns.device_list();
+    let mut snapshot = Vec::new();
+    snapshot
+        .try_reserve_exact(devices.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    for (_, iface) in devices.iter() {
+        let Some(ipv4) = iface.common().ipv4_addr() else {
+            continue;
+        };
+        let mut ifreq = IfReq::default();
+        ifreq.set_name(&iface.iface_name());
+        ifreq.set_sockaddr_in(&SockAddrIn {
+            sin_family: 2,
+            sin_port: 0,
+            sin_addr: u32::from_ne_bytes(ipv4.octets()),
+            sin_zero: [0; 8],
+        });
+        snapshot.push(ifreq);
+    }
+    Ok(snapshot)
+}
+
+pub(super) fn handle_siocgifconf(
+    netns: Arc<NetNamespace>,
+    data: usize,
+) -> Result<usize, SystemError> {
+    let input = read_ifconf(data)?;
+    let ifreqs = snapshot_ifconf(&netns)?;
+    let required = ifreqs.len() * size_of::<IfReq>();
+
+    if input.ifc_buf == 0 {
+        write_ifconf_len(data, required as i32)?;
+        return Ok(0);
+    }
+
+    let capacity = if input.ifc_len < 0 {
+        0
+    } else {
+        input.ifc_len as usize / size_of::<IfReq>()
+    };
+    let count = capacity.min(ifreqs.len());
+    let bytes = count * size_of::<IfReq>();
+    if bytes != 0 {
+        let mut writer = UserBufferWriter::new(input.ifc_buf as *mut u8, bytes, true)?;
+        let mut buffer = writer.buffer_protected(0)?;
+        for (index, ifreq) in ifreqs.iter().take(count).enumerate() {
+            buffer.write_one(index * size_of::<IfReq>(), ifreq)?;
+        }
+    }
+
+    write_ifconf_len(data, bytes as i32)?;
+    Ok(0)
+}

--- a/kernel/src/net/socket/ioctl.rs
+++ b/kernel/src/net/socket/ioctl.rs
@@ -121,7 +121,7 @@ pub(super) fn handle_netdev_query(
 
     match cmd {
         SIOCGIFINDEX => ifreq.set_i32(iface.nic_id() as i32),
-        SIOCGIFFLAGS => ifreq.set_flags(iface.flags().bits()),
+        SIOCGIFFLAGS => ifreq.set_flags(iface.user_visible_flags().bits()),
         SIOCGIFMTU => ifreq.set_i32(iface.mtu() as i32),
         SIOCGIFHWADDR => ifreq.set_hwaddr(&iface),
         _ => return Err(SystemError::ENOTTY),

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -4,6 +4,7 @@ pub mod endpoint;
 mod family;
 pub mod inet;
 mod inode;
+mod ioctl;
 pub mod netlink;
 pub mod packet;
 mod posix;

--- a/kernel/src/net/socket/netlink/common/mod.rs
+++ b/kernel/src/net/socket/netlink/common/mod.rs
@@ -384,6 +384,10 @@ impl<P: SupportedNetlinkProtocol + 'static> Socket for NetlinkSocket<P>
 where
     BoundNetlink<P::Message>: Bound<Endpoint = NetlinkSocketAddr>,
 {
+    fn netns(&self) -> Arc<NetNamespace> {
+        NetlinkSocket::netns(self)
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -136,6 +136,7 @@ fn iface_to_link_message(
     iface: &Arc<dyn Iface>,
 ) -> Result<LinkSegment, SystemError> {
     let flags = iface.common().link_flags_snapshot()?;
+    let user_visible_flags = iface.project_user_visible_flags(flags.configured);
     let header = CMsgSegHdr {
         len: 0,
         type_: msg_type as _,
@@ -148,7 +149,7 @@ fn iface_to_link_message(
         family: AddressFamily::Unspecified,
         type_: iface.type_(),
         index: NonZero::new(iface.nic_id() as u32),
-        flags: flags.configured,
+        flags: user_visible_flags,
         change: LinkMessageFlags::empty(),
         pad: None,
     };
@@ -219,12 +220,13 @@ pub(super) fn do_set_link(
     if change_mask.contains(InterfaceFlags::UP) {
         let was_up = old_flags.contains(InterfaceFlags::UP);
         let is_up = new_flags.contains(InterfaceFlags::UP);
-        let operstate = if is_up {
-            Operstate::IF_OPER_UP
+        if is_up {
+            iface.set_operstate(Operstate::IF_OPER_UP);
+            iface.set_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_START);
         } else {
-            Operstate::IF_OPER_DOWN
-        };
-        iface.set_operstate(operstate);
+            iface.clear_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_START);
+            iface.set_operstate(Operstate::IF_OPER_DOWN);
+        }
 
         if was_up != is_up {
             if is_up {

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -286,6 +286,10 @@ pub fn deliver_ip_to_packet_sockets(iface: &Arc<dyn Iface>, packet: &[u8], pkt_t
 }
 
 impl Socket for PacketSocket {
+    fn netns(&self) -> Arc<NetNamespace> {
+        PacketSocket::netns(self)
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/unix/datagram/mod.rs
+++ b/kernel/src/net/socket/unix/datagram/mod.rs
@@ -638,6 +638,10 @@ impl UnixDatagramSocket {
 }
 
 impl Socket for UnixDatagramSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        self.netns.clone()
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/unix/stream/mod.rs
+++ b/kernel/src/net/socket/unix/stream/mod.rs
@@ -566,6 +566,10 @@ impl UnixStreamSocket {
 }
 
 impl Socket for UnixStreamSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        self.netns.clone()
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/kernel/src/net/socket/vsock/stream.rs
+++ b/kernel/src/net/socket/vsock/stream.rs
@@ -836,6 +836,10 @@ impl VsockStreamSocket {
 }
 
 impl Socket for VsockStreamSocket {
+    fn netns(&self) -> Arc<crate::process::namespace::net_namespace::NetNamespace> {
+        crate::process::namespace::net_namespace::INIT_NET_NAMESPACE.clone()
+    }
+
     fn fsnotify_watch_counter(&self) -> &AtomicUsize {
         &self.fsnotify_watches
     }

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -16,5 +16,6 @@ normal/rtnetlink_link_semantics
 normal/rtnetlink_permission_semantics
 normal/rtnetlink_serialization_semantics
 normal/socket_getsockopt_semantics
+normal/socket_ioctl_netdev_query
 normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics

--- a/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
@@ -168,38 +168,14 @@ int GetIfIndex(int any_fd, const std::string& ifname) {
     return ifr.ifr_ifindex;
 }
 
-// Get local MAC: ioctl(SIOCGIFHWADDR) → sysfs → fallback MAC. Never fails.
-void GetIfHwaddr(int any_fd, const std::string& ifname, uint8_t mac[6]) {
+// Get the local MAC through the standard Linux network-device query ABI.
+bool GetIfHwaddr(int any_fd, const std::string& ifname, uint8_t mac[6]) {
     struct ifreq ifr;
     std::memset(&ifr, 0, sizeof(ifr));
     std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
-    if (ioctl(any_fd, SIOCGIFHWADDR, &ifr) == 0) {
-        std::memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
-        bool allzero = true;
-        for (int i = 0; i < 6; ++i) {
-            if (mac[i]) {
-                allzero = false;
-                break;
-            }
-        }
-        if (!allzero) return;
-    }
-    // fall back to sysfs
-    char path[64];
-    std::snprintf(path, sizeof(path), "/sys/class/net/%s/address", ifname.c_str());
-    FILE* f = std::fopen(path, "r");
-    if (f) {
-        unsigned int v[6];
-        int n = std::fscanf(f, "%x:%x:%x:%x:%x:%x", &v[0], &v[1], &v[2], &v[3], &v[4], &v[5]);
-        std::fclose(f);
-        if (n == 6) {
-            for (int i = 0; i < 6; ++i) mac[i] = static_cast<uint8_t>(v[i]);
-            return;
-        }
-    }
-    // final fallback: default QEMU virtio-net MAC
-    static const uint8_t kDefaultMac[6] = {0x52, 0x54, 0x00, 0x12, 0x34, 0x56};
-    std::memcpy(mac, kDefaultMac, 6);
+    if (ioctl(any_fd, SIOCGIFHWADDR, &ifr) != 0) return false;
+    std::memcpy(mac, ifr.ifr_hwaddr.sa_data, 6);
+    return true;
 }
 
 // Build a broadcast ARP request frame (ether_header + ArpHdr), length = kArpFrameLen
@@ -308,7 +284,10 @@ int MakeBoundRaw(const std::string& ifname, int ifindex, uint8_t mac[6]) {
         close(fd);
         return -1;
     }
-    GetIfHwaddr(fd, ifname, mac);
+    if (!GetIfHwaddr(fd, ifname, mac)) {
+        close(fd);
+        return -1;
+    }
     struct timeval tv;
     tv.tv_sec = 1;
     tv.tv_usec = 0;
@@ -371,7 +350,7 @@ TEST(AfPacketE2E, RawSendtoAndSendmsg) {
     ASSERT_GE(raw_fd.Get(), 0) << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(raw_fd.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(raw_fd.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[kArpFrameLen];
     BuildArpRequest(frame, local_mac);
     uint8_t bcast[6] = {0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
@@ -410,7 +389,7 @@ TEST(AfPacketE2E, SendmsgIovecGather) {
     ASSERT_GE(raw_fd.Get(), 0) << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(raw_fd.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(raw_fd.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[kArpFrameLen];
     BuildArpRequest(frame, local_mac);
 
@@ -590,7 +569,7 @@ TEST(AfPacketE2E, DgramSendReturnsLayer3PayloadLen) {
         << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(dgram_fd.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(dgram_fd.Get(), ifname, local_mac)) << ErrnoString(errno);
 
     // DGRAM sends only L3 payload (ARP 28 bytes), kernel adds Ethernet header
     ArpHdr arp;
@@ -641,7 +620,7 @@ TEST(AfPacketE2E, DgramReceivesHeaderOnlyFrameWithoutFilter) {
         << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[kEthHdrLen]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);
@@ -689,7 +668,7 @@ TEST(AfPacketE2E, WildcardRecvmsgTruncAndAuxdata) {
         << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(fd.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(fd.Get(), ifname, local_mac)) << ErrnoString(errno);
     Stimulate(fd.Get(), ifindex, local_mac);
 
     uint8_t short_buf[8]{};
@@ -781,7 +760,7 @@ TEST(AfPacketE2E, VethAcceptsFullMtuVlanFrame) {
     FdGuard fd(socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL)));
     ASSERT_GE(fd.Get(), 0) << ErrnoString(errno);
     uint8_t local_mac[6];
-    GetIfHwaddr(fd.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(fd.Get(), ifname, local_mac)) << ErrnoString(errno);
 
     uint8_t frame[kVlanFrameLen]{};
     std::memset(frame, 0xff, 6);
@@ -907,7 +886,7 @@ TEST(AfPacketE2E, ReceiveBufferSizeControlsQueuedBytes) {
               0);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[512]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);
@@ -973,7 +952,7 @@ TEST(AfPacketE2E, ClassicFilterSnaplenAndRuntimeErrorsAreFailClosed) {
     ASSERT_GE(sender.Get(), 0) << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[96]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);
@@ -1072,7 +1051,7 @@ TEST(AfPacketE2E, FilterReplacementPreservesReceiveState) {
         << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[96]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);
@@ -1151,7 +1130,7 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
         << ErrnoString(errno);
 
     uint8_t local_mac[6];
-    GetIfHwaddr(sender.Get(), ifname, local_mac);
+    ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[96]{};
     std::memset(frame, 0xff, 6);
     std::memcpy(frame + 6, local_mac, 6);

--- a/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_e2e.cc
@@ -1129,6 +1129,10 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
     ASSERT_EQ(setsockopt(second.Get(), SOL_PACKET, PACKET_FANOUT, &fanout, sizeof(fanout)), 0)
         << ErrnoString(errno);
 
+    static uint32_t fanout_run;
+    const uint32_t fanout_magic =
+        0x46414e4fU ^ (static_cast<uint32_t>(getpid()) << 8) ^ ++fanout_run;
+
     uint8_t local_mac[6];
     ASSERT_TRUE(GetIfHwaddr(sender.Get(), ifname, local_mac)) << ErrnoString(errno);
     uint8_t frame[96]{};
@@ -1136,6 +1140,7 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
     std::memcpy(frame + 6, local_mac, 6);
     frame[12] = static_cast<uint8_t>(kPrivateEtherType >> 8);
     frame[13] = static_cast<uint8_t>(kPrivateEtherType);
+    std::memcpy(frame + kEthHdrLen, &fanout_magic, sizeof(fanout_magic));
 
     struct sockaddr_ll dst{};
     dst.sll_family = AF_PACKET;
@@ -1147,17 +1152,35 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
 
     constexpr int kFrames = 16;
     for (int sequence = 0; sequence < kFrames; ++sequence) {
-        std::memcpy(frame + kEthHdrLen, &sequence, sizeof(sequence));
+        std::memcpy(frame + kEthHdrLen + sizeof(fanout_magic), &sequence, sizeof(sequence));
         ASSERT_EQ(sendto(sender.Get(), frame, sizeof(frame), 0,
                          reinterpret_cast<sockaddr*>(&dst), sizeof(dst)),
                   static_cast<ssize_t>(sizeof(frame)))
             << ErrnoString(errno);
     }
 
-    auto drain = [](int fd) {
+    int seen[kFrames]{};
+    auto drain = [&](int fd) {
         uint8_t buffer[128];
         int count = 0;
-        while (recv(fd, buffer, sizeof(buffer), MSG_DONTWAIT) > 0) ++count;
+        ssize_t received;
+        while ((received = recv(fd, buffer, sizeof(buffer), MSG_DONTWAIT)) > 0) {
+            if (received < kEthHdrLen + static_cast<ssize_t>(sizeof(fanout_magic) + sizeof(int))) {
+                continue;
+            }
+            uint32_t magic;
+            std::memcpy(&magic, buffer + kEthHdrLen, sizeof(magic));
+            if (magic != fanout_magic) continue;
+
+            int sequence;
+            std::memcpy(&sequence, buffer + kEthHdrLen + sizeof(magic), sizeof(sequence));
+            if (sequence < 0 || sequence >= kFrames) {
+                ADD_FAILURE() << "fanout frame has invalid sequence=" << sequence;
+                continue;
+            }
+            ++seen[sequence];
+            ++count;
+        }
         return count;
     };
     const int first_count = drain(first.Get());
@@ -1167,6 +1190,9 @@ TEST(AfPacketE2E, FanoutLbDeliversExactlyOneCopyPerFrame) {
         << " second=" << second_count;
     EXPECT_EQ(first_count, kFrames / 2);
     EXPECT_EQ(second_count, kFrames / 2);
+    for (int sequence = 0; sequence < kFrames; ++sequence) {
+        EXPECT_EQ(seen[sequence], 1) << "sequence=" << sequence;
+    }
 }
 
 int main(int argc, char** argv) {

--- a/user/apps/tests/dunitest/suites/normal/af_packet_mcast.cc
+++ b/user/apps/tests/dunitest/suites/normal/af_packet_mcast.cc
@@ -149,6 +149,17 @@ int GetIfIndex(const std::string& ifname) {
     return ifr.ifr_ifindex;
 }
 
+std::optional<unsigned int> GetIfFlags(const std::string& ifname) {
+    struct ifreq ifr {};
+    std::strncpy(ifr.ifr_name, ifname.c_str(), IFNAMSIZ - 1);
+
+    FdGuard control(socket(AF_INET, SOCK_DGRAM, 0));
+    if (control.Get() < 0 || ioctl(control.Get(), SIOCGIFFLAGS, &ifr) < 0) {
+        return std::nullopt;
+    }
+    return static_cast<unsigned short>(ifr.ifr_flags);
+}
+
 // Probe for a NIC and create a SOCK_RAW socket.
 // GTEST_SKIP if no NIC or insufficient permissions; the returned FdGuard holds a valid fd.
 // Returns ifindex, outputs socket fd via out_fd.
@@ -575,6 +586,46 @@ TEST(AfPacketMcast, DuplicateMembershipAndCloseUseOneDeviceReference) {
     auto closed = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
     ASSERT_TRUE(closed.has_value());
     EXPECT_EQ(closed->promiscuity, baseline->promiscuity);
+}
+
+TEST(AfPacketMcast, MembershipCountsDoNotChangeConfiguredFlags) {
+    const std::string ifname = DiscoverIfname();
+    FdGuard packet_fd;
+    const int ifindex = SetupMcastEnv(&packet_fd);
+    if (ifindex == -1) GTEST_SKIP() << "No usable NIC found";
+    ASSERT_NE(ifindex, -2) << ErrnoString(errno);
+
+    FdGuard route_fd(OpenRouteSocket());
+    ASSERT_GE(route_fd.Get(), 0) << ErrnoString(errno);
+    uint32_t seq = 125;
+    const auto baseline = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
+    const auto baseline_ioctl = GetIfFlags(ifname);
+    ASSERT_TRUE(baseline.has_value());
+    ASSERT_TRUE(baseline_ioctl.has_value());
+
+    PacketMreq promisc {};
+    promisc.mr_ifindex = ifindex;
+    promisc.mr_type = PACKET_MR_PROMISC;
+    PacketMreq allmulti = promisc;
+    allmulti.mr_type = PACKET_MR_ALLMULTI;
+    ASSERT_EQ(setsockopt(packet_fd.Get(), SOL_PACKET, PACKET_ADD_MEMBERSHIP, &promisc,
+                         sizeof(promisc)),
+              0);
+    ASSERT_EQ(setsockopt(packet_fd.Get(), SOL_PACKET, PACKET_ADD_MEMBERSHIP, &allmulti,
+                         sizeof(allmulti)),
+              0);
+
+    const auto active = GetLinkSnapshot(route_fd.Get(), ifindex, ++seq);
+    const auto active_ioctl = GetIfFlags(ifname);
+    ASSERT_TRUE(active.has_value());
+    ASSERT_TRUE(active_ioctl.has_value());
+    EXPECT_EQ(active->promiscuity, baseline->promiscuity + 1);
+    EXPECT_EQ(active->allmulti, baseline->allmulti + 1);
+
+    constexpr unsigned int kConfiguredModes = IFF_PROMISC | IFF_ALLMULTI;
+    EXPECT_EQ(active->configured_flags & kConfiguredModes,
+              baseline->configured_flags & kConfiguredModes);
+    EXPECT_EQ(*active_ioctl & kConfiguredModes, *baseline_ioctl & kConfiguredModes);
 }
 
 TEST(AfPacketMcast, FanoutCloseReleasesPromiscMembership) {

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -2,13 +2,18 @@
 
 #include <arpa/inet.h>
 #include <linux/if_link.h>
+#include <linux/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
-#include <net/if.h>
+#include <sched.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
+#include <array>
 #include <cerrno>
 #include <cstdint>
 #include <cstring>
@@ -31,6 +36,111 @@ class FdGuard {
   private:
     int fd_;
 };
+
+bool IsDragonOS() {
+    struct utsname uts {};
+    return uname(&uts) == 0 && std::strstr(uts.release, "dragonos") != nullptr;
+}
+
+int OpenRouteSocket() {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) return -1;
+
+    timeval timeout {};
+    timeout.tv_sec = 2;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+
+    sockaddr_nl address {};
+    address.nl_family = AF_NETLINK;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+int RecvAck(int fd, uint32_t seq) {
+    std::array<unsigned char, 4096> buffer {};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq || header->nlmsg_type != NLMSG_ERROR) continue;
+            const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+            return error->error == 0 ? 0 : -error->error;
+        }
+    }
+}
+
+int SetLinkUp(int fd, int ifindex, bool up, uint32_t seq) {
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request {};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_SETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    request.header.nlmsg_seq = seq;
+    request.link.ifi_family = AF_UNSPEC;
+    request.link.ifi_index = ifindex;
+    request.link.ifi_flags = up ? IFF_UP : 0;
+    request.link.ifi_change = IFF_UP;
+
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) {
+        return errno;
+    }
+    return RecvAck(fd, seq);
+}
+
+std::optional<short> QueryIoctlFlags(int fd, const char* name) {
+    ifreq request {};
+    std::strncpy(request.ifr_name, name, IFNAMSIZ - 1);
+    if (ioctl(fd, SIOCGIFFLAGS, &request) < 0) return std::nullopt;
+    return request.ifr_flags;
+}
+
+std::optional<uint32_t> QueryLinkFlags(int fd, int ifindex, uint32_t seq) {
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request {};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_GETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST;
+    request.header.nlmsg_seq = seq;
+    request.link.ifi_family = AF_UNSPEC;
+    request.link.ifi_index = ifindex;
+
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) {
+        return std::nullopt;
+    }
+
+    std::array<unsigned char, 4096> buffer {};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return std::nullopt;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_ERROR) return std::nullopt;
+            if (header->nlmsg_type != RTM_NEWLINK) continue;
+            const auto* link = reinterpret_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            if (link->ifi_index == ifindex) return link->ifi_flags;
+        }
+    }
+}
 
 std::optional<int> FindEthernetIfindex() {
     FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
@@ -107,6 +217,67 @@ TEST(RtnetlinkLinkSemantics, VirtioEthernetReportsStandardIpMtu) {
     ASSERT_TRUE(mtu.has_value()) << "RTM_GETLINK did not return IFLA_MTU: errno=" << errno
                                 << " (" << std::strerror(errno) << ")";
     EXPECT_EQ(*mtu, 1500U);
+}
+
+int RunVisibleFlagsCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+
+    FdGuard ioctl_fd(socket(AF_INET, SOCK_DGRAM, 0));
+    FdGuard route_fd(OpenRouteSocket());
+    if (ioctl_fd.Get() < 0 || route_fd.Get() < 0) return 10;
+
+    ifreq index_request {};
+    std::strncpy(index_request.ifr_name, "lo", IFNAMSIZ - 1);
+    if (ioctl(ioctl_fd.Get(), SIOCGIFINDEX, &index_request) < 0) return 11;
+    const int ifindex = index_request.ifr_ifindex;
+
+    if (SetLinkUp(route_fd.Get(), ifindex, true, 1) != 0) return 12;
+    const auto ioctl_up = QueryIoctlFlags(ioctl_fd.Get(), "lo");
+    const auto rtnl_up = QueryLinkFlags(route_fd.Get(), ifindex, 2);
+    if (!ioctl_up.has_value() || !rtnl_up.has_value()) return 13;
+    constexpr uint32_t kRuntimeFlags = IFF_RUNNING | IFF_LOWER_UP | IFF_DORMANT;
+    constexpr uint32_t kExpectedUp = IFF_UP | IFF_RUNNING;
+    if ((static_cast<uint16_t>(*ioctl_up) & kExpectedUp) != kExpectedUp) return 14;
+    if ((*rtnl_up & kExpectedUp) != kExpectedUp) return 15;
+    if ((static_cast<uint16_t>(*ioctl_up) & IFF_LOOPBACK) == 0 ||
+        (*rtnl_up & IFF_LOOPBACK) == 0) {
+        return 16;
+    }
+
+    if (SetLinkUp(route_fd.Get(), ifindex, false, 3) != 0) return 17;
+    const auto ioctl_down = QueryIoctlFlags(ioctl_fd.Get(), "lo");
+    const auto rtnl_down = QueryLinkFlags(route_fd.Get(), ifindex, 4);
+    if (!ioctl_down.has_value() || !rtnl_down.has_value()) return 18;
+    if ((static_cast<uint16_t>(*ioctl_down) & (IFF_UP | kRuntimeFlags)) != 0) return 19;
+    if ((*rtnl_down & (IFF_UP | kRuntimeFlags)) != 0) return 20;
+    if ((static_cast<uint16_t>(*ioctl_down) & IFF_LOOPBACK) == 0 ||
+        (*rtnl_down & IFF_LOOPBACK) == 0) {
+        return 21;
+    }
+    if ((static_cast<uint16_t>(*ioctl_down) & 0xffffU) != (*rtnl_down & 0xffffU)) return 22;
+
+    if (SetLinkUp(route_fd.Get(), ifindex, true, 5) != 0) return 23;
+    const auto ioctl_restored = QueryIoctlFlags(ioctl_fd.Get(), "lo");
+    const auto rtnl_restored = QueryLinkFlags(route_fd.Get(), ifindex, 6);
+    if (!ioctl_restored.has_value() || !rtnl_restored.has_value()) return 24;
+    if ((static_cast<uint16_t>(*ioctl_restored) & kExpectedUp) != kExpectedUp) return 25;
+    if ((*rtnl_restored & kExpectedUp) != kExpectedUp) return 26;
+    return 0;
+}
+
+TEST(RtnetlinkLinkSemantics, VisibleFlagsFollowAdministrativeAndRuntimeState) {
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) _exit(RunVisibleFlagsCase());
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    const int result = WEXITSTATUS(status);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_query.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_query.cc
@@ -1,0 +1,338 @@
+#include <gtest/gtest.h>
+
+#include <errno.h>
+#include <linux/capability.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <sched.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr std::array<unsigned long, 4> kQueryCommands = {
+    SIOCGIFINDEX, SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFHWADDR};
+constexpr unsigned char kSentinel = 0xa5;
+
+class ScopedFd {
+  public:
+    explicit ScopedFd(int fd = -1) : fd_(fd) {}
+    ~ScopedFd() {
+        if (fd_ >= 0) close(fd_);
+    }
+    ScopedFd(const ScopedFd&) = delete;
+    ScopedFd& operator=(const ScopedFd&) = delete;
+    int get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+bool IsDragonOS() {
+    struct utsname uts {};
+    return uname(&uts) == 0 && std::strstr(uts.release, "dragonos") != nullptr;
+}
+
+void InitIfreq(struct ifreq* ifr, const char* name) {
+    std::memset(ifr, kSentinel, sizeof(*ifr));
+    std::memset(ifr->ifr_name, 0, IFNAMSIZ);
+    std::strncpy(ifr->ifr_name, name, IFNAMSIZ - 1);
+}
+
+void ExpectSentinelFrom(const struct ifreq& ifr, size_t offset) {
+    static_assert(sizeof(struct ifreq) == 40);
+    const auto* bytes = reinterpret_cast<const unsigned char*>(&ifr) + IFNAMSIZ;
+    for (size_t i = offset; i < sizeof(struct ifreq) - IFNAMSIZ; ++i) {
+        EXPECT_EQ(bytes[i], kSentinel) << "union byte " << i << " changed";
+    }
+}
+
+std::vector<std::string> ListInterfaces(int fd) {
+    std::array<struct ifreq, 64> entries {};
+    struct ifconf ifc {};
+    ifc.ifc_len = static_cast<int>(sizeof(entries));
+    ifc.ifc_req = entries.data();
+    if (ioctl(fd, SIOCGIFCONF, &ifc) != 0) return {};
+
+    std::vector<std::string> names;
+    const int count = ifc.ifc_len / static_cast<int>(sizeof(struct ifreq));
+    for (int i = 0; i < count; ++i) {
+        entries[i].ifr_name[IFNAMSIZ - 1] = '\0';
+        std::string name(entries[i].ifr_name);
+        if (!name.empty() &&
+            std::find(names.begin(), names.end(), name) == names.end()) {
+            names.push_back(std::move(name));
+        }
+    }
+    return names;
+}
+
+bool Contains(const std::vector<std::string>& names, const std::string& name) {
+    return std::find(names.begin(), names.end(), name) != names.end();
+}
+
+int DropAllCapabilities() {
+    struct __user_cap_header_struct header {};
+    std::array<struct __user_cap_data_struct, 2> data {};
+    header.version = _LINUX_CAPABILITY_VERSION_3;
+    header.pid = 0;
+    return static_cast<int>(syscall(SYS_capset, &header, data.data()));
+}
+
+TEST(SocketIoctlNetdevQuery, LoopbackFieldsAndUnionWidths) {
+    ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.get(), 0);
+
+    struct ifreq ifr {};
+    InitIfreq(&ifr, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &ifr), 0) << strerror(errno);
+    EXPECT_GT(ifr.ifr_ifindex, 0);
+    ExpectSentinelFrom(ifr, sizeof(int));
+
+    InitIfreq(&ifr, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFFLAGS, &ifr), 0) << strerror(errno);
+    EXPECT_NE(ifr.ifr_flags & IFF_LOOPBACK, 0);
+    ExpectSentinelFrom(ifr, sizeof(short));
+
+    InitIfreq(&ifr, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFMTU, &ifr), 0) << strerror(errno);
+    EXPECT_GT(ifr.ifr_mtu, 0);
+    ExpectSentinelFrom(ifr, sizeof(int));
+
+    InitIfreq(&ifr, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFHWADDR, &ifr), 0) << strerror(errno);
+    EXPECT_EQ(ifr.ifr_hwaddr.sa_family, ARPHRD_LOOPBACK);
+    for (size_t i = 0; i < 6; ++i) {
+        EXPECT_EQ(static_cast<unsigned char>(ifr.ifr_hwaddr.sa_data[i]), 0);
+    }
+    ExpectSentinelFrom(ifr, sizeof(sa_family_t) + 6);
+}
+
+TEST(SocketIoctlNetdevQuery, NameNormalizationAndAliases) {
+    ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.get(), 0);
+
+    struct ifreq plain {};
+    InitIfreq(&plain, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &plain), 0);
+
+    struct ifreq alias {};
+    InitIfreq(&alias, "lo:1");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &alias), 0) << strerror(errno);
+    EXPECT_EQ(alias.ifr_ifindex, plain.ifr_ifindex);
+    EXPECT_STREQ(alias.ifr_name, "lo:1");
+
+    struct ifreq terminated {};
+    InitIfreq(&terminated, "lo");
+    terminated.ifr_name[IFNAMSIZ - 1] = 'x';
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &terminated), 0) << strerror(errno);
+    EXPECT_EQ(terminated.ifr_name[IFNAMSIZ - 1], '\0');
+
+    struct ifreq invalid {};
+    InitIfreq(&invalid, "");
+    errno = 0;
+    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &invalid), -1);
+    EXPECT_EQ(errno, ENODEV);
+
+    std::memset(&invalid, kSentinel, sizeof(invalid));
+    std::memset(invalid.ifr_name, 'x', IFNAMSIZ);
+    errno = 0;
+    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &invalid), -1);
+    EXPECT_EQ(errno, ENODEV);
+
+    InitIfreq(&invalid, "lo");
+    invalid.ifr_name[0] = static_cast<char>(0xff);
+    invalid.ifr_name[1] = '\0';
+    errno = 0;
+    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &invalid), -1);
+    EXPECT_EQ(errno, ENODEV);
+}
+
+TEST(SocketIoctlNetdevQuery, MissingDeviceAndUserCopyFaults) {
+    ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.get(), 0);
+
+    for (unsigned long command : kQueryCommands) {
+        struct ifreq ifr {};
+        InitIfreq(&ifr, "no-such-netdev");
+        const auto before = ifr;
+        errno = 0;
+        EXPECT_EQ(ioctl(fd.get(), command, &ifr), -1) << command;
+        EXPECT_EQ(errno, ENODEV) << command;
+        EXPECT_EQ(std::memcmp(&ifr, &before, sizeof(ifr)), 0) << command;
+
+        errno = 0;
+        EXPECT_EQ(ioctl(fd.get(), command, nullptr), -1) << command;
+        EXPECT_EQ(errno, EFAULT) << command;
+    }
+
+    const long page_size = sysconf(_SC_PAGESIZE);
+    ASSERT_GT(page_size, 0);
+    void* mapping = mmap(nullptr, page_size * 2, PROT_READ | PROT_WRITE,
+                         MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(mapping, MAP_FAILED);
+    ASSERT_EQ(mprotect(static_cast<char*>(mapping) + page_size, page_size,
+                       PROT_NONE),
+              0);
+    auto* partial = reinterpret_cast<struct ifreq*>(
+        static_cast<char*>(mapping) + page_size - sizeof(struct ifreq) + 1);
+    std::memset(partial, 0, sizeof(struct ifreq) - 1);
+    std::memcpy(partial->ifr_name, "lo", 3);
+    errno = 0;
+    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, partial), -1);
+    EXPECT_EQ(errno, EFAULT);
+    ASSERT_EQ(mprotect(static_cast<char*>(mapping) + page_size, page_size,
+                       PROT_READ | PROT_WRITE),
+              0);
+    ASSERT_EQ(munmap(mapping, page_size * 2), 0);
+
+    void* readonly = mmap(nullptr, page_size, PROT_READ | PROT_WRITE,
+                          MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+    ASSERT_NE(readonly, MAP_FAILED);
+    auto* readonly_ifr = static_cast<struct ifreq*>(readonly);
+    InitIfreq(readonly_ifr, "lo");
+    ASSERT_EQ(mprotect(readonly, page_size, PROT_READ), 0);
+    errno = 0;
+    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, readonly_ifr), -1);
+    EXPECT_EQ(errno, EFAULT);
+    ASSERT_EQ(mprotect(readonly, page_size, PROT_READ | PROT_WRITE), 0);
+    ASSERT_EQ(munmap(readonly, page_size), 0);
+}
+
+TEST(SocketIoctlNetdevQuery, EnumeratedDeviceProperties) {
+    ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.get(), 0);
+    const auto names = ListInterfaces(fd.get());
+    ASSERT_FALSE(names.empty());
+
+    bool found_ethernet = false;
+    for (const auto& name : names) {
+        struct ifreq ifr {};
+        InitIfreq(&ifr, name.c_str());
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFINDEX, &ifr), 0) << name;
+        EXPECT_GT(ifr.ifr_ifindex, 0) << name;
+
+        InitIfreq(&ifr, name.c_str());
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFFLAGS, &ifr), 0) << name;
+
+        InitIfreq(&ifr, name.c_str());
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFMTU, &ifr), 0) << name;
+        EXPECT_GT(ifr.ifr_mtu, 0) << name;
+
+        InitIfreq(&ifr, name.c_str());
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFHWADDR, &ifr), 0) << name;
+        if (ifr.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+            found_ethernet = true;
+            bool all_zero = true;
+            for (size_t i = 0; i < 6; ++i) {
+                all_zero &= ifr.ifr_hwaddr.sa_data[i] == 0;
+            }
+            EXPECT_FALSE(all_zero) << name;
+        }
+    }
+    if (IsDragonOS()) {
+        EXPECT_TRUE(found_ethernet);
+    }
+}
+
+TEST(SocketIoctlNetdevQuery, IfconfWritesOnlyLength) {
+    ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(fd.get(), 0);
+
+    struct ifconf ifc;
+    std::memset(&ifc, kSentinel, sizeof(ifc));
+    ifc.ifc_len = 0;
+    ifc.ifc_buf = nullptr;
+
+    std::array<unsigned char, offsetof(struct ifconf, ifc_buf) - sizeof(int)>
+        padding {};
+    std::memcpy(padding.data(),
+                reinterpret_cast<unsigned char*>(&ifc) + sizeof(int),
+                padding.size());
+
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFCONF, &ifc), 0) << strerror(errno);
+    EXPECT_GE(ifc.ifc_len, 0);
+    EXPECT_EQ(ifc.ifc_buf, nullptr);
+    EXPECT_EQ(std::memcmp(reinterpret_cast<unsigned char*>(&ifc) + sizeof(int),
+                          padding.data(), padding.size()),
+              0);
+}
+
+int RunSocketNetnsCase() {
+    ScopedFd old_fd(socket(AF_INET, SOCK_DGRAM, 0));
+    if (old_fd.get() < 0) return 10;
+    const auto old_names = ListInterfaces(old_fd.get());
+    auto non_lo = std::find_if(old_names.begin(), old_names.end(),
+                               [](const std::string& name) {
+                                   return name != "lo";
+                               });
+    const std::string old_unique =
+        non_lo == old_names.end() ? std::string() : *non_lo;
+
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+
+    struct ifreq ifr {};
+    if (!old_unique.empty()) {
+        InitIfreq(&ifr, old_unique.c_str());
+        if (ioctl(old_fd.get(), SIOCGIFINDEX, &ifr) != 0) return 11;
+    }
+
+    ScopedFd new_fd(socket(AF_INET, SOCK_DGRAM, 0));
+    if (new_fd.get() < 0) return 12;
+    InitIfreq(&ifr, "lo");
+    if (ioctl(new_fd.get(), SIOCGIFINDEX, &ifr) != 0) return 13;
+
+    if (!old_unique.empty()) {
+        InitIfreq(&ifr, old_unique.c_str());
+        errno = 0;
+        if (ioctl(new_fd.get(), SIOCGIFINDEX, &ifr) != -1 || errno != ENODEV) {
+            return 14;
+        }
+        if (!Contains(ListInterfaces(old_fd.get()), old_unique)) return 15;
+        if (Contains(ListInterfaces(new_fd.get()), old_unique)) return 16;
+    } else if (IsDragonOS()) {
+        return 17;
+    }
+
+    if (DropAllCapabilities() != 0) return 18;
+    InitIfreq(&ifr, "lo");
+    if (ioctl(new_fd.get(), SIOCGIFHWADDR, &ifr) != 0) return 19;
+    if (ioctl(new_fd.get(), SIOCGIFFLAGS, &ifr) != 0) return 20;
+    if (ioctl(new_fd.get(), SIOCGIFMTU, &ifr) != 0) return 21;
+    return 0;
+}
+
+TEST(SocketIoctlNetdevQuery, SocketNamespaceIsStableAndQueriesAreUnprivileged) {
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) _exit(RunSocketNetnsCase());
+
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    const int result = WEXITSTATUS(status);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -54,6 +54,7 @@ normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics
 normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics
+normal/socket_ioctl_netdev_query
 normal/unix_socket_shutdown
 fuse/fuse_core
 fuse/fuse_extended


### PR DESCRIPTION
## Summary

- add a shared query-only socket ioctl adapter for SIOCGIFINDEX, SIOCGIFFLAGS, SIOCGIFMTU, and SIOCGIFHWADDR
- use the network namespace captured by each socket, matching Linux sock_net behavior across unshare and descriptor transfer
- move SIOCGIFCONF into the adapter, take its multi-device snapshot under RTNL, remove synthetic loopback ordering, and only write back ifc_len
- remove AF_PACKET MAC fallbacks so tests exercise the standard ioctl ABI directly

## Linux compatibility

The implementation follows Linux 6.6.139 struct ifreq layout, full ifreq copy-in and copy-out, name termination and alias lookup, legacy flag width, ARPHRD hardware address encoding, unprivileged query semantics, and socket-bound network namespace selection.

SIOCGIFCONF snapshots registered devices under RTNL, releases the lock before user copies, and writes only ifc_len to avoid exposing structure padding.

## Validation

- make fmt
- make kernel
- host Linux socket_ioctl_netdev_query: 6/6 passed
- DragonOS QEMU socket_ioctl_netdev_query: 6/6 passed
- DragonOS QEMU af_packet_e2e: 14/14 passed
- pre-change DragonOS baseline: all 5 original query tests failed as expected
- final three-person adversarial review: no remaining accepted, rejected, or disputed findings

Cube testing was intentionally not repeated because this PR changes the generic Linux socket ioctl ABI and the tracking roadmap does not require Cube validation for this step.

Part of #2233.