### PR TITLE
refactor(net): centralize interface address mutations

### DIFF
--- a/kernel/src/driver/net/bridge.rs
+++ b/kernel/src/driver/net/bridge.rs
@@ -317,10 +317,14 @@ fn bridge_probe() {
     let addr4 = IpAddress::v4(200, 0, 0, 4);
     let cidr4 = IpCidr::new(addr4, 24);
 
-    iface1.update_ip_addrs(cidr1);
-    iface2.update_ip_addrs(cidr2);
-    iface3.update_ip_addrs(cidr3);
-    iface4.update_ip_addrs(cidr4);
+    crate::net::address::initialize_address(&(iface1.clone() as Arc<dyn Iface>), cidr1)
+        .expect("initialize veth address");
+    crate::net::address::initialize_address(&(iface2.clone() as Arc<dyn Iface>), cidr2)
+        .expect("initialize veth address");
+    crate::net::address::initialize_address(&(iface3.clone() as Arc<dyn Iface>), cidr3)
+        .expect("initialize veth address");
+    crate::net::address::initialize_address(&(iface4.clone() as Arc<dyn Iface>), cidr4)
+        .expect("initialize veth address");
 
     iface1.add_default_route_to_peer(addr2);
     iface2.add_default_route_to_peer(addr1);

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -1,3 +1,4 @@
+use alloc::ffi::CString;
 use alloc::sync::Weak;
 use alloc::{fmt, vec::Vec};
 use alloc::{string::String, sync::Arc};
@@ -62,6 +63,18 @@ pub enum Operstate {
     IF_OPER_DORMANT = 5,
     /// 网络接口已启用
     IF_OPER_UP = 6,
+}
+
+/// Control-plane metadata attached to one configured interface address.
+///
+/// `label == None` means the interface's current primary name. Keeping that
+/// distinction avoids stale labels after a device rename while preserving an
+/// explicitly supplied Linux IFA_LABEL alias verbatim.
+#[derive(Debug, Clone)]
+pub(crate) struct AddressMetadata {
+    pub cidr: smoltcp::wire::IpCidr,
+    pub label: Option<CString>,
+    pub owner_token: Option<u64>,
 }
 
 #[allow(dead_code)]
@@ -324,6 +337,10 @@ pub struct IfaceCommon {
     /// NAPI 结构体
     napi_struct: RwLock<Option<Arc<NapiStruct>>>,
     netlink_routes: RwSem<Vec<NetlinkRouteEntry>>,
+    /// Per-address control-plane state committed together with smoltcp's
+    /// address list. It carries Linux IFA_LABEL semantics and opaque ownership
+    /// tokens for in-kernel actors such as DHCP.
+    address_metadata: Mutex<Vec<AddressMetadata>>,
     static_neighbors: RwSem<Vec<StaticNeighborEntry>>,
     /// TCP close(2) 语义辅助：延迟回收 smoltcp TCP socket（Linux-like）。
     tcp_close_defer: crate::net::tcp_close_defer::TcpCloseDefer,
@@ -357,6 +374,15 @@ impl IfaceCommon {
             .ip_addrs
             .write()
             .extend_from_slice(iface.ip_addrs());
+        let address_metadata = iface
+            .ip_addrs()
+            .iter()
+            .map(|cidr| AddressMetadata {
+                cidr: *cidr,
+                label: None,
+                owner_token: None,
+            })
+            .collect();
         IfaceCommon {
             iface_id,
             name: RwLock::new(name),
@@ -372,6 +398,7 @@ impl IfaceCommon {
             type_,
             napi_struct: RwLock::new(None),
             netlink_routes: RwSem::new(Vec::new()),
+            address_metadata: Mutex::new(address_metadata),
             static_neighbors: RwSem::new(Vec::new()),
             tcp_close_defer: crate::net::tcp_close_defer::TcpCloseDefer::new(),
             tcp_listener_backlog: crate::net::tcp_listener_backlog::TcpListenerBacklog::new(),
@@ -742,6 +769,10 @@ impl IfaceCommon {
         self.netlink_routes.read()
     }
 
+    pub(crate) fn address_metadata(&self) -> &Mutex<Vec<AddressMetadata>> {
+        &self.address_metadata
+    }
+
     pub fn upsert_netlink_route(&self, route: NetlinkRouteEntry) {
         let mut routes = self.netlink_routes.write();
         if let Some(existing) = routes.iter_mut().find(|existing| {
@@ -767,11 +798,10 @@ impl IfaceCommon {
         destination: smoltcp::wire::IpCidr,
         source: Option<smoltcp::wire::IpCidr>,
         table: u8,
-    ) -> bool {
+    ) -> Option<NetlinkRouteEntry> {
         let mut routes = self.netlink_routes.write();
-        let before = routes.len();
-        routes.retain(|existing| {
-            !(existing.destination == destination
+        let index = routes.iter().position(|existing| {
+            existing.destination == destination
                 && existing.table == table
                 && existing
                     .source
@@ -779,9 +809,9 @@ impl IfaceCommon {
                     .map(|cidr| (cidr.address(), cidr.prefix_len()))
                     == source
                         .as_ref()
-                        .map(|cidr| (cidr.address(), cidr.prefix_len())))
-        });
-        routes.len() != before
+                        .map(|cidr| (cidr.address(), cidr.prefix_len()))
+        })?;
+        Some(routes.remove(index))
     }
 
     pub fn static_neighbors(&self) -> RwSemReadGuard<'_, Vec<StaticNeighborEntry>> {

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -135,16 +135,6 @@ pub trait Iface: crate::driver::base::device::Device {
         false
     }
 
-    /// # `update_ip_addrs`
-    /// 用于更新接口的 IP 地址
-    /// ## 参数
-    /// - `ip_addrs` ：一个包含 `smoltcp::wire::IpCidr` 的切片，表示要设置的 IP 地址和子网掩码
-    /// ## 返回值
-    /// - 如果 `ip_addrs` 的长度不为 1，返回 `Err(SystemError::EINVAL)`，表示输入参数无效
-    fn update_ip_addrs(&self, ip_addrs: &[smoltcp::wire::IpCidr]) -> Result<(), SystemError> {
-        self.common().update_ip_addrs(ip_addrs)
-    }
-
     /// @brief 获取smoltcp的网卡接口类型
     #[inline(always)]
     fn smol_iface(&self) -> &Mutex<smoltcp::iface::Interface> {
@@ -619,23 +609,6 @@ impl IfaceCommon {
         if let Some(netns) = self.net_namespace() {
             netns.notify_deadline_changed();
         }
-    }
-
-    pub fn update_ip_addrs(&self, ip_addrs: &[smoltcp::wire::IpCidr]) -> Result<(), SystemError> {
-        if ip_addrs.len() != 1 {
-            return Err(SystemError::EINVAL);
-        }
-
-        self.smol_iface.lock().update_ip_addrs(|addrs| {
-            let dest = addrs.iter_mut().next();
-
-            if let Some(dest) = dest {
-                *dest = ip_addrs[0];
-            } else {
-                addrs.push(ip_addrs[0]).expect("Push ipCidr failed: full");
-            }
-        });
-        return Ok(());
     }
 
     // 需要bounds储存具体的Inet Socket信息，以提供不同种类inet socket的事件分发

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -450,32 +450,6 @@ impl VethInterface {
         self.inner.lock()
     }
 
-    /// # `update_ip_addrs`
-    /// 更新虚拟以太网设备的 IP 地址
-    /// ## 参数
-    /// - `cidr`: 要添加的 IP 地址和子网掩码
-    /// ## 描述
-    /// 该方法会将指定的 IP 地址添加到虚拟以太网设备的 IP 地址列表中。
-    /// 如果添加失败（例如列表已满），则会触发 panic。
-    pub fn update_ip_addrs(&self, cidr: IpCidr) {
-        let iface = &mut self.common.smol_iface.lock();
-        iface.update_ip_addrs(|ip_addrs| {
-            ip_addrs.push(cidr).expect("Push ipCidr failed: full");
-        });
-        self.common.router_common_data.ip_addrs.write().push(cidr);
-
-        // // 直接更新对端的arp_table
-        // self.inner.lock().peer_veth.upgrade().map(|peer| {
-        //     peer.common
-        //         .router_common_data
-        //         .arp_table
-        //         .write()
-        //         .insert(cidr.address(), self.mac())
-        // });
-
-        // log::info!("VethInterface {} updated IP address: {}", self.name, addr);
-    }
-
     /// # `add_default_route_to_peer`
     /// 添加默认路由到对端虚拟以太网设备
     /// ## 参数
@@ -789,19 +763,23 @@ fn veth_route_test() {
 
     let addr1 = IpAddress::v4(192, 168, 1, 1);
     let cidr1 = IpCidr::new(addr1, 24);
-    iface_ns1.update_ip_addrs(cidr1);
+    crate::net::address::initialize_address(&(iface_ns1.clone() as Arc<dyn Iface>), cidr1)
+        .expect("initialize veth address");
 
     let addr2 = IpAddress::v4(192, 168, 1, 254);
     let cidr2 = IpCidr::new(addr2, 24);
-    iface_host1.update_ip_addrs(cidr2);
+    crate::net::address::initialize_address(&(iface_host1.clone() as Arc<dyn Iface>), cidr2)
+        .expect("initialize veth address");
 
     let addr3 = IpAddress::v4(192, 168, 2, 254);
     let cidr3 = IpCidr::new(addr3, 24);
-    iface_host2.update_ip_addrs(cidr3);
+    crate::net::address::initialize_address(&(iface_host2.clone() as Arc<dyn Iface>), cidr3)
+        .expect("initialize veth address");
 
     let addr4 = IpAddress::v4(192, 168, 2, 3);
     let cidr4 = IpCidr::new(addr4, 24);
-    iface_ns2.update_ip_addrs(cidr4);
+    crate::net::address::initialize_address(&(iface_ns2.clone() as Arc<dyn Iface>), cidr4)
+        .expect("initialize veth address");
 
     // 添加默认路由
     iface_ns1.add_default_route_to_peer(addr2);
@@ -880,11 +858,13 @@ fn veth_epoll_test() {
 
     let addr1 = IpAddress::v4(111, 111, 11, 1);
     let cidr1 = IpCidr::new(addr1, 24);
-    iface1.update_ip_addrs(cidr1);
+    crate::net::address::initialize_address(&(iface1.clone() as Arc<dyn Iface>), cidr1)
+        .expect("initialize veth address");
 
     let addr2 = IpAddress::v4(111, 111, 11, 2);
     let cidr2 = IpCidr::new(addr2, 24);
-    iface2.update_ip_addrs(cidr2);
+    crate::net::address::initialize_address(&(iface2.clone() as Arc<dyn Iface>), cidr2)
+        .expect("initialize veth address");
 
     iface1.add_default_route_to_peer(addr2);
     iface2.add_default_route_to_peer(addr1);

--- a/kernel/src/net/address.rs
+++ b/kernel/src/net/address.rs
@@ -4,22 +4,25 @@
 //! address list, its connected-route projection, and the router compatibility
 //! projection are committed under one smoltcp interface lock.
 
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{ffi::CString, format, sync::Arc, vec::Vec};
+use core::sync::atomic::{AtomicU64, Ordering};
 
 use smoltcp::{
     iface::Route,
-    wire::{IpAddress, IpCidr},
+    wire::{IpAddress, IpCidr, Ipv6AddressExt, Ipv6Cidr},
 };
 use system_error::SystemError;
 
-use crate::{driver::net::Iface, net::rtnl::RtnlGuard};
+use crate::{
+    driver::net::{AddressMetadata, Iface},
+    net::rtnl::RtnlGuard,
+};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AddressMutation {
     Add(IpCidr),
     Delete(IpCidr),
     Replace(IpCidr),
-    ExchangeOwned { old: IpCidr, new: IpCidr },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,13 +33,178 @@ pub(crate) enum AddressMutationOutcome {
     Exchanged { old: IpCidr, new: IpCidr },
 }
 
+/// Identity of an address object created by an in-kernel control plane.
+///
+/// The token is deliberately opaque outside this module. A userspace
+/// delete/re-add of the same CIDR creates a different object and invalidates
+/// the old token, preventing cross-event ABA ownership bugs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(in crate::net) struct AddressLease {
+    cidr: IpCidr,
+    token: u64,
+}
+
+impl AddressLease {
+    pub(in crate::net) fn cidr(self) -> IpCidr {
+        self.cidr
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CommitMutation {
+    Plain(AddressMutation),
+    AddOwned { cidr: IpCidr, token: u64 },
+    DeleteOwned(AddressLease),
+    ExchangeOwned { old: AddressLease, new: IpCidr },
+}
+
+struct CommitResult {
+    outcome: AddressMutationOutcome,
+    lease: Option<AddressLease>,
+}
+
+static NEXT_ADDRESS_OWNER_TOKEN: AtomicU64 = AtomicU64::new(1);
+
 /// Mutates an address on an interface that is already visible in a netns.
 pub(in crate::net) fn mutate_address(
     _rtnl: &RtnlGuard,
     iface: &Arc<dyn Iface>,
     mutation: AddressMutation,
 ) -> Result<AddressMutationOutcome, SystemError> {
-    commit(iface, mutation)
+    commit(iface, CommitMutation::Plain(mutation), None).map(|result| result.outcome)
+}
+
+pub(in crate::net) fn mutate_labeled_address(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    mutation: AddressMutation,
+    label: Option<CString>,
+) -> Result<AddressMutationOutcome, SystemError> {
+    commit(iface, CommitMutation::Plain(mutation), label).map(|result| result.outcome)
+}
+
+pub(in crate::net) fn add_owned_address(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+) -> Result<(AddressMutationOutcome, AddressLease), SystemError> {
+    let token = NEXT_ADDRESS_OWNER_TOKEN
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |current| {
+            current.checked_add(1)
+        })
+        .map_err(|_| SystemError::EOVERFLOW)?;
+    let result = commit(iface, CommitMutation::AddOwned { cidr, token }, None)?;
+    Ok((
+        result.outcome,
+        result.lease.expect("owned add returns a lease"),
+    ))
+}
+
+pub(in crate::net) fn exchange_owned_address(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    old: AddressLease,
+    new: IpCidr,
+) -> Result<(AddressMutationOutcome, AddressLease), SystemError> {
+    let result = commit(iface, CommitMutation::ExchangeOwned { old, new }, None)?;
+    Ok((
+        result.outcome,
+        result.lease.expect("owned exchange returns a lease"),
+    ))
+}
+
+pub(in crate::net) fn delete_owned_address(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    lease: AddressLease,
+) -> Result<AddressMutationOutcome, SystemError> {
+    commit(iface, CommitMutation::DeleteOwned(lease), None).map(|result| result.outcome)
+}
+
+pub(in crate::net) fn address_label(
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+) -> Result<CString, SystemError> {
+    let explicit = iface
+        .common()
+        .address_metadata()
+        .lock()
+        .iter()
+        .find(|entry| entry.cidr == cidr)
+        .and_then(|entry| entry.label.clone());
+    explicit
+        .map(Ok)
+        .unwrap_or_else(|| CString::new(iface.iface_name()).map_err(|_| SystemError::EINVAL))
+}
+
+pub(in crate::net) fn address_snapshot(
+    iface: &Arc<dyn Iface>,
+) -> Result<Vec<(IpCidr, CString)>, SystemError> {
+    let smol_iface = iface.smol_iface().lock();
+    let metadata = iface.common().address_metadata().lock();
+    let default_label = CString::new(iface.iface_name()).map_err(|_| SystemError::EINVAL)?;
+    smol_iface
+        .ip_addrs()
+        .iter()
+        .map(|cidr| {
+            let label = metadata
+                .iter()
+                .find(|entry| entry.cidr == *cidr)
+                .and_then(|entry| entry.label.clone())
+                .unwrap_or_else(|| default_label.clone());
+            Ok((*cidr, label))
+        })
+        .collect()
+}
+
+/// Applies Linux's IPv4 alias-label rename rules while RTNL is held.
+pub(in crate::net) fn rename_address_labels(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    new_name: &str,
+) -> Result<Vec<IpCidr>, SystemError> {
+    const IFNAME_MAX: usize = 15;
+
+    let old_name = iface.iface_name();
+    let mut metadata = iface.common().address_metadata().lock();
+    let mut renamed = Vec::new();
+    let mut ordinal = 0usize;
+    for entry in metadata
+        .iter_mut()
+        .filter(|entry| matches!(entry.cidr, IpCidr::Ipv4(_)))
+    {
+        ordinal += 1;
+        renamed.push(entry.cidr);
+        if ordinal == 1 {
+            entry.label = None;
+            continue;
+        }
+
+        let old_label = entry
+            .label
+            .as_ref()
+            .map(|label| label.as_bytes())
+            .unwrap_or_else(|| old_name.as_bytes());
+        let generated_suffix;
+        let suffix = match old_label.iter().position(|byte| *byte == b':') {
+            Some(index) => &old_label[index..],
+            None => {
+                generated_suffix = format!(":{ordinal}").into_bytes();
+                generated_suffix.as_slice()
+            }
+        };
+        let suffix = if suffix.len() > IFNAME_MAX {
+            &suffix[suffix.len() - IFNAME_MAX..]
+        } else {
+            suffix
+        };
+        let prefix_len = new_name.len().min(IFNAME_MAX - suffix.len());
+        let mut label = Vec::with_capacity(prefix_len + suffix.len());
+        label.extend_from_slice(&new_name.as_bytes()[..prefix_len]);
+        label.extend_from_slice(suffix);
+        entry.label = Some(CString::new(label).map_err(|_| SystemError::EINVAL)?);
+    }
+    Ok(renamed)
 }
 
 /// Initializes an address before an interface is published in a netns.
@@ -48,21 +216,105 @@ pub(crate) fn initialize_address(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result
     if iface.net_namespace().is_some() {
         return Err(SystemError::EBUSY);
     }
-    commit(iface, AddressMutation::Add(cidr)).map(|_| ())
+    commit(
+        iface,
+        CommitMutation::Plain(AddressMutation::Add(cidr)),
+        None,
+    )
+    .map(|_| ())
 }
 
 fn commit(
     iface: &Arc<dyn Iface>,
-    mutation: AddressMutation,
-) -> Result<AddressMutationOutcome, SystemError> {
+    mutation: CommitMutation,
+    requested_label: Option<CString>,
+) -> Result<CommitResult, SystemError> {
     validate_mutation(mutation)?;
 
+    let old_explicit_owner = match mutation {
+        CommitMutation::Plain(AddressMutation::Add(cidr))
+        | CommitMutation::Plain(AddressMutation::Delete(cidr))
+        | CommitMutation::Plain(AddressMutation::Replace(cidr))
+        | CommitMutation::AddOwned { cidr, .. }
+        | CommitMutation::DeleteOwned(AddressLease { cidr, .. }) => {
+            has_explicit_connected_owner(iface, cidr)
+        }
+        CommitMutation::ExchangeOwned { old, .. } => has_explicit_connected_owner(iface, old.cidr),
+    };
+    let new_explicit_owner = match mutation {
+        CommitMutation::ExchangeOwned { new, .. } => has_explicit_connected_owner(iface, new),
+        _ => false,
+    };
+
     let mut smol_iface = iface.smol_iface().lock();
-    let outcome = match mutation {
-        AddressMutation::Add(cidr) => add(&mut smol_iface, cidr)?,
-        AddressMutation::Delete(cidr) => delete(&mut smol_iface, cidr)?,
-        AddressMutation::Replace(cidr) => replace(&mut smol_iface, cidr)?,
-        AddressMutation::ExchangeOwned { old, new } => exchange_owned(&mut smol_iface, old, new)?,
+    let mut metadata = iface.common().address_metadata().lock();
+    let (outcome, lease) = match mutation {
+        CommitMutation::Plain(AddressMutation::Add(cidr)) => {
+            let outcome = add(&mut smol_iface, cidr, old_explicit_owner)?;
+            metadata.push(AddressMetadata {
+                cidr,
+                label: requested_label,
+                owner_token: None,
+            });
+            (outcome, None)
+        }
+        CommitMutation::Plain(AddressMutation::Delete(cidr)) => {
+            let outcome = delete(&mut smol_iface, cidr, old_explicit_owner)?;
+            metadata.retain(|entry| entry.cidr != cidr);
+            (outcome, None)
+        }
+        CommitMutation::Plain(AddressMutation::Replace(cidr)) => {
+            let outcome = replace(&mut smol_iface, cidr, old_explicit_owner)?;
+            if matches!(outcome, AddressMutationOutcome::Added(_)) {
+                metadata.push(AddressMetadata {
+                    cidr,
+                    label: requested_label,
+                    owner_token: None,
+                });
+            }
+            (outcome, None)
+        }
+        CommitMutation::AddOwned { cidr, token } => {
+            let outcome = add(&mut smol_iface, cidr, old_explicit_owner)?;
+            metadata.push(AddressMetadata {
+                cidr,
+                label: None,
+                owner_token: Some(token),
+            });
+            (outcome, Some(AddressLease { cidr, token }))
+        }
+        CommitMutation::DeleteOwned(lease) => {
+            let owner_index = metadata
+                .iter()
+                .position(|entry| {
+                    entry.cidr == lease.cidr && entry.owner_token == Some(lease.token)
+                })
+                .ok_or(SystemError::ESTALE)?;
+            let outcome = delete(&mut smol_iface, lease.cidr, old_explicit_owner)?;
+            metadata.remove(owner_index);
+            (outcome, None)
+        }
+        CommitMutation::ExchangeOwned { old, new } => {
+            let owner_index = metadata
+                .iter()
+                .position(|entry| entry.cidr == old.cidr && entry.owner_token == Some(old.token))
+                .ok_or(SystemError::ESTALE)?;
+            let outcome = exchange_owned(
+                &mut smol_iface,
+                old.cidr,
+                new,
+                old_explicit_owner,
+                new_explicit_owner,
+            )?;
+            metadata[owner_index].cidr = new;
+            (
+                outcome,
+                Some(AddressLease {
+                    cidr: new,
+                    token: old.token,
+                }),
+            )
+        }
     };
 
     // Preserve the established smoltcp -> router projection lock order. Veth
@@ -73,18 +325,20 @@ fn commit(
     projection.clear();
     projection.extend_from_slice(&snapshot);
 
-    Ok(outcome)
+    Ok(CommitResult { outcome, lease })
 }
 
-fn validate_mutation(mutation: AddressMutation) -> Result<(), SystemError> {
+fn validate_mutation(mutation: CommitMutation) -> Result<(), SystemError> {
     match mutation {
-        AddressMutation::Add(cidr)
-        | AddressMutation::Delete(cidr)
-        | AddressMutation::Replace(cidr) => validate_cidr(cidr),
-        AddressMutation::ExchangeOwned { old, new } => {
-            validate_cidr(old)?;
+        CommitMutation::Plain(AddressMutation::Add(cidr))
+        | CommitMutation::Plain(AddressMutation::Delete(cidr))
+        | CommitMutation::Plain(AddressMutation::Replace(cidr))
+        | CommitMutation::AddOwned { cidr, .. }
+        | CommitMutation::DeleteOwned(AddressLease { cidr, .. }) => validate_cidr(cidr),
+        CommitMutation::ExchangeOwned { old, new } => {
+            validate_cidr(old.cidr)?;
             validate_cidr(new)?;
-            if same_family(old, new) {
+            if same_family(old.cidr, new) {
                 Ok(())
             } else {
                 Err(SystemError::EINVAL)
@@ -106,6 +360,7 @@ fn validate_cidr(cidr: IpCidr) -> Result<(), SystemError> {
 fn add(
     iface: &mut smoltcp::iface::Interface,
     cidr: IpCidr,
+    share_existing_projection: bool,
 ) -> Result<AddressMutationOutcome, SystemError> {
     if find_for_new_or_replace(iface.ip_addrs(), cidr).is_some() {
         return Err(SystemError::EEXIST);
@@ -126,7 +381,12 @@ fn add(
         return Err(SystemError::ENOSPC);
     }
 
-    if !insert_connected_route(iface, cidr) {
+    let share_existing_projection = share_existing_projection
+        || iface
+            .ip_addrs()
+            .iter()
+            .any(|configured| same_connected_projection(*configured, cidr));
+    if !insert_connected_route(iface, cidr, share_existing_projection) {
         iface.update_ip_addrs(|addresses| {
             if let Some(index) = addresses.iter().position(|item| *item == cidr) {
                 addresses.remove(index);
@@ -141,14 +401,23 @@ fn add(
 fn delete(
     iface: &mut smoltcp::iface::Interface,
     cidr: IpCidr,
+    preserve_connected_route: bool,
 ) -> Result<AddressMutationOutcome, SystemError> {
     let index = find_for_delete(iface.ip_addrs(), cidr).ok_or(SystemError::EADDRNOTAVAIL)?;
     let effective = iface.ip_addrs()[index];
+    let preserve_connected_route = preserve_connected_route
+        || iface
+            .ip_addrs()
+            .iter()
+            .enumerate()
+            .any(|(other, configured)| {
+                other != index && same_connected_projection(*configured, effective)
+            });
 
     iface.update_ip_addrs(|addresses| {
         addresses.remove(index);
     });
-    remove_connected_route(iface, effective);
+    set_connected_route_presence(iface, effective, preserve_connected_route);
 
     Ok(AddressMutationOutcome::Deleted(effective))
 }
@@ -156,13 +425,14 @@ fn delete(
 fn replace(
     iface: &mut smoltcp::iface::Interface,
     cidr: IpCidr,
+    share_existing_projection: bool,
 ) -> Result<AddressMutationOutcome, SystemError> {
     let Some(index) = find_for_new_or_replace(iface.ip_addrs(), cidr) else {
-        return add(iface, cidr);
+        return add(iface, cidr, share_existing_projection);
     };
     let effective = iface.ip_addrs()[index];
 
-    if !ensure_connected_route(iface, effective) {
+    if !ensure_connected_route(iface, effective, true) {
         return Err(SystemError::ENOSPC);
     }
     Ok(AddressMutationOutcome::Replaced(effective))
@@ -172,10 +442,28 @@ fn exchange_owned(
     iface: &mut smoltcp::iface::Interface,
     old: IpCidr,
     new: IpCidr,
+    old_has_explicit_owner: bool,
+    new_has_explicit_owner: bool,
 ) -> Result<AddressMutationOutcome, SystemError> {
     let old_index = find_for_delete(iface.ip_addrs(), old).ok_or(SystemError::EADDRNOTAVAIL)?;
+    let old_has_explicit_owner = old_has_explicit_owner
+        || iface
+            .ip_addrs()
+            .iter()
+            .enumerate()
+            .any(|(index, configured)| {
+                index != old_index && same_connected_projection(*configured, old)
+            });
+    let new_has_explicit_owner = new_has_explicit_owner
+        || iface
+            .ip_addrs()
+            .iter()
+            .enumerate()
+            .any(|(index, configured)| {
+                index != old_index && same_connected_projection(*configured, new)
+            });
     if old == new {
-        if !ensure_connected_route(iface, old) {
+        if !ensure_connected_route(iface, old, true) {
             return Err(SystemError::ENOSPC);
         }
         return Ok(AddressMutationOutcome::Replaced(old));
@@ -190,22 +478,32 @@ fn exchange_owned(
     {
         return Err(SystemError::EEXIST);
     }
+    if canonical_projection_cidr(old) == canonical_projection_cidr(new) {
+        if !ensure_connected_route(iface, old, true) {
+            return Err(SystemError::ENOSPC);
+        }
+        iface.update_ip_addrs(|addresses| addresses[old_index] = new);
+        return Ok(AddressMutationOutcome::Exchanged { old, new });
+    }
 
-    // Prepare the route transition first. Replacing the address at a known
-    // index cannot fail, so an ENOSPC return still leaves the old state intact.
+    // Prepare the route transition first. If the old projection has no other
+    // logical owner, its fixed-capacity slot can be reused in place. Otherwise
+    // the old projection must remain and a missing new projection needs a free
+    // slot. Replacing the address at a known index cannot fail, so ENOSPC still
+    // leaves the old state intact.
     let mut route_ready = false;
     iface.routes_mut().update(|routes| {
-        let old_index = routes.iter().position(|route| is_connected(route, old));
-
-        if let Some(index) = old_index {
-            routes[index].cidr = new;
+        if new_has_explicit_owner && routes.iter().any(|route| is_connected(route, new)) {
             route_ready = true;
+        } else if !old_has_explicit_owner {
+            if let Some(index) = routes.iter().rposition(|route| is_connected(route, old)) {
+                routes[index].cidr = new;
+                route_ready = true;
+            } else {
+                route_ready = routes.push(connected_route(new)).is_ok();
+            }
         } else {
-            let index = routes
-                .iter()
-                .position(|route| is_connected(route, new))
-                .unwrap_or(routes.len());
-            route_ready = routes.insert(index, connected_route(new)).is_ok();
+            route_ready = routes.push(connected_route(new)).is_ok();
         }
     });
     if !route_ready {
@@ -213,6 +511,8 @@ fn exchange_owned(
     }
 
     iface.update_ip_addrs(|addresses| addresses[old_index] = new);
+    set_connected_route_presence(iface, old, old_has_explicit_owner);
+    set_connected_route_presence(iface, new, true);
     Ok(AddressMutationOutcome::Exchanged { old, new })
 }
 
@@ -243,10 +543,14 @@ fn same_family(left: IpCidr, right: IpCidr) -> bool {
     )
 }
 
-fn ensure_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) -> bool {
+fn ensure_connected_route(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+    share_existing_projection: bool,
+) -> bool {
     let mut ready = false;
     iface.routes_mut().update(|routes| {
-        if routes.iter().any(|route| is_connected(route, cidr)) {
+        if share_existing_projection && routes.iter().any(|route| is_connected(route, cidr)) {
             ready = true;
         } else {
             ready = routes.push(connected_route(cidr)).is_ok();
@@ -255,32 +559,39 @@ fn ensure_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) -
     ready
 }
 
-fn insert_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) -> bool {
-    let mut inserted = false;
-    iface.routes_mut().update(|routes| {
-        // Put the derived projection before an equal explicit route. Without
-        // owner metadata this stable ordering lets Delete remove exactly the
-        // address-owned slot while preserving userspace's route object.
-        let index = routes
-            .iter()
-            .position(|route| is_connected(route, cidr))
-            .unwrap_or(routes.len());
-        inserted = routes.insert(index, connected_route(cidr)).is_ok();
-    });
-    inserted
+fn insert_connected_route(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+    share_existing_projection: bool,
+) -> bool {
+    ensure_connected_route(iface, cidr, share_existing_projection)
 }
 
-fn remove_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) {
+fn set_connected_route_presence(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+    present: bool,
+) {
     iface.routes_mut().update(|routes| {
-        if let Some(index) = routes.iter().position(|route| is_connected(route, cidr)) {
-            routes.remove(index);
+        if !present {
+            if let Some(index) = routes.iter().rposition(|route| is_connected(route, cidr)) {
+                routes.remove(index);
+            }
         }
     });
 }
 
+fn has_explicit_connected_owner(iface: &Arc<dyn Iface>, cidr: IpCidr) -> bool {
+    iface
+        .common()
+        .netlink_routes()
+        .iter()
+        .any(|route| route.gateway.is_none() && same_connected_projection(route.destination, cidr))
+}
+
 fn connected_route(cidr: IpCidr) -> Route {
     Route {
-        cidr,
+        cidr: canonical_projection_cidr(cidr),
         via_router: None,
         preferred_until: None,
         expires_at: None,
@@ -289,5 +600,19 @@ fn connected_route(cidr: IpCidr) -> Route {
 
 #[inline]
 fn is_connected(route: &Route, cidr: IpCidr) -> bool {
-    route.cidr == cidr && route.via_router.is_none()
+    same_connected_projection(route.cidr, cidr) && route.via_router.is_none()
+}
+
+pub(crate) fn canonical_projection_cidr(cidr: IpCidr) -> IpCidr {
+    match cidr {
+        IpCidr::Ipv4(cidr) => IpCidr::Ipv4(cidr.network()),
+        IpCidr::Ipv6(cidr) => IpCidr::Ipv6(Ipv6Cidr::new(
+            cidr.address().mask(cidr.prefix_len()).into(),
+            cidr.prefix_len(),
+        )),
+    }
+}
+
+fn same_connected_projection(left: IpCidr, right: IpCidr) -> bool {
+    canonical_projection_cidr(left) == canonical_projection_cidr(right)
 }

--- a/kernel/src/net/address.rs
+++ b/kernel/src/net/address.rs
@@ -1,0 +1,293 @@
+//! Protocol-independent interface address mutation core.
+//!
+//! Runtime callers must hold RTNL for the whole operation.  The smoltcp
+//! address list, its connected-route projection, and the router compatibility
+//! projection are committed under one smoltcp interface lock.
+
+use alloc::{sync::Arc, vec::Vec};
+
+use smoltcp::{
+    iface::Route,
+    wire::{IpAddress, IpCidr},
+};
+use system_error::SystemError;
+
+use crate::{driver::net::Iface, net::rtnl::RtnlGuard};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddressMutation {
+    Add(IpCidr),
+    Delete(IpCidr),
+    Replace(IpCidr),
+    ExchangeOwned { old: IpCidr, new: IpCidr },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AddressMutationOutcome {
+    Added(IpCidr),
+    Deleted(IpCidr),
+    Replaced(IpCidr),
+    Exchanged { old: IpCidr, new: IpCidr },
+}
+
+/// Mutates an address on an interface that is already visible in a netns.
+pub(in crate::net) fn mutate_address(
+    _rtnl: &RtnlGuard,
+    iface: &Arc<dyn Iface>,
+    mutation: AddressMutation,
+) -> Result<AddressMutationOutcome, SystemError> {
+    commit(iface, mutation)
+}
+
+/// Initializes an address before an interface is published in a netns.
+///
+/// This narrow construction-time entry point exists so drivers do not grow a
+/// second, weaker address mutation path. Published interfaces must use
+/// [`mutate_address`] under RTNL.
+pub(crate) fn initialize_address(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemError> {
+    if iface.net_namespace().is_some() {
+        return Err(SystemError::EBUSY);
+    }
+    commit(iface, AddressMutation::Add(cidr)).map(|_| ())
+}
+
+fn commit(
+    iface: &Arc<dyn Iface>,
+    mutation: AddressMutation,
+) -> Result<AddressMutationOutcome, SystemError> {
+    validate_mutation(mutation)?;
+
+    let mut smol_iface = iface.smol_iface().lock();
+    let outcome = match mutation {
+        AddressMutation::Add(cidr) => add(&mut smol_iface, cidr)?,
+        AddressMutation::Delete(cidr) => delete(&mut smol_iface, cidr)?,
+        AddressMutation::Replace(cidr) => replace(&mut smol_iface, cidr)?,
+        AddressMutation::ExchangeOwned { old, new } => exchange_owned(&mut smol_iface, old, new)?,
+    };
+
+    // Preserve the established smoltcp -> router projection lock order. Veth
+    // ingress reads this projection while holding the smoltcp lock, so
+    // publishing it after unlocking would expose a stale-address window.
+    let snapshot: Vec<IpCidr> = smol_iface.ip_addrs().to_vec();
+    let mut projection = iface.router_common().ip_addrs.write();
+    projection.clear();
+    projection.extend_from_slice(&snapshot);
+
+    Ok(outcome)
+}
+
+fn validate_mutation(mutation: AddressMutation) -> Result<(), SystemError> {
+    match mutation {
+        AddressMutation::Add(cidr)
+        | AddressMutation::Delete(cidr)
+        | AddressMutation::Replace(cidr) => validate_cidr(cidr),
+        AddressMutation::ExchangeOwned { old, new } => {
+            validate_cidr(old)?;
+            validate_cidr(new)?;
+            if same_family(old, new) {
+                Ok(())
+            } else {
+                Err(SystemError::EINVAL)
+            }
+        }
+    }
+}
+
+fn validate_cidr(cidr: IpCidr) -> Result<(), SystemError> {
+    // smoltcp asserts on multicast/broadcast addresses in update_ip_addrs().
+    // Its unspecified address is not a configured interface object either;
+    // the IPv4 rtnetlink no-op compatibility case is handled by the adapter.
+    if !cidr.address().is_unicast() {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(())
+}
+
+fn add(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+) -> Result<AddressMutationOutcome, SystemError> {
+    if find_for_new_or_replace(iface.ip_addrs(), cidr).is_some() {
+        return Err(SystemError::EEXIST);
+    }
+
+    let mut inserted = false;
+    iface.update_ip_addrs(|addresses| {
+        let index = match cidr.address() {
+            IpAddress::Ipv4(_) => addresses
+                .iter()
+                .position(|item| matches!(item.address(), IpAddress::Ipv6(_)))
+                .unwrap_or(addresses.len()),
+            IpAddress::Ipv6(_) => addresses.len(),
+        };
+        inserted = addresses.insert(index, cidr).is_ok();
+    });
+    if !inserted {
+        return Err(SystemError::ENOSPC);
+    }
+
+    if !insert_connected_route(iface, cidr) {
+        iface.update_ip_addrs(|addresses| {
+            if let Some(index) = addresses.iter().position(|item| *item == cidr) {
+                addresses.remove(index);
+            }
+        });
+        return Err(SystemError::ENOSPC);
+    }
+
+    Ok(AddressMutationOutcome::Added(cidr))
+}
+
+fn delete(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+) -> Result<AddressMutationOutcome, SystemError> {
+    let index = find_for_delete(iface.ip_addrs(), cidr).ok_or(SystemError::EADDRNOTAVAIL)?;
+    let effective = iface.ip_addrs()[index];
+
+    iface.update_ip_addrs(|addresses| {
+        addresses.remove(index);
+    });
+    remove_connected_route(iface, effective);
+
+    Ok(AddressMutationOutcome::Deleted(effective))
+}
+
+fn replace(
+    iface: &mut smoltcp::iface::Interface,
+    cidr: IpCidr,
+) -> Result<AddressMutationOutcome, SystemError> {
+    let Some(index) = find_for_new_or_replace(iface.ip_addrs(), cidr) else {
+        return add(iface, cidr);
+    };
+    let effective = iface.ip_addrs()[index];
+
+    if !ensure_connected_route(iface, effective) {
+        return Err(SystemError::ENOSPC);
+    }
+    Ok(AddressMutationOutcome::Replaced(effective))
+}
+
+fn exchange_owned(
+    iface: &mut smoltcp::iface::Interface,
+    old: IpCidr,
+    new: IpCidr,
+) -> Result<AddressMutationOutcome, SystemError> {
+    let old_index = find_for_delete(iface.ip_addrs(), old).ok_or(SystemError::EADDRNOTAVAIL)?;
+    if old == new {
+        if !ensure_connected_route(iface, old) {
+            return Err(SystemError::ENOSPC);
+        }
+        return Ok(AddressMutationOutcome::Replaced(old));
+    }
+    if iface
+        .ip_addrs()
+        .iter()
+        .enumerate()
+        .any(|(index, configured)| {
+            index != old_index && same_new_or_replace_identity(*configured, new)
+        })
+    {
+        return Err(SystemError::EEXIST);
+    }
+
+    // Prepare the route transition first. Replacing the address at a known
+    // index cannot fail, so an ENOSPC return still leaves the old state intact.
+    let mut route_ready = false;
+    iface.routes_mut().update(|routes| {
+        let old_index = routes.iter().position(|route| is_connected(route, old));
+
+        if let Some(index) = old_index {
+            routes[index].cidr = new;
+            route_ready = true;
+        } else {
+            let index = routes
+                .iter()
+                .position(|route| is_connected(route, new))
+                .unwrap_or(routes.len());
+            route_ready = routes.insert(index, connected_route(new)).is_ok();
+        }
+    });
+    if !route_ready {
+        return Err(SystemError::ENOSPC);
+    }
+
+    iface.update_ip_addrs(|addresses| addresses[old_index] = new);
+    Ok(AddressMutationOutcome::Exchanged { old, new })
+}
+
+fn find_for_new_or_replace(addresses: &[IpCidr], requested: IpCidr) -> Option<usize> {
+    addresses
+        .iter()
+        .position(|configured| same_new_or_replace_identity(*configured, requested))
+}
+
+fn find_for_delete(addresses: &[IpCidr], requested: IpCidr) -> Option<usize> {
+    addresses
+        .iter()
+        .position(|configured| *configured == requested)
+}
+
+fn same_new_or_replace_identity(configured: IpCidr, requested: IpCidr) -> bool {
+    match (configured.address(), requested.address()) {
+        (IpAddress::Ipv4(_), IpAddress::Ipv4(_)) => configured == requested,
+        (IpAddress::Ipv6(configured), IpAddress::Ipv6(requested)) => configured == requested,
+        _ => false,
+    }
+}
+
+fn same_family(left: IpCidr, right: IpCidr) -> bool {
+    matches!(
+        (left.address(), right.address()),
+        (IpAddress::Ipv4(_), IpAddress::Ipv4(_)) | (IpAddress::Ipv6(_), IpAddress::Ipv6(_))
+    )
+}
+
+fn ensure_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) -> bool {
+    let mut ready = false;
+    iface.routes_mut().update(|routes| {
+        if routes.iter().any(|route| is_connected(route, cidr)) {
+            ready = true;
+        } else {
+            ready = routes.push(connected_route(cidr)).is_ok();
+        }
+    });
+    ready
+}
+
+fn insert_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) -> bool {
+    let mut inserted = false;
+    iface.routes_mut().update(|routes| {
+        // Put the derived projection before an equal explicit route. Without
+        // owner metadata this stable ordering lets Delete remove exactly the
+        // address-owned slot while preserving userspace's route object.
+        let index = routes
+            .iter()
+            .position(|route| is_connected(route, cidr))
+            .unwrap_or(routes.len());
+        inserted = routes.insert(index, connected_route(cidr)).is_ok();
+    });
+    inserted
+}
+
+fn remove_connected_route(iface: &mut smoltcp::iface::Interface, cidr: IpCidr) {
+    iface.routes_mut().update(|routes| {
+        if let Some(index) = routes.iter().position(|route| is_connected(route, cidr)) {
+            routes.remove(index);
+        }
+    });
+}
+
+fn connected_route(cidr: IpCidr) -> Route {
+    Route {
+        cidr,
+        via_router: None,
+        preferred_until: None,
+        expires_at: None,
+    }
+}
+
+#[inline]
+fn is_connected(route: &Route, cidr: IpCidr) -> bool {
+    route.cidr == cidr && route.via_router.is_none()
+}

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -6,6 +6,7 @@ use core::sync::atomic::AtomicUsize;
 
 use crate::driver::net::Iface;
 
+pub(crate) mod address;
 pub mod neighbor;
 pub mod net_core;
 pub mod posix;

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -3,6 +3,7 @@ use system_error::SystemError;
 
 use crate::{
     driver::net::Operstate,
+    net::address::{AddressMutation, AddressMutationOutcome},
     process::{
         kthread::{KernelThreadClosure, KernelThreadMechanism},
         namespace::net_namespace::INIT_NET_NAMESPACE,
@@ -69,6 +70,9 @@ fn dhcp_query() -> Result<(), SystemError> {
 
     const DHCP_RETRY_INTERVAL_NS: i64 = 50_000_000;
     const DHCP_TRY_ROUND: u16 = 200;
+    // Ownership is deliberately scoped to this one-shot worker invocation.
+    // PR-08 owns the longer-lived lease state machine.
+    let mut owned_address: Option<wire::IpCidr> = None;
     for i in 0..DHCP_TRY_ROUND {
         log::debug!("DHCP try round: {}", i);
         net_face.poll();
@@ -93,14 +97,43 @@ fn dhcp_query() -> Result<(), SystemError> {
                 // The DHCP socket guard is released before RTNL. Lease commits
                 // share the same global serialization domain as userspace
                 // rtnetlink mutations without extending it over DHCP polling.
-                let _rtnl_guard = crate::net::rtnl::lock();
+                let rtnl_guard = crate::net::rtnl::lock();
+                revalidate_dhcp_iface(&net_face)?;
                 // debug!("Find Config!! {config:?}");
                 // debug!("Find ip address: {}", config.address);
                 // debug!("iface.ip_addrs={:?}", net_face.inner_iface.ip_addrs());
 
-                net_face
-                    .update_ip_addrs(&[wire::IpCidr::Ipv4(address)])
-                    .ok();
+                let requested = wire::IpCidr::Ipv4(address);
+                let mutation = match owned_address {
+                    None => AddressMutation::Add(requested),
+                    Some(old) if old == requested => AddressMutation::Replace(requested),
+                    Some(old) => AddressMutation::ExchangeOwned {
+                        old,
+                        new: requested,
+                    },
+                };
+                match crate::net::address::mutate_address(&rtnl_guard, &net_face, mutation) {
+                    Ok(outcome) => {
+                        owned_address = match outcome {
+                            AddressMutationOutcome::Added(effective)
+                            | AddressMutationOutcome::Replaced(effective) => Some(effective),
+                            AddressMutationOutcome::Exchanged { new, .. } => Some(new),
+                            AddressMutationOutcome::Deleted(_) => unreachable!(),
+                        };
+                        crate::net::socket::netlink::notify_address_outcome(
+                            INIT_NET_NAMESPACE.clone(),
+                            &net_face,
+                            outcome,
+                        );
+                    }
+                    Err(SystemError::EEXIST) if owned_address.is_none() => {
+                        // A pre-existing address remains owned by its original
+                        // writer. DHCP may use it for this invocation but must
+                        // never delete or exchange it later.
+                        log::debug!("DHCP address {requested} already configured");
+                    }
+                    Err(err) => return Err(err),
+                }
 
                 if let Some(router) = router {
                     let mut smol_iface = net_face.smol_iface().lock();
@@ -139,14 +172,28 @@ fn dhcp_query() -> Result<(), SystemError> {
             }
 
             Some(DhcpControlEvent::Deconfigured) => {
-                let _rtnl_guard = crate::net::rtnl::lock();
+                let rtnl_guard = crate::net::rtnl::lock();
+                revalidate_dhcp_iface(&net_face)?;
                 log::debug!("Dhcp v4 deconfigured");
-                net_face
-                    .update_ip_addrs(&[smoltcp::wire::IpCidr::Ipv4(wire::Ipv4Cidr::new(
-                        wire::Ipv4Address::UNSPECIFIED,
-                        0,
-                    ))])
-                    .ok();
+                if let Some(owned) = owned_address.take() {
+                    match crate::net::address::mutate_address(
+                        &rtnl_guard,
+                        &net_face,
+                        AddressMutation::Delete(owned),
+                    ) {
+                        Ok(outcome) => crate::net::socket::netlink::notify_address_outcome(
+                            INIT_NET_NAMESPACE.clone(),
+                            &net_face,
+                            outcome,
+                        ),
+                        Err(SystemError::EADDRNOTAVAIL) => {
+                            // A concurrent authorized control-plane writer may
+                            // already have removed the object between events.
+                            log::debug!("owned DHCP address {owned} was already removed");
+                        }
+                        Err(err) => return Err(err),
+                    }
+                }
                 net_face
                     .smol_iface()
                     .lock()
@@ -162,4 +209,15 @@ fn dhcp_query() -> Result<(), SystemError> {
     }
 
     return Err(SystemError::ETIMEDOUT);
+}
+
+fn revalidate_dhcp_iface(
+    iface: &alloc::sync::Arc<dyn crate::driver::net::Iface>,
+) -> Result<(), SystemError> {
+    let devices = INIT_NET_NAMESPACE.device_list();
+    let current = devices.get(&iface.nic_id()).ok_or(SystemError::ENODEV)?;
+    if !alloc::sync::Arc::ptr_eq(current, iface) {
+        return Err(SystemError::ENODEV);
+    }
+    Ok(())
 }

--- a/kernel/src/net/net_core.rs
+++ b/kernel/src/net/net_core.rs
@@ -3,7 +3,7 @@ use system_error::SystemError;
 
 use crate::{
     driver::net::Operstate,
-    net::address::{AddressMutation, AddressMutationOutcome},
+    net::address::AddressLease,
     process::{
         kthread::{KernelThreadClosure, KernelThreadMechanism},
         namespace::net_namespace::INIT_NET_NAMESPACE,
@@ -72,7 +72,8 @@ fn dhcp_query() -> Result<(), SystemError> {
     const DHCP_TRY_ROUND: u16 = 200;
     // Ownership is deliberately scoped to this one-shot worker invocation.
     // PR-08 owns the longer-lived lease state machine.
-    let mut owned_address: Option<wire::IpCidr> = None;
+    let mut owned_address: Option<AddressLease> = None;
+    let mut owned_router: Option<wire::Ipv4Address> = None;
     for i in 0..DHCP_TRY_ROUND {
         log::debug!("DHCP try round: {}", i);
         net_face.poll();
@@ -104,22 +105,31 @@ fn dhcp_query() -> Result<(), SystemError> {
                 // debug!("iface.ip_addrs={:?}", net_face.inner_iface.ip_addrs());
 
                 let requested = wire::IpCidr::Ipv4(address);
-                let mutation = match owned_address {
-                    None => AddressMutation::Add(requested),
-                    Some(old) if old == requested => AddressMutation::Replace(requested),
-                    Some(old) => AddressMutation::ExchangeOwned {
+                let commit = match owned_address {
+                    None => {
+                        crate::net::address::add_owned_address(&rtnl_guard, &net_face, requested)
+                    }
+                    Some(old) => crate::net::address::exchange_owned_address(
+                        &rtnl_guard,
+                        &net_face,
                         old,
-                        new: requested,
-                    },
+                        requested,
+                    ),
                 };
-                match crate::net::address::mutate_address(&rtnl_guard, &net_face, mutation) {
-                    Ok(outcome) => {
-                        owned_address = match outcome {
-                            AddressMutationOutcome::Added(effective)
-                            | AddressMutationOutcome::Replaced(effective) => Some(effective),
-                            AddressMutationOutcome::Exchanged { new, .. } => Some(new),
-                            AddressMutationOutcome::Deleted(_) => unreachable!(),
-                        };
+                let commit = match commit {
+                    Err(SystemError::ESTALE) if owned_address.is_some() => {
+                        // An authorized writer deleted the old object. A
+                        // same-CIDR re-add is a different object, so retry as
+                        // an unowned acquisition instead of acting on the
+                        // stale cross-event lease.
+                        owned_address = None;
+                        crate::net::address::add_owned_address(&rtnl_guard, &net_face, requested)
+                    }
+                    result => result,
+                };
+                match commit {
+                    Ok((outcome, lease)) => {
+                        owned_address = Some(lease);
                         crate::net::socket::netlink::notify_address_outcome(
                             INIT_NET_NAMESPACE.clone(),
                             &net_face,
@@ -148,9 +158,7 @@ fn dhcp_query() -> Result<(), SystemError> {
                             expires_at: None,
                         });
                     });
-                    if smol_iface
-                        .routes_mut()
-                        .add_default_ipv4_route(router)
+                    if update_dhcp_default_route(&mut smol_iface, &mut owned_router, Some(router))
                         .is_err()
                     {
                         log::warn!("Route table full");
@@ -163,11 +171,11 @@ fn dhcp_query() -> Result<(), SystemError> {
                         return Ok(());
                     }
                 } else {
-                    net_face
-                        .smol_iface()
-                        .lock()
-                        .routes_mut()
-                        .remove_default_ipv4_route();
+                    update_dhcp_default_route(
+                        &mut net_face.smol_iface().lock(),
+                        &mut owned_router,
+                        None,
+                    )?;
                 }
             }
 
@@ -176,29 +184,25 @@ fn dhcp_query() -> Result<(), SystemError> {
                 revalidate_dhcp_iface(&net_face)?;
                 log::debug!("Dhcp v4 deconfigured");
                 if let Some(owned) = owned_address.take() {
-                    match crate::net::address::mutate_address(
-                        &rtnl_guard,
-                        &net_face,
-                        AddressMutation::Delete(owned),
-                    ) {
+                    match crate::net::address::delete_owned_address(&rtnl_guard, &net_face, owned) {
                         Ok(outcome) => crate::net::socket::netlink::notify_address_outcome(
                             INIT_NET_NAMESPACE.clone(),
                             &net_face,
                             outcome,
                         ),
-                        Err(SystemError::EADDRNOTAVAIL) => {
+                        Err(SystemError::ESTALE | SystemError::EADDRNOTAVAIL) => {
                             // A concurrent authorized control-plane writer may
                             // already have removed the object between events.
-                            log::debug!("owned DHCP address {owned} was already removed");
+                            log::debug!("owned DHCP address {} was already replaced", owned.cidr());
                         }
                         Err(err) => return Err(err),
                     }
                 }
-                net_face
-                    .smol_iface()
-                    .lock()
-                    .routes_mut()
-                    .remove_default_ipv4_route();
+                update_dhcp_default_route(
+                    &mut net_face.smol_iface().lock(),
+                    &mut owned_router,
+                    None,
+                )?;
             }
         }
         let sleep_time = PosixTimeSpec {
@@ -209,6 +213,70 @@ fn dhcp_query() -> Result<(), SystemError> {
     }
 
     return Err(SystemError::ETIMEDOUT);
+}
+
+/// Updates only the default-route projection owned by this DHCP worker.
+///
+/// smoltcp's convenience API removes an arbitrary IPv4 default route before
+/// adding a new one. That is unsafe once userspace can own a distinct default
+/// route through rtnetlink, so the worker remembers and mutates its exact
+/// projection instead.
+fn update_dhcp_default_route(
+    iface: &mut smoltcp::iface::Interface,
+    owned: &mut Option<wire::Ipv4Address>,
+    requested: Option<wire::Ipv4Address>,
+) -> Result<(), SystemError> {
+    let old = *owned;
+    let mut committed = requested.is_none();
+    iface.routes_mut().update(|routes| match (old, requested) {
+        (Some(old), Some(new)) if old == new => {
+            committed = routes.iter().any(|route| {
+                route.cidr
+                    == wire::IpCidr::Ipv4(wire::Ipv4Cidr::new(wire::Ipv4Address::UNSPECIFIED, 0))
+                    && route.via_router == Some(wire::IpAddress::Ipv4(old))
+            });
+            if !committed {
+                committed = routes
+                    .push(smoltcp::iface::Route::new_ipv4_gateway(old))
+                    .is_ok();
+            }
+        }
+        (Some(old), Some(new)) => {
+            if let Some(index) = routes.iter().rposition(|route| {
+                route.cidr
+                    == wire::IpCidr::Ipv4(wire::Ipv4Cidr::new(wire::Ipv4Address::UNSPECIFIED, 0))
+                    && route.via_router == Some(wire::IpAddress::Ipv4(old))
+            }) {
+                routes[index] = smoltcp::iface::Route::new_ipv4_gateway(new);
+                committed = true;
+            } else {
+                committed = routes
+                    .push(smoltcp::iface::Route::new_ipv4_gateway(new))
+                    .is_ok();
+            }
+        }
+        (None, Some(new)) => {
+            committed = routes
+                .push(smoltcp::iface::Route::new_ipv4_gateway(new))
+                .is_ok();
+        }
+        (Some(old), None) => {
+            if let Some(index) = routes.iter().rposition(|route| {
+                route.cidr
+                    == wire::IpCidr::Ipv4(wire::Ipv4Cidr::new(wire::Ipv4Address::UNSPECIFIED, 0))
+                    && route.via_router == Some(wire::IpAddress::Ipv4(old))
+            }) {
+                routes.remove(index);
+            }
+        }
+        (None, None) => {}
+    });
+
+    if !committed {
+        return Err(SystemError::ENOSPC);
+    }
+    *owned = requested;
+    Ok(())
 }
 
 fn revalidate_dhcp_iface(

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -57,3 +57,11 @@ pub fn create_netlink_socket(
 pub(crate) fn notify_link_change(iface: &Arc<dyn crate::driver::net::Iface>) {
     route::kern::notify_link_change(iface);
 }
+
+pub(crate) fn notify_address_outcome(
+    netns: Arc<crate::process::namespace::net_namespace::NetNamespace>,
+    iface: &Arc<dyn crate::driver::net::Iface>,
+    outcome: crate::net::address::AddressMutationOutcome,
+) {
+    route::notify_address_outcome(netns, iface, outcome);
+}

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -100,13 +100,14 @@ pub(super) fn do_new_addr(
     }
 
     let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
+    let label = find_label_attr(request_segment).cloned();
     let mutation =
         if flags.contains(NewRequestFlags::REPLACE) && !flags.contains(NewRequestFlags::EXCL) {
             AddressMutation::Replace(cidr)
         } else {
             AddressMutation::Add(cidr)
         };
-    let outcome = crate::net::address::mutate_address(rtnl, &iface, mutation)?;
+    let outcome = crate::net::address::mutate_labeled_address(rtnl, &iface, mutation, label)?;
     notify_address_outcome(netns, &iface, outcome);
     Ok(Vec::new())
 }
@@ -119,8 +120,9 @@ pub(super) fn do_del_addr(
     let selector = parse_delete_selector(request_segment)?;
     let iface = lookup_iface_by_index(request_segment, &netns)?;
     let cidr = resolve_delete_cidr(&iface, selector)?;
+    let deleted_label = crate::net::address::address_label(&iface, cidr)?;
     let outcome = crate::net::address::mutate_address(rtnl, &iface, AddressMutation::Delete(cidr))?;
-    notify_address_outcome(netns, &iface, outcome);
+    notify_address_outcome_with_label(netns, &iface, outcome, Some(&deleted_label));
     Ok(Vec::new())
 }
 
@@ -190,11 +192,6 @@ fn parse_delete_selector(request_segment: &AddrSegment) -> Result<DeleteSelector
     let prefix_len = request_segment.body().prefix_len;
     let local = find_address_attr(request_segment, true);
     let address = find_address_attr(request_segment, false);
-    let label = request_segment.attrs().iter().find_map(|attr| match attr {
-        AddrAttr::Label(label) => Some(label.clone()),
-        _ => None,
-    });
-
     let match_ = match family {
         AddressFamily::INet => {
             let local = local
@@ -229,37 +226,42 @@ fn parse_delete_selector(request_segment: &AddrSegment) -> Result<DeleteSelector
         _ => return Err(SystemError::EAFNOSUPPORT),
     };
 
-    Ok(DeleteSelector { match_, label })
+    Ok(DeleteSelector {
+        match_,
+        label: find_label_attr(request_segment).cloned(),
+    })
 }
 
 fn resolve_delete_cidr(
     iface: &Arc<dyn Iface>,
     selector: DeleteSelector,
 ) -> Result<IpCidr, SystemError> {
-    if selector
-        .label
-        .as_ref()
-        .is_some_and(|label| label.to_bytes() != iface.iface_name().as_bytes())
-    {
-        return Err(SystemError::EADDRNOTAVAIL);
-    }
-
     let smol_iface = iface.smol_iface().lock();
     smol_iface
         .ip_addrs()
         .iter()
-        .find(|configured| match selector.match_ {
-            DeleteMatch::Ipv4 { local, prefix } => {
-                let IpAddress::Ipv4(configured_address) = configured.address() else {
+        .find(|configured| {
+            if let Some(requested) = selector.label.as_ref() {
+                let Ok(actual) = crate::net::address::address_label(iface, **configured) else {
                     return false;
                 };
-                local.is_none_or(|local| local == configured_address)
-                    && prefix.is_none_or(|prefix| {
-                        prefix.prefix_len() == configured.prefix_len()
-                            && prefix.contains_addr(&configured.address())
-                    })
+                if actual.as_bytes() != requested.as_bytes() {
+                    return false;
+                }
             }
-            DeleteMatch::Exact(cidr) => **configured == cidr,
+            match selector.match_ {
+                DeleteMatch::Ipv4 { local, prefix } => {
+                    let IpAddress::Ipv4(configured_address) = configured.address() else {
+                        return false;
+                    };
+                    local.is_none_or(|local| local == configured_address)
+                        && prefix.is_none_or(|prefix| {
+                            prefix.prefix_len() == configured.prefix_len()
+                                && prefix.contains_addr(&configured.address())
+                        })
+                }
+                DeleteMatch::Exact(cidr) => **configured == cidr,
+            }
         })
         .copied()
         .ok_or(SystemError::EADDRNOTAVAIL)
@@ -269,6 +271,13 @@ fn find_address_attr(request_segment: &AddrSegment, local: bool) -> Option<&[u8]
     request_segment.attrs().iter().find_map(|attr| match attr {
         AddrAttr::Local(bytes) if local => Some(bytes.as_slice()),
         AddrAttr::Address(bytes) if !local => Some(bytes.as_slice()),
+        _ => None,
+    })
+}
+
+fn find_label_attr(request_segment: &AddrSegment) -> Option<&CString> {
+    request_segment.attrs().iter().find_map(|attr| match attr {
+        AddrAttr::Label(label) => Some(label),
         _ => None,
     })
 }
@@ -312,13 +321,18 @@ fn parse_ip_cidr(
 
 fn iface_to_new_addr(request_header: &CMsgSegHdr, iface: &Arc<dyn Iface>) -> Vec<AddrSegment> {
     let mut segments = Vec::new();
-    let ip_addrs: Vec<IpCidr> = {
-        let smol_iface = iface.smol_iface().lock();
-        smol_iface.ip_addrs().to_vec()
+    let Ok(ip_addrs) = crate::net::address::address_snapshot(iface) else {
+        return segments;
     };
 
-    for cidr in &ip_addrs {
-        if let Ok(segment) = addr_to_segment(request_header, iface, *cidr, CSegmentType::NEWADDR) {
+    for (cidr, label) in ip_addrs {
+        if let Ok(segment) = addr_to_segment(
+            request_header,
+            iface,
+            cidr,
+            CSegmentType::NEWADDR,
+            Some(&label),
+        ) {
             segments.push(segment);
         }
     }
@@ -331,6 +345,7 @@ fn addr_to_segment(
     iface: &Arc<dyn Iface>,
     cidr: IpCidr,
     msg_type: CSegmentType,
+    label_override: Option<&CString>,
 ) -> Result<AddrSegment, SystemError> {
     let (family, octets): (i32, Vec<u8>) = match cidr.address() {
         IpAddress::Ipv4(addr) => (AddressFamily::INet as i32, addr.octets().to_vec()),
@@ -349,7 +364,7 @@ fn addr_to_segment(
         family,
         prefix_len: cidr.prefix_len(),
         flags: AddrMessageFlags::PERMANENT,
-        scope: if iface.name() == "lo" {
+        scope: if iface.type_() == crate::driver::net::types::InterfaceType::LOOPBACK {
             RtScope::HOST
         } else {
             RtScope::UNIVERSE
@@ -357,9 +372,13 @@ fn addr_to_segment(
         index: NonZeroU32::new(iface.nic_id() as u32),
     };
 
+    let label = match label_override {
+        Some(label) => label.clone(),
+        None => crate::net::address::address_label(iface, cidr)?,
+    };
     let attrs = vec![
         AddrAttr::Address(octets.clone()),
-        AddrAttr::Label(CString::new(iface.iface_name()).map_err(|_| SystemError::EINVAL)?),
+        AddrAttr::Label(label),
         AddrAttr::Local(octets),
     ];
 
@@ -371,16 +390,33 @@ pub(in crate::net::socket::netlink::route) fn notify_address_outcome(
     iface: &Arc<dyn Iface>,
     outcome: AddressMutationOutcome,
 ) {
+    notify_address_outcome_with_label(netns, iface, outcome, None)
+}
+
+pub(super) fn notify_address_change(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+) {
+    notify_one(netns, iface, cidr, CSegmentType::NEWADDR, None);
+}
+
+fn notify_address_outcome_with_label(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    outcome: AddressMutationOutcome,
+    deleted_label: Option<&CString>,
+) {
     match outcome {
         AddressMutationOutcome::Added(cidr) | AddressMutationOutcome::Replaced(cidr) => {
-            notify_one(netns, iface, cidr, CSegmentType::NEWADDR)
+            notify_one(netns, iface, cidr, CSegmentType::NEWADDR, None)
         }
         AddressMutationOutcome::Deleted(cidr) => {
-            notify_one(netns, iface, cidr, CSegmentType::DELADDR)
+            notify_one(netns, iface, cidr, CSegmentType::DELADDR, deleted_label)
         }
         AddressMutationOutcome::Exchanged { old, new } => {
-            notify_one(netns.clone(), iface, old, CSegmentType::DELADDR);
-            notify_one(netns, iface, new, CSegmentType::NEWADDR);
+            notify_one(netns.clone(), iface, old, CSegmentType::DELADDR, None);
+            notify_one(netns, iface, new, CSegmentType::NEWADDR, None);
         }
     }
 }
@@ -390,9 +426,10 @@ fn notify_one(
     iface: &Arc<dyn Iface>,
     cidr: IpCidr,
     msg_type: CSegmentType,
+    label_override: Option<&CString>,
 ) {
     let header = kernel_notify_header(msg_type);
-    let segment = match addr_to_segment(&header, iface, cidr, msg_type) {
+    let segment = match addr_to_segment(&header, iface, cidr, msg_type, label_override) {
         Ok(segment) => segment,
         Err(err) => {
             // Notification encoding is best effort after a successful commit;

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -12,7 +12,7 @@ use crate::{
                     RTMGRP_IPV6_IFADDR,
                 },
                 message::{
-                    attr::addr::AddrAttr,
+                    attr::{addr::AddrAttr, IFNAME_SIZE},
                     segment::{
                         addr::{AddrMessageFlags, AddrSegment, AddrSegmentBody, RtScope},
                         RouteNlSegment,
@@ -85,6 +85,9 @@ pub(super) fn do_new_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
+    // Linux applies the IPv4 attribute policy before address, device, and
+    // special-case validation. Preserve that errno priority here.
+    let label = parse_request_label(request_segment)?;
     let cidr = parse_new_cidr(request_segment)?;
     let iface = lookup_iface_by_index(request_segment, &netns)?;
 
@@ -100,7 +103,6 @@ pub(super) fn do_new_addr(
     }
 
     let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
-    let label = find_label_attr(request_segment).cloned();
     let mutation =
         if flags.contains(NewRequestFlags::REPLACE) && !flags.contains(NewRequestFlags::EXCL) {
             AddressMutation::Replace(cidr)
@@ -117,7 +119,8 @@ pub(super) fn do_del_addr(
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let selector = parse_delete_selector(request_segment)?;
+    let label = parse_request_label(request_segment)?;
+    let selector = parse_delete_selector(request_segment, label)?;
     let iface = lookup_iface_by_index(request_segment, &netns)?;
     let cidr = resolve_delete_cidr(&iface, selector)?;
     let deleted_label = crate::net::address::address_label(&iface, cidr)?;
@@ -186,7 +189,10 @@ struct DeleteSelector {
     label: Option<CString>,
 }
 
-fn parse_delete_selector(request_segment: &AddrSegment) -> Result<DeleteSelector, SystemError> {
+fn parse_delete_selector(
+    request_segment: &AddrSegment,
+    label: Option<CString>,
+) -> Result<DeleteSelector, SystemError> {
     let family = AddressFamily::try_from(request_segment.body().family as u16)
         .map_err(|_| SystemError::EAFNOSUPPORT)?;
     let prefix_len = request_segment.body().prefix_len;
@@ -226,10 +232,7 @@ fn parse_delete_selector(request_segment: &AddrSegment) -> Result<DeleteSelector
         _ => return Err(SystemError::EAFNOSUPPORT),
     };
 
-    Ok(DeleteSelector {
-        match_,
-        label: find_label_attr(request_segment).cloned(),
-    })
+    Ok(DeleteSelector { match_, label })
 }
 
 fn resolve_delete_cidr(
@@ -275,11 +278,38 @@ fn find_address_attr(request_segment: &AddrSegment, local: bool) -> Option<&[u8]
     })
 }
 
-fn find_label_attr(request_segment: &AddrSegment) -> Option<&CString> {
-    request_segment.attrs().iter().find_map(|attr| match attr {
-        AddrAttr::Label(label) => Some(label),
-        _ => None,
-    })
+fn parse_ipv4_label_attr(request_segment: &AddrSegment) -> Result<Option<CString>, SystemError> {
+    let mut parsed = None;
+    for attr in request_segment.attrs() {
+        if let AddrAttr::Label(payload) = attr {
+            parsed = Some(parse_ipv4_label(payload)?);
+        }
+    }
+    Ok(parsed)
+}
+
+fn parse_request_label(request_segment: &AddrSegment) -> Result<Option<CString>, SystemError> {
+    // IFA_LABEL is an IPv4 alias attribute. Linux's IPv6 policy leaves it
+    // untyped and the IPv6 handlers ignore it, regardless of payload length.
+    match AddressFamily::try_from(request_segment.body().family as u16) {
+        Ok(AddressFamily::INet) => parse_ipv4_label_attr(request_segment),
+        _ => Ok(None),
+    }
+}
+
+fn parse_ipv4_label(payload: &[u8]) -> Result<CString, SystemError> {
+    if payload.is_empty() {
+        return Err(SystemError::ERANGE);
+    }
+    let effective_len = payload.len() - usize::from(payload.last() == Some(&0));
+    if effective_len >= IFNAME_SIZE {
+        return Err(SystemError::ERANGE);
+    }
+    let nul_pos = payload
+        .iter()
+        .position(|byte| *byte == 0)
+        .unwrap_or(payload.len());
+    CString::new(&payload[..nul_pos]).map_err(|_| SystemError::EINVAL)
 }
 
 fn parse_ip_cidr(
@@ -372,15 +402,19 @@ fn addr_to_segment(
         index: NonZeroU32::new(iface.nic_id() as u32),
     };
 
-    let label = match label_override {
-        Some(label) => label.clone(),
-        None => crate::net::address::address_label(iface, cidr)?,
-    };
-    let attrs = vec![
-        AddrAttr::Address(octets.clone()),
-        AddrAttr::Label(label),
-        AddrAttr::Local(octets),
-    ];
+    let mut attrs = vec![AddrAttr::Address(octets.clone())];
+    if matches!(cidr.address(), IpAddress::Ipv4(_)) {
+        let label = match label_override {
+            Some(label) => label.clone(),
+            None => crate::net::address::address_label(iface, cidr)?,
+        };
+        // Linux keeps an explicit empty label for IPv4 delete matching but
+        // inet_fill_ifaddr() omits IFA_LABEL when ifa_label[0] is NUL.
+        if !label.as_bytes().is_empty() {
+            attrs.push(AddrAttr::Label(label.to_bytes_with_nul().to_vec()));
+        }
+    }
+    attrs.push(AddrAttr::Local(octets));
 
     Ok(AddrSegment::new(header, addr_message, attrs))
 }

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -22,6 +22,10 @@ use crate::{
         },
         AddressFamily,
     },
+    net::{
+        address::{AddressMutation, AddressMutationOutcome},
+        rtnl::RtnlGuard,
+    },
     process::namespace::net_namespace::NetNamespace,
 };
 use alloc::ffi::CString;
@@ -77,125 +81,57 @@ pub(super) fn do_get_addr(
 }
 
 pub(super) fn do_new_addr(
+    rtnl: &RtnlGuard,
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let iface = lookup_iface_by_index(request_segment, netns.clone())?;
-    let cidr = parse_cidr(request_segment)?;
-    let notification = addr_to_segment(
-        &kernel_notify_header(CSegmentType::NEWADDR),
-        &iface,
-        cidr,
-        CSegmentType::NEWADDR,
-    )?;
-    let changed = add_addr(request_segment, &iface, cidr)?;
-    if changed {
-        multicast_notify(
-            netns,
-            addr_notify_group(cidr.address()),
-            RouteNlSegment::NewAddr(notification),
-        );
+    let cidr = parse_new_cidr(request_segment)?;
+    let iface = lookup_iface_by_index(request_segment, &netns)?;
+
+    match cidr.address() {
+        // Linux accepts an IPv4 local address of zero but does not insert an
+        // in_ifaddr object or emit RTM_NEWADDR for it.
+        IpAddress::Ipv4(address) if address.is_unspecified() => return Ok(Vec::new()),
+        // inet6_addr_add() rejects IPV6_ADDR_ANY as a configured object.
+        IpAddress::Ipv6(address) if address.is_unspecified() => {
+            return Err(SystemError::EADDRNOTAVAIL)
+        }
+        _ => {}
     }
+
+    let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
+    let mutation =
+        if flags.contains(NewRequestFlags::REPLACE) && !flags.contains(NewRequestFlags::EXCL) {
+            AddressMutation::Replace(cidr)
+        } else {
+            AddressMutation::Add(cidr)
+        };
+    let outcome = crate::net::address::mutate_address(rtnl, &iface, mutation)?;
+    notify_address_outcome(netns, &iface, outcome);
     Ok(Vec::new())
 }
 
 pub(super) fn do_del_addr(
+    rtnl: &RtnlGuard,
     request_segment: &AddrSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let iface = lookup_iface_by_index(request_segment, netns.clone())?;
-    let cidr = parse_cidr(request_segment)?;
-    let notification = addr_to_segment(
-        &kernel_notify_header(CSegmentType::DELADDR),
-        &iface,
-        cidr,
-        CSegmentType::DELADDR,
-    )?;
-    del_addr(&iface, cidr)?;
-    multicast_notify(
-        netns,
-        addr_notify_group(cidr.address()),
-        RouteNlSegment::DelAddr(notification),
-    );
+    let selector = parse_delete_selector(request_segment)?;
+    let iface = lookup_iface_by_index(request_segment, &netns)?;
+    let cidr = resolve_delete_cidr(&iface, selector)?;
+    let outcome = crate::net::address::mutate_address(rtnl, &iface, AddressMutation::Delete(cidr))?;
+    notify_address_outcome(netns, &iface, outcome);
     Ok(Vec::new())
-}
-
-fn add_addr(
-    request_segment: &AddrSegment,
-    iface: &Arc<dyn Iface>,
-    cidr: IpCidr,
-) -> Result<bool, SystemError> {
-    let flags = NewRequestFlags::from_bits_truncate(request_segment.header().flags);
-
-    let mut exists = false;
-    let mut pushed = false;
-
-    iface.smol_iface().lock().update_ip_addrs(|ip_addrs| {
-        exists = ip_addrs.contains(&cidr);
-        if !exists {
-            let insert_index = match cidr.address() {
-                IpAddress::Ipv4(_) => ip_addrs
-                    .iter()
-                    .position(|configured| matches!(configured.address(), IpAddress::Ipv6(_)))
-                    .unwrap_or(ip_addrs.len()),
-                IpAddress::Ipv6(_) => ip_addrs.len(),
-            };
-
-            if ip_addrs.insert(insert_index, cidr).is_ok() {
-                pushed = true;
-            }
-        }
-    });
-
-    if exists {
-        if flags.contains(NewRequestFlags::REPLACE) {
-            return Ok(false);
-        }
-        return Err(SystemError::EEXIST);
-    }
-
-    if !pushed {
-        return Err(SystemError::ENOSPC);
-    }
-
-    if let Err(err) = add_local_route(iface, cidr) {
-        rollback_added_addr(iface, cidr);
-        return Err(err);
-    }
-
-    sync_router_ip_addrs(iface);
-
-    Ok(true)
-}
-
-fn del_addr(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemError> {
-    let mut removed = false;
-
-    iface.smol_iface().lock().update_ip_addrs(|ip_addrs| {
-        if let Some(index) = ip_addrs.iter().position(|configured| *configured == cidr) {
-            ip_addrs.remove(index);
-            removed = true;
-        }
-    });
-
-    if !removed {
-        return Err(SystemError::EADDRNOTAVAIL);
-    }
-
-    remove_local_route(iface, cidr);
-    sync_router_ip_addrs(iface);
-
-    Ok(())
 }
 
 fn lookup_iface_by_index(
     request_segment: &AddrSegment,
-    netns: Arc<NetNamespace>,
+    netns: &Arc<NetNamespace>,
 ) -> Result<Arc<dyn Iface>, SystemError> {
     let index = request_segment
         .body()
         .index
-        .ok_or(SystemError::EINVAL)?
+        .ok_or(SystemError::ENODEV)?
         .get() as usize;
 
     netns
@@ -205,44 +141,170 @@ fn lookup_iface_by_index(
         .ok_or(SystemError::ENODEV)
 }
 
-fn parse_cidr(request_segment: &AddrSegment) -> Result<IpCidr, SystemError> {
+fn parse_new_cidr(request_segment: &AddrSegment) -> Result<IpCidr, SystemError> {
     let family = AddressFamily::try_from(request_segment.body().family as u16)
         .map_err(|_| SystemError::EAFNOSUPPORT)?;
-
-    let addr = request_segment
-        .attrs()
-        .iter()
-        .find_map(|attr| match attr {
-            AddrAttr::Local(addr) | AddrAttr::Address(addr) => Some(addr.as_slice()),
-            AddrAttr::Label(_) => None,
-        })
-        .ok_or(SystemError::EINVAL)?;
-
     let prefix_len = request_segment.body().prefix_len;
+    let local = find_address_attr(request_segment, true);
+    let address = find_address_attr(request_segment, false);
 
+    match family {
+        AddressFamily::INet => {
+            let local = local.ok_or(SystemError::EINVAL)?;
+            if let Some(address) = address {
+                if address != local {
+                    return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+                }
+            }
+            parse_ip_cidr(family, local, prefix_len)
+        }
+        AddressFamily::INet6 => {
+            let bytes = address.or(local).ok_or(SystemError::EINVAL)?;
+            if let (Some(local), Some(address)) = (local, address) {
+                if local != address {
+                    return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+                }
+            }
+            parse_ip_cidr(family, bytes, prefix_len)
+        }
+        _ => Err(SystemError::EAFNOSUPPORT),
+    }
+}
+
+enum DeleteMatch {
+    Ipv4 {
+        local: Option<Ipv4Address>,
+        prefix: Option<IpCidr>,
+    },
+    Exact(IpCidr),
+}
+
+struct DeleteSelector {
+    match_: DeleteMatch,
+    label: Option<CString>,
+}
+
+fn parse_delete_selector(request_segment: &AddrSegment) -> Result<DeleteSelector, SystemError> {
+    let family = AddressFamily::try_from(request_segment.body().family as u16)
+        .map_err(|_| SystemError::EAFNOSUPPORT)?;
+    let prefix_len = request_segment.body().prefix_len;
+    let local = find_address_attr(request_segment, true);
+    let address = find_address_attr(request_segment, false);
+    let label = request_segment.attrs().iter().find_map(|attr| match attr {
+        AddrAttr::Label(label) => Some(label.clone()),
+        _ => None,
+    });
+
+    let match_ = match family {
+        AddressFamily::INet => {
+            let local = local
+                .map(|bytes| parse_ip_cidr(family, bytes, 32))
+                .transpose()?
+                .map(|cidr| match cidr.address() {
+                    IpAddress::Ipv4(address) => address,
+                    _ => unreachable!(),
+                });
+            let prefix = if let Some(address) = address {
+                if prefix_len > 32 {
+                    return Err(SystemError::EINVAL);
+                }
+                Some(parse_ip_cidr(family, address, prefix_len)?)
+            } else {
+                None
+            };
+            if local.is_none() && prefix.is_none() {
+                return Err(SystemError::EINVAL);
+            }
+            DeleteMatch::Ipv4 { local, prefix }
+        }
+        AddressFamily::INet6 => {
+            let bytes = address.or(local).ok_or(SystemError::EINVAL)?;
+            if let (Some(local), Some(address)) = (local, address) {
+                if local != address {
+                    return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+                }
+            }
+            DeleteMatch::Exact(parse_ip_cidr(family, bytes, prefix_len)?)
+        }
+        _ => return Err(SystemError::EAFNOSUPPORT),
+    };
+
+    Ok(DeleteSelector { match_, label })
+}
+
+fn resolve_delete_cidr(
+    iface: &Arc<dyn Iface>,
+    selector: DeleteSelector,
+) -> Result<IpCidr, SystemError> {
+    if selector
+        .label
+        .as_ref()
+        .is_some_and(|label| label.to_bytes() != iface.iface_name().as_bytes())
+    {
+        return Err(SystemError::EADDRNOTAVAIL);
+    }
+
+    let smol_iface = iface.smol_iface().lock();
+    smol_iface
+        .ip_addrs()
+        .iter()
+        .find(|configured| match selector.match_ {
+            DeleteMatch::Ipv4 { local, prefix } => {
+                let IpAddress::Ipv4(configured_address) = configured.address() else {
+                    return false;
+                };
+                local.is_none_or(|local| local == configured_address)
+                    && prefix.is_none_or(|prefix| {
+                        prefix.prefix_len() == configured.prefix_len()
+                            && prefix.contains_addr(&configured.address())
+                    })
+            }
+            DeleteMatch::Exact(cidr) => **configured == cidr,
+        })
+        .copied()
+        .ok_or(SystemError::EADDRNOTAVAIL)
+}
+
+fn find_address_attr(request_segment: &AddrSegment, local: bool) -> Option<&[u8]> {
+    request_segment.attrs().iter().find_map(|attr| match attr {
+        AddrAttr::Local(bytes) if local => Some(bytes.as_slice()),
+        AddrAttr::Address(bytes) if !local => Some(bytes.as_slice()),
+        _ => None,
+    })
+}
+
+fn parse_ip_cidr(
+    family: AddressFamily,
+    addr: &[u8],
+    prefix_len: u8,
+) -> Result<IpCidr, SystemError> {
     match family {
         AddressFamily::INet => {
             if addr.len() != 4 || prefix_len > 32 {
                 return Err(SystemError::EINVAL);
             }
-            let ip = Ipv4Address::new(addr[0], addr[1], addr[2], addr[3]);
-            Ok(IpCidr::new(IpAddress::Ipv4(ip), prefix_len))
+            Ok(IpCidr::new(
+                IpAddress::Ipv4(Ipv4Address::new(addr[0], addr[1], addr[2], addr[3])),
+                prefix_len,
+            ))
         }
         AddressFamily::INet6 => {
             if addr.len() != 16 || prefix_len > 128 {
                 return Err(SystemError::EINVAL);
             }
-            let ip = Ipv6Address::new(
-                u16::from_be_bytes([addr[0], addr[1]]),
-                u16::from_be_bytes([addr[2], addr[3]]),
-                u16::from_be_bytes([addr[4], addr[5]]),
-                u16::from_be_bytes([addr[6], addr[7]]),
-                u16::from_be_bytes([addr[8], addr[9]]),
-                u16::from_be_bytes([addr[10], addr[11]]),
-                u16::from_be_bytes([addr[12], addr[13]]),
-                u16::from_be_bytes([addr[14], addr[15]]),
-            );
-            Ok(IpCidr::new(IpAddress::Ipv6(ip), prefix_len))
+            Ok(IpCidr::new(
+                IpAddress::Ipv6(Ipv6Address::new(
+                    u16::from_be_bytes([addr[0], addr[1]]),
+                    u16::from_be_bytes([addr[2], addr[3]]),
+                    u16::from_be_bytes([addr[4], addr[5]]),
+                    u16::from_be_bytes([addr[6], addr[7]]),
+                    u16::from_be_bytes([addr[8], addr[9]]),
+                    u16::from_be_bytes([addr[10], addr[11]]),
+                    u16::from_be_bytes([addr[12], addr[13]]),
+                    u16::from_be_bytes([addr[14], addr[15]]),
+                )),
+                prefix_len,
+            ))
         }
         _ => Err(SystemError::EAFNOSUPPORT),
     }
@@ -304,71 +366,47 @@ fn addr_to_segment(
     Ok(AddrSegment::new(header, addr_message, attrs))
 }
 
-fn sync_router_ip_addrs(iface: &Arc<dyn Iface>) {
-    let smol_ip_addrs: Vec<IpCidr> = {
-        let smol_iface = iface.smol_iface().lock();
-        smol_iface.ip_addrs().to_vec()
-    };
-
-    let mut router_ip_addrs = iface.router_common().ip_addrs.write();
-    router_ip_addrs.clear();
-    router_ip_addrs.extend_from_slice(&smol_ip_addrs);
+pub(in crate::net::socket::netlink::route) fn notify_address_outcome(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    outcome: AddressMutationOutcome,
+) {
+    match outcome {
+        AddressMutationOutcome::Added(cidr) | AddressMutationOutcome::Replaced(cidr) => {
+            notify_one(netns, iface, cidr, CSegmentType::NEWADDR)
+        }
+        AddressMutationOutcome::Deleted(cidr) => {
+            notify_one(netns, iface, cidr, CSegmentType::DELADDR)
+        }
+        AddressMutationOutcome::Exchanged { old, new } => {
+            notify_one(netns.clone(), iface, old, CSegmentType::DELADDR);
+            notify_one(netns, iface, new, CSegmentType::NEWADDR);
+        }
+    }
 }
 
-fn add_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) -> Result<(), SystemError> {
-    let mut pushed = false;
-
-    iface.smol_iface().lock().routes_mut().update(|routes| {
-        let exists = routes.iter().any(|route| is_same_local_route(route, cidr));
-        if exists {
-            pushed = true;
+fn notify_one(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+    msg_type: CSegmentType,
+) {
+    let header = kernel_notify_header(msg_type);
+    let segment = match addr_to_segment(&header, iface, cidr, msg_type) {
+        Ok(segment) => segment,
+        Err(err) => {
+            // Notification encoding is best effort after a successful commit;
+            // it must not turn the request ACK into an error for committed state.
+            log::warn!("failed to encode address notification for {cidr}: {err:?}");
             return;
         }
-
-        pushed = routes
-            .push(smoltcp::iface::Route {
-                cidr,
-                via_router: None,
-                preferred_until: None,
-                expires_at: None,
-            })
-            .is_ok();
-    });
-
-    if !pushed {
-        log::warn!(
-            "netlink add_addr: route table full while adding local route {}",
-            cidr
-        );
-        return Err(SystemError::ENOSPC);
-    }
-
-    Ok(())
-}
-
-fn remove_local_route(iface: &Arc<dyn Iface>, cidr: IpCidr) {
-    iface.smol_iface().lock().routes_mut().update(|routes| {
-        if let Some(index) = routes
-            .iter()
-            .position(|route| is_same_local_route(route, cidr))
-        {
-            routes.remove(index);
-        }
-    });
-}
-
-fn rollback_added_addr(iface: &Arc<dyn Iface>, cidr: IpCidr) {
-    iface.smol_iface().lock().update_ip_addrs(|ip_addrs| {
-        if let Some(index) = ip_addrs.iter().position(|configured| *configured == cidr) {
-            ip_addrs.remove(index);
-        }
-    });
-    sync_router_ip_addrs(iface);
-}
-
-#[inline]
-fn is_same_local_route(route: &smoltcp::iface::Route, cidr: IpCidr) -> bool {
-    route.cidr == cidr && route.via_router.is_none()
+    };
+    let segment = if msg_type == CSegmentType::DELADDR {
+        RouteNlSegment::DelAddr(segment)
+    } else {
+        RouteNlSegment::NewAddr(segment)
+    };
+    multicast_notify(netns, addr_notify_group(cidr.address()), segment);
 }
 
 fn addr_notify_group(ip: IpAddress) -> u32 {

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -195,6 +195,7 @@ pub(super) fn do_del_link(
 }
 
 pub(super) fn do_set_link(
+    rtnl: &crate::net::rtnl::RtnlGuard,
     request_segment: &LinkSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
@@ -240,6 +241,12 @@ pub(super) fn do_set_link(
         }
     }
 
+    let renamed_addresses = if let Some(ref name) = updates.name {
+        crate::net::address::rename_address_labels(rtnl, &iface, name)?
+    } else {
+        Vec::new()
+    };
+
     if let Some(name) = updates.name {
         iface.set_name(name);
     }
@@ -249,6 +256,9 @@ pub(super) fn do_set_link(
     }
 
     notify_link_change(&iface);
+    for cidr in renamed_addresses {
+        super::addr::notify_address_change(netns.clone(), &iface, cidr);
+    }
 
     Ok(Vec::new())
 }

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -171,7 +171,7 @@ fn dispatch_request(
         RouteNlSegment::SetLink(request) if seg_type == CSegmentType::DELLINK => {
             link::do_del_link(request, netns)
         }
-        RouteNlSegment::SetLink(request) => link::do_set_link(request, netns),
+        RouteNlSegment::SetLink(request) => link::do_set_link(rtnl, request, netns),
         RouteNlSegment::GetRoute(request) if seg_type == CSegmentType::GETRULE => {
             route::do_get_rule(request, netns)
         }

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -22,7 +22,7 @@ use alloc::sync::Arc;
 use core::marker::PhantomData;
 use system_error::SystemError;
 
-mod addr;
+pub(super) mod addr;
 mod link;
 mod neigh;
 mod route;
@@ -125,8 +125,8 @@ impl NetlinkRouteKernelSocket {
                 // RTNL unless a handler is explicitly registered as unlocked.
                 // Keep response delivery outside this scope so ACKs cannot
                 // extend the global control-plane critical section.
-                let _rtnl_guard = crate::net::rtnl::lock();
-                dispatch_request(segment, seg_type, netns.clone())
+                let rtnl_guard = crate::net::rtnl::lock();
+                dispatch_request(&rtnl_guard, segment, seg_type, netns.clone())
             };
 
             let response = match response_segments {
@@ -158,14 +158,15 @@ impl NetlinkRouteKernelSocket {
 }
 
 fn dispatch_request(
+    rtnl: &crate::net::rtnl::RtnlGuard,
     segment: &RouteNlSegment,
     seg_type: CSegmentType,
     netns: Arc<NetNamespace>,
 ) -> Result<alloc::vec::Vec<RouteNlSegment>, SystemError> {
     match segment {
         RouteNlSegment::GetAddr(request) => addr::do_get_addr(request, netns),
-        RouteNlSegment::NewAddr(request) => addr::do_new_addr(request, netns),
-        RouteNlSegment::DelAddr(request) => addr::do_del_addr(request, netns),
+        RouteNlSegment::NewAddr(request) => addr::do_new_addr(rtnl, request, netns),
+        RouteNlSegment::DelAddr(request) => addr::do_del_addr(rtnl, request, netns),
         RouteNlSegment::GetLink(request) => link::do_get_link(request, netns),
         RouteNlSegment::SetLink(request) if seg_type == CSegmentType::DELLINK => {
             link::do_del_link(request, netns)

--- a/kernel/src/net/socket/netlink/route/kern/route.rs
+++ b/kernel/src/net/socket/netlink/route/kern/route.rs
@@ -1,3 +1,4 @@
+use crate::net::address::canonical_projection_cidr;
 use crate::{
     driver::net::{Iface, NetlinkRouteEntry},
     net::socket::{
@@ -41,7 +42,9 @@ fn effective_route_table(table: u8) -> u8 {
     }
 }
 
-fn route_entry_key(entry: &NetlinkRouteEntry) -> (IpCidr, u8, Option<(IpAddress, u8)>) {
+type RouteEntryKey = (IpCidr, u8, Option<(IpAddress, u8)>);
+
+fn route_entry_key(entry: &NetlinkRouteEntry) -> RouteEntryKey {
     (
         entry.destination,
         entry.table,
@@ -52,13 +55,17 @@ fn route_entry_key(entry: &NetlinkRouteEntry) -> (IpCidr, u8, Option<(IpAddress,
     )
 }
 
-fn netlink_route_exists(iface: &Arc<dyn Iface>, entry: &NetlinkRouteEntry) -> bool {
+fn find_netlink_route(
+    iface: &Arc<dyn Iface>,
+    entry: &NetlinkRouteEntry,
+) -> Option<NetlinkRouteEntry> {
     let key = route_entry_key(entry);
     iface
         .common()
         .netlink_routes()
         .iter()
-        .any(|existing| route_entry_key(existing) == key)
+        .find(|existing| route_entry_key(existing) == key)
+        .cloned()
 }
 
 pub(super) fn do_get_route(
@@ -138,7 +145,8 @@ pub(super) fn do_new_route(
 
     let replace = NewRequestFlags::from_bits_truncate(request_segment.header().flags)
         .contains(NewRequestFlags::REPLACE);
-    if netlink_route_exists(&iface, &entry) && !replace {
+    let previous = find_netlink_route(&iface, &entry);
+    if previous.is_some() && !replace {
         return Err(SystemError::EEXIST);
     }
 
@@ -159,7 +167,7 @@ pub(super) fn do_new_route(
         },
     )?;
 
-    sync_iface_route_table(&iface, &parsed)?;
+    sync_iface_route_table(&iface, &parsed, previous.as_ref())?;
     iface.common().upsert_netlink_route(entry);
 
     multicast_notify(
@@ -198,20 +206,12 @@ pub(super) fn do_del_route(
             flags: RouteFlags::empty(),
         },
     )?;
-    if !iface
+    let removed = iface
         .common()
         .remove_netlink_route(parsed.destination, parsed.source, table)
-    {
-        return Err(SystemError::ESRCH);
-    }
+        .ok_or(SystemError::ESRCH)?;
 
-    sync_iface_route_table_remove(
-        &iface,
-        parsed.destination,
-        parsed.source,
-        parsed.gateway,
-        table,
-    );
+    sync_iface_route_table_remove(&iface, &removed);
     multicast_notify(
         netns,
         route_notify_group(parsed.destination.address()),
@@ -437,66 +437,160 @@ fn route_to_segment(
 fn sync_iface_route_table(
     iface: &Arc<dyn Iface>,
     route: &ParsedRouteRequest,
+    previous: Option<&NetlinkRouteEntry>,
 ) -> Result<(), SystemError> {
     let new_route = smoltcp::iface::Route {
-        cidr: route.destination,
+        cidr: canonical_projection_cidr(route.destination),
         via_router: route.gateway,
         preferred_until: None,
         expires_at: None,
     };
-    let mut push_failed = false;
+    let replaced_key = previous.map(route_entry_key);
+    let new_has_other_owner =
+        projection_has_other_owner(iface, new_route.cidr, new_route.via_router, replaced_key);
+    let old_has_other_owner = previous.is_some_and(|old| {
+        projection_has_other_owner(iface, old.destination, old.gateway, replaced_key)
+    });
+    let mut projection_ready = false;
+    let mut reused_old_projection = false;
     iface.smol_iface().lock().routes_mut().update(|routes| {
-        // Replacing in place cannot fail when the fixed-capacity table is full.
-        // Canonicalize legacy duplicates while preserving connected routes.
-        let mut first_match = None;
-        let mut index = 0;
-        while index < routes.len() {
-            let replaceable = routes[index].cidr == route.destination
-                && !is_local_connected_route(iface, &routes[index]);
-            if !replaceable {
-                index += 1;
-                continue;
-            }
-
-            if first_match.is_none() {
+        let same_as_previous = previous.is_some_and(|old| {
+            same_projection(
+                old.destination,
+                old.gateway,
+                new_route.cidr,
+                new_route.via_router,
+            )
+        });
+        if (same_as_previous || new_has_other_owner)
+            && routes.iter().any(|existing| {
+                same_projection(
+                    existing.cidr,
+                    existing.via_router,
+                    new_route.cidr,
+                    new_route.via_router,
+                )
+            })
+        {
+            projection_ready = true;
+        } else if let Some(old) = previous.filter(|old| {
+            !same_projection(
+                old.destination,
+                old.gateway,
+                new_route.cidr,
+                new_route.via_router,
+            ) && !old_has_other_owner
+        }) {
+            if let Some(index) = routes.iter().rposition(|existing| {
+                same_projection(
+                    existing.cidr,
+                    existing.via_router,
+                    old.destination,
+                    old.gateway,
+                )
+            }) {
                 routes[index] = new_route;
-                first_match = Some(index);
-                index += 1;
-            } else {
-                routes.remove(index);
+                projection_ready = true;
+                reused_old_projection = true;
             }
         }
 
-        if first_match.is_none() && routes.push(new_route).is_err() {
-            push_failed = true;
+        if !projection_ready {
+            projection_ready = routes.push(new_route).is_ok();
+        }
+        if !projection_ready {
+            return;
+        }
+
+        if let Some(old) = previous.filter(|old| {
+            !same_projection(
+                old.destination,
+                old.gateway,
+                new_route.cidr,
+                new_route.via_router,
+            )
+        }) {
+            if !old_has_other_owner && !reused_old_projection {
+                if let Some(index) = routes.iter().rposition(|existing| {
+                    same_projection(
+                        existing.cidr,
+                        existing.via_router,
+                        old.destination,
+                        old.gateway,
+                    )
+                }) {
+                    routes.remove(index);
+                }
+            }
         }
     });
-    if push_failed {
-        Err(SystemError::ENOSPC)
-    } else {
+    if projection_ready {
         Ok(())
+    } else {
+        Err(SystemError::ENOSPC)
     }
 }
 
-fn sync_iface_route_table_remove(
+fn sync_iface_route_table_remove(iface: &Arc<dyn Iface>, removed: &NetlinkRouteEntry) {
+    let preserve_projection = address_owns_projection(iface, removed.destination, removed.gateway)
+        || iface.common().netlink_routes().iter().any(|existing| {
+            same_projection(
+                existing.destination,
+                existing.gateway,
+                removed.destination,
+                removed.gateway,
+            )
+        });
+    if !preserve_projection {
+        iface.smol_iface().lock().routes_mut().update(|routes| {
+            if let Some(index) = routes.iter().rposition(|existing| {
+                same_projection(
+                    existing.cidr,
+                    existing.via_router,
+                    removed.destination,
+                    removed.gateway,
+                )
+            }) {
+                routes.remove(index);
+            }
+        });
+    }
+}
+
+fn projection_has_other_owner(
     iface: &Arc<dyn Iface>,
     destination: IpCidr,
-    source: Option<IpCidr>,
     gateway: Option<IpAddress>,
-    table: u8,
-) {
-    iface.smol_iface().lock().routes_mut().update(|routes| {
-        routes.retain(|existing| {
-            if is_local_connected_route(iface, existing) {
-                return true;
-            }
-            if existing.cidr != destination {
-                return true;
-            }
-            existing.via_router != gateway
-        });
-    });
-    let _ = (source, table);
+    excluded_key: Option<RouteEntryKey>,
+) -> bool {
+    address_owns_projection(iface, destination, gateway)
+        || iface.common().netlink_routes().iter().any(|existing| {
+            Some(route_entry_key(existing)) != excluded_key
+                && same_projection(existing.destination, existing.gateway, destination, gateway)
+        })
+}
+
+fn address_owns_projection(
+    iface: &Arc<dyn Iface>,
+    destination: IpCidr,
+    gateway: Option<IpAddress>,
+) -> bool {
+    gateway.is_none()
+        && iface
+            .common()
+            .ip_addrs()
+            .iter()
+            .any(|cidr| canonical_projection_cidr(*cidr) == canonical_projection_cidr(destination))
+}
+
+fn same_projection(
+    left_cidr: IpCidr,
+    left_gateway: Option<IpAddress>,
+    right_cidr: IpCidr,
+    right_gateway: Option<IpAddress>,
+) -> bool {
+    canonical_projection_cidr(left_cidr) == canonical_projection_cidr(right_cidr)
+        && left_gateway == right_gateway
 }
 
 fn family_matches(requested_family: AddressFamily, actual_family: AddressFamily) -> bool {
@@ -579,10 +673,6 @@ fn route_destination_prefix(cidr: IpCidr) -> IpAddress {
             IpAddress::Ipv6(Ipv6Address::from(octets))
         }
     }
-}
-
-fn is_local_connected_route(iface: &Arc<dyn Iface>, route: &smoltcp::iface::Route) -> bool {
-    route.via_router.is_none() && iface.common().ip_addrs().contains(&route.cidr)
 }
 
 fn route_notify_group(ip: IpAddress) -> u32 {

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -1,5 +1,4 @@
-use crate::net::socket::netlink::{message::attr::Attribute, route::message::attr::IFNAME_SIZE};
-use alloc::ffi::CString;
+use crate::net::socket::netlink::message::attr::Attribute;
 use alloc::vec::Vec;
 use system_error::SystemError;
 
@@ -46,7 +45,9 @@ impl TryFrom<u16> for AddrAttrClass {
 pub enum AddrAttr {
     Address(Vec<u8>),
     Local(Vec<u8>),
-    Label(CString),
+    /// Raw IFA_LABEL payload. Validation is address-family specific: IPv4
+    /// uses NLA_STRING(IFNAMSIZ - 1), while Linux ignores it for IPv6.
+    Label(Vec<u8>),
 }
 
 impl AddrAttr {
@@ -68,7 +69,7 @@ impl Attribute for AddrAttr {
         match self {
             AddrAttr::Address(addr) => addr.as_ref(),
             AddrAttr::Local(addr) => addr.as_ref(),
-            AddrAttr::Label(label) => label.to_bytes_with_nul(),
+            AddrAttr::Label(label) => label.as_slice(),
         }
     }
 
@@ -101,17 +102,8 @@ impl Attribute for AddrAttr {
                 addr.copy_from_slice(buf);
                 AddrAttr::Local(addr)
             }
-            (AddrAttrClass::LABEL, 1..) => {
-                let effective_len = buf.len() - usize::from(buf.last() == Some(&0));
-                if effective_len >= IFNAME_SIZE {
-                    return Err(SystemError::ERANGE);
-                }
-                // 查找第一个0字节作为结尾，否则用全部
-                let nul_pos = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
-                let cstr = CString::new(&buf[..nul_pos]).map_err(|_| SystemError::EINVAL)?;
-                AddrAttr::Label(cstr)
-            }
-            (AddrAttrClass::ADDRESS | AddrAttrClass::LOCAL | AddrAttrClass::LABEL, _) => {
+            (AddrAttrClass::LABEL, _) => AddrAttr::Label(buf.to_vec()),
+            (AddrAttrClass::ADDRESS | AddrAttrClass::LOCAL, _) => {
                 log::warn!(
                     "address attribute `{:?}` contains invalid payload",
                     addr_class

--- a/kernel/src/net/socket/netlink/route/message/attr/addr.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/addr.rs
@@ -101,7 +101,11 @@ impl Attribute for AddrAttr {
                 addr.copy_from_slice(buf);
                 AddrAttr::Local(addr)
             }
-            (AddrAttrClass::LABEL, 1..=IFNAME_SIZE) => {
+            (AddrAttrClass::LABEL, 1..) => {
+                let effective_len = buf.len() - usize::from(buf.last() == Some(&0));
+                if effective_len >= IFNAME_SIZE {
+                    return Err(SystemError::ERANGE);
+                }
                 // 查找第一个0字节作为结尾，否则用全部
                 let nul_pos = buf.iter().position(|&b| b == 0).unwrap_or(buf.len());
                 let cstr = CString::new(&buf[..nul_pos]).map_err(|_| SystemError::EINVAL)?;

--- a/kernel/src/net/socket/netlink/route/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/mod.rs
@@ -7,7 +7,7 @@ pub mod neigh;
 pub mod route;
 
 /// 网卡名字长度
-const IFNAME_SIZE: usize = 16;
+pub(in crate::net::socket::netlink::route) const IFNAME_SIZE: usize = 16;
 
 pub(super) fn convert_one_from_raw_buf<T>(src: &[u8]) -> Result<&T, SystemError> {
     log::info!("convert_one_from_raw_buf: src.len() = {}", src.len());

--- a/kernel/src/net/socket/netlink/route/mod.rs
+++ b/kernel/src/net/socket/netlink/route/mod.rs
@@ -1,7 +1,26 @@
-use crate::net::socket::netlink::{common::NetlinkSocket, table::NetlinkRouteProtocol};
+use alloc::sync::Arc;
+
+use crate::{
+    driver::net::Iface,
+    net::{
+        address::AddressMutationOutcome,
+        socket::netlink::{common::NetlinkSocket, table::NetlinkRouteProtocol},
+    },
+    process::namespace::net_namespace::NetNamespace,
+};
 
 pub(super) mod bound;
 pub(super) mod kern;
 pub(super) mod message;
 
 pub(super) type NetlinkRouteSocket = NetlinkSocket<NetlinkRouteProtocol>;
+
+/// Emits the narrow address multicast contract shared by rtnetlink and
+/// in-kernel address producers such as DHCP.
+pub(crate) fn notify_address_outcome(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    outcome: AddressMutationOutcome,
+) {
+    kern::addr::notify_address_outcome(netns, iface, outcome);
+}

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
@@ -67,6 +67,7 @@ struct DumpedAddress {
     IpBytes local;
     uint8_t prefix_len = 0;
     uint32_t ifindex = 0;
+    bool has_label = false;
     std::string label;
 };
 
@@ -206,7 +207,8 @@ int SetLinkName(int fd, uint32_t ifindex, const char* name, uint32_t sequence) {
 
 int ChangeAddress(int fd, uint16_t type, uint16_t flags, const AddressSpec& address,
                   bool include_local, bool include_address, uint32_t sequence,
-                  const char* label = nullptr) {
+                  const char* label = nullptr,
+                  std::optional<size_t> label_length = std::nullopt) {
     auto request = NewRequest<ifaddrmsg>(type, flags, sequence);
     auto* message = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()));
     message->ifa_family = address.family;
@@ -220,7 +222,9 @@ int ChangeAddress(int fd, uint16_t type, uint16_t flags, const AddressSpec& addr
     if (include_address) {
         AddAttr(&request, IFA_ADDRESS, address.local.bytes.data(), address.local.length);
     }
-    if (label != nullptr) AddAttr(&request, IFA_LABEL, label, std::strlen(label) + 1);
+    if (label != nullptr) {
+        AddAttr(&request, IFA_LABEL, label, label_length.value_or(std::strlen(label) + 1));
+    }
     return SendAndReceiveAck(fd, request);
 }
 
@@ -272,10 +276,13 @@ int DumpAddresses(int fd, int family, uint32_t sequence, std::vector<DumpedAddre
             int attr_length = IFA_PAYLOAD(header);
             for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
                  attr = RTA_NEXT(attr, attr_length)) {
-                if (attr->rta_type == IFA_LABEL && RTA_PAYLOAD(attr) > 0) {
-                    address.label.assign(static_cast<const char*>(RTA_DATA(attr)),
-                                         strnlen(static_cast<const char*>(RTA_DATA(attr)),
-                                                 RTA_PAYLOAD(attr)));
+                if (attr->rta_type == IFA_LABEL) {
+                    address.has_label = true;
+                    if (RTA_PAYLOAD(attr) > 0) {
+                        address.label.assign(static_cast<const char*>(RTA_DATA(attr)),
+                                             strnlen(static_cast<const char*>(RTA_DATA(attr)),
+                                                     RTA_PAYLOAD(attr)));
+                    }
                     continue;
                 }
                 if ((attr->rta_type != IFA_LOCAL && attr->rta_type != IFA_ADDRESS) ||
@@ -374,6 +381,18 @@ int CountAddressWithLabel(int fd, const AddressSpec& expected, const char* label
     }));
 }
 
+int CountAddressWithoutLabel(int fd, const AddressSpec& expected, uint32_t sequence) {
+    std::vector<DumpedAddress> addresses;
+    if (const int error = DumpAddresses(fd, expected.family, sequence, &addresses); error != 0) {
+        return -error;
+    }
+    return static_cast<int>(std::count_if(addresses.begin(), addresses.end(), [&](const auto& item) {
+        return item.family == expected.family && item.ifindex == expected.ifindex &&
+               item.prefix_len == expected.prefix_len && SameAddress(item.local, expected.local) &&
+               !item.has_label;
+    }));
+}
+
 int CountRoute(int fd, const RouteSpec& expected, uint32_t sequence) {
     std::vector<DumpedRoute> routes;
     if (const int error = DumpRoutes(fd, sequence, &routes); error != 0) return -error;
@@ -388,7 +407,8 @@ int CountRoute(int fd, const RouteSpec& expected, uint32_t sequence) {
 }
 
 bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
-                                const AddressSpec& expected, const char* label = nullptr) {
+                                const AddressSpec& expected, const char* label = nullptr,
+                                bool require_label_absent = false) {
     if (header->nlmsg_type != type) return false;
     const auto* message = reinterpret_cast<const ifaddrmsg*>(NLMSG_DATA(header));
     if (message->ifa_family != expected.family || message->ifa_index != expected.ifindex ||
@@ -398,6 +418,7 @@ bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
     int attr_length = IFA_PAYLOAD(header);
     bool address_matches = false;
     bool label_matches = label == nullptr;
+    bool has_label = false;
     for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
          attr = RTA_NEXT(attr, attr_length)) {
         if ((attr->rta_type == IFA_LOCAL || attr->rta_type == IFA_ADDRESS) &&
@@ -407,10 +428,13 @@ bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
         } else if (attr->rta_type == IFA_LABEL && label != nullptr && RTA_PAYLOAD(attr) > 0 &&
                    strncmp(static_cast<const char*>(RTA_DATA(attr)), label, RTA_PAYLOAD(attr)) ==
                        0) {
+            has_label = true;
             label_matches = true;
+        } else if (attr->rta_type == IFA_LABEL) {
+            has_label = true;
         }
     }
-    return address_matches && label_matches;
+    return address_matches && label_matches && (!require_label_absent || !has_label);
 }
 
 void DrainNotifications(int fd) {
@@ -424,7 +448,7 @@ void DrainNotifications(int fd) {
 }
 
 int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address,
-                              const char* label = nullptr) {
+                              const char* label = nullptr, bool require_label_absent = false) {
     std::array<uint8_t, 16384> buffer{};
     int count = 0;
     bool received_any = false;
@@ -440,7 +464,9 @@ int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address,
         int remaining = static_cast<int>(received);
         for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
              NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
-            if (NotificationMatchesAddress(header, type, address, label)) ++count;
+            if (NotificationMatchesAddress(header, type, address, label, require_label_absent)) {
+                ++count;
+            }
         }
     }
 }
@@ -615,9 +641,14 @@ int RunIdentityFlagsAndErrorPriority() {
 
     const AddressSpec ipv6 = MakeAddress(AF_INET6, "2001:db8:2::1", 64, ifindex);
     const AddressSpec ipv6_other_prefix = MakeAddress(AF_INET6, "2001:db8:2::1", 96, ifindex);
+    constexpr char kIgnoredIpv6Label[] =
+        "1234567890123456123456789012345612345678901234561234567890123456";
+    DrainNotifications(notifications.Get());
     if (ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv6, false, true,
-                      ++sequence) != 0 ||
+                      ++sequence, kIgnoredIpv6Label) != 0 ||
+        CountAddressWithoutLabel(fd.Get(), ipv6, ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, ipv6, nullptr, true) != 1 ||
         ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv6_other_prefix,
                       false, true, ++sequence) != EEXIST) {
@@ -625,7 +656,7 @@ int RunIdentityFlagsAndErrorPriority() {
     }
     DrainNotifications(notifications.Get());
     if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE,
-                      ipv6_other_prefix, false, true, ++sequence) != 0) {
+                      ipv6_other_prefix, false, true, ++sequence, "", 0) != 0) {
         return 3600;
     }
     if (CountAddress(fd.Get(), ipv6, ++sequence) != 1) return 3601;
@@ -636,7 +667,8 @@ int RunIdentityFlagsAndErrorPriority() {
     if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ipv6_other_prefix,
                       false, true, ++sequence) != EADDRNOTAVAIL ||
         ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ipv6, false, true,
-                      ++sequence) != 0) {
+                      ++sequence, kIgnoredIpv6Label) != 0 ||
+        CountAddressNotifications(notifications.Get(), RTM_DELADDR, ipv6, nullptr, true) != 1) {
         return 3700;
     }
 
@@ -725,8 +757,20 @@ int RunIdentityFlagsAndErrorPriority() {
     }
 
     const AddressSpec long_label = MakeAddress(AF_INET, "198.51.100.45", 24, ifindex);
+    AddressSpec long_label_unknown = long_label;
+    long_label_unknown.ifindex = 0x7fffffffu;
+    const AddressSpec zero_address = MakeAddress(AF_INET, "0.0.0.0", 0, ifindex);
     if (ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, long_label, true,
+                      true, ++sequence, "", 0) != ERANGE ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, long_label, true,
+                      true, ++sequence, "1234567890123456") != ERANGE ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                      long_label_unknown, true, true, ++sequence, "1234567890123456") != ERANGE ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, zero_address, true,
                       true, ++sequence, "1234567890123456") != ERANGE) {
         return 4180;
     }
@@ -735,11 +779,17 @@ int RunIdentityFlagsAndErrorPriority() {
     if (ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, empty_label, true,
                       true, ++sequence, "") != 0 ||
-        CountAddressWithLabel(fd.Get(), empty_label, "", ++sequence) != 1 ||
-        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, empty_label, "") != 1 ||
+        CountAddressWithoutLabel(fd.Get(), empty_label, ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, empty_label, nullptr, true) !=
+            1 ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, empty_label, true, true,
+                      ++sequence, "", 0) != ERANGE ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, empty_label, true, true,
+                      ++sequence, "lo") != EADDRNOTAVAIL ||
         ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, empty_label, true, true,
                       ++sequence, "") != 0 ||
-        CountAddressNotifications(notifications.Get(), RTM_DELADDR, empty_label, "") != 1) {
+        CountAddressNotifications(notifications.Get(), RTM_DELADDR, empty_label, nullptr, true) !=
+            1) {
         return 4190;
     }
 

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
@@ -1,0 +1,1002 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <linux/if_addr.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <poll.h>
+#include <sched.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace {
+
+constexpr int kHostHasNoFixedRouteCapacity = -2;
+constexpr int kNamespaceUnavailable = -3;
+constexpr int kMaxRouteFillAttempts = 64;
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    int Get() const { return fd_; }
+
+    void Reset(int fd = -1) {
+        if (fd_ >= 0) close(fd_);
+        fd_ = fd;
+    }
+
+  private:
+    int fd_;
+};
+
+struct IpBytes {
+    std::array<uint8_t, 16> bytes{};
+    size_t length = 0;
+};
+
+struct AddressSpec {
+    int family;
+    IpBytes local;
+    uint8_t prefix_len;
+    uint32_t ifindex;
+};
+
+struct DumpedAddress {
+    int family = AF_UNSPEC;
+    IpBytes local;
+    uint8_t prefix_len = 0;
+    uint32_t ifindex = 0;
+};
+
+struct RouteSpec {
+    uint32_t destination;
+    uint8_t prefix_len;
+    uint32_t ifindex;
+};
+
+struct DumpedRoute {
+    uint32_t destination = 0;
+    uint8_t prefix_len = 0;
+    uint32_t ifindex = 0;
+    bool has_gateway = false;
+};
+
+struct ChildOutcome {
+    bool timed_out;
+    int wait_status;
+    int stage;
+};
+
+bool IsDragonOS() {
+    utsname name{};
+    return uname(&name) == 0 && std::strstr(name.release, "dragonos") != nullptr;
+}
+
+IpBytes ParseAddress(int family, const char* text) {
+    IpBytes result{};
+    result.length = family == AF_INET ? sizeof(in_addr) : sizeof(in6_addr);
+    if (inet_pton(family, text, result.bytes.data()) != 1) result.length = 0;
+    return result;
+}
+
+uint32_t Ipv4(const std::string& text) {
+    uint32_t address = 0;
+    if (inet_pton(AF_INET, text.c_str(), &address) != 1) return 0;
+    return address;
+}
+
+bool SameAddress(const IpBytes& left, const IpBytes& right) {
+    return left.length == right.length && left.length != 0 &&
+           std::memcmp(left.bytes.data(), right.bytes.data(), left.length) == 0;
+}
+
+int OpenRouteSocket(uint32_t groups = 0) {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) return -1;
+
+    timeval timeout{};
+    timeout.tv_sec = 2;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+
+    sockaddr_nl local{};
+    local.nl_family = AF_NETLINK;
+    local.nl_groups = groups;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) != 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+template <typename Body>
+std::vector<uint8_t> NewRequest(uint16_t type, uint16_t flags, uint32_t sequence) {
+    std::vector<uint8_t> request(NLMSG_LENGTH(sizeof(Body)), 0);
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    header->nlmsg_len = request.size();
+    header->nlmsg_type = type;
+    header->nlmsg_flags = flags;
+    header->nlmsg_seq = sequence;
+    return request;
+}
+
+void AddAttr(std::vector<uint8_t>* request, uint16_t type, const void* data, size_t length) {
+    auto* header = reinterpret_cast<nlmsghdr*>(request->data());
+    const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
+    const size_t attr_length = RTA_LENGTH(length);
+    const size_t end = offset + RTA_ALIGN(attr_length);
+    request->resize(end, 0);
+
+    header = reinterpret_cast<nlmsghdr*>(request->data());
+    auto* attr = reinterpret_cast<rtattr*>(request->data() + offset);
+    attr->rta_type = type;
+    attr->rta_len = attr_length;
+    std::memcpy(RTA_DATA(attr), data, length);
+    header->nlmsg_len = end;
+}
+
+int ReceiveAck(int fd, uint32_t sequence) {
+    std::array<uint8_t, 8192> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != sequence || header->nlmsg_type != NLMSG_ERROR) continue;
+            const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+            return error->error == 0 ? 0 : -error->error;
+        }
+    }
+}
+
+int SendAndReceiveAck(int fd, const std::vector<uint8_t>& request) {
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+    return ReceiveAck(fd, reinterpret_cast<const nlmsghdr*>(request.data())->nlmsg_seq);
+}
+
+int SetLinkUp(int fd, uint32_t ifindex, uint32_t sequence) {
+    auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, sequence);
+    auto* message = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
+    message->ifi_family = AF_UNSPEC;
+    message->ifi_index = static_cast<int>(ifindex);
+    message->ifi_flags = IFF_UP;
+    message->ifi_change = IFF_UP;
+    return SendAndReceiveAck(fd, request);
+}
+
+int ChangeAddress(int fd, uint16_t type, uint16_t flags, const AddressSpec& address,
+                  bool include_local, bool include_address, uint32_t sequence) {
+    auto request = NewRequest<ifaddrmsg>(type, flags, sequence);
+    auto* message = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()));
+    message->ifa_family = address.family;
+    message->ifa_prefixlen = address.prefix_len;
+    message->ifa_scope = address.family == AF_INET6 ? RT_SCOPE_UNIVERSE : RT_SCOPE_HOST;
+    message->ifa_index = address.ifindex;
+    if (address.family == AF_INET6) message->ifa_flags = IFA_F_NODAD;
+    if (include_local) {
+        AddAttr(&request, IFA_LOCAL, address.local.bytes.data(), address.local.length);
+    }
+    if (include_address) {
+        AddAttr(&request, IFA_ADDRESS, address.local.bytes.data(), address.local.length);
+    }
+    return SendAndReceiveAck(fd, request);
+}
+
+int ChangeRoute(int fd, uint16_t type, uint16_t flags, const RouteSpec& route,
+                uint32_t sequence) {
+    auto request = NewRequest<rtmsg>(type, flags, sequence);
+    auto* message = reinterpret_cast<rtmsg*>(NLMSG_DATA(request.data()));
+    message->rtm_family = AF_INET;
+    message->rtm_dst_len = route.prefix_len;
+    message->rtm_table = RT_TABLE_MAIN;
+    message->rtm_protocol = RTPROT_STATIC;
+    message->rtm_scope = RT_SCOPE_LINK;
+    message->rtm_type = RTN_UNICAST;
+    AddAttr(&request, RTA_DST, &route.destination, sizeof(route.destination));
+    AddAttr(&request, RTA_OIF, &route.ifindex, sizeof(route.ifindex));
+    return SendAndReceiveAck(fd, request);
+}
+
+int DumpAddresses(int fd, int family, uint32_t sequence, std::vector<DumpedAddress>* result) {
+    auto request = NewRequest<ifaddrmsg>(RTM_GETADDR, NLM_F_REQUEST | NLM_F_DUMP, sequence);
+    reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()))->ifa_family = family;
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != sequence) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? 0 : -error->error;
+            }
+            if (header->nlmsg_type != RTM_NEWADDR) continue;
+
+            const auto* message = reinterpret_cast<const ifaddrmsg*>(NLMSG_DATA(header));
+            DumpedAddress address{};
+            address.family = message->ifa_family;
+            address.prefix_len = message->ifa_prefixlen;
+            address.ifindex = message->ifa_index;
+            address.local.length = message->ifa_family == AF_INET ? sizeof(in_addr)
+                                                                  : sizeof(in6_addr);
+            std::optional<IpBytes> fallback;
+            int attr_length = IFA_PAYLOAD(header);
+            for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if ((attr->rta_type != IFA_LOCAL && attr->rta_type != IFA_ADDRESS) ||
+                    RTA_PAYLOAD(attr) < address.local.length) {
+                    continue;
+                }
+                IpBytes parsed{};
+                parsed.length = address.local.length;
+                std::memcpy(parsed.bytes.data(), RTA_DATA(attr), parsed.length);
+                if (attr->rta_type == IFA_LOCAL) {
+                    address.local = parsed;
+                } else {
+                    fallback = parsed;
+                }
+            }
+            if (address.local.length != 0 &&
+                std::all_of(address.local.bytes.begin(), address.local.bytes.end(),
+                            [](uint8_t byte) { return byte == 0; }) &&
+                fallback.has_value()) {
+                address.local = *fallback;
+            }
+            result->push_back(address);
+        }
+    }
+}
+
+int DumpRoutes(int fd, uint32_t sequence, std::vector<DumpedRoute>* result) {
+    auto request = NewRequest<rtmsg>(RTM_GETROUTE, NLM_F_REQUEST | NLM_F_DUMP, sequence);
+    reinterpret_cast<rtmsg*>(NLMSG_DATA(request.data()))->rtm_family = AF_INET;
+    if (send(fd, request.data(), request.size(), 0) != static_cast<ssize_t>(request.size())) {
+        return errno;
+    }
+
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != sequence) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? 0 : -error->error;
+            }
+            if (header->nlmsg_type != RTM_NEWROUTE) continue;
+
+            const auto* message = reinterpret_cast<const rtmsg*>(NLMSG_DATA(header));
+            if (message->rtm_family != AF_INET) continue;
+            DumpedRoute route{};
+            route.prefix_len = message->rtm_dst_len;
+            int attr_length = RTM_PAYLOAD(header);
+            for (auto* attr = RTM_RTA(message); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type == RTA_DST && RTA_PAYLOAD(attr) >= sizeof(route.destination)) {
+                    std::memcpy(&route.destination, RTA_DATA(attr), sizeof(route.destination));
+                } else if (attr->rta_type == RTA_OIF &&
+                           RTA_PAYLOAD(attr) >= sizeof(route.ifindex)) {
+                    std::memcpy(&route.ifindex, RTA_DATA(attr), sizeof(route.ifindex));
+                } else if (attr->rta_type == RTA_GATEWAY) {
+                    route.has_gateway = true;
+                }
+            }
+            result->push_back(route);
+        }
+    }
+}
+
+int CountAddress(int fd, const AddressSpec& expected, uint32_t sequence) {
+    std::vector<DumpedAddress> addresses;
+    if (const int error = DumpAddresses(fd, expected.family, sequence, &addresses); error != 0) {
+        return -error;
+    }
+    int count = 0;
+    for (const auto& address : addresses) {
+        if (address.family == expected.family && address.ifindex == expected.ifindex &&
+            address.prefix_len == expected.prefix_len &&
+            SameAddress(address.local, expected.local)) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int CountRoute(int fd, const RouteSpec& expected, uint32_t sequence) {
+    std::vector<DumpedRoute> routes;
+    if (const int error = DumpRoutes(fd, sequence, &routes); error != 0) return -error;
+    int count = 0;
+    for (const auto& route : routes) {
+        if (route.destination == expected.destination && route.prefix_len == expected.prefix_len &&
+            route.ifindex == expected.ifindex && !route.has_gateway) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
+                                const AddressSpec& expected) {
+    if (header->nlmsg_type != type) return false;
+    const auto* message = reinterpret_cast<const ifaddrmsg*>(NLMSG_DATA(header));
+    if (message->ifa_family != expected.family || message->ifa_index != expected.ifindex ||
+        message->ifa_prefixlen != expected.prefix_len) {
+        return false;
+    }
+    int attr_length = IFA_PAYLOAD(header);
+    for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
+         attr = RTA_NEXT(attr, attr_length)) {
+        if ((attr->rta_type == IFA_LOCAL || attr->rta_type == IFA_ADDRESS) &&
+            RTA_PAYLOAD(attr) >= expected.local.length &&
+            std::memcmp(RTA_DATA(attr), expected.local.bytes.data(), expected.local.length) == 0) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void DrainNotifications(int fd) {
+    std::array<uint8_t, 16384> buffer{};
+    for (;;) {
+        pollfd descriptor{fd, POLLIN, 0};
+        const int polled = poll(&descriptor, 1, 20);
+        if (polled <= 0) return;
+        if (recv(fd, buffer.data(), buffer.size(), MSG_DONTWAIT) <= 0) return;
+    }
+}
+
+int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address) {
+    std::array<uint8_t, 16384> buffer{};
+    int count = 0;
+    bool received_any = false;
+    for (;;) {
+        pollfd descriptor{fd, POLLIN, 0};
+        const int polled = poll(&descriptor, 1, received_any ? 10 : 100);
+        if (polled == 0) return count;
+        if (polled < 0) return -errno;
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), MSG_DONTWAIT);
+        if (received < 0) return errno == EAGAIN || errno == EWOULDBLOCK ? count : -errno;
+        if (received == 0) return count;
+        received_any = true;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (NotificationMatchesAddress(header, type, address)) ++count;
+        }
+    }
+}
+
+int BindUdp(const AddressSpec& address, uint16_t port, int* fd_out = nullptr) {
+    int fd = socket(address.family, SOCK_DGRAM, 0);
+    if (fd < 0) return errno;
+    int error = 0;
+    if (address.family == AF_INET) {
+        sockaddr_in local{};
+        local.sin_family = AF_INET;
+        local.sin_port = htons(port);
+        std::memcpy(&local.sin_addr, address.local.bytes.data(), sizeof(local.sin_addr));
+        if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) != 0) error = errno;
+    } else {
+        sockaddr_in6 local{};
+        local.sin6_family = AF_INET6;
+        local.sin6_port = htons(port);
+        local.sin6_scope_id = address.ifindex;
+        std::memcpy(&local.sin6_addr, address.local.bytes.data(), sizeof(local.sin6_addr));
+        if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) != 0) error = errno;
+    }
+    if (error != 0 || fd_out == nullptr) {
+        close(fd);
+    } else {
+        *fd_out = fd;
+    }
+    return error;
+}
+
+int VerifyBoundUdpDelivery(const AddressSpec& address) {
+    int receiver_raw = -1;
+    if (const int error = BindUdp(address, 0, &receiver_raw); error != 0) return 100 + error;
+    FdGuard receiver(receiver_raw);
+    timeval timeout{};
+    timeout.tv_sec = 2;
+    if (setsockopt(receiver.Get(), SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        return 200 + errno;
+    }
+
+    int sender_raw = -1;
+    if (const int error = BindUdp(address, 0, &sender_raw); error != 0) return 300 + error;
+    FdGuard sender(sender_raw);
+    const char payload[] = "address-route";
+    if (address.family == AF_INET) {
+        sockaddr_in destination{};
+        socklen_t length = sizeof(destination);
+        if (getsockname(receiver.Get(), reinterpret_cast<sockaddr*>(&destination), &length) != 0) {
+            return 400 + errno;
+        }
+        if (sendto(sender.Get(), payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), length) !=
+            static_cast<ssize_t>(sizeof(payload))) {
+            return 500 + errno;
+        }
+    } else {
+        sockaddr_in6 destination{};
+        socklen_t length = sizeof(destination);
+        if (getsockname(receiver.Get(), reinterpret_cast<sockaddr*>(&destination), &length) != 0) {
+            return 600 + errno;
+        }
+        if (sendto(sender.Get(), payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), length) !=
+            static_cast<ssize_t>(sizeof(payload))) {
+            return 700 + errno;
+        }
+    }
+    std::array<char, sizeof(payload)> received{};
+    if (recv(receiver.Get(), received.data(), received.size(), 0) !=
+        static_cast<ssize_t>(sizeof(payload))) {
+        return 800 + errno;
+    }
+    return std::memcmp(payload, received.data(), sizeof(payload)) == 0 ? 0 : EIO;
+}
+
+int PrepareNamespace(FdGuard* netlink, uint32_t* ifindex, uint32_t* sequence) {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return kNamespaceUnavailable;
+    const int fd = OpenRouteSocket();
+    if (fd < 0) return 1000 + errno;
+    netlink->Reset(fd);
+    *ifindex = if_nametoindex("lo");
+    if (*ifindex == 0) return 1200 + errno;
+    if (const int error = SetLinkUp(netlink->Get(), *ifindex, ++(*sequence)); error != 0) {
+        return 1300 + error;
+    }
+    return 0;
+}
+
+AddressSpec MakeAddress(int family, const char* text, uint8_t prefix_len, uint32_t ifindex) {
+    return {family, ParseAddress(family, text), prefix_len, ifindex};
+}
+
+int RunMultipleAddressConsistency() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 100;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+
+    const AddressSpec first = MakeAddress(AF_INET, "192.0.2.1", 24, ifindex);
+    const AddressSpec second = MakeAddress(AF_INET, "198.51.100.1", 24, ifindex);
+    const AddressSpec ipv6 = MakeAddress(AF_INET6, "2001:db8:1::1", 64, ifindex);
+    const std::array<AddressSpec, 3> addresses{first, second, ipv6};
+    for (const auto& address : addresses) {
+        if (const int error = ChangeAddress(fd.Get(), RTM_NEWADDR,
+                                            NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE |
+                                                NLM_F_EXCL,
+                                            address, true, true, ++sequence);
+            error != 0) {
+            return 2000 + error;
+        }
+        if (CountAddress(fd.Get(), address, ++sequence) != 1) return 2100;
+        if (const int error = BindUdp(address, 0); error != 0) return 2200 + error;
+    }
+
+    const RouteSpec first_route{Ipv4("192.0.2.0"), 24, ifindex};
+    const RouteSpec second_route{Ipv4("198.51.100.0"), 24, ifindex};
+    if (CountRoute(fd.Get(), first_route, ++sequence) < 1 ||
+        CountRoute(fd.Get(), second_route, ++sequence) < 1) {
+        return 2300;
+    }
+    if (const int error = ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK,
+                                        second, true, true, ++sequence);
+        error != 0) {
+        return 2500 + error;
+    }
+    if (CountAddress(fd.Get(), second, ++sequence) != 0 ||
+        CountRoute(fd.Get(), second_route, ++sequence) != 0 ||
+        CountRoute(fd.Get(), first_route, ++sequence) < 1 ||
+        CountAddress(fd.Get(), first, ++sequence) != 1 ||
+        CountAddress(fd.Get(), ipv6, ++sequence) != 1) {
+        return 2600;
+    }
+    // Explicitly bind both endpoints to the configured address. This tests
+    // address ownership and smoltcp delivery without conflating the result
+    // with the separate implicit-source selection policy for non-127/8
+    // addresses assigned to a loopback device.
+    if (const int error = VerifyBoundUdpDelivery(first); error != 0) return 2700 + error;
+    return 0;
+}
+
+int RunIdentityFlagsAndErrorPriority() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 1000;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+    FdGuard notifications(OpenRouteSocket(RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR));
+    if (notifications.Get() < 0) return 3000 + errno;
+
+    AddressSpec ipv4 = MakeAddress(AF_INET, "192.0.2.33", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv4, true, true,
+                      ++sequence) != 0) {
+        return 3100;
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv4, true, true,
+                      ++sequence) != EEXIST) {
+        return 3200;
+    }
+    DrainNotifications(notifications.Get());
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE, ipv4,
+                      true, true, ++sequence) != 0 ||
+        CountAddress(fd.Get(), ipv4, ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, ipv4) != 1) {
+        return 3300;
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE | NLM_F_EXCL, ipv4, true, true,
+                      ++sequence) != EEXIST) {
+        return 3400;
+    }
+
+    const AddressSpec ipv6 = MakeAddress(AF_INET6, "2001:db8:2::1", 64, ifindex);
+    const AddressSpec ipv6_other_prefix = MakeAddress(AF_INET6, "2001:db8:2::1", 96, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv6, false, true,
+                      ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, ipv6_other_prefix,
+                      false, true, ++sequence) != EEXIST) {
+        return 3500;
+    }
+    DrainNotifications(notifications.Get());
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE,
+                      ipv6_other_prefix, false, true, ++sequence) != 0) {
+        return 3600;
+    }
+    if (CountAddress(fd.Get(), ipv6, ++sequence) != 1) return 3601;
+    if (CountAddress(fd.Get(), ipv6_other_prefix, ++sequence) != 0) return 3602;
+    const int ipv6_notifications =
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, ipv6);
+    if (ipv6_notifications != 1) return 36030 + ipv6_notifications;
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ipv6_other_prefix,
+                      false, true, ++sequence) != EADDRNOTAVAIL ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, ipv6, false, true,
+                      ++sequence) != 0) {
+        return 3700;
+    }
+
+    AddressSpec wrong_prefix = ipv4;
+    wrong_prefix.prefix_len = 255;
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, wrong_prefix, true, false,
+                      ++sequence) != 0 ||
+        CountAddress(fd.Get(), ipv4, ++sequence) != 0) {
+        return 3800;
+    }
+
+    const AddressSpec local_only = MakeAddress(AF_INET, "192.0.2.44", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, local_only, false,
+                      true, ++sequence) != EINVAL ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, local_only, true,
+                      false, ++sequence) != 0) {
+        return 3900;
+    }
+    AddressSpec network_selector = local_only;
+    network_selector.local = ParseAddress(AF_INET, "192.0.2.0");
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, network_selector, false,
+                      true, ++sequence) != 0 ||
+        CountAddress(fd.Get(), local_only, ++sequence) != 0) {
+        return 3950;
+    }
+
+    AddressSpec unknown = MakeAddress(AF_INET, "198.51.100.9", 24, 0x7fffffffu);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK, unknown, false, false,
+                      ++sequence) != EINVAL) {
+        return 4000;
+    }
+    const AddressSpec unsupported{AF_UNSPEC, {}, 0, unknown.ifindex};
+    const int unsupported_error = ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK,
+                                                unsupported, false, false, ++sequence);
+    if ((IsDragonOS() && unsupported_error != EAFNOSUPPORT) ||
+        (!IsDragonOS() && unsupported_error != EAFNOSUPPORT && unsupported_error != EOPNOTSUPP)) {
+        return 4050;
+    }
+    AddressSpec invalid_prefix = unknown;
+    invalid_prefix.prefix_len = 33;
+    AddressSpec zero_index = unknown;
+    zero_index.ifindex = 0;
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK, invalid_prefix, true,
+                      true, ++sequence) != EINVAL ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK, unknown, true, true,
+                      ++sequence) != ENODEV ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK, zero_index, true, true,
+                      ++sequence) != ENODEV) {
+        return 4100;
+    }
+
+    const AddressSpec absent = MakeAddress(AF_INET, "203.0.113.77", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE, absent,
+                      true, true, ++sequence) != 0 ||
+        CountAddress(fd.Get(), absent, ++sequence) != 1) {
+        return 4200;
+    }
+    const AddressSpec missing = MakeAddress(AF_INET, "203.0.113.78", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, missing, true, true,
+                      ++sequence) != EADDRNOTAVAIL) {
+        return 4300;
+    }
+    return 0;
+}
+
+int RunInvalidAddressSafety() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 2000;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+    FdGuard notifications(OpenRouteSocket(RTMGRP_IPV4_IFADDR | RTMGRP_IPV6_IFADDR));
+    if (notifications.Get() < 0) return 5000 + errno;
+
+    const AddressSpec multicast4 = MakeAddress(AF_INET, "224.0.0.123", 24, ifindex);
+    const int multicast4_error = ChangeAddress(
+        fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+        multicast4, true, true, ++sequence);
+    if (IsDragonOS() && multicast4_error == 0) return 5100;
+
+    const AddressSpec multicast6 = MakeAddress(AF_INET6, "ff02::123", 64, ifindex);
+    const int multicast6_error = ChangeAddress(
+        fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+        multicast6, false, true, ++sequence);
+    if (IsDragonOS() && multicast6_error == 0) return 5200;
+
+    DrainNotifications(notifications.Get());
+    const AddressSpec unspecified4 = MakeAddress(AF_INET, "0.0.0.0", 0, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, unspecified4, true,
+                      true, ++sequence) != 0 ||
+        CountAddress(fd.Get(), unspecified4, ++sequence) != 0 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, unspecified4) != 0) {
+        return 5300;
+    }
+
+    const AddressSpec unspecified6 = MakeAddress(AF_INET6, "::", 0, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, unspecified6,
+                      false, true, ++sequence) == 0) {
+        return 5400;
+    }
+
+    const AddressSpec valid = MakeAddress(AF_INET, "198.51.100.123", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, valid, true, true,
+                      ++sequence) != 0 ||
+        CountAddress(fd.Get(), valid, ++sequence) != 1) {
+        return 5500;
+    }
+    return 0;
+}
+
+RouteSpec FillCandidate(int index, uint32_t ifindex) {
+    const std::string destination = "198.18." + std::to_string(index) + ".0";
+    return {Ipv4(destination), 24, ifindex};
+}
+
+int FillRoutesToCapacity(int fd, uint32_t ifindex, uint32_t* sequence,
+                         std::vector<RouteSpec>* added, RouteSpec* failed) {
+    for (int index = 0; index < kMaxRouteFillAttempts; ++index) {
+        const RouteSpec candidate = FillCandidate(index, ifindex);
+        const int error = ChangeRoute(fd, RTM_NEWROUTE,
+                                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                                      candidate, ++(*sequence));
+        if (error == 0) {
+            added->push_back(candidate);
+        } else if (error == ENOSPC) {
+            *failed = candidate;
+            return 0;
+        } else {
+            return error;
+        }
+    }
+    return kHostHasNoFixedRouteCapacity;
+}
+
+int RunAddressRollbackAndCapacityRelease() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 3000;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+    if (!IsDragonOS()) return kHostHasNoFixedRouteCapacity;
+    FdGuard notifications(OpenRouteSocket(RTMGRP_IPV4_IFADDR));
+    if (notifications.Get() < 0) return 6000 + errno;
+
+    std::vector<RouteSpec> fillers;
+    RouteSpec failed_route{};
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers,
+                                               &failed_route);
+        error != 0) {
+        return error == kHostHasNoFixedRouteCapacity ? error : 6100 + error;
+    }
+    if (fillers.empty()) return 6200;
+
+    const AddressSpec address = MakeAddress(AF_INET, "203.0.113.1", 24, ifindex);
+    const RouteSpec connected{Ipv4("203.0.113.0"), 24, ifindex};
+    DrainNotifications(notifications.Get());
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != ENOSPC) {
+        return 6300;
+    }
+    if (CountAddress(fd.Get(), address, ++sequence) != 0 ||
+        CountRoute(fd.Get(), connected, ++sequence) != 0 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, address) != 0) {
+        return 6400;
+    }
+    if (BindUdp(address, 0) != EADDRNOTAVAIL) return 6500;
+
+    for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
+        if (const int error = ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK,
+                                          *iterator, ++sequence);
+            error != 0) {
+            return 6600 + error;
+        }
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != 0 ||
+        CountAddress(fd.Get(), address, ++sequence) != 1 ||
+        CountRoute(fd.Get(), connected, ++sequence) < 1) {
+        return 6700;
+    }
+
+    // The current route model has no owner tag. A same-value explicit route
+    // must nevertheless survive deletion of the address projection.
+    const RouteSpec explicit_same_value{Ipv4("203.0.113.1"), 24, ifindex};
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                    explicit_same_value, ++sequence) != 0) {
+        return 6750;
+    }
+
+    fillers.clear();
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers,
+                                               &failed_route);
+        error != 0) {
+        return 6800 + error;
+    }
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
+        CountAddress(fd.Get(), address, ++sequence) != 0 ||
+        CountRoute(fd.Get(), connected, ++sequence) < 1) {
+        return 6900;
+    }
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed_route,
+                    ++sequence) != 0) {
+        return 7000;
+    }
+    const RouteSpec capacity_probe{Ipv4("192.88.99.0"), 24, ifindex};
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, capacity_probe,
+                    ++sequence) != ENOSPC ||
+        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, explicit_same_value,
+                    ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, capacity_probe,
+                    ++sequence) != 0) {
+        return 7050;
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != ENOSPC) {
+        return 7100;
+    }
+    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, capacity_probe,
+                    ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != 0) {
+        return 7200;
+    }
+    if (CountAddress(fd.Get(), address, ++sequence) != 1 ||
+        CountRoute(fd.Get(), connected, ++sequence) < 1) {
+        return 7300;
+    }
+
+    // Repeat the ownership check with the opposite creation order. An
+    // explicit route must not satisfy a later address's dedicated projection.
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, failed_route,
+                    ++sequence) != 0) {
+        return 7400;
+    }
+    for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
+        if (const int error = ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK,
+                                          *iterator, ++sequence);
+            error != 0) {
+            return 7450 + error;
+        }
+    }
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                    explicit_same_value, ++sequence) != 0) {
+        return 7500;
+    }
+
+    fillers.clear();
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers,
+                                               &failed_route);
+        error != 0 || fillers.empty()) {
+        return 7600 + (error < 0 ? 0 : error);
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != ENOSPC ||
+        CountAddress(fd.Get(), address, ++sequence) != 0) {
+        return 7700;
+    }
+    const RouteSpec released = fillers.back();
+    fillers.pop_back();
+    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, released,
+                    ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, released,
+                    ++sequence) != 0) {
+        return 7800;
+    }
+    const RouteSpec explicit_first_probe{Ipv4("192.88.100.0"), 24, ifindex};
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                    explicit_first_probe, ++sequence) != ENOSPC ||
+        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, explicit_same_value,
+                    ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                    explicit_first_probe, ++sequence) != 0) {
+        return 7900;
+    }
+    return 0;
+}
+
+template <typename Function>
+ChildOutcome RunWithWatchdog(Function function) {
+    int result_pipe[2];
+    if (pipe(result_pipe) != 0) return {false, -1, 8000 + errno};
+    const pid_t child = fork();
+    if (child < 0) {
+        const int saved = errno;
+        close(result_pipe[0]);
+        close(result_pipe[1]);
+        return {false, -1, 8100 + saved};
+    }
+    if (child == 0) {
+        close(result_pipe[0]);
+        const int stage = function();
+        const ssize_t written = write(result_pipe[1], &stage, sizeof(stage));
+        (void)written;
+        close(result_pipe[1]);
+        _exit(stage == 0 || stage == kHostHasNoFixedRouteCapacity ||
+                      stage == kNamespaceUnavailable
+                  ? 0
+                  : 1);
+    }
+
+    close(result_pipe[1]);
+    int status = 0;
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(20);
+    for (;;) {
+        const pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) break;
+        if (waited < 0) {
+            close(result_pipe[0]);
+            return {false, -1, 8200 + errno};
+        }
+        if (std::chrono::steady_clock::now() >= deadline) {
+            (void)kill(child, SIGKILL);
+            (void)waitpid(child, &status, 0);
+            close(result_pipe[0]);
+            return {true, status, 0};
+        }
+        usleep(10 * 1000);
+    }
+
+    int stage = -1;
+    if (read(result_pipe[0], &stage, sizeof(stage)) != static_cast<ssize_t>(sizeof(stage))) {
+        stage = 8300;
+    }
+    close(result_pipe[0]);
+    return {false, status, stage};
+}
+
+void ExpectSuccessfulChild(const ChildOutcome& outcome, const char* timeout_message) {
+    ASSERT_FALSE(outcome.timed_out) << timeout_message;
+    ASSERT_TRUE(WIFEXITED(outcome.wait_status));
+    if (outcome.stage == kNamespaceUnavailable) {
+        if (!IsDragonOS()) GTEST_SKIP() << "host does not permit a fresh user/network namespace";
+        FAIL() << "DragonOS failed to create the required fresh user/network namespace";
+    }
+    EXPECT_EQ(outcome.stage, 0) << "encoded stage/error=" << outcome.stage;
+    EXPECT_EQ(WEXITSTATUS(outcome.wait_status), 0);
+}
+
+TEST(RtnetlinkAddressSemantics, MultipleAddressesStayConsistentAcrossAddrRouteAndDataPlane) {
+    ExpectSuccessfulChild(RunWithWatchdog(RunMultipleAddressConsistency),
+                          "multi-address mutation or UDP data path deadlocked");
+}
+
+TEST(RtnetlinkAddressSemantics, DuplicateReplaceDeleteAndParserSemanticsMatchLinux) {
+    ExpectSuccessfulChild(RunWithWatchdog(RunIdentityFlagsAndErrorPriority),
+                          "address identity or error-priority request deadlocked");
+}
+
+TEST(RtnetlinkAddressSemantics, InvalidAddressCannotPanicKernel) {
+    ExpectSuccessfulChild(RunWithWatchdog(RunInvalidAddressSafety),
+                          "invalid address request hung or panicked the kernel");
+}
+
+TEST(RtnetlinkAddressSemantics, CapacityFailureRollsBackAndDeleteReleasesRouteSlot) {
+    const ChildOutcome outcome = RunWithWatchdog(RunAddressRollbackAndCapacityRelease);
+    ASSERT_FALSE(outcome.timed_out) << "address capacity rollback path deadlocked";
+    ASSERT_TRUE(WIFEXITED(outcome.wait_status));
+    if (outcome.stage == kNamespaceUnavailable) {
+        if (!IsDragonOS()) GTEST_SKIP() << "host does not permit a fresh user/network namespace";
+        FAIL() << "DragonOS failed to create the required fresh user/network namespace";
+    }
+    if (outcome.stage == kHostHasNoFixedRouteCapacity) {
+        if (!IsDragonOS()) {
+            GTEST_SKIP() << "Linux FIB has no DragonOS smoltcp fixed-capacity ENOSPC boundary";
+        }
+        FAIL() << "DragonOS route table did not reach ENOSPC within the bounded dynamic fill";
+    }
+    EXPECT_EQ(outcome.stage, 0) << "encoded stage/error=" << outcome.stage;
+    EXPECT_EQ(WEXITSTATUS(outcome.wait_status), 0);
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
@@ -67,6 +67,7 @@ struct DumpedAddress {
     IpBytes local;
     uint8_t prefix_len = 0;
     uint32_t ifindex = 0;
+    std::string label;
 };
 
 struct RouteSpec {
@@ -194,8 +195,18 @@ int SetLinkUp(int fd, uint32_t ifindex, uint32_t sequence) {
     return SendAndReceiveAck(fd, request);
 }
 
+int SetLinkName(int fd, uint32_t ifindex, const char* name, uint32_t sequence) {
+    auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, sequence);
+    auto* message = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
+    message->ifi_family = AF_UNSPEC;
+    message->ifi_index = static_cast<int>(ifindex);
+    AddAttr(&request, IFLA_IFNAME, name, std::strlen(name) + 1);
+    return SendAndReceiveAck(fd, request);
+}
+
 int ChangeAddress(int fd, uint16_t type, uint16_t flags, const AddressSpec& address,
-                  bool include_local, bool include_address, uint32_t sequence) {
+                  bool include_local, bool include_address, uint32_t sequence,
+                  const char* label = nullptr) {
     auto request = NewRequest<ifaddrmsg>(type, flags, sequence);
     auto* message = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(request.data()));
     message->ifa_family = address.family;
@@ -209,6 +220,7 @@ int ChangeAddress(int fd, uint16_t type, uint16_t flags, const AddressSpec& addr
     if (include_address) {
         AddAttr(&request, IFA_ADDRESS, address.local.bytes.data(), address.local.length);
     }
+    if (label != nullptr) AddAttr(&request, IFA_LABEL, label, std::strlen(label) + 1);
     return SendAndReceiveAck(fd, request);
 }
 
@@ -260,6 +272,12 @@ int DumpAddresses(int fd, int family, uint32_t sequence, std::vector<DumpedAddre
             int attr_length = IFA_PAYLOAD(header);
             for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
                  attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type == IFA_LABEL && RTA_PAYLOAD(attr) > 0) {
+                    address.label.assign(static_cast<const char*>(RTA_DATA(attr)),
+                                         strnlen(static_cast<const char*>(RTA_DATA(attr)),
+                                                 RTA_PAYLOAD(attr)));
+                    continue;
+                }
                 if ((attr->rta_type != IFA_LOCAL && attr->rta_type != IFA_ADDRESS) ||
                     RTA_PAYLOAD(attr) < address.local.length) {
                     continue;
@@ -343,6 +361,19 @@ int CountAddress(int fd, const AddressSpec& expected, uint32_t sequence) {
     return count;
 }
 
+int CountAddressWithLabel(int fd, const AddressSpec& expected, const char* label,
+                          uint32_t sequence) {
+    std::vector<DumpedAddress> addresses;
+    if (const int error = DumpAddresses(fd, expected.family, sequence, &addresses); error != 0) {
+        return -error;
+    }
+    return static_cast<int>(std::count_if(addresses.begin(), addresses.end(), [&](const auto& item) {
+        return item.family == expected.family && item.ifindex == expected.ifindex &&
+               item.prefix_len == expected.prefix_len && SameAddress(item.local, expected.local) &&
+               item.label == label;
+    }));
+}
+
 int CountRoute(int fd, const RouteSpec& expected, uint32_t sequence) {
     std::vector<DumpedRoute> routes;
     if (const int error = DumpRoutes(fd, sequence, &routes); error != 0) return -error;
@@ -357,7 +388,7 @@ int CountRoute(int fd, const RouteSpec& expected, uint32_t sequence) {
 }
 
 bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
-                                const AddressSpec& expected) {
+                                const AddressSpec& expected, const char* label = nullptr) {
     if (header->nlmsg_type != type) return false;
     const auto* message = reinterpret_cast<const ifaddrmsg*>(NLMSG_DATA(header));
     if (message->ifa_family != expected.family || message->ifa_index != expected.ifindex ||
@@ -365,15 +396,21 @@ bool NotificationMatchesAddress(const nlmsghdr* header, uint16_t type,
         return false;
     }
     int attr_length = IFA_PAYLOAD(header);
+    bool address_matches = false;
+    bool label_matches = label == nullptr;
     for (auto* attr = IFA_RTA(message); RTA_OK(attr, attr_length);
          attr = RTA_NEXT(attr, attr_length)) {
         if ((attr->rta_type == IFA_LOCAL || attr->rta_type == IFA_ADDRESS) &&
             RTA_PAYLOAD(attr) >= expected.local.length &&
             std::memcmp(RTA_DATA(attr), expected.local.bytes.data(), expected.local.length) == 0) {
-            return true;
+            address_matches = true;
+        } else if (attr->rta_type == IFA_LABEL && label != nullptr && RTA_PAYLOAD(attr) > 0 &&
+                   strncmp(static_cast<const char*>(RTA_DATA(attr)), label, RTA_PAYLOAD(attr)) ==
+                       0) {
+            label_matches = true;
         }
     }
-    return false;
+    return address_matches && label_matches;
 }
 
 void DrainNotifications(int fd) {
@@ -386,7 +423,8 @@ void DrainNotifications(int fd) {
     }
 }
 
-int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address) {
+int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address,
+                              const char* label = nullptr) {
     std::array<uint8_t, 16384> buffer{};
     int count = 0;
     bool received_any = false;
@@ -402,7 +440,7 @@ int CountAddressNotifications(int fd, uint16_t type, const AddressSpec& address)
         int remaining = static_cast<int>(received);
         for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
              NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
-            if (NotificationMatchesAddress(header, type, address)) ++count;
+            if (NotificationMatchesAddress(header, type, address, label)) ++count;
         }
     }
 }
@@ -652,6 +690,59 @@ int RunIdentityFlagsAndErrorPriority() {
         return 4100;
     }
 
+    const AddressSpec alias = MakeAddress(AF_INET, "198.51.100.44", 24, ifindex);
+    DrainNotifications(notifications.Get());
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, alias, true, true,
+                      ++sequence, "lo:1") != 0 ||
+        CountAddressWithLabel(fd.Get(), alias, "lo:1", ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, alias, "lo:1") != 1) {
+        return 4150;
+    }
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE, alias,
+                      true, true, ++sequence, "lo:9") != 0 ||
+        CountAddressWithLabel(fd.Get(), alias, "lo:1", ++sequence) != 1) {
+        return 4155;
+    }
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, alias, true, true,
+                      ++sequence, "lo:2") != EADDRNOTAVAIL ||
+        CountAddressWithLabel(fd.Get(), alias, "lo:1", ++sequence) != 1) {
+        return 4160;
+    }
+    DrainNotifications(notifications.Get());
+    if (SetLinkName(fd.Get(), ifindex, "ren0", ++sequence) != 0 ||
+        CountAddressWithLabel(fd.Get(), alias, "ren0:1", ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, alias, "ren0:1") != 1 ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, alias, true, true,
+                      ++sequence, "lo:1") != EADDRNOTAVAIL) {
+        return 4165;
+    }
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, alias, true, true,
+                      ++sequence, "ren0:1") != 0 ||
+        CountAddress(fd.Get(), alias, ++sequence) != 0 ||
+        CountAddressNotifications(notifications.Get(), RTM_DELADDR, alias, "ren0:1") != 1) {
+        return 4170;
+    }
+
+    const AddressSpec long_label = MakeAddress(AF_INET, "198.51.100.45", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, long_label, true,
+                      true, ++sequence, "1234567890123456") != ERANGE) {
+        return 4180;
+    }
+    const AddressSpec empty_label = MakeAddress(AF_INET, "198.51.100.46", 24, ifindex);
+    DrainNotifications(notifications.Get());
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, empty_label, true,
+                      true, ++sequence, "") != 0 ||
+        CountAddressWithLabel(fd.Get(), empty_label, "", ++sequence) != 1 ||
+        CountAddressNotifications(notifications.Get(), RTM_NEWADDR, empty_label, "") != 1 ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, empty_label, true, true,
+                      ++sequence, "") != 0 ||
+        CountAddressNotifications(notifications.Get(), RTM_DELADDR, empty_label, "") != 1) {
+        return 4190;
+    }
+
     const AddressSpec absent = MakeAddress(AF_INET, "203.0.113.77", 24, ifindex);
     if (ChangeAddress(fd.Get(), RTM_NEWADDR, NLM_F_REQUEST | NLM_F_ACK | NLM_F_REPLACE, absent,
                       true, true, ++sequence) != 0 ||
@@ -754,6 +845,7 @@ int RunAddressRollbackAndCapacityRelease() {
         return error == kHostHasNoFixedRouteCapacity ? error : 6100 + error;
     }
     if (fillers.empty()) return 6200;
+    const size_t route_capacity = fillers.size();
 
     const AddressSpec address = MakeAddress(AF_INET, "203.0.113.1", 24, ifindex);
     const RouteSpec connected{Ipv4("203.0.113.0"), 24, ifindex};
@@ -785,117 +877,189 @@ int RunAddressRollbackAndCapacityRelease() {
         return 6700;
     }
 
-    // The current route model has no owner tag. A same-value explicit route
-    // must nevertheless survive deletion of the address projection.
-    const RouteSpec explicit_same_value{Ipv4("203.0.113.1"), 24, ifindex};
-    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
-                    explicit_same_value, ++sequence) != 0) {
-        return 6750;
-    }
-
+    const RouteSpec explicit_same_value{Ipv4("203.0.113.0"), 24, ifindex};
     fillers.clear();
     if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers,
                                                &failed_route);
         error != 0) {
         return 6800 + error;
     }
