### PR TITLE
feat(sched): expose Linux-compatible SCHED_FIFO to userspace

### DIFF
--- a/kernel/src/process/fork.rs
+++ b/kernel/src/process/fork.rs
@@ -287,7 +287,11 @@ impl ProcessManager {
         let name = current_pcb.basic().name().to_string();
 
         args.verify()?;
-        let pcb = ProcessControlBlock::new(name, new_kstack);
+        let pcb = ProcessControlBlock::new(
+            name,
+            new_kstack,
+            args.flags.contains(CloneFlags::CLONE_THREAD),
+        );
         let ptrace_fork_session = Self::copy_process(&current_pcb, &pcb, args, current_trapframe)
             .map_err(|e| {
             error!(
@@ -768,8 +772,10 @@ impl ProcessManager {
             )
         });
 
-        // 继承 rlimit
-        pcb.inherit_rlimits_from(current_pcb);
+        // Resource limits were shared (CLONE_THREAD) or copied (fork) when
+        // the unpublished PCB was constructed. Preserve the existing eager
+        // RLIMIT_NOFILE fd-table sizing after copy_files().
+        pcb.sync_fd_table_to_nofile_limit();
 
         // 继承 executable_path
         // 修复：fork时需要复制父进程的可执行文件路径，而不是使用进程名

--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -23,6 +23,7 @@ pub(crate) enum SchedChangeRequest {
     },
     Fifo {
         priority: i32,
+        reset_on_fork: bool,
     },
 }
 
@@ -148,7 +149,7 @@ impl ProcessManager {
         pcb: &Arc<ProcessControlBlock>,
         request: SchedChangeRequest,
     ) -> Result<(), SystemError> {
-        if let SchedChangeRequest::Fifo { priority } = request {
+        if let SchedChangeRequest::Fifo { priority, .. } = request {
             if !(0..crate::sched::prio::MAX_RT_PRIO - 1).contains(&priority) {
                 return Err(SystemError::EINVAL);
             }
@@ -202,7 +203,10 @@ impl ProcessManager {
                     pcb.sched_info().static_prio(),
                     reset_on_fork,
                 ),
-                SchedChangeRequest::Fifo { priority } => (LinuxSchedPolicy::Fifo, priority, false),
+                SchedChangeRequest::Fifo {
+                    priority,
+                    reset_on_fork,
+                } => (LinuxSchedPolicy::Fifo, priority, reset_on_fork),
             };
             let new_class = new_policy.base_sched_class();
 
@@ -277,7 +281,13 @@ impl ProcessManager {
             return Err(SystemError::EPERM);
         }
 
-        Self::set_scheduler(pcb, SchedChangeRequest::Fifo { priority: prio })
+        Self::set_scheduler(
+            pcb,
+            SchedChangeRequest::Fifo {
+                priority: prio,
+                reset_on_fork: false,
+            },
+        )
     }
 
     /// Publish a validated affinity mask and apply any required migration.

--- a/kernel/src/process/syscall/clone_utils.rs
+++ b/kernel/src/process/syscall/clone_utils.rs
@@ -76,7 +76,7 @@ pub fn do_clone(
     let new_kstack = KernelStack::new()?;
     let name = current_pcb.basic().name().to_string();
 
-    let pcb = ProcessControlBlock::new(name, new_kstack);
+    let pcb = ProcessControlBlock::new(name, new_kstack, flags.contains(CloneFlags::CLONE_THREAD));
     // 克隆pcb
     let ptrace_fork_session = ProcessManager::copy_process(&current_pcb, &pcb, clone_args, frame)?;
 

--- a/kernel/src/process/syscall/sys_prlimit64.rs
+++ b/kernel/src/process/syscall/sys_prlimit64.rs
@@ -103,21 +103,22 @@ pub fn do_prlimit64(
         ProcessManager::find_task_by_vpid(pid).ok_or(SystemError::ESRCH)?
     };
 
-    // 读取旧限制
-    if let Some(mut writer) = writer {
-        let cur = target.get_rlimit(resource);
-        let rlimit = writer.buffer::<RLimit64>(0)?;
-        rlimit[0].rlim_cur = cur.rlim_cur;
-        rlimit[0].rlim_max = cur.rlim_max;
-    }
-
-    // 设置新限制
-    if !new_limit.is_null() {
+    // Copy the new value first, then obtain the old value from the same
+    // serialized update that replaces it. This keeps prlimit(old, new)
+    // coherent when another thread in the group updates a shared limit.
+    let old_value = if !new_limit.is_null() {
         // 从用户拷贝新值
         let reader = UserBufferReader::new(new_limit, core::mem::size_of::<RLimit64>(), true)?;
         let newval = reader.read_one_from_user::<RLimit64>(0)?;
         // 应用到目标进程
-        target.set_rlimit(resource, newval)?;
+        target.set_rlimit(resource, newval)?
+    } else {
+        target.get_rlimit(resource)
+    };
+
+    if let Some(mut writer) = writer {
+        let rlimit = writer.buffer::<RLimit64>(0)?;
+        rlimit[0] = old_value;
     }
 
     Ok(0)

--- a/kernel/src/process/task.rs
+++ b/kernel/src/process/task.rs
@@ -304,8 +304,9 @@ pub struct ProcessControlBlock {
     /// Process command line (used for /proc/<pid>/cmdline; Linux semantics: argv
     /// entries are separated by '\0').
     pub(super) cmdline: RwLock<Vec<u8>>,
-    /// Resource limit (rlimit) array.
-    pub(super) rlimits: RwLock<[RLimit64; RLimitID::Nlimits as usize]>,
+    /// Resource limits are shared by a thread group, like Linux's
+    /// `signal_struct::rlim`. A process fork receives a copied Arc.
+    pub(super) rlimits: Arc<RwLock<[RLimit64; RLimitID::Nlimits as usize]>>,
 }
 
 impl ProcessControlBlock {
@@ -315,12 +316,20 @@ impl ProcessControlBlock {
     ///
     /// - `name`: The process name.
     /// - `kstack`: The kernel stack for the process.
+    /// - `share_resource_limits`: share the current thread group's limits for
+    ///   `CLONE_THREAD`; otherwise snapshot them for a new process.
     ///
     /// ## Returns
     ///
     /// A new PCB.
-    pub fn new(name: String, kstack: KernelStack) -> Arc<Self> {
-        return Self::do_create_pcb(name, kstack, false);
+    pub fn new(name: String, kstack: KernelStack, share_resource_limits: bool) -> Arc<Self> {
+        let current = ProcessManager::current_pcb();
+        let rlimits = if share_resource_limits {
+            current.rlimits.clone()
+        } else {
+            Arc::new(RwLock::new(*current.rlimits.read()))
+        };
+        return Self::do_create_pcb(name, kstack, false, Some(rlimits));
     }
 
     /// Create a new idle process.
@@ -329,7 +338,7 @@ impl ProcessControlBlock {
     /// initialization.
     pub fn new_idle(cpu_id: u32, kstack: KernelStack) -> Arc<Self> {
         let name = format!("idle-{}", cpu_id);
-        return Self::do_create_pcb(name, kstack, true);
+        return Self::do_create_pcb(name, kstack, true, None);
     }
 
     /// Returns whether the process is a kernel thread.
@@ -352,7 +361,12 @@ impl ProcessControlBlock {
     }
 
     #[inline(never)]
-    fn do_create_pcb(name: String, kstack: KernelStack, is_idle: bool) -> Arc<Self> {
+    fn do_create_pcb(
+        name: String,
+        kstack: KernelStack,
+        is_idle: bool,
+        rlimits: Option<Arc<RwLock<[RLimit64; RLimitID::Nlimits as usize]>>>,
+    ) -> Arc<Self> {
         // Initialize the namespace proxy.
         let nsproxy = if is_idle {
             // The idle process uses the root namespace.
@@ -478,7 +492,9 @@ impl ProcessControlBlock {
                 restart_block: SpinLock::new(None),
                 executable_path: RwLock::new(name),
                 cmdline: RwLock::new(Vec::new()),
-                rlimits: RwLock::new(Self::default_rlimits()),
+                rlimits: rlimits
+                    .clone()
+                    .unwrap_or_else(|| Arc::new(RwLock::new(Self::default_rlimits()))),
                 #[cfg(target_arch = "x86_64")]
                 uprobe: super::uprobe::TaskXolState::new(),
             };
@@ -571,7 +587,7 @@ impl ProcessControlBlock {
         &self,
         res: RLimitID,
         newv: crate::process::resource::RLimit64,
-    ) -> Result<(), system_error::SystemError> {
+    ) -> Result<crate::process::resource::RLimit64, system_error::SystemError> {
         use system_error::SystemError;
         if newv.rlim_cur > newv.rlim_max {
             return Err(SystemError::EINVAL);
@@ -591,41 +607,43 @@ impl ProcessControlBlock {
             }
         }
 
-        let cur = self.rlimits.read()[res as usize];
-        if newv.rlim_max > cur.rlim_max {
-            let cred = self.cred();
-            if !cred.has_capability(crate::process::cred::CAPFlags::CAP_SYS_RESOURCE) {
+        // The whole thread group shares this lock. Compare the hard limit and
+        // publish the replacement in one critical section, matching Linux's
+        // group-leader task_lock serialization. Otherwise a writer authorized
+        // against a stale hard limit could restore a concurrently lowered one.
+        let can_raise_hard =
+            crate::process::cred::capable(crate::process::cred::CAPFlags::CAP_SYS_RESOURCE);
+        let cur = {
+            let mut rlimits = self.rlimits.write();
+            let cur = rlimits[res as usize];
+            if newv.rlim_max > cur.rlim_max && !can_raise_hard {
                 return Err(SystemError::EPERM);
             }
-        }
+            rlimits[res as usize] = newv;
+            cur
+        };
 
-        // Update the rlimit.
-        self.rlimits.write()[res as usize] = newv;
-
-        // If RLIMIT_NOFILE changed, adjust the file descriptor table.
+        // File-descriptor allocation always enforces the shared limit and
+        // grows on demand. Keep eager resizing as a lock-order-safe
+        // best-effort optimization; a failure must not roll back over a newer
+        // concurrent group update.
         if res == RLimitID::Nofile {
             if let Err(e) = self.adjust_fd_table_for_rlimit_change(newv.rlim_cur as usize) {
-                // If adjustment fails, roll back the rlimit.
-                self.rlimits.write()[res as usize] = cur;
-                return Err(e);
+                warn!("Failed to resize fd table after RLIMIT_NOFILE update: {e:?}");
             }
         }
 
-        Ok(())
+        Ok(cur)
     }
 
-    /// Inherit all rlimits from the parent process.
-    pub fn inherit_rlimits_from(&self, parent: &Arc<ProcessControlBlock>) {
-        let src = *parent.rlimits.read();
-        *self.rlimits.write() = src;
-
-        // After inheritance, adjust the file descriptor table to match the new
-        // RLIMIT_NOFILE.
-        let nofile_limit = src[RLimitID::Nofile as usize].rlim_cur as usize;
+    /// Match the eager fd-table capacity optimization to the resource limits
+    /// already shared or copied when this PCB was constructed. Allocation
+    /// paths still enforce the shared RLIMIT_NOFILE on every operation.
+    pub(crate) fn sync_fd_table_to_nofile_limit(&self) {
+        let nofile_limit = self.get_rlimit(RLimitID::Nofile).rlim_cur as usize;
         if let Err(e) = self.adjust_fd_table_for_rlimit_change(nofile_limit) {
-            // If adjustment fails, log the error but do not block inheritance.
             error!(
-                "Failed to adjust fd table after inheriting rlimits: {:?}",
+                "Failed to adjust fd table after inheriting RLIMIT_NOFILE: {:?}",
                 e
             );
         }

--- a/kernel/src/sched/fifo_demo.rs
+++ b/kernel/src/sched/fifo_demo.rs
@@ -437,8 +437,13 @@ fn run_remote_class_transitions(cpu: ProcessorId) {
         observer.sched_info().prio(),
         *observer.sched_info().on_rq.lock_irqsave(),
     );
-    ok &= ProcessManager::set_scheduler(&observer, SchedChangeRequest::Fifo { priority: -1 })
-        == Err(system_error::SystemError::EINVAL);
+    ok &= ProcessManager::set_scheduler(
+        &observer,
+        SchedChangeRequest::Fifo {
+            priority: -1,
+            reset_on_fork: false,
+        },
+    ) == Err(system_error::SystemError::EINVAL);
     ok &= invalid_snapshot
         == (
             observer.sched_info().policy(),
@@ -452,6 +457,7 @@ fn run_remote_class_transitions(cpu: ProcessorId) {
         &candidate,
         SchedChangeRequest::Fifo {
             priority: CANDIDATE_PRIO,
+            reset_on_fork: false,
         },
     )
     .is_ok();
@@ -625,6 +631,7 @@ fn run_priority_order_changes(cpu: ProcessorId) {
         &target,
         SchedChangeRequest::Fifo {
             priority: MAX_RT_PRIO,
+            reset_on_fork: false,
         },
     ) == Err(system_error::SystemError::EINVAL);
     let reset_after = target.sched_info().pi_lock_irqsave().sched_reset_on_fork();
@@ -642,6 +649,7 @@ fn run_priority_order_changes(cpu: ProcessorId) {
         &target,
         SchedChangeRequest::Fifo {
             priority: SHARED_PRIO,
+            reset_on_fork: false,
         },
     )
     .is_ok();
@@ -654,6 +662,7 @@ fn run_priority_order_changes(cpu: ProcessorId) {
         &target,
         SchedChangeRequest::Fifo {
             priority: LOWERED_PRIO,
+            reset_on_fork: false,
         },
     )
     .is_ok();
@@ -808,8 +817,14 @@ fn run_policy_affinity_race(control_cpu: ProcessorId, remote_cpus: &[ProcessorId
             "Fair migration preflight did not reach the destination CPU"
         );
         assert!(
-            ProcessManager::set_scheduler(&target, SchedChangeRequest::Fifo { priority: 50 })
-                .is_ok(),
+            ProcessManager::set_scheduler(
+                &target,
+                SchedChangeRequest::Fifo {
+                    priority: 50,
+                    reset_on_fork: false,
+                },
+            )
+            .is_ok(),
             "FIFO migration preflight policy update failed"
         );
         assert!(
@@ -837,7 +852,10 @@ fn run_policy_affinity_race(control_cpu: ProcessorId, remote_cpus: &[ProcessorId
 
     for round in 0..AFFINITY_RACE_ROUNDS {
         let request = if round & 1 == 0 {
-            SchedChangeRequest::Fifo { priority: 50 }
+            SchedChangeRequest::Fifo {
+                priority: 50,
+                reset_on_fork: false,
+            }
         } else {
             SchedChangeRequest::Normal {
                 reset_on_fork: false,
@@ -915,7 +933,10 @@ fn run_policy_exit_race(cpu: ProcessorId) {
         // the remaining teardown and the final Exited -> schedule transition.
         for change in 0..4 {
             let request = if change & 1 == 0 {
-                SchedChangeRequest::Fifo { priority: 45 }
+                SchedChangeRequest::Fifo {
+                    priority: 45,
+                    reset_on_fork: false,
+                }
             } else {
                 SchedChangeRequest::Normal {
                     reset_on_fork: false,

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1354,7 +1354,7 @@ fn __schedule_inner(sched_mod: SchedMode, current: Option<Arc<ProcessControlBloc
 
 pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     let current = ProcessManager::current_pcb();
-    let (mut fork_prio, mut fork_static_prio, parent_policy, reset_on_fork) = {
+    let (mut fork_prio, mut fork_static_prio, mut fork_policy, reset_on_fork) = {
         let pi_guard = current.sched_info().pi_lock_irqsave();
         (
             current.sched_info().normal_prio(),
@@ -1364,14 +1364,18 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
         )
     };
 
-    // This PR can only set RESET_ON_FORK on CFS tasks. Match Linux's fair
-    // policy rule: preserve non-negative nice, but reset negative nice to 0.
-    if reset_on_fork
-        && parent_policy == LinuxSchedPolicy::Normal
-        && fork_static_prio < prio::DEFAULT_PRIO
-    {
-        fork_prio = prio::DEFAULT_PRIO;
-        fork_static_prio = prio::DEFAULT_PRIO;
+    if reset_on_fork {
+        if fork_policy == LinuxSchedPolicy::Fifo {
+            // Linux resets RT children to SCHED_NORMAL at nice 0.
+            fork_policy = LinuxSchedPolicy::Normal;
+            fork_prio = prio::DEFAULT_PRIO;
+            fork_static_prio = prio::DEFAULT_PRIO;
+        } else if fork_static_prio < prio::DEFAULT_PRIO {
+            // Fair children preserve non-negative nice, but reset negative
+            // nice to zero when RESET_ON_FORK is set.
+            fork_prio = prio::DEFAULT_PRIO;
+            fork_static_prio = prio::DEFAULT_PRIO;
+        }
     }
 
     // 子进程是 TASK_NEW，不可见。可以直接写裸字段
@@ -1385,12 +1389,13 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
 
     if PrioUtil::dl_prio(fork_prio) {
         return Err(SystemError::EAGAIN_OR_EWOULDBLOCK);
-    } else if PrioUtil::rt_prio(fork_prio) {
-        // 实时子进程继承父进程的基础策略。
-        pcb.sched_info().set_policy(parent_policy);
-    } else {
-        pcb.sched_info().set_policy(LinuxSchedPolicy::Normal);
     }
+    debug_assert_eq!(
+        PrioUtil::rt_prio(fork_prio),
+        fork_policy == LinuxSchedPolicy::Fifo,
+        "fork policy and inherited normal priority disagree"
+    );
+    pcb.sched_info().set_policy(fork_policy);
 
     pcb.sched_info()
         .sched_entity()

--- a/kernel/src/sched/prio.rs
+++ b/kernel/src/sched/prio.rs
@@ -39,4 +39,13 @@ impl PrioUtil {
             .contains(&prio)
             .then_some((MAX_RT_PRIO - 1) - prio)
     }
+
+    /// Convert the legacy Linux userspace RT priority (1..=99, high to low)
+    /// to DragonOS's internal priority (98..=0, low numeric value wins).
+    #[inline]
+    pub fn user_rt_prio_to_internal(prio: i32) -> Option<i32> {
+        (1..MAX_RT_PRIO)
+            .contains(&prio)
+            .then_some((MAX_RT_PRIO - 1) - prio)
+    }
 }

--- a/kernel/src/sched/syscall/sys_sched_setscheduler.rs
+++ b/kernel/src/sched/syscall/sys_sched_setscheduler.rs
@@ -6,9 +6,10 @@ use crate::{
     arch::{interrupt::TrapFrame, syscall::nr::SYS_SCHED_SETSCHEDULER},
     process::{
         cred::{capable, CAPFlags},
-        ProcessManager,
+        resource::RLimitID,
+        ProcessManager, SchedChangeRequest,
     },
-    sched::LinuxSchedPolicy,
+    sched::{prio::PrioUtil, LinuxSchedPolicy},
     syscall::{
         table::{FormattedSyscallParam, Syscall},
         user_access::UserBufferReader,
@@ -26,32 +27,87 @@ use super::{
 struct SysSchedSetscheduler;
 
 impl SysSchedSetscheduler {
-    fn validate_policy(policy: i32, priority: i32) -> Result<bool, SystemError> {
+    fn build_request(policy: i32, priority: i32) -> Result<SchedChangeRequest, SystemError> {
         let base_policy = policy & !SCHED_RESET_ON_FORK;
+        let reset_on_fork = policy & SCHED_RESET_ON_FORK != 0;
         match base_policy {
             SCHED_OTHER => {
                 if priority != 0 {
                     return Err(SystemError::EINVAL);
                 }
-                Ok(true)
+                Ok(SchedChangeRequest::Normal { reset_on_fork })
             }
-            SCHED_FIFO | SCHED_RR => {
-                if !(1..=99).contains(&priority) {
-                    return Err(SystemError::EINVAL);
-                }
-                Ok(false)
+            SCHED_FIFO => {
+                let priority =
+                    PrioUtil::user_rt_prio_to_internal(priority).ok_or(SystemError::EINVAL)?;
+                Ok(SchedChangeRequest::Fifo {
+                    priority,
+                    reset_on_fork,
+                })
+            }
+            SCHED_RR => {
+                PrioUtil::user_rt_prio_to_internal(priority).ok_or(SystemError::EINVAL)?;
+                Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
             }
             SCHED_BATCH | SCHED_IDLE => {
                 if priority != 0 {
                     return Err(SystemError::EINVAL);
                 }
-                Ok(false)
+                Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
             }
             // The legacy ABI has no runtime/deadline/period fields, so it
             // cannot express a valid SCHED_DEADLINE request.
             SCHED_DEADLINE => Err(SystemError::EINVAL),
             _ => Err(SystemError::EINVAL),
         }
+    }
+
+    /// Check the Linux unprivileged sched_setscheduler rules without invoking
+    /// capability lookup while a scheduler spin lock is held.
+    fn unprivileged_allowed(
+        target: &alloc::sync::Arc<crate::process::ProcessControlBlock>,
+        request: SchedChangeRequest,
+    ) -> Result<bool, SystemError> {
+        let current = ProcessManager::current_pcb();
+        if !same_sched_owner(&current.cred(), &target.cred()) {
+            return Ok(false);
+        }
+
+        let rtprio_limit = match request {
+            SchedChangeRequest::Fifo { .. } => Some(target.get_rlimit(RLimitID::Rtprio).rlim_cur),
+            SchedChangeRequest::Normal { .. } => None,
+        };
+        let pi_guard = target.sched_info().pi_lock_irqsave();
+        let reset_on_fork = match request {
+            SchedChangeRequest::Normal { reset_on_fork }
+            | SchedChangeRequest::Fifo { reset_on_fork, .. } => reset_on_fork,
+        };
+        if pi_guard.sched_reset_on_fork() && !reset_on_fork {
+            return Ok(false);
+        }
+
+        let SchedChangeRequest::Fifo { priority, .. } = request else {
+            return Ok(true);
+        };
+        let new_user_priority =
+            PrioUtil::internal_rt_prio_to_user(priority).ok_or(SystemError::EINVAL)?;
+        let old_policy = target.sched_info().policy();
+        let old_user_priority = match old_policy {
+            LinuxSchedPolicy::Normal => 0,
+            LinuxSchedPolicy::Fifo => {
+                PrioUtil::internal_rt_prio_to_user(target.sched_info().normal_prio())
+                    .ok_or(SystemError::EIO)?
+            }
+        };
+        let rtprio_limit = rtprio_limit.expect("FIFO authorization must read RLIMIT_RTPRIO");
+
+        if old_policy != LinuxSchedPolicy::Fifo && rtprio_limit == 0 {
+            return Ok(false);
+        }
+        if new_user_priority > old_user_priority && new_user_priority as u64 > rtprio_limit {
+            return Ok(false);
+        }
+        Ok(true)
     }
 }
 
@@ -83,36 +139,13 @@ impl Syscall for SysSchedSetscheduler {
         let sched_param: KernelSchedParam = reader.buffer_protected(0)?.read_one(0)?;
 
         let target = find_sched_target(pid)?;
-        let supported_fast_path = Self::validate_policy(policy, sched_param.sched_priority)?;
-        if !supported_fast_path {
-            return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+        let request = Self::build_request(policy, sched_param.sched_priority)?;
+        if !Self::unprivileged_allowed(&target, request)? && !capable(CAPFlags::CAP_SYS_NICE) {
+            return Err(SystemError::EPERM);
         }
 
-        let reset_on_fork = policy & SCHED_RESET_ON_FORK != 0;
-        let current = ProcessManager::current_pcb();
-        let same_owner = same_sched_owner(&current.cred(), &target.cred());
-        let mut privileged = false;
-
-        loop {
-            let mut pi_guard = target.sched_info().pi_lock_irqsave();
-            if target.sched_info().policy() != LinuxSchedPolicy::Normal {
-                return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
-            }
-
-            let clearing_protected_flag = pi_guard.sched_reset_on_fork() && !reset_on_fork;
-            if (same_owner && !clearing_protected_flag) || privileged {
-                pi_guard.set_sched_reset_on_fork(reset_on_fork);
-                return Ok(0);
-            }
-
-            // Capability lookup may take user-namespace locks. Never perform
-            // it while holding a scheduler spin lock.
-            drop(pi_guard);
-            if !capable(CAPFlags::CAP_SYS_NICE) {
-                return Err(SystemError::EPERM);
-            }
-            privileged = true;
-        }
+        ProcessManager::set_scheduler(&target, request)?;
+        Ok(0)
     }
 
     fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -12,6 +12,7 @@
 #include <sched.h>
 #include <signal.h>
 #include <sys/mman.h>
+#include <sys/resource.h>
 #include <sys/syscall.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
@@ -19,6 +20,10 @@
 
 #ifndef SCHED_RESET_ON_FORK
 #define SCHED_RESET_ON_FORK 0x40000000
+#endif
+
+#ifndef CLONE_NEWUSER
+#define CLONE_NEWUSER 0x10000000
 #endif
 
 namespace {
@@ -107,6 +112,94 @@ int WaitForChild(pid_t child) {
     while (waitpid(child, nullptr, 0) < 0 && errno == EINTR) {
     }
     return 253;
+}
+
+using ScenarioFn = int (*)();
+
+int RunIsolatedScenario(ScenarioFn scenario, int timeout_ms = 5000) {
+    pid_t child = fork();
+    if (child < 0) return 250;
+    if (child == 0) {
+        if (setpgid(0, 0) != 0) _exit(251);
+        _exit(scenario());
+    }
+
+    // The child also calls setpgid, so EACCES/ESRCH here only means it won
+    // the race or already exited.
+    (void)setpgid(child, child);
+    int status = 0;
+    const int attempts = timeout_ms / 10;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        pid_t waited = waitpid(child, &status, WNOHANG);
+        if (waited == child) {
+            if (!WIFEXITED(status)) {
+                (void)kill(-child, SIGKILL);
+                return 252;
+            }
+            const int result = WEXITSTATUS(status);
+            if (result != 0) (void)kill(-child, SIGKILL);
+            return result;
+        }
+        if (waited < 0 && errno != EINTR) return 253;
+        usleep(10 * 1000);
+    }
+
+    // Kill every FIFO worker in the isolated group before reaping the
+    // coordinator, so a failed scenario cannot starve later test cases.
+    (void)kill(-child, SIGKILL);
+    (void)kill(child, SIGKILL);
+    while (waitpid(child, nullptr, 0) < 0 && errno == EINTR) {
+    }
+    return 254;
+}
+
+bool WaitStopped(pid_t child, int timeout_ms = 2000) {
+    int status = 0;
+    const int attempts = timeout_ms / 10;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        pid_t waited = waitpid(child, &status, WNOHANG | WUNTRACED);
+        if (waited == child) return WIFSTOPPED(status);
+        if (waited < 0 && errno != EINTR) return false;
+        usleep(10 * 1000);
+    }
+    return false;
+}
+
+bool SetPolicy(pid_t tid, int policy, int priority) {
+    RawSchedParam param {priority};
+    return RawSetScheduler(tid, policy, &param) == 0;
+}
+
+bool ReadPolicyAndPriority(pid_t tid, int policy, int priority) {
+    RawSchedParam param {-1};
+    return sched_getscheduler(tid) == policy && RawGetParam(tid, &param) == 0 &&
+           param.sched_priority == priority;
+}
+
+bool PickAllowedCpus(int* first, int* second = nullptr) {
+    cpu_set_t allowed;
+    CPU_ZERO(&allowed);
+    if (sched_getaffinity(0, sizeof(allowed), &allowed) != 0) return false;
+
+    *first = -1;
+    if (second != nullptr) *second = -1;
+    for (int cpu = 0; cpu < CPU_SETSIZE; ++cpu) {
+        if (!CPU_ISSET(cpu, &allowed)) continue;
+        if (*first < 0) {
+            *first = cpu;
+        } else if (second != nullptr) {
+            *second = cpu;
+            break;
+        }
+    }
+    return *first >= 0;
+}
+
+bool PinTask(pid_t tid, int cpu) {
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    CPU_SET(cpu, &mask);
+    return sched_setaffinity(tid, sizeof(mask), &mask) == 0;
 }
 
 class ChildGuard {
@@ -319,13 +412,49 @@ TEST(SchedSetScheduler, ErrorOrderingAndPolicyMatrix) {
     EXPECT_EQ(-1, RawSetScheduler(0, SCHED_FIFO, &zero));
     EXPECT_EQ(EINVAL, errno);
 
-    // On Linux a valid FIFO request may really enter RT scheduling. Only the
-    // DragonOS guest exercises its documented staging boundary.
-    if (IsDragonOS()) {
-        errno = 0;
-        EXPECT_EQ(-1, RawSetScheduler(0, SCHED_FIFO, &one));
-        EXPECT_EQ(EOPNOTSUPP, errno);
+    errno = 0;
+    RawSchedParam hundred {100};
+    EXPECT_EQ(-1, RawSetScheduler(0, SCHED_FIFO, &hundred));
+    EXPECT_EQ(EINVAL, errno);
+}
+
+int FifoRoundTripScenario() {
+    if (!SetPolicy(0, SCHED_FIFO, 1)) return 10;
+    if (!ReadPolicyAndPriority(0, SCHED_FIFO, 1)) return 11;
+    if (!SetPolicy(0, SCHED_FIFO, 99)) return 12;
+    if (!ReadPolicyAndPriority(0, SCHED_FIFO, 99)) return 13;
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 14;
+    return ReadPolicyAndPriority(0, SCHED_OTHER, 0) ? 0 : 15;
+}
+
+TEST(SchedFifoPolicy, FairFifoPriorityRoundTrip) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoRoundTripScenario));
+}
+
+int FifoForkScenario() {
+    if (!SetPolicy(0, SCHED_FIFO, 20)) return 20;
+    pid_t inherited = fork();
+    if (inherited < 0) return 21;
+    if (inherited == 0) {
+        _exit(ReadPolicyAndPriority(0, SCHED_FIFO, 20) ? 0 : 22);
     }
+    if (WaitForChild(inherited) != 0) return 23;
+
+    if (!SetPolicy(0, SCHED_FIFO | SCHED_RESET_ON_FORK, 20)) return 24;
+    pid_t reset = fork();
+    if (reset < 0) return 25;
+    if (reset == 0) {
+        _exit(ReadPolicyAndPriority(0, SCHED_OTHER, 0) ? 0 : 26);
+    }
+    if (WaitForChild(reset) != 0) return 27;
+    if (!ReadPolicyAndPriority(0, SCHED_FIFO | SCHED_RESET_ON_FORK, 20)) return 28;
+    return SetPolicy(0, SCHED_OTHER, 0) ? 0 : 29;
+}
+
+TEST(SchedFifoReset, ForkInheritanceAndResetOnFork) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoForkScenario));
 }
 
 TEST(SchedSetScheduler, SelfResetFlagRoundTripAndFork) {
@@ -470,6 +599,507 @@ TEST(SchedPermission, OwnerCapabilityAndProtectedClearMatrix) {
     close(hold[1]);
     EXPECT_EQ(0, WaitForChild(target));
     target_guard.Release();
+}
+
+bool WaitAtomicValue(const std::atomic<int>& value, int expected, int timeout_ms = 2000) {
+    const int attempts = timeout_ms / 10;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        if (value.load(std::memory_order_acquire) == expected) return true;
+        usleep(10 * 1000);
+    }
+    return false;
+}
+
+struct RlimitThreadState {
+    std::atomic<int> phase {0};
+    int first_result = -1;
+    int second_result = -1;
+    int third_result = -1;
+    int race_cpu = -1;
+};
+
+constexpr int kRlimitRaceRounds = 1024;
+
+void* RlimitWorker(void* arg) {
+    auto* state = static_cast<RlimitThreadState*>(arg);
+    if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) {
+        state->phase.store(90 + errno, std::memory_order_release);
+        return nullptr;
+    }
+    state->phase.store(1, std::memory_order_release);
+
+    while (state->phase.load(std::memory_order_acquire) != 2) sched_yield();
+    struct rlimit limit {};
+    if (getrlimit(RLIMIT_RTPRIO, &limit) != 0 || limit.rlim_cur != 10) {
+        state->first_result = 80;
+    } else if (!SetPolicy(0, SCHED_FIFO, 10)) {
+        state->first_result = errno;
+    } else {
+        state->first_result = 0;
+    }
+    state->phase.store(3, std::memory_order_release);
+
+    while (state->phase.load(std::memory_order_acquire) != 4) sched_yield();
+    limit = {};
+    if (getrlimit(RLIMIT_RTPRIO, &limit) != 0 || limit.rlim_cur != 0) {
+        state->second_result = 81;
+    } else if (!SetPolicy(0, SCHED_FIFO, 1)) {
+        // Lowering an existing FIFO priority remains permitted after the
+        // soft limit is reduced to zero.
+        state->second_result = 82 + errno;
+    } else if (!SetPolicy(0, SCHED_OTHER, 0)) {
+        state->second_result = 83 + errno;
+    } else {
+        state->second_result = 0;
+    }
+    state->phase.store(5, std::memory_order_release);
+
+    while (state->phase.load(std::memory_order_acquire) != 6) sched_yield();
+    errno = 0;
+    if (!SetPolicy(0, SCHED_FIFO, 1) && errno == EPERM) {
+        state->third_result = 0;
+    } else {
+        const int saved_errno = errno;
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        state->third_result = 84 + saved_errno;
+    }
+    state->phase.store(7, std::memory_order_release);
+
+    while (state->phase.load(std::memory_order_acquire) != 8) sched_yield();
+    if (state->race_cpu < 0) {
+        state->phase.store(9, std::memory_order_release);
+        return nullptr;
+    }
+    if (!PinTask(0, state->race_cpu)) {
+        state->phase.store(-1, std::memory_order_release);
+        return nullptr;
+    }
+    state->phase.store(9, std::memory_order_release);
+    for (int round = 0; round < kRlimitRaceRounds; ++round) {
+        const int start_phase = 10 + round * 2;
+        while (state->phase.load(std::memory_order_acquire) != start_phase) sched_yield();
+        struct rlimit stale_high {10, 10};
+        // Depending on serialization order this either succeeds before the
+        // privileged lowering writer, or fails with EPERM after it. It must
+        // never restore the group's hard limit after that writer completes.
+        (void)setrlimit(RLIMIT_RTPRIO, &stale_high);
+        state->phase.store(start_phase + 1, std::memory_order_release);
+    }
+    return nullptr;
+}
+
+int ThreadGroupRlimitScenario() {
+    struct rlimit high {10, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &high) != 0) return 10 + errno;
+
+    pid_t child = fork();
+    if (child < 0) return 11;
+    if (child == 0) {
+        struct rlimit child_limit {0, 10};
+        _exit(setrlimit(RLIMIT_RTPRIO, &child_limit) == 0 ? 0 : 12 + errno);
+    }
+    if (WaitForChild(child) != 0) return 13;
+    struct rlimit parent_limit {};
+    if (getrlimit(RLIMIT_RTPRIO, &parent_limit) != 0 || parent_limit.rlim_cur != 10) return 14;
+
+    RlimitThreadState state;
+    pthread_t worker;
+    if (pthread_create(&worker, nullptr, RlimitWorker, &state) != 0) return 20;
+    if (!WaitAtomicValue(state.phase, 1)) return 21;
+
+    state.phase.store(2, std::memory_order_release);
+    if (!WaitAtomicValue(state.phase, 3) || state.first_result != 0) return 30 + state.first_result;
+
+    struct rlimit low {0, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &low) != 0) return 40 + errno;
+    state.phase.store(4, std::memory_order_release);
+    if (!WaitAtomicValue(state.phase, 5) || state.second_result != 0) {
+        return 50 + state.second_result;
+    }
+    state.phase.store(6, std::memory_order_release);
+    if (!WaitAtomicValue(state.phase, 7) || state.third_result != 0) return 60 + state.third_result;
+
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, &worker_cpu)) return 70;
+    state.race_cpu = worker_cpu;
+    state.phase.store(8, std::memory_order_release);
+    if (!WaitAtomicValue(state.phase, 9)) return 71;
+    if (worker_cpu >= 0) {
+        if (!PinTask(0, controller_cpu)) return 72;
+        for (int round = 0; round < kRlimitRaceRounds; ++round) {
+            if (setrlimit(RLIMIT_RTPRIO, &high) != 0) return 73;
+            const int start_phase = 10 + round * 2;
+            state.phase.store(start_phase, std::memory_order_release);
+            struct rlimit zero {0, 0};
+            if (setrlimit(RLIMIT_RTPRIO, &zero) != 0) return 74;
+            while (state.phase.load(std::memory_order_acquire) != start_phase + 1) {
+                if (state.phase.load(std::memory_order_relaxed) < 0) return 75;
+                __atomic_signal_fence(__ATOMIC_SEQ_CST);
+            }
+            struct rlimit observed {};
+            if (getrlimit(RLIMIT_RTPRIO, &observed) != 0 || observed.rlim_cur != 0 ||
+                observed.rlim_max != 0) {
+                return 76;
+            }
+        }
+    }
+    return pthread_join(worker, nullptr) == 0 ? 0 : 77;
+}
+
+int RunRlimitMismatchCase(rlim_t target_limit, rlim_t caller_limit, int priority,
+                          int expected_errno) {
+    int ready[2];
+    int hold[2];
+    if (pipe(ready) != 0 || pipe(hold) != 0) return 100;
+
+    pid_t target = fork();
+    if (target < 0) return 101;
+    if (target == 0) {
+        close(ready[0]);
+        close(hold[1]);
+        struct rlimit limit {target_limit, target_limit};
+        if (setrlimit(RLIMIT_RTPRIO, &limit) != 0) _exit(10 + errno);
+        if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) _exit(20 + errno);
+        WriteByteOrExit(ready[1], 'r');
+        _exit(ReadByte(hold[0]) ? 0 : 30);
+    }
+    close(ready[1]);
+    close(hold[0]);
+    if (!ReadByteWithTimeout(ready[0], 2000)) {
+        kill(target, SIGKILL);
+        WaitForChild(target);
+        return 102;
+    }
+    close(ready[0]);
+
+    pid_t caller = fork();
+    if (caller < 0) return 103;
+    if (caller == 0) {
+        struct rlimit limit {caller_limit, caller_limit};
+        if (setrlimit(RLIMIT_RTPRIO, &limit) != 0) _exit(40 + errno);
+        if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) _exit(50 + errno);
+        errno = 0;
+        const bool changed = SetPolicy(target, SCHED_FIFO, priority);
+        if (expected_errno == 0) {
+            if (!changed || !ReadPolicyAndPriority(target, SCHED_FIFO, priority)) _exit(60 + errno);
+            if (!SetPolicy(target, SCHED_OTHER, 0)) _exit(70 + errno);
+            _exit(0);
+        }
+        _exit(!changed && errno == expected_errno ? 0 : 80 + errno);
+    }
+
+    int result = WaitForChild(caller);
+    const bool released = write(hold[1], "x", 1) == 1;
+    close(hold[1]);
+    const int target_result = WaitForChild(target);
+    return result == 0 && released && target_result == 0 ? 0 : 110 + result;
+}
+
+int RlimitTargetVsCallerScenario() {
+    int result = RunRlimitMismatchCase(10, 0, 10, 0);
+    if (result != 0) return result;
+    result = RunRlimitMismatchCase(0, 10, 1, EPERM);
+    if (result != 0) return result;
+    return RunRlimitMismatchCase(10, 0, 11, EPERM);
+}
+
+int NestedUserNamespaceRlimitScenario() {
+    struct rlimit initial {};
+    if (getrlimit(RLIMIT_RTPRIO, &initial) != 0 || initial.rlim_max != 0) return 120;
+    if (unshare(CLONE_NEWUSER) != 0) return 121 + errno;
+
+    struct rlimit raised {1, 1};
+    errno = 0;
+    if (setrlimit(RLIMIT_RTPRIO, &raised) == 0 || errno != EPERM) return 130 + errno;
+
+    errno = 0;
+    if (SetPolicy(0, SCHED_FIFO, 1) || errno != EPERM) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 140 + errno;
+    }
+    return 0;
+}
+
+TEST(SchedFifoRlimit, ThreadGroupSharesRaisedAndLoweredLimit) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(ThreadGroupRlimitScenario));
+}
+
+TEST(SchedFifoRlimit, AuthorizationUsesTargetNotCallerLimit) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(RlimitTargetVsCallerScenario));
+}
+
+TEST(SchedFifoRlimit, NestedUserNamespaceCannotRaiseHardLimit) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(NestedUserNamespaceRlimitScenario));
+}
+
+struct SharedFifoState {
+    int sequence_index;
+    char sequence[4];
+    int throttle_stage;
+    int remote_runner_started;
+    int remote_candidate_ran;
+    int remote_runner_release;
+    int stress_started;
+    int stress_release;
+};
+
+SharedFifoState* NewSharedFifoState() {
+    void* mapping = mmap(nullptr, sizeof(SharedFifoState), PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (mapping == MAP_FAILED) return nullptr;
+    memset(mapping, 0, sizeof(SharedFifoState));
+    return static_cast<SharedFifoState*>(mapping);
+}
+
+void RecordEvent(SharedFifoState* state, char event) {
+    int position = __atomic_fetch_add(&state->sequence_index, 1, __ATOMIC_SEQ_CST);
+    if (position >= 0 && position < static_cast<int>(sizeof(state->sequence))) {
+        state->sequence[position] = event;
+    }
+}
+
+int FifoYieldScenario() {
+    int cpu = -1;
+    if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 10;
+    SharedFifoState* state = NewSharedFifoState();
+    if (state == nullptr) return 11;
+
+    pid_t first = fork();
+    if (first < 0) return 12;
+    if (first == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'A');
+        if (sched_yield() != 0) _exit(20);
+        RecordEvent(state, 'A');
+        _exit(0);
+    }
+    if (!WaitStopped(first) || !PinTask(first, cpu) || !SetPolicy(first, SCHED_FIFO, 20)) {
+        kill(first, SIGKILL);
+        return 13;
+    }
+
+    pid_t second = fork();
+    if (second < 0) {
+        kill(first, SIGKILL);
+        return 14;
+    }
+    if (second == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'B');
+        _exit(0);
+    }
+    if (!WaitStopped(second) || !PinTask(second, cpu) || !SetPolicy(second, SCHED_FIFO, 20)) {
+        kill(first, SIGKILL);
+        kill(second, SIGKILL);
+        return 15;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 50)) return 16;
+    if (kill(first, SIGCONT) != 0 || kill(second, SIGCONT) != 0) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 17;
+    }
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 18;
+
+    int first_result = WaitForChild(first);
+    int second_result = WaitForChild(second);
+    bool ordered = __atomic_load_n(&state->sequence_index, __ATOMIC_SEQ_CST) == 3 &&
+                   state->sequence[0] == 'A' && state->sequence[1] == 'B' &&
+                   state->sequence[2] == 'A';
+    munmap(state, sizeof(*state));
+    return first_result == 0 && second_result == 0 && ordered ? 0 : 19;
+}
+
+int FifoThrottlingScenario() {
+    int cpu = -1;
+    if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 30;
+    SharedFifoState* state = NewSharedFifoState();
+    if (state == nullptr) return 31;
+
+    pid_t runner = fork();
+    if (runner < 0) return 32;
+    if (runner == 0) {
+        raise(SIGSTOP);
+        __atomic_store_n(&state->throttle_stage, 1, __ATOMIC_RELEASE);
+        while (__atomic_load_n(&state->throttle_stage, __ATOMIC_ACQUIRE) == 1) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        if (__atomic_load_n(&state->throttle_stage, __ATOMIC_ACQUIRE) != 2) _exit(121);
+        __atomic_store_n(&state->throttle_stage, 3, __ATOMIC_RELEASE);
+        _exit(0);
+    }
+    if (!WaitStopped(runner) || !PinTask(runner, cpu) || !SetPolicy(runner, SCHED_FIFO, 20)) {
+        kill(runner, SIGKILL);
+        return 33;
+    }
+
+    pid_t observer = fork();
+    if (observer < 0) {
+        kill(runner, SIGKILL);
+        return 34;
+    }
+    if (observer == 0) {
+        raise(SIGSTOP);
+        int expected = 1;
+        if (!__atomic_compare_exchange_n(&state->throttle_stage, &expected, 2, false,
+                                         __ATOMIC_ACQ_REL, __ATOMIC_ACQUIRE)) {
+            __atomic_store_n(&state->throttle_stage, -1, __ATOMIC_RELEASE);
+            _exit(122);
+        }
+        while (__atomic_load_n(&state->throttle_stage, __ATOMIC_ACQUIRE) != 3) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        _exit(0);
+    }
+    if (!WaitStopped(observer) || !PinTask(observer, cpu)) {
+        kill(runner, SIGKILL);
+        kill(observer, SIGKILL);
+        return 35;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 50)) return 36;
+    // Queue Fair first, then RT, while the higher-priority coordinator keeps
+    // both from running. After the coordinator demotes, only RT throttling can
+    // make the observer run; period replenishment must then resume the runner.
+    if (kill(observer, SIGCONT) != 0 || kill(runner, SIGCONT) != 0) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 37;
+    }
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 38;
+
+    int runner_result = WaitForChild(runner);
+    int observer_result = WaitForChild(observer);
+    bool completed = __atomic_load_n(&state->throttle_stage, __ATOMIC_ACQUIRE) == 3;
+    munmap(state, sizeof(*state));
+    return runner_result == 0 && observer_result == 0 && completed ? 0 : 39;
+}
+
+int FifoRemoteScenario() {
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, &worker_cpu) || worker_cpu < 0 ||
+        !PinTask(0, controller_cpu)) {
+        return 40;
+    }
+    SharedFifoState* state = NewSharedFifoState();
+    if (state == nullptr) return 41;
+
+    pid_t runner = fork();
+    if (runner < 0) return 42;
+    if (runner == 0) {
+        raise(SIGSTOP);
+        __atomic_store_n(&state->remote_runner_started, 1, __ATOMIC_RELEASE);
+        while (__atomic_load_n(&state->remote_runner_release, __ATOMIC_ACQUIRE) == 0) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        _exit(0);
+    }
+    if (!WaitStopped(runner) || !PinTask(runner, worker_cpu) ||
+        !SetPolicy(runner, SCHED_FIFO, 10)) {
+        kill(runner, SIGKILL);
+        return 43;
+    }
+
+    pid_t candidate = fork();
+    if (candidate < 0) return 44;
+    if (candidate == 0) {
+        raise(SIGSTOP);
+        __atomic_store_n(&state->remote_candidate_ran, 1, __ATOMIC_RELEASE);
+        _exit(0);
+    }
+    if (!WaitStopped(candidate) || !PinTask(candidate, worker_cpu)) {
+        kill(runner, SIGKILL);
+        kill(candidate, SIGKILL);
+        return 45;
+    }
+
+    if (kill(runner, SIGCONT) != 0) return 46;
+    bool runner_started = false;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (__atomic_load_n(&state->remote_runner_started, __ATOMIC_ACQUIRE) == 1) {
+            runner_started = true;
+            break;
+        }
+        usleep(10 * 1000);
+    }
+    if (!runner_started || kill(candidate, SIGCONT) != 0) return 47;
+    // SIGCONT makes the Fair candidate runnable behind the busy FIFO runner.
+    // The remote policy transaction below must be the event that preempts CPU1.
+    if (__atomic_load_n(&state->remote_candidate_ran, __ATOMIC_ACQUIRE) != 0 ||
+        !ReadPolicyAndPriority(candidate, SCHED_OTHER, 0) ||
+        !SetPolicy(candidate, SCHED_FIFO, 20)) {
+        return 48;
+    }
+
+    bool preempted = false;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (__atomic_load_n(&state->remote_candidate_ran, __ATOMIC_ACQUIRE) == 1) {
+            preempted = true;
+            break;
+        }
+        usleep(10 * 1000);
+    }
+    __atomic_store_n(&state->remote_runner_release, 1, __ATOMIC_RELEASE);
+    int candidate_result = WaitForChild(candidate);
+    int runner_result = WaitForChild(runner);
+    if (!preempted || candidate_result != 0 || runner_result != 0) return 49;
+
+    pid_t stress = fork();
+    if (stress < 0) return 50;
+    if (stress == 0) {
+        if (!PinTask(0, worker_cpu)) _exit(51);
+        __atomic_store_n(&state->stress_started, 1, __ATOMIC_RELEASE);
+        while (__atomic_load_n(&state->stress_release, __ATOMIC_ACQUIRE) == 0) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        _exit(0);
+    }
+    bool stress_started = false;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (__atomic_load_n(&state->stress_started, __ATOMIC_ACQUIRE) == 1) {
+            stress_started = true;
+            break;
+        }
+        usleep(10 * 1000);
+    }
+    if (!stress_started) return 52;
+
+    for (int round = 0; round < 64; ++round) {
+        const int priority = (round & 1) == 0 ? 1 : 99;
+        if (!SetPolicy(stress, SCHED_FIFO, priority) ||
+            !ReadPolicyAndPriority(stress, SCHED_FIFO, priority) ||
+            !SetPolicy(stress, SCHED_OTHER, 0) ||
+            !ReadPolicyAndPriority(stress, SCHED_OTHER, 0)) {
+            return 53;
+        }
+    }
+    __atomic_store_n(&state->stress_release, 1, __ATOMIC_RELEASE);
+    int stress_result = WaitForChild(stress);
+    munmap(state, sizeof(*state));
+    return stress_result == 0 ? 0 : 54;
+}
+
+TEST(SchedFifoBehavior, SamePriorityYieldMovesCurrentToTail) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoYieldScenario));
+}
+
+TEST(SchedFifoBehavior, RuntimeThrottlingLetsFairRunAndRecovers) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoThrottlingScenario));
+}
+
+TEST(SchedFifoSmp, RemotePreemptionAndRunningTargetStress) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    int first = -1;
+    int second = -1;
+    ASSERT_TRUE(PickAllowedCpus(&first, &second));
+    if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoRemoteScenario));
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

