### PR TITLE
refactor(sched): separate policy from scheduler class

### DIFF
--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -65,7 +65,15 @@ impl StatusFileOps {
             .on_cpu()
             .map(|cpu| cpu.data() as i32)
             .unwrap_or(-1);
-        let priority = pcb.sched_info().policy();
+        // Preserve this pre-existing DragonOS field while Linux policy and
+        // effective scheduler class are represented separately.
+        let priority = match sched_info_guard.sched_class() {
+            crate::sched::SchedClass::Idle => "IDLE",
+            _ => match sched_info_guard.policy() {
+                crate::sched::LinuxSchedPolicy::Normal => "CFS",
+                crate::sched::LinuxSchedPolicy::Fifo => "FIFO",
+            },
+        };
         let vrtime = pcb.sched_info().sched_entity.vruntime;
         let time = pcb.sched_info().sched_entity.sum_exec_runtime;
         let start_time = pcb.sched_info().sched_entity.exec_start;
@@ -141,7 +149,7 @@ impl StatusFileOps {
         // Kthread
         pdata.append(&mut format!("\nKthread:\t{}", pcb.is_kthread() as usize).into());
         pdata.append(&mut format!("\ncpu_id:\t{}", cpu_id).as_bytes().to_owned());
-        pdata.append(&mut format!("\npriority:\t{:?}", priority).as_bytes().to_owned());
+        pdata.append(&mut format!("\npriority:\t{}", priority).as_bytes().to_owned());
 
         pdata.append(&mut format!("\nvrtime:\t{}", vrtime).as_bytes().to_owned());
 

--- a/kernel/src/init/initial_kthread.rs
+++ b/kernel/src/init/initial_kthread.rs
@@ -123,8 +123,7 @@ fn kenrel_init_freeable() -> Result<(), SystemError> {
 
 /// 切换到用户态
 ///
-/// DragonOS 的 init 进程以 BSP idle task 身份创建（调度策略为 IDLE），
-/// 此处清除 kthread 标志并将策略改为 CFS，使其作为普通用户进程被调度。
+/// 将 init 内核线程切换到用户态。
 #[inline(never)]
 fn switch_to_user() -> ! {
     let current_pcb = ProcessManager::current_pcb();
@@ -133,10 +132,6 @@ fn switch_to_user() -> ! {
     current_pcb.flags().remove(ProcessFlags::KTHREAD);
     current_pcb.worker_private().take();
 
-    // BSP idle task 的调度策略为 IDLE，必须切换为 CFS 才能被正常调度
-    current_pcb
-        .sched_info()
-        .set_policy(crate::sched::SchedPolicy::CFS);
     drop(current_pcb);
 
     let mut proc_init_info = ProcInitInfo::new("");

--- a/kernel/src/process/idle.rs
+++ b/kernel/src/process/idle.rs
@@ -85,14 +85,14 @@ impl ProcessManager {
                 .force_mut()
                 .set_cfs(Arc::downgrade(&rq.cfs_rq()));
 
+            debug_assert_eq!(
+                idle_pcb.sched_info().sched_class(),
+                crate::sched::SchedClass::Idle
+            );
+
             // 释放顺序：先 rq_lock，再 pi_lock
             drop(rq_guard);
             drop(pi_guard);
-
-            // 在锁外设置调度策略
-            idle_pcb
-                .sched_info()
-                .set_policy(crate::sched::SchedPolicy::IDLE);
 
             v.push(idle_pcb);
         }

--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -8,8 +8,8 @@ use crate::{
     exception::InterruptArch,
     process::{ProcessControlBlock, ProcessFlags, ProcessManager, ProcessState},
     sched::{
-        cpu_rq, enqueue_task_on_cpu, select_task_rq, DequeueFlag, EnqueueFlag, OnRq, SchedPolicy,
-        Scheduler, WakeupFlags,
+        cpu_rq, enqueue_task_on_cpu, select_task_rq, DequeueFlag, EnqueueFlag, LinuxSchedPolicy,
+        OnRq, SchedClass, Scheduler, WakeupFlags,
     },
     smp::{core::smp_get_processor_id, kick_cpu},
 };
@@ -159,7 +159,7 @@ impl ProcessManager {
         }
 
         // Read task state under the lock.
-        let old_policy = pcb.sched_info().policy();
+        let old_class = pcb.sched_info().sched_class();
         let queued = *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued;
 
         // Determine whether the target is the currently running task on this rq.
@@ -177,17 +177,16 @@ impl ProcessManager {
         // A running task must first be put_prev_task to yield its current
         // execution position.
         if running {
-            match old_policy {
-                SchedPolicy::FIFO => {
+            match old_class {
+                SchedClass::Realtime => {
                     crate::sched::fifo::FifoScheduler::put_prev_task(rq, pcb.clone())
                 }
-                SchedPolicy::CFS => {
+                SchedClass::Fair => {
                     crate::sched::fair::CompletelyFairScheduler::put_prev_task(rq, pcb.clone())
                 }
-                SchedPolicy::IDLE => {
+                SchedClass::Idle => {
                     crate::sched::idle::IdleScheduler::put_prev_task(rq, pcb.clone())
                 }
-                SchedPolicy::RT => todo!("RT scheduler not implemented yet"),
             }
         }
 
@@ -198,7 +197,7 @@ impl ProcessManager {
         //     already passes the kernel prio)
         //   - static_prio is left unchanged (Linux only modifies static_prio for
         //     fair_policy, core.c:7528-7529)
-        pcb.sched_info().set_policy(SchedPolicy::FIFO);
+        pcb.sched_info().set_policy(LinuxSchedPolicy::Fifo);
         pcb.sched_info().set_prio(prio);
         pcb.sched_info().set_normal_prio(prio);
         // This internal API has no RESET_ON_FORK argument. Do not carry a
@@ -218,15 +217,7 @@ impl ProcessManager {
         // Matches Linux __sched_setscheduler: after a running task changes its
         // policy, set_next_task is required.
         if running {
-            match pcb.sched_info().policy() {
-                SchedPolicy::FIFO => {
-                    crate::sched::fifo::FifoScheduler::set_next_task(rq, pcb.clone());
-                }
-                SchedPolicy::CFS => {
-                    crate::sched::fair::CompletelyFairScheduler::set_next_task(rq, pcb.clone());
-                }
-                _ => {}
-            }
+            crate::sched::fifo::FifoScheduler::set_next_task(rq, pcb.clone());
         }
 
         // check_class_changed → preemption check.

--- a/kernel/src/process/sched_info.rs
+++ b/kernel/src/process/sched_info.rs
@@ -11,7 +11,9 @@ use crate::{
         spinlock::{SpinLock, SpinLockGuard},
     },
     process::{ProcessControlBlock, ProcessState},
-    sched::{cpu_is_online, fair::FairSchedEntity, prio::MAX_PRIO, OnRq, SchedPolicy},
+    sched::{
+        cpu_is_online, fair::FairSchedEntity, prio::MAX_PRIO, LinuxSchedPolicy, OnRq, SchedClass,
+    },
     smp::cpu::{AtomicProcessorId, ProcessorId},
 };
 
@@ -42,8 +44,10 @@ pub struct ProcessSchedulerInfo {
     /// Time slice managed by the real-time scheduler.
     // rt_time_slice: AtomicIsize,
     pub sched_stat: RwLock<SchedInfo>,
-    /// Scheduling policy (protected by rq_lock / pi_lock).
+    /// Linux base scheduling policy (protected by rq_lock / pi_lock).
     sched_policy: AtomicU8,
+    /// Effective scheduler class (protected by rq_lock / pi_lock).
+    sched_class: AtomicU8,
     /// CFS scheduling entity.
     pub sched_entity: Arc<FairSchedEntity>,
     pub on_rq: SpinLock<OnRq>,
@@ -122,7 +126,7 @@ impl ProcessSchedulerInfo {
     }
 
     #[inline(never)]
-    pub fn new(on_cpu: Option<ProcessorId>) -> Self {
+    pub fn new(on_cpu: Option<ProcessorId>, initial_class: SchedClass) -> Self {
         let cpu_id = on_cpu.unwrap_or(ProcessorId::INVALID);
         let cpus_allowed = Self::default_cpus_allowed();
         return Self {
@@ -135,7 +139,8 @@ impl ProcessSchedulerInfo {
             // rt_time_slice: AtomicIsize::new(0),
             // priority: SchedPriority::new(100).unwrap(),
             sched_stat: RwLock::new(SchedInfo::default()),
-            sched_policy: AtomicU8::new(SchedPolicy::CFS.to_u8()),
+            sched_policy: AtomicU8::new(LinuxSchedPolicy::Normal.to_u8()),
+            sched_class: AtomicU8::new(initial_class.to_u8()),
             sched_entity: FairSchedEntity::new(),
             on_rq: SpinLock::new(OnRq::None),
             placement: SpinLock::new(NewTaskPlacement::default()),
@@ -347,14 +352,27 @@ impl ProcessSchedulerInfo {
 
     /// Read the scheduling policy.
     #[inline]
-    pub fn policy(&self) -> SchedPolicy {
-        SchedPolicy::from_u8(self.sched_policy.load(Ordering::Relaxed))
+    pub fn policy(&self) -> LinuxSchedPolicy {
+        LinuxSchedPolicy::from_u8(self.sched_policy.load(Ordering::Relaxed))
     }
 
-    /// Set the scheduling policy.
+    /// Set the Linux base policy and its effective base class.
+    ///
+    /// The task must either be unpublished or protected by the existing
+    /// scheduler policy-change lock domain (`pi_lock` and, when applicable,
+    /// its runqueue lock). A future priority-inheritance path may override the
+    /// effective class separately.
     #[inline]
-    pub fn set_policy(&self, policy: SchedPolicy) {
+    pub(crate) fn set_policy(&self, policy: LinuxSchedPolicy) {
+        self.sched_class
+            .store(policy.base_sched_class().to_u8(), Ordering::Relaxed);
         self.sched_policy.store(policy.to_u8(), Ordering::Relaxed);
+    }
+
+    /// Read the scheduler class currently responsible for this task.
+    #[inline]
+    pub fn sched_class(&self) -> SchedClass {
+        SchedClass::from_u8(self.sched_class.load(Ordering::Relaxed))
     }
 
     /// Read the dynamic priority.

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -398,7 +398,12 @@ impl ProcessControlBlock {
         let initial_sighand = SigHand::new();
         initial_sighand.attach_task_ref();
 
-        let sched_info = ProcessSchedulerInfo::new(None);
+        let initial_sched_class = if is_idle {
+            crate::sched::SchedClass::Idle
+        } else {
+            crate::sched::SchedClass::Fair
+        };
+        let sched_info = ProcessSchedulerInfo::new(None, initial_sched_class);
 
         let ppcb: Weak<ProcessControlBlock> = ProcessManager::find_task_by_vpid(ppid)
             .map(|p| Arc::downgrade(&p))

--- a/kernel/src/rcu/mod.rs
+++ b/kernel/src/rcu/mod.rs
@@ -38,7 +38,7 @@ use crate::{
         kthread::KernelThreadClosure, kthread::KernelThreadMechanism, preempt::PreemptGuard,
         ProcessFlags, ProcessManager,
     },
-    sched::{clock::SchedClock, cond_resched, sched_yield, SchedPolicy},
+    sched::{clock::SchedClock, cond_resched, sched_yield, SchedClass},
     smp::{
         core::smp_get_processor_id,
         cpu::{smp_cpu_manager, smp_cpu_manager_initialized, ProcessorId},
@@ -1263,7 +1263,7 @@ fn participating_context_snapshot(
 
 #[inline]
 fn current_task_is_idle() -> bool {
-    ProcessManager::current_pcb().sched_info().policy() == SchedPolicy::IDLE
+    ProcessManager::current_pcb().sched_info().sched_class() == SchedClass::Idle
 }
 
 #[inline]

--- a/kernel/src/sched/cputime.rs
+++ b/kernel/src/sched/cputime.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 use alloc::sync::Arc;
 
-use super::{clock::SchedClock, cpu_irq_time, cpu_rq, prio::PrioUtil, SchedPolicy};
+use super::{clock::SchedClock, cpu_irq_time, cpu_rq, prio::PrioUtil, SchedClass};
 
 /// CPU 时间类型枚举（对齐 Linux kernel_stat.h 的 cpu_usage_stat）
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,8 +204,8 @@ impl CpuTimeFunc {
         let kcpustat = kcpustat_this_cpu();
 
         // 判断是否是 idle 进程
-        let policy = pcb.sched_info().policy();
-        if policy == SchedPolicy::IDLE {
+        let sched_class = pcb.sched_info().sched_class();
+        if sched_class == SchedClass::Idle {
             // idle 进程：根据 nr_iowait 区分 IDLE 和 IOWAIT
             let cpu_id = smp_get_processor_id();
             let rq = cpu_rq(cpu_id.data() as usize);
@@ -241,7 +241,7 @@ impl CpuTimeFunc {
         }
 
         // 只有非 idle 进程才累加 sum_exec_runtime
-        if policy != SchedPolicy::IDLE {
+        if sched_class != SchedClass::Idle {
             pcb.add_sum_exec_runtime(accounted_cputime);
         }
 

--- a/kernel/src/sched/fair.rs
+++ b/kernel/src/sched/fair.rs
@@ -17,8 +17,8 @@ use alloc::sync::{Arc, Weak};
 
 use super::pelt::{add_positive, sub_positive, SchedulerAvg, UpdateAvgFlags, PELT_MIN_DIVIDER};
 use super::{
-    CpuRunQueue, DequeueFlag, EnqueueFlag, LoadWeight, OnRq, SchedPolicy, Scheduler, TaskGroup,
-    WakeupFlags, SCHED_CAPACITY_SHIFT,
+    CpuRunQueue, DequeueFlag, EnqueueFlag, LoadWeight, OnRq, Scheduler, TaskGroup, WakeupFlags,
+    SCHED_CAPACITY_SHIFT,
 };
 
 /// 用于设置 CPU-bound 任务的最小抢占粒度的参数。
@@ -161,7 +161,7 @@ impl FairSchedEntity {
     #[inline]
     pub fn is_idle(&self) -> bool {
         if self.is_task() {
-            return self.pcb().sched_info().policy() == SchedPolicy::IDLE;
+            return false;
         }
 
         return self.cfs_rq().is_idle();
@@ -1398,7 +1398,7 @@ impl Scheduler for CompletelyFairScheduler {
             Arc::ptr_eq(&se.cfs_rq(), &rq.cfs_rq()),
             "enqueue: SE's cfs_rq must match target rq's cfs_rq"
         );
-        let mut idle_h_nr_running = pcb.sched_info().policy() == SchedPolicy::IDLE;
+        let mut idle_h_nr_running = false;
         let (should_continue, se) = FairSchedEntity::for_each_in_group(&mut se, |se| {
             if se.on_rq() {
                 return (false, false);
@@ -1460,7 +1460,7 @@ impl Scheduler for CompletelyFairScheduler {
         mut flags: DequeueFlag,
     ) {
         let mut se = pcb.sched_info().sched_entity();
-        let mut idle_h_nr_running = pcb.sched_info().policy() == SchedPolicy::IDLE;
+        let mut idle_h_nr_running = false;
         let task_sleep = flags.contains(DequeueFlag::DEQUEUE_SLEEP);
         let was_sched_idle = rq.sched_idle_rq();
 
@@ -1593,16 +1593,7 @@ impl Scheduler for CompletelyFairScheduler {
             return;
         }
 
-        if unlikely(curr.sched_info().policy() == SchedPolicy::IDLE)
-            && likely(pcb.sched_info().policy() != SchedPolicy::IDLE)
-        {
-            rq.resched_current();
-            return;
-        }
-
-        if unlikely(pcb.sched_info().policy() != SchedPolicy::CFS)
-            || !SCHED_FEATURES.contains(SchedFeature::WAKEUP_PREEMPTION)
-        {
+        if !SCHED_FEATURES.contains(SchedFeature::WAKEUP_PREEMPTION) {
             return;
         }
 

--- a/kernel/src/sched/fifo.rs
+++ b/kernel/src/sched/fifo.rs
@@ -2,7 +2,7 @@ use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 
 use crate::{process::ProcessControlBlock, sched::prio::MAX_RT_PRIO};
 
-use super::{CpuRunQueue, DequeueFlag, EnqueueFlag, PrioUtil, SchedPolicy, Scheduler, WakeupFlags};
+use super::{CpuRunQueue, DequeueFlag, EnqueueFlag, PrioUtil, SchedClass, Scheduler, WakeupFlags};
 
 #[derive(Debug)]
 pub struct FifoRunQueue {
@@ -124,9 +124,7 @@ impl Scheduler for FifoScheduler {
 
     fn yield_task(rq: &mut CpuRunQueue) {
         let curr = rq.current();
-        if curr.sched_info().policy() != SchedPolicy::FIFO {
-            return;
-        }
+        debug_assert_eq!(curr.sched_info().sched_class(), SchedClass::Realtime);
         rq.fifo.yield_current(&curr);
         rq.resched_current();
     }
@@ -137,10 +135,7 @@ impl Scheduler for FifoScheduler {
         _flags: WakeupFlags,
     ) {
         let curr = rq.current();
-        if curr.sched_info().policy() != SchedPolicy::FIFO {
-            rq.resched_current();
-            return;
-        }
+        debug_assert_eq!(curr.sched_info().sched_class(), SchedClass::Realtime);
 
         let new_prio = Self::rt_prio(pcb);
         let curr_prio = Self::rt_prio(&curr);
@@ -161,10 +156,7 @@ impl Scheduler for FifoScheduler {
     }
 
     fn tick(rq: &mut CpuRunQueue, pcb: Arc<ProcessControlBlock>, _queued: bool) {
-        if pcb.sched_info().policy() != SchedPolicy::FIFO {
-            rq.resched_current();
-            return;
-        }
+        debug_assert_eq!(pcb.sched_info().sched_class(), SchedClass::Realtime);
 
         let Some(highest) = rq.fifo.highest_prio() else {
             return;

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -9,6 +9,7 @@ pub mod fifo_demo;
 pub mod idle;
 pub mod loadavg;
 pub mod pelt;
+pub mod policy;
 pub mod prio;
 pub mod syscall;
 
@@ -59,6 +60,8 @@ use self::{
     prio::{PrioUtil, MAX_RT_PRIO},
 };
 
+pub use policy::{LinuxSchedPolicy, SchedClass};
+
 static mut CPU_IRQ_TIME: Option<Vec<&'static mut IrqTime>> = None;
 pub static IDLE_CPUS: AtomicCpuMask = AtomicCpuMask::new();
 
@@ -91,7 +94,7 @@ pub fn cpu_rq(cpu: usize) -> Arc<CpuRunQueue> {
 
 #[inline]
 fn task_is_idle(pcb: &Arc<ProcessControlBlock>) -> bool {
-    pcb.sched_info().policy() == SchedPolicy::IDLE
+    pcb.sched_info().sched_class() == SchedClass::Idle
 }
 
 #[inline]
@@ -209,7 +212,8 @@ pub fn select_task_rq(
             .unwrap_or(prev_cpu)
     };
 
-    if pcb.flags().contains(ProcessFlags::KTHREAD) || pcb.sched_info().policy() != SchedPolicy::CFS
+    if pcb.flags().contains(ProcessFlags::KTHREAD)
+        || pcb.sched_info().sched_class() != SchedClass::Fair
     {
         return fallback_cpu;
     }
@@ -283,41 +287,6 @@ pub trait Scheduler {
     fn task_fork(pcb: Arc<ProcessControlBlock>);
 
     fn put_prev_task(rq: &mut CpuRunQueue, prev: Arc<ProcessControlBlock>);
-}
-
-/// 调度策略
-///
-/// 裸字段，由调用者持 rq_lock 或 pi_lock 保护。
-#[allow(dead_code)]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
-#[repr(u8)]
-pub enum SchedPolicy {
-    /// 实时进程
-    RT = 0,
-    /// 先进先出调度
-    FIFO = 1,
-    /// 完全公平调度
-    CFS = 2,
-    /// IDLE
-    IDLE = 3,
-}
-
-impl SchedPolicy {
-    #[inline]
-    pub fn to_u8(self) -> u8 {
-        self as u8
-    }
-
-    #[inline]
-    pub fn from_u8(val: u8) -> Self {
-        match val {
-            0 => SchedPolicy::RT,
-            1 => SchedPolicy::FIFO,
-            2 => SchedPolicy::CFS,
-            3 => SchedPolicy::IDLE,
-            _ => panic!("Invalid SchedPolicy value: {val}"),
-        }
-    }
 }
 
 #[allow(dead_code)]
@@ -617,11 +586,10 @@ impl CpuRunQueue {
             }
         }
 
-        match pcb.sched_info().policy() {
-            SchedPolicy::CFS => CompletelyFairScheduler::enqueue(self, pcb, flags),
-            SchedPolicy::FIFO => FifoScheduler::enqueue(self, pcb, flags),
-            SchedPolicy::RT => todo!(),
-            SchedPolicy::IDLE => IdleScheduler::enqueue(self, pcb, flags),
+        match pcb.sched_info().sched_class() {
+            SchedClass::Realtime => FifoScheduler::enqueue(self, pcb, flags),
+            SchedClass::Fair => CompletelyFairScheduler::enqueue(self, pcb, flags),
+            SchedClass::Idle => IdleScheduler::enqueue(self, pcb, flags),
         }
 
         // TODO:https://code.dragonos.org.cn/xref/linux-6.6.21/kernel/sched/core.c#239
@@ -648,11 +616,10 @@ impl CpuRunQueue {
             }
         }
 
-        match pcb.sched_info().policy() {
-            SchedPolicy::CFS => CompletelyFairScheduler::dequeue(self, pcb, flags),
-            SchedPolicy::FIFO => FifoScheduler::dequeue(self, pcb, flags),
-            SchedPolicy::RT => todo!(),
-            SchedPolicy::IDLE => IdleScheduler::dequeue(self, pcb, flags),
+        match pcb.sched_info().sched_class() {
+            SchedClass::Realtime => FifoScheduler::dequeue(self, pcb, flags),
+            SchedClass::Fair => CompletelyFairScheduler::dequeue(self, pcb, flags),
+            SchedClass::Idle => IdleScheduler::dequeue(self, pcb, flags),
         }
     }
 
@@ -675,18 +642,19 @@ impl CpuRunQueue {
     }
 
     /// 检查对应的task是否可以抢占当前运行的task
-    #[allow(clippy::comparison_chain)]
     pub fn check_preempt_current(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
-        if pcb.sched_info().policy() == self.current().sched_info().policy() {
-            match self.current().sched_info().policy() {
-                SchedPolicy::CFS => {
+        let current_class = self.current().sched_info().sched_class();
+        let waking_class = pcb.sched_info().sched_class();
+
+        if waking_class == current_class {
+            match current_class {
+                SchedClass::Fair => {
                     CompletelyFairScheduler::check_preempt_current(self, pcb, flags)
                 }
-                SchedPolicy::FIFO => FifoScheduler::check_preempt_current(self, pcb, flags),
-                SchedPolicy::RT => todo!(),
-                SchedPolicy::IDLE => IdleScheduler::check_preempt_current(self, pcb, flags),
+                SchedClass::Realtime => FifoScheduler::check_preempt_current(self, pcb, flags),
+                SchedClass::Idle => IdleScheduler::check_preempt_current(self, pcb, flags),
             }
-        } else if pcb.sched_info().policy() < self.current().sched_info().policy() {
+        } else if waking_class.outranks(current_class) {
             // 调度优先级更高
             self.resched_current();
         }
@@ -711,27 +679,25 @@ impl CpuRunQueue {
     ///
     /// CFS 的 wakeup-preempt 需要像 Linux `check_preempt_wakeup()` 一样先更新当前实体；
     /// 调用者若不能证明已持目标 rq lock 并更新 rq clock，就必须在这里跳过。
-    #[allow(clippy::comparison_chain)]
     pub fn check_preempt_remote(&mut self, pcb: &Arc<ProcessControlBlock>, flags: WakeupFlags) {
         let current = self.current();
-        let current_policy = current.sched_info().policy();
-        let next_policy = pcb.sched_info().policy();
+        let current_class = current.sched_info().sched_class();
+        let next_class = pcb.sched_info().sched_class();
 
         if current.flags().contains(ProcessFlags::NEED_SCHEDULE) {
-            if current_policy == SchedPolicy::IDLE {
+            if current_class == SchedClass::Idle {
                 self.resched_current();
             }
             return;
         }
 
-        if next_policy < current_policy {
+        if next_class.outranks(current_class) {
             self.resched_current();
-        } else if next_policy == current_policy {
-            match current_policy {
-                SchedPolicy::CFS => {}
-                SchedPolicy::FIFO => FifoScheduler::check_preempt_current(self, pcb, flags),
-                SchedPolicy::RT => todo!(),
-                SchedPolicy::IDLE => IdleScheduler::check_preempt_current(self, pcb, flags),
+        } else if next_class == current_class {
+            match current_class {
+                SchedClass::Fair => {}
+                SchedClass::Realtime => FifoScheduler::check_preempt_current(self, pcb, flags),
+                SchedClass::Idle => IdleScheduler::check_preempt_current(self, pcb, flags),
             }
         }
 
@@ -893,7 +859,7 @@ impl CpuRunQueue {
 
         // A remote idle CPU may be halted; kick it even if the flag was already
         // set so it observes the pending reschedule promptly.
-        if already_requested && current.sched_info().policy() != SchedPolicy::IDLE {
+        if already_requested && current.sched_info().sched_class() != SchedClass::Idle {
             return;
         }
 
@@ -926,14 +892,13 @@ impl CpuRunQueue {
         let next = next.unwrap_or_else(|| self.idle.upgrade().unwrap());
 
         if !Arc::ptr_eq(&prev, &next) {
-            match prev.sched_info().policy() {
-                SchedPolicy::FIFO => FifoScheduler::put_prev_task(self, prev),
-                SchedPolicy::RT => todo!(),
-                SchedPolicy::CFS => CompletelyFairScheduler::put_prev_task(self, prev),
-                SchedPolicy::IDLE => IdleScheduler::put_prev_task(self, prev),
+            match prev.sched_info().sched_class() {
+                SchedClass::Realtime => FifoScheduler::put_prev_task(self, prev),
+                SchedClass::Fair => CompletelyFairScheduler::put_prev_task(self, prev),
+                SchedClass::Idle => IdleScheduler::put_prev_task(self, prev),
             }
 
-            if next.sched_info().policy() == SchedPolicy::CFS {
+            if next.sched_info().sched_class() == SchedClass::Fair {
                 CompletelyFairScheduler::set_next_task(self, next.clone());
             }
         }
@@ -1065,11 +1030,10 @@ pub fn scheduler_tick() {
 
     // 更新请求队列时钟
     rq.update_rq_clock();
-    match current.sched_info().policy() {
-        SchedPolicy::CFS => CompletelyFairScheduler::tick(rq, current, false),
-        SchedPolicy::FIFO => FifoScheduler::tick(rq, current, false),
-        SchedPolicy::RT => todo!(),
-        SchedPolicy::IDLE => IdleScheduler::tick(rq, current, false),
+    match current.sched_info().sched_class() {
+        SchedClass::Realtime => FifoScheduler::tick(rq, current, false),
+        SchedClass::Fair => CompletelyFairScheduler::tick(rq, current, false),
+        SchedClass::Idle => IdleScheduler::tick(rq, current, false),
     }
 
     rq.calculate_global_load_tick();
@@ -1234,7 +1198,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
                 DequeueFlag::DEQUEUE_MOVE | DequeueFlag::DEQUEUE_NOCLOCK,
             );
 
-            if prev.sched_info().policy() == SchedPolicy::CFS {
+            if prev.sched_info().sched_class() == SchedClass::Fair {
                 let mut se = prev.sched_info().sched_entity();
                 crate::sched::fair::FairSchedEntity::for_each_in_group(&mut se, |se| {
                     se.cfs_rq().force_mut().set_current(Weak::default());
@@ -1312,7 +1276,10 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
     // This PR can only set RESET_ON_FORK on CFS tasks. Match Linux's fair
     // policy rule: preserve non-negative nice, but reset negative nice to 0.
-    if reset_on_fork && parent_policy == SchedPolicy::CFS && fork_static_prio < prio::DEFAULT_PRIO {
+    if reset_on_fork
+        && parent_policy == LinuxSchedPolicy::Normal
+        && fork_static_prio < prio::DEFAULT_PRIO
+    {
         fork_prio = prio::DEFAULT_PRIO;
         fork_static_prio = prio::DEFAULT_PRIO;
     }
@@ -1329,10 +1296,10 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     if PrioUtil::dl_prio(fork_prio) {
         return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
     } else if PrioUtil::rt_prio(fork_prio) {
-        // 子进程继承父进程的调度策略（FIFO/RR），而非统一设为 RT
+        // 实时子进程继承父进程的基础策略。
         pcb.sched_info().set_policy(parent_policy);
     } else {
-        pcb.sched_info().set_policy(SchedPolicy::CFS);
+        pcb.sched_info().set_policy(LinuxSchedPolicy::Normal);
     }
 
     pcb.sched_info()
@@ -1353,11 +1320,10 @@ pub fn sched_cgroup_fork(pcb: &Arc<ProcessControlBlock>) {
     let fork_cpu = smp_get_processor_id();
 
     __set_task_cpu(pcb, fork_cpu);
-    match pcb.sched_info().policy() {
-        SchedPolicy::RT => todo!(),
-        SchedPolicy::FIFO => FifoScheduler::task_fork(pcb.clone()),
-        SchedPolicy::CFS => CompletelyFairScheduler::task_fork(pcb.clone()),
-        SchedPolicy::IDLE => todo!(),
+    match pcb.sched_info().sched_class() {
+        SchedClass::Realtime => FifoScheduler::task_fork(pcb.clone()),
+        SchedClass::Fair => CompletelyFairScheduler::task_fork(pcb.clone()),
+        SchedClass::Idle => unreachable!("a fork child cannot use the idle scheduling class"),
     }
 
     debug_assert_eq!(
@@ -1524,11 +1490,10 @@ pub fn sched_yield() {
 
     // TODO: schedstat_inc(rq->yld_count);
 
-    match pcb.sched_info().policy() {
-        SchedPolicy::CFS => CompletelyFairScheduler::yield_task(rq),
-        SchedPolicy::FIFO => FifoScheduler::yield_task(rq),
-        SchedPolicy::RT => rq.resched_current(),
-        SchedPolicy::IDLE => {}
+    match pcb.sched_info().sched_class() {
+        SchedClass::Realtime => FifoScheduler::yield_task(rq),
+        SchedClass::Fair => CompletelyFairScheduler::yield_task(rq),
+        SchedClass::Idle => {}
     }
 
     let preempt_guard = PreemptGuard::new();

--- a/kernel/src/sched/pelt.rs
+++ b/kernel/src/sched/pelt.rs
@@ -6,7 +6,7 @@ use crate::process::ProcessControlBlock;
 
 use super::{
     fair::{CfsRunQueue, FairSchedEntity},
-    CpuRunQueue, LoadWeight, SchedPolicy, SCHED_CAPACITY_SCALE, SCHED_CAPACITY_SHIFT,
+    CpuRunQueue, LoadWeight, SchedClass, SCHED_CAPACITY_SCALE, SCHED_CAPACITY_SHIFT,
 };
 
 const RUNNABLE_AVG_Y_N_INV: [u32; 32] = [
@@ -174,7 +174,7 @@ impl SchedulerAvg {
 
         let cap = (cpu_scale as isize - cfs_rq.avg.util_avg as isize) / 2;
 
-        if pcb.sched_info().policy() != SchedPolicy::CFS {
+        if pcb.sched_info().sched_class() != SchedClass::Fair {
             sa.last_update_time = cfs_rq.cfs_rq_clock_pelt();
         }
 

--- a/kernel/src/sched/policy.rs
+++ b/kernel/src/sched/policy.rs
@@ -1,0 +1,84 @@
+/// Linux scheduling policy implemented by DragonOS.
+///
+/// This is the task's base policy. Flags such as `SCHED_RESET_ON_FORK` and the
+/// scheduler's effective class are deliberately stored separately.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum LinuxSchedPolicy {
+    Normal = 0,
+    Fifo = 1,
+}
+
+impl LinuxSchedPolicy {
+    /// Return the policy's class when no priority-inheritance override applies.
+    #[inline]
+    pub const fn base_sched_class(self) -> SchedClass {
+        match self {
+            Self::Normal => SchedClass::Fair,
+            Self::Fifo => SchedClass::Realtime,
+        }
+    }
+
+    #[inline]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Normal,
+            1 => Self::Fifo,
+            _ => panic!("invalid Linux scheduling policy"),
+        }
+    }
+}
+
+/// Scheduler implementation currently responsible for a task.
+///
+/// Unlike [`LinuxSchedPolicy`], this is an effective property: a future
+/// priority-inheritance implementation may temporarily move a task to a class
+/// other than its base policy's class.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum SchedClass {
+    Realtime = 0,
+    Fair = 1,
+    Idle = 2,
+}
+
+impl SchedClass {
+    #[inline]
+    pub const fn outranks(self, other: Self) -> bool {
+        matches!(
+            (self, other),
+            (Self::Realtime, Self::Fair | Self::Idle) | (Self::Fair, Self::Idle)
+        )
+    }
+
+    #[inline]
+    pub const fn to_u8(self) -> u8 {
+        self as u8
+    }
+
+    #[inline]
+    pub const fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Realtime,
+            1 => Self::Fair,
+            2 => Self::Idle,
+            _ => panic!("invalid scheduler class"),
+        }
+    }
+}
+
+const _: () = {
+    assert!(LinuxSchedPolicy::Normal.base_sched_class() as u8 == SchedClass::Fair as u8);
+    assert!(LinuxSchedPolicy::Fifo.base_sched_class() as u8 == SchedClass::Realtime as u8);
+    assert!(SchedClass::Realtime.outranks(SchedClass::Fair));
+    assert!(SchedClass::Realtime.outranks(SchedClass::Idle));
+    assert!(SchedClass::Fair.outranks(SchedClass::Idle));
+    assert!(!SchedClass::Fair.outranks(SchedClass::Realtime));
+    assert!(!SchedClass::Idle.outranks(SchedClass::Fair));
+    assert!(!SchedClass::Idle.outranks(SchedClass::Realtime));
+};

--- a/kernel/src/sched/syscall/sys_sched_getparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_getparam.rs
@@ -4,7 +4,7 @@ use system_error::SystemError;
 
 use crate::{
     arch::{interrupt::TrapFrame, syscall::nr::SYS_SCHED_GETPARAM},
-    sched::{prio::PrioUtil, SchedPolicy},
+    sched::{prio::PrioUtil, LinuxSchedPolicy},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::UserBufferWriter,
@@ -38,9 +38,9 @@ impl Syscall for SysSchedGetparam {
         };
 
         let sched_priority = match policy {
-            SchedPolicy::CFS | SchedPolicy::IDLE => 0,
-            SchedPolicy::RT | SchedPolicy::FIFO => PrioUtil::internal_rt_prio_to_user(normal_prio)
-                .ok_or_else(|| {
+            LinuxSchedPolicy::Normal => 0,
+            LinuxSchedPolicy::Fifo => {
+                PrioUtil::internal_rt_prio_to_user(normal_prio).ok_or_else(|| {
                     log::error!(
                         "task {} has invalid internal RT priority {}",
                         target.raw_pid().data(),
@@ -52,7 +52,8 @@ impl Syscall for SysSchedGetparam {
                         target.raw_pid().data()
                     );
                     SystemError::EIO
-                })?,
+                })?
+            }
         };
 
         let sched_param = KernelSchedParam { sched_priority };

--- a/kernel/src/sched/syscall/sys_sched_setscheduler.rs
+++ b/kernel/src/sched/syscall/sys_sched_setscheduler.rs
@@ -8,7 +8,7 @@ use crate::{
         cred::{capable, CAPFlags},
         ProcessManager,
     },
-    sched::SchedPolicy,
+    sched::LinuxSchedPolicy,
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::UserBufferReader,
@@ -95,7 +95,7 @@ impl Syscall for SysSchedSetscheduler {
 
         loop {
             let mut pi_guard = target.sched_info().pi_lock_irqsave();
-            if target.sched_info().policy() != SchedPolicy::CFS {
+            if target.sched_info().policy() != LinuxSchedPolicy::Normal {
                 return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
             }
 

--- a/kernel/src/sched/syscall/types.rs
+++ b/kernel/src/sched/syscall/types.rs
@@ -1,4 +1,4 @@
-use crate::sched::SchedPolicy;
+use crate::sched::LinuxSchedPolicy;
 
 /// Legacy Linux scheduler parameter ABI.
 ///
@@ -35,11 +35,9 @@ pub(super) fn legacy_policy_priority_range(policy: i32) -> Option<(i32, i32)> {
 }
 
 #[inline]
-pub(super) fn policy_to_linux(policy: SchedPolicy) -> i32 {
+pub(super) fn policy_to_linux(policy: LinuxSchedPolicy) -> i32 {
     match policy {
-        SchedPolicy::CFS => SCHED_OTHER,
-        SchedPolicy::FIFO => SCHED_FIFO,
-        SchedPolicy::RT => SCHED_RR,
-        SchedPolicy::IDLE => SCHED_IDLE,
+        LinuxSchedPolicy::Normal => SCHED_OTHER,
+        LinuxSchedPolicy::Fifo => SCHED_FIFO,
     }
 }

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -5,6 +5,7 @@
 #include <climits>
 #include <cstddef>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <pthread.h>
 #include <poll.h>
@@ -53,6 +54,41 @@ long RawGetPriorityMin(uint64_t policy) {
 bool IsDragonOS() {
     struct utsname info {};
     return uname(&info) == 0 && strstr(info.release, "dragonos") != nullptr;
+}
+
+bool ReadAggregateIdleClassTicks(uint64_t* idle_class_ticks) {
+    FILE* stat = fopen("/proc/stat", "r");
+    if (stat == nullptr) return false;
+
+    char label[8] = {};
+    unsigned long long user = 0;
+    unsigned long long nice = 0;
+    unsigned long long system = 0;
+    unsigned long long idle = 0;
+    unsigned long long iowait = 0;
+    const int fields = fscanf(stat, "%7s %llu %llu %llu %llu %llu", label, &user, &nice,
+                              &system, &idle, &iowait);
+    const int close_result = fclose(stat);
+    if (fields != 6 || close_result != 0 || strcmp(label, "cpu") != 0) return false;
+
+    *idle_class_ticks = static_cast<uint64_t>(idle) + static_cast<uint64_t>(iowait);
+    return true;
+}
+
+bool ReadSelfSchedulerLabel(char* label, size_t label_size) {
+    if (label_size < 16) return false;
+    FILE* status = fopen("/proc/self/status", "r");
+    if (status == nullptr) return false;
+
+    char line[128] = {};
+    bool found = false;
+    while (fgets(line, sizeof(line), status) != nullptr) {
+        if (strncmp(line, "priority:\t", 10) != 0) continue;
+        found = sscanf(line + 10, "%15s", label) == 1;
+        break;
+    }
+    const int close_result = fclose(status);
+    return found && close_result == 0;
 }
 
 int WaitForChild(pid_t child) {
@@ -179,6 +215,28 @@ TEST(SchedGetScheduler, CurrentAndErrorsMatchLinux) {
     errno = 0;
     EXPECT_EQ(-1, sched_getscheduler(INT_MAX));
     EXPECT_EQ(ESRCH, errno);
+}
+
+TEST(SchedGetScheduler, ProcStatusKeepsLegacyClassLabel) {
+    if (!IsDragonOS()) GTEST_SKIP() << "DragonOS-specific proc status field";
+
+    char label[16] = {};
+    ASSERT_TRUE(ReadSelfSchedulerLabel(label, sizeof(label)))
+        << "failed to read priority field from /proc/self/status";
+    EXPECT_STREQ("CFS", label);
+}
+
+TEST(SchedClassAccounting, IdleClassTicksAdvanceWhileCallerSleeps) {
+    if (!IsDragonOS()) GTEST_SKIP() << "DragonOS idle-class accounting regression";
+
+    uint64_t before = 0;
+    ASSERT_TRUE(ReadAggregateIdleClassTicks(&before))
+        << "failed to parse aggregate /proc/stat cpu line";
+    ASSERT_EQ(0, usleep(300 * 1000)) << strerror(errno);
+    uint64_t after = 0;
+    ASSERT_TRUE(ReadAggregateIdleClassTicks(&after))
+        << "failed to parse aggregate /proc/stat cpu line";
+    EXPECT_GT(after, before) << "idle-class accounting did not advance while the test slept";
 }
 
 TEST(SchedPriorityQueries, KnownPolicyMatrixMatchesLinux) {


### PR DESCRIPTION
Related to #760.

## Summary

- introduce explicit Linux scheduling policy and effective scheduler class types
- store policy and class independently and dispatch scheduler operations by class
- initialize CPU idle tasks with the Idle class before publication
- preserve syscall and procfs policy behavior while removing obsolete policy branches
- cover idle/iowait accounting and the legacy proc status scheduler label

## Design

The Linux ABI policy describes user-visible configuration, while the scheduler class controls runtime dispatch. Keeping these concepts separate prevents CPU idle classification and future effective-class overrides from being represented as fake user policies.

This change intentionally models only the currently implemented Normal and FIFO policies. It does not add RR, PI, or a generic scheduler-class framework.

## Validation

- make fmt ARCH=x86_64
- kernel clippy with all features
- x86_64, riscv64, and loongarch64 kernel builds
- scheduler policy dunitest: 14/14
- RCU selftest: 6/6
- affinity: 7/7
- tracepoint: 9/9
- fork: 10/10
- RCU torture: 1/1
- FIFO demo repeated sleep/wakeup smoke test with concurrent shell progress
- git diff --check