-    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
-                      ++sequence) != 0 ||
-        CountAddress(fd.Get(), address, ++sequence) != 0 ||
-        CountRoute(fd.Get(), connected, ++sequence) < 1) {
-        return 6900;
+    if (fillers.size() + 1 != route_capacity)
+        return 6900 + static_cast<int>(fillers.size());
+    // The table is full, but the explicit route is a second logical owner of
+    // the address's canonical projection and therefore needs no new slot.
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
+                    explicit_same_value, ++sequence) != 0) {
+        return 6905;
+    }
+    if (const int error = ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK,
+                                        address, true, true, ++sequence);
+        error != 0) {
+        return 6910 + error;
+    }
+    if (CountAddress(fd.Get(), address, ++sequence) != 0) return 6920;
+    if (CountRoute(fd.Get(), connected, ++sequence) != 1) return 6930;
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed_route,
+                    ++sequence) != ENOSPC) {
+        return 6940;
+    }
+    if (const int error = ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK,
+                                      explicit_same_value, ++sequence);
+        error != 0) {
+        return 6950 + error;
     }
     if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
                     NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed_route,
                     ++sequence) != 0) {
-        return 7000;
-    }
-    const RouteSpec capacity_probe{Ipv4("192.88.99.0"), 24, ifindex};
-    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, capacity_probe,
-                    ++sequence) != ENOSPC ||
-        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, explicit_same_value,
-                    ++sequence) != 0 ||
-        ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, capacity_probe,
-                    ++sequence) != 0) {
-        return 7050;
-    }
-    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
-                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
-                      ++sequence) != ENOSPC) {
-        return 7100;
-    }
-    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, capacity_probe,
-                    ++sequence) != 0 ||
-        ChangeAddress(fd.Get(), RTM_NEWADDR,
-                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
-                      ++sequence) != 0) {
-        return 7200;
-    }
-    if (CountAddress(fd.Get(), address, ++sequence) != 1 ||
-        CountRoute(fd.Get(), connected, ++sequence) < 1) {
-        return 7300;
+        return 6960;
     }
 
