### PR TITLE
feat(sched): add legacy scheduler priority queries

### DIFF
--- a/kernel/src/sched/syscall/mod.rs
+++ b/kernel/src/sched/syscall/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(target_arch = "x86_64")]
 mod sys_pause;
 
+mod sys_sched_get_priority;
 mod sys_sched_getparam;
 mod sys_sched_getscheduler;
 mod sys_sched_setscheduler;

--- a/kernel/src/sched/syscall/sys_sched_get_priority.rs
+++ b/kernel/src/sched/syscall/sys_sched_get_priority.rs
@@ -1,0 +1,58 @@
+use alloc::{string::ToString, vec::Vec};
+
+use system_error::SystemError;
+
+use crate::{
+    arch::{
+        interrupt::TrapFrame,
+        syscall::nr::{SYS_SCHED_GET_PRIORITY_MAX, SYS_SCHED_GET_PRIORITY_MIN},
+    },
+    syscall::table::{FormattedSyscallParam, Syscall},
+};
+
+use super::types::legacy_policy_priority_range;
+
+struct SysSchedGetPriorityMax;
+
+impl Syscall for SysSchedGetPriorityMax {
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let policy = args[0] as i32;
+        let (_, maximum) = legacy_policy_priority_range(policy).ok_or(SystemError::EINVAL)?;
+        Ok(maximum as usize)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "policy",
+            (args[0] as i32).to_string(),
+        )]
+    }
+}
+
+struct SysSchedGetPriorityMin;
+
+impl Syscall for SysSchedGetPriorityMin {
+    fn num_args(&self) -> usize {
+        1
+    }
+
+    fn handle(&self, args: &[usize], _frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let policy = args[0] as i32;
+        let (minimum, _) = legacy_policy_priority_range(policy).ok_or(SystemError::EINVAL)?;
+        Ok(minimum as usize)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![FormattedSyscallParam::new(
+            "policy",
+            (args[0] as i32).to_string(),
+        )]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_GET_PRIORITY_MAX, SysSchedGetPriorityMax);
+syscall_table_macros::declare_syscall!(SYS_SCHED_GET_PRIORITY_MIN, SysSchedGetPriorityMin);

--- a/kernel/src/sched/syscall/types.rs
+++ b/kernel/src/sched/syscall/types.rs
@@ -20,6 +20,20 @@ pub(super) const SCHED_IDLE: i32 = 5;
 pub(super) const SCHED_DEADLINE: i32 = 6;
 pub(super) const SCHED_RESET_ON_FORK: i32 = 0x4000_0000;
 
+/// Returns the legacy scheduler priority range as `(min, max)`.
+///
+/// Keep this table aligned with Linux's `sched_get_priority_{min,max}` ABI.
+/// Policy flags are intentionally rejected because these syscalls accept a
+/// policy value, not the flag-bearing value returned by `sched_getscheduler`.
+#[inline]
+pub(super) fn legacy_policy_priority_range(policy: i32) -> Option<(i32, i32)> {
+    match policy {
+        SCHED_FIFO | SCHED_RR => Some((1, crate::sched::prio::MAX_RT_PRIO - 1)),
+        SCHED_OTHER | SCHED_BATCH | SCHED_IDLE | SCHED_DEADLINE => Some((0, 0)),
+        _ => None,
+    }
+}
+
 #[inline]
 pub(super) fn policy_to_linux(policy: SchedPolicy) -> i32 {
     match policy {

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -42,6 +42,14 @@ long RawSetScheduler(pid_t tid, int policy, const RawSchedParam* param) {
     return syscall(SYS_sched_setscheduler, tid, policy, param);
 }
 
+long RawGetPriorityMax(uint64_t policy) {
+    return syscall(SYS_sched_get_priority_max, policy);
+}
+
+long RawGetPriorityMin(uint64_t policy) {
+    return syscall(SYS_sched_get_priority_min, policy);
+}
+
 bool IsDragonOS() {
     struct utsname info {};
     return uname(&info) == 0 && strstr(info.release, "dragonos") != nullptr;
@@ -171,6 +179,54 @@ TEST(SchedGetScheduler, CurrentAndErrorsMatchLinux) {
     errno = 0;
     EXPECT_EQ(-1, sched_getscheduler(INT_MAX));
     EXPECT_EQ(ESRCH, errno);
+}
+
+TEST(SchedPriorityQueries, KnownPolicyMatrixMatchesLinux) {
+    struct PolicyRange {
+        int policy;
+        int maximum;
+        int minimum;
+    };
+    const PolicyRange ranges[] = {
+        {SCHED_OTHER, 0, 0},    {SCHED_FIFO, 99, 1}, {SCHED_RR, 99, 1},
+        {SCHED_BATCH, 0, 0},    {SCHED_IDLE, 0, 0},  {SCHED_DEADLINE, 0, 0},
+    };
+
+    for (const auto& range : ranges) {
+        EXPECT_EQ(range.maximum, sched_get_priority_max(range.policy))
+            << "policy=" << range.policy << ": " << strerror(errno);
+        EXPECT_EQ(range.minimum, sched_get_priority_min(range.policy))
+            << "policy=" << range.policy << ": " << strerror(errno);
+    }
+}
+
+TEST(SchedPriorityQueries, InvalidPoliciesReturnEinval) {
+    const int invalid_policies[] = {
+        -1, 4, 7, SCHED_OTHER | SCHED_RESET_ON_FORK, SCHED_FIFO | SCHED_RESET_ON_FORK, INT_MAX,
+    };
+
+    for (int policy : invalid_policies) {
+        errno = 0;
+        EXPECT_EQ(-1, sched_get_priority_max(policy)) << "policy=" << policy;
+        EXPECT_EQ(EINVAL, errno) << "policy=" << policy;
+        errno = 0;
+        EXPECT_EQ(-1, sched_get_priority_min(policy)) << "policy=" << policy;
+        EXPECT_EQ(EINVAL, errno) << "policy=" << policy;
+    }
+}
+
+TEST(SchedPriorityQueries, RawSyscallUsesSignedIntAbi) {
+    constexpr uint64_t kNonzeroHighBits = uint64_t {1} << 32;
+
+    EXPECT_EQ(99, RawGetPriorityMax(kNonzeroHighBits | SCHED_FIFO));
+    EXPECT_EQ(1, RawGetPriorityMin(kNonzeroHighBits | SCHED_FIFO));
+
+    errno = 0;
+    EXPECT_EQ(-1, RawGetPriorityMax(kNonzeroHighBits | 4));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawGetPriorityMin(kNonzeroHighBits | 4));
+    EXPECT_EQ(EINVAL, errno);
 }
 
 TEST(SchedSetScheduler, ErrorOrderingAndPolicyMatrix) {


### PR DESCRIPTION
## Summary

- implement Linux-compatible sched_get_priority_min and sched_get_priority_max
- centralize the legacy scheduling policy priority range mapping
- decode policy arguments with signed 32-bit syscall ABI semantics
- return EINVAL for unknown policies and policy flag combinations
- extend dunitest coverage for known policies, invalid values, and raw syscall high bits

## Linux compatibility

The policy matrix follows Linux 6.6 semantics:

- SCHED_FIFO and SCHED_RR: minimum 1, maximum 99
- SCHED_OTHER, SCHED_BATCH, SCHED_IDLE, and SCHED_DEADLINE: minimum and maximum 0
- unknown policies and reset-on-fork flag combinations: EINVAL

## Validation

- make fmt
- dunitest suite build
- host Linux focused scheduler priority tests: 3/3 passed
- DragonOS focused scheduler priority tests: 3/3 passed
- DragonOS complete sched_policy_semantics suite: 12/12 passed
- make kernel ARCH=x86_64
- make kernel ARCH=riscv64
- make kernel ARCH=loongarch64
- git diff --check