- expose SCHED_FIFO through sched_setscheduler(2) with Linux-compatible priority conversion, validation, ownership, CAP_SYS_NICE, and target RLIMIT_RTPRIO checks
- carry FIFO reset-on-fork state through the existing atomic scheduler transaction and reset realtime children to SCHED_NORMAL at nice 0 when requested
- share the complete rlimit array across CLONE_THREAD tasks while preserving fork snapshots
- serialize hard-limit authorization and replacement, return coherent prlimit64 old values, and keep RLIMIT_NOFILE table resizing as a lock-safe best-effort optimization
- enforce CAP_SYS_RESOURCE in the initial user namespace so nested user namespace capabilities cannot raise the realtime hard limit

## Architecture

The syscall layer parses the legacy Linux ABI and performs authorization. Policy, priority, reset-on-fork state, class accounting, runqueue placement, and local or remote rescheduling remain owned by ProcessManager::set_scheduler under the existing pi-lock to runqueue-lock transaction.

Resource limits use one shared Arc-backed lock per thread group and are copied for a new process. Hard-limit comparison and publication are linearized by that shared lock. File descriptor table resizing stays outside the resource-limit lock and cannot roll back a newer group update; allocation paths continue to read and enforce the current shared RLIMIT_NOFILE value.

This change reuses the existing realtime runqueue and runtime bandwidth enforcement. It does not add SCHED_RR, a second queue, a scheduler plugin framework, RT group scheduling, or a test-only kernel interface.

## Validation

- make fmt, including all-features clippy
- make kernel
- host sched_policy_semantics_test: 12 passed, 10 DragonOS-only tests skipped
- DragonOS 2-vCPU sched_policy_semantics_test: 22/22 passed
- DragonOS 2-vCPU sched_affinity_test: 7/7 passed
- DragonOS 2-vCPU sched_tracepoint_test: 9/9 passed
- DragonOS 2-vCPU proc_self_limits_test: 1/1 passed
- DragonOS 1-vCPU scheduler checkpoint: 20/20 passed, 1 SMP-only test skipped
- git diff --check
- two rounds of adversarial Linux semantics, architecture/concurrency, security, performance, maintainability, and test-determinism review

Refs #760