-    // Repeat the ownership check with the opposite creation order. An
-    // explicit route must not satisfy a later address's dedicated projection.
-    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
-                      ++sequence) != 0 ||
-        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, failed_route,
+    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, failed_route,
                     ++sequence) != 0) {
-        return 7400;
+        return 7000;
     }
     for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
-        if (const int error = ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK,
-                                          *iterator, ++sequence);
-            error != 0) {
-            return 7450 + error;
+        if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, *iterator,
+                        ++sequence) != 0) {
+            return 7100;
         }
     }
+
+    // Repeat with the opposite creation order and delete the explicit owner
+    // while the address still exists. The shared projection must remain until
+    // the final owner disappears, then release exactly one physical slot.
     if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
                     NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
                     explicit_same_value, ++sequence) != 0) {
-        return 7500;
+        return 7200;
     }
-
     fillers.clear();
     if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers,
                                                &failed_route);
-        error != 0 || fillers.empty()) {
-        return 7600 + (error < 0 ? 0 : error);
+        error != 0 || fillers.size() + 1 != route_capacity) {
+        return 7300 + (error > 0 ? error : 0);
     }
+    // Exercise the inverse full-table fast path: the address shares the
+    // already projected explicit route.
     if (ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
-                      ++sequence) != ENOSPC ||
-        CountAddress(fd.Get(), address, ++sequence) != 0) {
-        return 7700;
+                      ++sequence) != 0) {
+        return 7350;
     }
-    const RouteSpec released = fillers.back();
-    fillers.pop_back();
-    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, released,
+    if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, explicit_same_value,
+                    ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed_route,
+                    ++sequence) != ENOSPC ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed_route,
+                    ++sequence) != 0) {
+        return 7400;
+    }
+    return 0;
+}
+
+int RunSharedAddressAndExplicitRouteProjection() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 4000;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+    if (!IsDragonOS()) return kHostHasNoFixedRouteCapacity;
+
+    const AddressSpec address = MakeAddress(AF_INET, "203.0.113.1", 24, ifindex);
+    const RouteSpec route{Ipv4("203.0.113.0"), 24, ifindex};
+
+    std::vector<RouteSpec> fillers;
+    RouteSpec failed{};
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers, &failed);
+        error != 0 || fillers.empty()) {
+        return 8350 + (error > 0 ? error : 0);
+    }
+    const size_t route_capacity = fillers.size();
+    for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
+        if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, *iterator,
+                        ++sequence) != 0) {
+            return 8375;
+        }
+    }
+    fillers.clear();
+
+    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
                     ++sequence) != 0 ||
         ChangeAddress(fd.Get(), RTM_NEWADDR,
                       NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
                       ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, ++sequence) != 0 ||
         ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0) {
+        return 8400;
+    }
+
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers, &failed);
+        error != 0 || fillers.size() != route_capacity) {
+        return 8500 + (error > 0 ? error : static_cast<int>(fillers.size()));
+    }
+    for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
+        if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, *iterator,
+                        ++sequence) != 0) {
+            return 8600;
+        }
+    }
+
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
                       ++sequence) != 0 ||
         ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, released,
-                    ++sequence) != 0) {
-        return 7800;
-    }
-    const RouteSpec explicit_first_probe{Ipv4("192.88.100.0"), 24, ifindex};
-    if (ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
-                    explicit_first_probe, ++sequence) != ENOSPC ||
-        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, explicit_same_value,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, route,
                     ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, ++sequence) != 0) {
+        return 8700;
+    }
+
+    fillers.clear();
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers, &failed);
+        error != 0 || fillers.size() != route_capacity) {
+        return 8800 + (error > 0 ? error : static_cast<int>(fillers.size()));
+    }
+    for (auto iterator = fillers.rbegin(); iterator != fillers.rend(); ++iterator) {
+        if (ChangeRoute(fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, *iterator,
+                        ++sequence) != 0) {
+            return 8900;
+        }
+    }
+
+    const AddressSpec second = MakeAddress(AF_INET, "203.0.113.2", 24, ifindex);
+    if (ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true, true,
+                      ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, second, true, true,
+                      ++sequence) != 0) {
+        return 9000;
+    }
+    fillers.clear();
+    if (const int error = FillRoutesToCapacity(fd.Get(), ifindex, &sequence, &fillers, &failed);
+        error != 0 || fillers.size() + 1 != route_capacity) {
+        return 9100 + (error > 0 ? error : static_cast<int>(fillers.size()));
+    }
+    if (ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, address, true, true,
+                      ++sequence) != 0 ||
         ChangeRoute(fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL,
-                    explicit_first_probe, ++sequence) != 0) {
-        return 7900;
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed,
+                    ++sequence) != ENOSPC ||
+        ChangeAddress(fd.Get(), RTM_DELADDR, NLM_F_REQUEST | NLM_F_ACK, second, true, true,
+                      ++sequence) != 0 ||
+        ChangeRoute(fd.Get(), RTM_NEWROUTE,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, failed,
+                    ++sequence) != 0) {
+        return 9200;
     }
     return 0;
 }
@@ -979,6 +1143,24 @@ TEST(RtnetlinkAddressSemantics, InvalidAddressCannotPanicKernel) {
 TEST(RtnetlinkAddressSemantics, CapacityFailureRollsBackAndDeleteReleasesRouteSlot) {
     const ChildOutcome outcome = RunWithWatchdog(RunAddressRollbackAndCapacityRelease);
     ASSERT_FALSE(outcome.timed_out) << "address capacity rollback path deadlocked";
+    ASSERT_TRUE(WIFEXITED(outcome.wait_status));
+    if (outcome.stage == kNamespaceUnavailable) {
+        if (!IsDragonOS()) GTEST_SKIP() << "host does not permit a fresh user/network namespace";
+        FAIL() << "DragonOS failed to create the required fresh user/network namespace";
+    }
+    if (outcome.stage == kHostHasNoFixedRouteCapacity) {
+        if (!IsDragonOS()) {
+            GTEST_SKIP() << "Linux FIB has no DragonOS smoltcp fixed-capacity ENOSPC boundary";
+        }
+        FAIL() << "DragonOS route table did not reach ENOSPC within the bounded dynamic fill";
+    }
+    EXPECT_EQ(outcome.stage, 0) << "encoded stage/error=" << outcome.stage;
+    EXPECT_EQ(WEXITSTATUS(outcome.wait_status), 0);
+}
+
+TEST(RtnetlinkAddressSemantics, AddressAndExplicitRouteShareOneDataPlaneProjection) {
+    const ChildOutcome outcome = RunWithWatchdog(RunSharedAddressAndExplicitRouteProjection);
+    ASSERT_FALSE(outcome.timed_out) << "shared address/route projection path deadlocked";
     ASSERT_TRUE(WIFEXITED(outcome.wait_status));
     if (outcome.stage == kNamespaceUnavailable) {
         if (!IsDragonOS()) GTEST_SKIP() << "host does not permit a fresh user/network namespace";

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_serialization_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_serialization_semantics.cc
@@ -55,6 +55,7 @@ struct RouteSpec {
     uint8_t table = RT_TABLE_MAIN;
     uint32_t source = 0;
     uint8_t source_prefix_len = 0;
+    uint32_t gateway = 0;
 };
 
 struct ChildOutcome {
@@ -190,6 +191,9 @@ int ChangeRoute(int fd, uint16_t type, uint16_t flags, const RouteSpec& route, u
     AddAttr(&request, RTA_OIF, &route.ifindex, sizeof(route.ifindex));
     if (route.source_prefix_len != 0) {
         AddAttr(&request, RTA_SRC, &route.source, sizeof(route.source));
+    }
+    if (route.gateway != 0) {
+        AddAttr(&request, RTA_GATEWAY, &route.gateway, sizeof(route.gateway));
     }
     return SendAndRecvAck(fd, request);
 }
@@ -531,16 +535,12 @@ int RunFailedRouteAtomicity() {
                     NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, preserved,
                     seq++) != 0 ||
         ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, shadow, seq++) != 0 ||
-        ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, shadow, seq++) !=
-            0) {
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, shadow, seq++) != 0) {
         return 5000;
     }
-    // DragonOS currently projects route keys with the same destination onto
-    // one smoltcp entry. Removing the source-specific shadow key leaves the
-    // source-agnostic control record present while removing that projection,
-    // exposing the historical replace rollback failure through public
-    // rtnetlink operations.
+    // The source-specific shadow and source-agnostic record share one physical
+    // projection. Replacing one owner with a different gateway must allocate a
+    // second projection while retaining the old one for the shadow owner.
     DrainNotifications(notify_fd.Get());
 
     std::vector<RouteSpec> added;
@@ -590,8 +590,10 @@ int RunFailedRouteAtomicity() {
 
     // Replacing the preserved control record needs a new projection and must
     // fail atomically when the data-plane table is full.
+    RouteSpec replacement = preserved;
+    replacement.gateway = Ipv4("127.0.0.1");
     if (ChangeRoute(request_fd.Get(), RTM_NEWROUTE,
-                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE, preserved,
+                    NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_REPLACE, replacement,
                     seq++) != ENOSPC) {
         return 9000;
     }
@@ -604,20 +606,6 @@ int RunFailedRouteAtomicity() {
     if (notification > 0) return 11000;
     if (notification < 0) return 11000 - notification;
 
-    FdGuard udp(socket(AF_INET, SOCK_DGRAM, 0));
-    if (udp.Get() < 0) return 8000 + errno;
-    sockaddr_in destination{};
-    destination.sin_family = AF_INET;
-    destination.sin_port = htons(9);
-    destination.sin_addr.s_addr = preserved.dst | htonl(1);
-    const char payload = 'x';
-    errno = 0;
-    if (sendto(udp.Get(), &payload, sizeof(payload), 0,
-               reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) >= 0 ||
-        errno != ENETUNREACH) {
-        return 12000 + errno;
-    }
-
     for (const auto& route : added) {
         const int error =
             ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, route, seq++);
@@ -626,6 +614,10 @@ int RunFailedRouteAtomicity() {
     if (ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, preserved,
                     seq++) != 0) {
         return 14000;
+    }
+    if (ChangeRoute(request_fd.Get(), RTM_DELROUTE, NLM_F_REQUEST | NLM_F_ACK, shadow, seq++) !=
+        0) {
+        return 15000;
     }
     return 0;
 }


### PR DESCRIPTION
Part of #2233.

## Summary

- add a typed, RTNL-protected interface address mutation core
- commit smoltcp addresses, connected routes, and the router compatibility projection under one lock with rollback on capacity failure
- migrate rtnetlink, the one-shot DHCP client, and construction-time veth/bridge initialization away from runtime direct writers
- preserve Linux 6.6 IPv4/IPv6 address identity, replace/delete, errno, and notification semantics
- add focused coverage for multi-address consistency, duplicate/replace/delete behavior, invalid input safety, explicit-route ownership, and capacity rollback

## Architecture

Runtime mutations require an `RtnlGuard` and return typed outcomes. The core owns the single lock order `RTNL -> smoltcp interface -> router projection`; notifications are emitted only after a successful commit. Construction-only initialization is restricted to interfaces that have not yet been published in a network namespace.

This deliberately does not introduce a second address database, a generic transaction framework, route-owner metadata, or a full DHCP lease manager.

## Validation

- `make fmt`
- `make kernel`
- Linux reference run: 3 compatible tests passed; the DragonOS fixed-capacity case skipped as designed
- DragonOS QEMU: `rtnetlink_addr_semantics_test` 4/4 passed
- DragonOS QEMU: `rtnetlink_route_semantics_test` 5/5 passed
- DragonOS QEMU: `rtnetlink_serialization_semantics_test` 2/2 passed
- DragonOS QEMU: `rtnetlink_permission_semantics_test` 8/8 passed
- normal boot completed and DHCP acquired `10.0.2.15/24`