### PR TITLE
feat(sched): implement SCHED_RR timeslicing

### DIFF
--- a/kernel/src/filesystem/procfs/pid/status.rs
+++ b/kernel/src/filesystem/procfs/pid/status.rs
@@ -72,6 +72,7 @@ impl StatusFileOps {
             _ => match sched_info_guard.policy() {
                 crate::sched::LinuxSchedPolicy::Normal => "CFS",
                 crate::sched::LinuxSchedPolicy::Fifo => "FIFO",
+                crate::sched::LinuxSchedPolicy::Rr => "RR",
             },
         };
         let vrtime = pcb.sched_info().sched_entity.vruntime;

--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -25,6 +25,10 @@ pub(crate) enum SchedChangeRequest {
         priority: i32,
         reset_on_fork: bool,
     },
+    Rr {
+        priority: i32,
+        reset_on_fork: bool,
+    },
 }
 
 impl ProcessManager {
@@ -149,7 +153,9 @@ impl ProcessManager {
         pcb: &Arc<ProcessControlBlock>,
         request: SchedChangeRequest,
     ) -> Result<(), SystemError> {
-        if let SchedChangeRequest::Fifo { priority, .. } = request {
+        if let SchedChangeRequest::Fifo { priority, .. } | SchedChangeRequest::Rr { priority, .. } =
+            request
+        {
             if !(0..crate::sched::prio::MAX_RT_PRIO - 1).contains(&priority) {
                 return Err(SystemError::EINVAL);
             }
@@ -196,6 +202,7 @@ impl ProcessManager {
 
             let old_policy = pcb.sched_info().policy();
             let old_prio = pcb.sched_info().prio();
+            let old_normal_prio = pcb.sched_info().normal_prio();
             let old_reset = pi_guard.sched_reset_on_fork();
             let (new_policy, new_prio, new_reset) = match request {
                 SchedChangeRequest::Normal { reset_on_fork } => (
@@ -207,10 +214,19 @@ impl ProcessManager {
                     priority,
                     reset_on_fork,
                 } => (LinuxSchedPolicy::Fifo, priority, reset_on_fork),
+                SchedChangeRequest::Rr {
+                    priority,
+                    reset_on_fork,
+                } => (LinuxSchedPolicy::Rr, priority, reset_on_fork),
             };
             let new_class = new_policy.base_sched_class();
 
-            if old_policy == new_policy && old_prio == new_prio && old_reset == new_reset {
+            // Linux treats a reset-on-fork-only update as a parameter fast
+            // path: it must not disturb the task's position in its queue.
+            if old_policy == new_policy && old_normal_prio == new_prio {
+                if old_reset != new_reset {
+                    pi_guard.set_sched_reset_on_fork(new_reset);
+                }
                 drop(rq_guard);
                 drop(pi_guard);
                 return Ok(());

--- a/kernel/src/process/sched_info.rs
+++ b/kernel/src/process/sched_info.rs
@@ -41,8 +41,12 @@ pub struct ProcessSchedulerInfo {
     // priority: SchedPriority,
     /// Virtual runtime of the current process.
     // virtual_runtime: AtomicIsize,
-    /// Time slice managed by the real-time scheduler.
-    // rt_time_slice: AtomicIsize,
+    /// Remaining SCHED_RR time slice in scheduler ticks.
+    ///
+    /// Semantic writes are serialized by the task's runqueue lock. The
+    /// atomic provides interior mutability consistent with the other
+    /// scheduler fields; it is not an independent synchronization domain.
+    rr_time_slice_remaining: AtomicU32,
     pub sched_stat: RwLock<SchedInfo>,
     /// Linux base scheduling policy (protected by rq_lock / pi_lock).
     sched_policy: AtomicU8,
@@ -136,7 +140,7 @@ impl ProcessSchedulerInfo {
             state_atomic: AtomicU32::new(ProcessState::Blocked(false).to_u32()),
             pi_lock: SpinLock::new(PiProtected::new(cpus_allowed)),
             // virtual_runtime: AtomicIsize::new(0),
-            // rt_time_slice: AtomicIsize::new(0),
+            rr_time_slice_remaining: AtomicU32::new(crate::sched::realtime::RR_TIMESLICE_TICKS),
             // priority: SchedPriority::new(100).unwrap(),
             sched_stat: RwLock::new(SchedInfo::default()),
             sched_policy: AtomicU8::new(LinuxSchedPolicy::Normal.to_u8()),
@@ -338,17 +342,16 @@ impl ProcessSchedulerInfo {
     //     self.virtual_runtime.fetch_add(delta, Ordering::SeqCst);
     // }
 
-    // pub fn rt_time_slice(&self) -> isize {
-    //     return self.rt_time_slice.load(Ordering::SeqCst);
-    // }
+    #[inline]
+    pub(crate) fn rr_time_slice_remaining(&self) -> u32 {
+        self.rr_time_slice_remaining.load(Ordering::Relaxed)
+    }
 
-    // pub fn set_rt_time_slice(&self, rt_time_slice: isize) {
-    //     self.rt_time_slice.store(rt_time_slice, Ordering::SeqCst);
-    // }
-
-    // pub fn increase_rt_time_slice(&self, delta: isize) {
-    //     self.rt_time_slice.fetch_add(delta, Ordering::SeqCst);
-    // }
+    #[inline]
+    pub(crate) fn set_rr_time_slice_remaining(&self, remaining: u32) {
+        self.rr_time_slice_remaining
+            .store(remaining, Ordering::Relaxed);
+    }
 
     /// Read the scheduling policy.
     #[inline]

--- a/kernel/src/sched/mod.rs
+++ b/kernel/src/sched/mod.rs
@@ -1365,7 +1365,7 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     };
 
     if reset_on_fork {
-        if fork_policy == LinuxSchedPolicy::Fifo {
+        if fork_policy.is_realtime() {
             // Linux resets RT children to SCHED_NORMAL at nice 0.
             fork_policy = LinuxSchedPolicy::Normal;
             fork_prio = prio::DEFAULT_PRIO;
@@ -1392,7 +1392,7 @@ pub fn sched_fork(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
     }
     debug_assert_eq!(
         PrioUtil::rt_prio(fork_prio),
-        fork_policy == LinuxSchedPolicy::Fifo,
+        fork_policy.is_realtime(),
         "fork policy and inherited normal priority disagree"
     );
     pcb.sched_info().set_policy(fork_policy);

--- a/kernel/src/sched/policy.rs
+++ b/kernel/src/sched/policy.rs
@@ -7,6 +7,7 @@
 pub enum LinuxSchedPolicy {
     Normal = 0,
     Fifo = 1,
+    Rr = 2,
 }
 
 impl LinuxSchedPolicy {
@@ -15,8 +16,13 @@ impl LinuxSchedPolicy {
     pub const fn base_sched_class(self) -> SchedClass {
         match self {
             Self::Normal => SchedClass::Fair,
-            Self::Fifo => SchedClass::Realtime,
+            Self::Fifo | Self::Rr => SchedClass::Realtime,
         }
+    }
+
+    #[inline]
+    pub const fn is_realtime(self) -> bool {
+        matches!(self, Self::Fifo | Self::Rr)
     }
 
     #[inline]
@@ -29,6 +35,7 @@ impl LinuxSchedPolicy {
         match value {
             0 => Self::Normal,
             1 => Self::Fifo,
+            2 => Self::Rr,
             _ => panic!("invalid Linux scheduling policy"),
         }
     }
@@ -75,6 +82,7 @@ impl SchedClass {
 const _: () = {
     assert!(LinuxSchedPolicy::Normal.base_sched_class() as u8 == SchedClass::Fair as u8);
     assert!(LinuxSchedPolicy::Fifo.base_sched_class() as u8 == SchedClass::Realtime as u8);
+    assert!(LinuxSchedPolicy::Rr.base_sched_class() as u8 == SchedClass::Realtime as u8);
     assert!(SchedClass::Realtime.outranks(SchedClass::Fair));
     assert!(SchedClass::Realtime.outranks(SchedClass::Idle));
     assert!(SchedClass::Fair.outranks(SchedClass::Idle));

--- a/kernel/src/sched/realtime.rs
+++ b/kernel/src/sched/realtime.rs
@@ -1,6 +1,10 @@
 use alloc::{collections::VecDeque, sync::Arc, vec::Vec};
 
-use crate::{process::ProcessControlBlock, sched::prio::MAX_RT_PRIO};
+use crate::{
+    process::ProcessControlBlock,
+    sched::{prio::MAX_RT_PRIO, LinuxSchedPolicy},
+    time::clocksource::HZ,
+};
 
 use super::{CpuRunQueue, DequeueFlag, EnqueueFlag, PrioUtil, SchedClass, Scheduler, WakeupFlags};
 
@@ -9,9 +13,13 @@ use super::{CpuRunQueue, DequeueFlag, EnqueueFlag, PrioUtil, SchedClass, Schedul
 const RT_PERIOD_NS: u64 = 1_000_000_000;
 const RT_RUNTIME_NS: u64 = 950_000_000;
 
+/// Linux's default SCHED_RR quantum, expressed in scheduler ticks.
+pub(crate) const RR_TIMESLICE_TICKS: u32 = (100 * HZ / 1000) as u32;
+
 const _: () = {
     assert!(MAX_RT_PRIO > 1);
     assert!(MAX_RT_PRIO <= u128::BITS as i32);
+    assert!(RR_TIMESLICE_TICKS > 0);
 };
 
 /// Per-CPU runqueue shared by every policy in the realtime scheduling class.
@@ -238,6 +246,26 @@ impl RealtimeRunQueue {
         true
     }
 
+    /// Move an existing task to the tail only when its priority bucket has a
+    /// peer which can run next.
+    fn requeue_to_tail_if_peer(&mut self, pcb: &Arc<ProcessControlBlock>) -> bool {
+        self.assert_consistent();
+        let prio = Self::prio_index(pcb);
+
+        #[cfg(any(debug_assertions, feature = "fifo_demo"))]
+        assert!(
+            self.queues[prio]
+                .iter()
+                .any(|queued| Arc::ptr_eq(queued, pcb)),
+            "realtime task is not queued"
+        );
+
+        if self.queues[prio].len() <= 1 {
+            return false;
+        }
+        self.requeue_to_tail(pcb)
+    }
+
     pub fn pick_next(&self) -> Option<Arc<ProcessControlBlock>> {
         let prio = self.highest_prio()?;
         self.queues[prio].front().cloned()
@@ -364,6 +392,26 @@ impl Scheduler for RealtimeScheduler {
 
         let curr_prio = Self::rt_prio(&pcb);
         if PrioUtil::rt_prio(curr_prio) && (highest as i32) < curr_prio {
+            rq.resched_current();
+        }
+
+        if pcb.sched_info().policy() != LinuxSchedPolicy::Rr {
+            return;
+        }
+
+        let remaining = pcb.sched_info().rr_time_slice_remaining();
+        debug_assert!(remaining > 0, "RR task has an empty time slice");
+        if remaining > 1 {
+            pcb.sched_info().set_rr_time_slice_remaining(remaining - 1);
+            return;
+        }
+
+        // Linux reloads an exhausted slice even when this is the only task in
+        // its priority bucket, but only rotates and reschedules when a peer can
+        // run next.
+        pcb.sched_info()
+            .set_rr_time_slice_remaining(RR_TIMESLICE_TICKS);
+        if rq.rt.requeue_to_tail_if_peer(&pcb) {
             rq.resched_current();
         }
     }

--- a/kernel/src/sched/syscall/mod.rs
+++ b/kernel/src/sched/syscall/mod.rs
@@ -4,6 +4,7 @@ mod sys_pause;
 mod sys_sched_get_priority;
 mod sys_sched_getparam;
 mod sys_sched_getscheduler;
+mod sys_sched_rr_get_interval;
 mod sys_sched_setscheduler;
 mod sys_sched_yield;
 mod types;

--- a/kernel/src/sched/syscall/sys_sched_getparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_getparam.rs
@@ -39,7 +39,7 @@ impl Syscall for SysSchedGetparam {
 
         let sched_priority = match policy {
             LinuxSchedPolicy::Normal => 0,
-            LinuxSchedPolicy::Fifo => {
+            LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr => {
                 PrioUtil::internal_rt_prio_to_user(normal_prio).ok_or_else(|| {
                     log::error!(
                         "task {} has invalid internal RT priority {}",

--- a/kernel/src/sched/syscall/sys_sched_rr_get_interval.rs
+++ b/kernel/src/sched/syscall/sys_sched_rr_get_interval.rs
@@ -1,0 +1,65 @@
+use alloc::{string::ToString, vec::Vec};
+
+use system_error::SystemError;
+
+use crate::{
+    arch::{interrupt::TrapFrame, syscall::nr::SYS_SCHED_RR_GET_INTERVAL},
+    sched::{realtime::RR_TIMESLICE_TICKS, LinuxSchedPolicy},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::UserBufferWriter,
+    },
+    time::{jiffies::TICK_NESC, PosixTimeSpec},
+};
+
+use super::util::find_sched_target;
+
+struct SysSchedRrGetInterval;
+
+impl Syscall for SysSchedRrGetInterval {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pid = args[0] as i32;
+        let interval = args[1] as *mut PosixTimeSpec;
+
+        // Linux resolves the target before touching the output buffer, so an
+        // absent task takes precedence over a bad userspace pointer.
+        let target = find_sched_target(pid)?;
+        let policy = {
+            let _pi_guard = target.sched_info().pi_lock_irqsave();
+            target.sched_info().policy()
+        };
+
+        // FIFO has no quantum. DragonOS Fair entities currently use a slice
+        // shorter than one scheduler tick, which Linux's jiffy ABI quantizes
+        // to zero as well. RR is the only supported policy with a nonzero
+        // interval in this ABI.
+        let interval_ticks = match policy {
+            LinuxSchedPolicy::Rr => RR_TIMESLICE_TICKS,
+            LinuxSchedPolicy::Normal | LinuxSchedPolicy::Fifo => 0,
+        };
+        let value =
+            PosixTimeSpec::from_ns(u64::from(interval_ticks).saturating_mul(u64::from(TICK_NESC)));
+
+        let mut writer = UserBufferWriter::new(
+            interval,
+            core::mem::size_of::<PosixTimeSpec>(),
+            frame.is_from_user(),
+        )?;
+        writer.buffer_protected(0)?.write_one(0, &value)?;
+
+        Ok(0)
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pid", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("interval", format!("{:#x}", args[1])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_RR_GET_INTERVAL, SysSchedRrGetInterval);

--- a/kernel/src/sched/syscall/sys_sched_setscheduler.rs
+++ b/kernel/src/sched/syscall/sys_sched_setscheduler.rs
@@ -46,8 +46,12 @@ impl SysSchedSetscheduler {
                 })
             }
             SCHED_RR => {
-                PrioUtil::user_rt_prio_to_internal(priority).ok_or(SystemError::EINVAL)?;
-                Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+                let priority =
+                    PrioUtil::user_rt_prio_to_internal(priority).ok_or(SystemError::EINVAL)?;
+                Ok(SchedChangeRequest::Rr {
+                    priority,
+                    reset_on_fork,
+                })
             }
             SCHED_BATCH | SCHED_IDLE => {
                 if priority != 0 {
@@ -74,34 +78,39 @@ impl SysSchedSetscheduler {
         }
 
         let rtprio_limit = match request {
-            SchedChangeRequest::Fifo { .. } => Some(target.get_rlimit(RLimitID::Rtprio).rlim_cur),
+            SchedChangeRequest::Fifo { .. } | SchedChangeRequest::Rr { .. } => {
+                Some(target.get_rlimit(RLimitID::Rtprio).rlim_cur)
+            }
             SchedChangeRequest::Normal { .. } => None,
         };
         let pi_guard = target.sched_info().pi_lock_irqsave();
         let reset_on_fork = match request {
             SchedChangeRequest::Normal { reset_on_fork }
-            | SchedChangeRequest::Fifo { reset_on_fork, .. } => reset_on_fork,
+            | SchedChangeRequest::Fifo { reset_on_fork, .. }
+            | SchedChangeRequest::Rr { reset_on_fork, .. } => reset_on_fork,
         };
         if pi_guard.sched_reset_on_fork() && !reset_on_fork {
             return Ok(false);
         }
 
-        let SchedChangeRequest::Fifo { priority, .. } = request else {
-            return Ok(true);
+        let (new_policy, priority) = match request {
+            SchedChangeRequest::Normal { .. } => return Ok(true),
+            SchedChangeRequest::Fifo { priority, .. } => (LinuxSchedPolicy::Fifo, priority),
+            SchedChangeRequest::Rr { priority, .. } => (LinuxSchedPolicy::Rr, priority),
         };
         let new_user_priority =
             PrioUtil::internal_rt_prio_to_user(priority).ok_or(SystemError::EINVAL)?;
         let old_policy = target.sched_info().policy();
         let old_user_priority = match old_policy {
             LinuxSchedPolicy::Normal => 0,
-            LinuxSchedPolicy::Fifo => {
+            LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr => {
                 PrioUtil::internal_rt_prio_to_user(target.sched_info().normal_prio())
                     .ok_or(SystemError::EIO)?
             }
         };
-        let rtprio_limit = rtprio_limit.expect("FIFO authorization must read RLIMIT_RTPRIO");
+        let rtprio_limit = rtprio_limit.expect("RT authorization must read RLIMIT_RTPRIO");
 
-        if old_policy != LinuxSchedPolicy::Fifo && rtprio_limit == 0 {
+        if old_policy != new_policy && rtprio_limit == 0 {
             return Ok(false);
         }
         if new_user_priority > old_user_priority && new_user_priority as u64 > rtprio_limit {

--- a/kernel/src/sched/syscall/types.rs
+++ b/kernel/src/sched/syscall/types.rs
@@ -39,5 +39,6 @@ pub(super) fn policy_to_linux(policy: LinuxSchedPolicy) -> i32 {
     match policy {
         LinuxSchedPolicy::Normal => SCHED_OTHER,
         LinuxSchedPolicy::Fifo => SCHED_FIFO,
+        LinuxSchedPolicy::Rr => SCHED_RR,
     }
 }

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -16,6 +16,7 @@
 #include <sys/syscall.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
+#include <time.h>
 #include <unistd.h>
 
 #ifndef SCHED_RESET_ON_FORK
@@ -235,6 +236,41 @@ bool ReadByteWithTimeout(int fd, int timeout_ms) {
     return result == 1 && (poll_fd.revents & POLLIN) != 0 && ReadByte(fd);
 }
 
+bool WaitForBlockedTask(pid_t pid, int timeout_ms = 2000) {
+    char path[64] = {};
+    snprintf(path, sizeof(path), "/proc/%d/stat", pid);
+    const int attempts = timeout_ms;
+    for (int attempt = 0; attempt < attempts; ++attempt) {
+        FILE* stat = fopen(path, "r");
+        if (stat != nullptr) {
+            char line[512] = {};
+            const bool read_ok = fgets(line, sizeof(line), stat) != nullptr;
+            fclose(stat);
+            if (read_ok) {
+                const char* comm_end = strrchr(line, ')');
+                if (comm_end != nullptr && comm_end[1] == ' ' &&
+                    (comm_end[2] == 'S' || comm_end[2] == 'D')) {
+                    return true;
+                }
+            }
+        }
+        usleep(1000);
+    }
+    return false;
+}
+
+uint64_t ThreadCpuTimeNs() {
+    struct timespec now {};
+    if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &now) != 0) return UINT64_MAX;
+    return static_cast<uint64_t>(now.tv_sec) * 1000 * 1000 * 1000 +
+           static_cast<uint64_t>(now.tv_nsec);
+}
+
+int CurrentCpu() {
+    unsigned int cpu = 0;
+    return syscall(SYS_getcpu, &cpu, nullptr, nullptr) == 0 ? static_cast<int>(cpu) : -1;
+}
+
 TEST(SchedParamAbi, GetParamWritesExactlyFourBytes) {
     RawSchedParamWithCanary value {};
     value.param.sched_priority = -1;
@@ -411,10 +447,16 @@ TEST(SchedSetScheduler, ErrorOrderingAndPolicyMatrix) {
     errno = 0;
     EXPECT_EQ(-1, RawSetScheduler(0, SCHED_FIFO, &zero));
     EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetScheduler(0, SCHED_RR, &zero));
+    EXPECT_EQ(EINVAL, errno);
 
     errno = 0;
     RawSchedParam hundred {100};
     EXPECT_EQ(-1, RawSetScheduler(0, SCHED_FIFO, &hundred));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetScheduler(0, SCHED_RR, &hundred));
     EXPECT_EQ(EINVAL, errno);
 }
 
@@ -430,6 +472,26 @@ int FifoRoundTripScenario() {
 TEST(SchedFifoPolicy, FairFifoPriorityRoundTrip) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
     EXPECT_EQ(0, RunIsolatedScenario(FifoRoundTripScenario));
+}
+
+int RrRoundTripScenario() {
+    if (!SetPolicy(0, SCHED_RR, 1)) return 30;
+    if (!ReadPolicyAndPriority(0, SCHED_RR, 1)) return 31;
+    char label[16] = {};
+    if (!ReadSelfSchedulerLabel(label, sizeof(label)) || strcmp(label, "RR") != 0) return 32;
+    if (!SetPolicy(0, SCHED_RR, 99)) return 33;
+    if (!ReadPolicyAndPriority(0, SCHED_RR, 99)) return 34;
+    if (!SetPolicy(0, SCHED_FIFO, 99)) return 35;
+    if (!ReadPolicyAndPriority(0, SCHED_FIFO, 99)) return 36;
+    if (!SetPolicy(0, SCHED_RR, 99)) return 37;
+    if (!ReadPolicyAndPriority(0, SCHED_RR, 99)) return 38;
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 39;
+    return ReadPolicyAndPriority(0, SCHED_OTHER, 0) ? 0 : 40;
+}
+
+TEST(SchedRrPolicy, FairFifoRrRoundTrip) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrRoundTripScenario));
 }
 
 int FifoForkScenario() {
@@ -455,6 +517,31 @@ int FifoForkScenario() {
 TEST(SchedFifoReset, ForkInheritanceAndResetOnFork) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
     EXPECT_EQ(0, RunIsolatedScenario(FifoForkScenario));
+}
+
+int RrForkScenario() {
+    if (!SetPolicy(0, SCHED_RR, 20)) return 40;
+    pid_t inherited = fork();
+    if (inherited < 0) return 41;
+    if (inherited == 0) {
+        _exit(ReadPolicyAndPriority(0, SCHED_RR, 20) ? 0 : 42);
+    }
+    if (WaitForChild(inherited) != 0) return 43;
+
+    if (!SetPolicy(0, SCHED_RR | SCHED_RESET_ON_FORK, 20)) return 44;
+    pid_t reset = fork();
+    if (reset < 0) return 45;
+    if (reset == 0) {
+        _exit(ReadPolicyAndPriority(0, SCHED_OTHER, 0) ? 0 : 46);
+    }
+    if (WaitForChild(reset) != 0) return 47;
+    if (!ReadPolicyAndPriority(0, SCHED_RR | SCHED_RESET_ON_FORK, 20)) return 48;
+    return SetPolicy(0, SCHED_OTHER, 0) ? 0 : 49;
+}
+
+TEST(SchedRrReset, ForkInheritanceAndResetOnFork) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrForkScenario));
 }
 
 TEST(SchedSetScheduler, SelfResetFlagRoundTripAndFork) {
@@ -836,6 +923,37 @@ TEST(SchedFifoRlimit, NestedUserNamespaceCannotRaiseHardLimit) {
     EXPECT_EQ(0, RunIsolatedScenario(NestedUserNamespaceRlimitScenario));
 }
 
+int RrRlimitScenario() {
+    struct rlimit high {10, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &high) != 0) return 10 + errno;
+    if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) return 20 + errno;
+
+    if (!SetPolicy(0, SCHED_RR, 10)) return 30 + errno;
+    errno = 0;
+    if (SetPolicy(0, SCHED_RR, 11) || errno != EPERM) return 40 + errno;
+
+    struct rlimit low {0, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &low) != 0) return 50 + errno;
+    if (!SetPolicy(0, SCHED_RR, 1)) return 60 + errno;
+
+    errno = 0;
+    if (SetPolicy(0, SCHED_FIFO, 1) || errno != EPERM) return 70 + errno;
+    if (!ReadPolicyAndPriority(0, SCHED_RR, 1)) return 80;
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 81 + errno;
+
+    errno = 0;
+    if (SetPolicy(0, SCHED_RR, 1) || errno != EPERM) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 90 + errno;
+    }
+    return 0;
+}
+
+TEST(SchedRrRlimit, PriorityAndExactPolicyRules) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrRlimitScenario));
+}
+
 struct SharedFifoState {
     int sequence_index;
     char sequence[4];
@@ -860,6 +978,332 @@ void RecordEvent(SharedFifoState* state, char event) {
     if (position >= 0 && position < static_cast<int>(sizeof(state->sequence))) {
         state->sequence[position] = event;
     }
+}
+
+struct SharedRtState {
+    int sequence_index;
+    char sequence[4];
+    int first_done;
+    int peer_ran_early;
+    int started_on_cpu1;
+    int seen_cpu0;
+};
+
+SharedRtState* NewSharedRtState() {
+    void* mapping = mmap(nullptr, sizeof(SharedRtState), PROT_READ | PROT_WRITE,
+                         MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+    if (mapping == MAP_FAILED) return nullptr;
+    memset(mapping, 0, sizeof(SharedRtState));
+    return static_cast<SharedRtState*>(mapping);
+}
+
+void RecordEvent(SharedRtState* state, char event) {
+    int position = __atomic_fetch_add(&state->sequence_index, 1, __ATOMIC_SEQ_CST);
+    if (position >= 0 && position < static_cast<int>(sizeof(state->sequence))) {
+        state->sequence[position] = event;
+    }
+}
+
+bool SequenceIs(const SharedRtState* state, const char* expected, int count) {
+    if (__atomic_load_n(&state->sequence_index, __ATOMIC_SEQ_CST) != count) return false;
+    return memcmp(state->sequence, expected, static_cast<size_t>(count)) == 0;
+}
+
+int OrderedRotationScenario(bool remote, bool mixed_fifo_peer) {
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, remote ? &worker_cpu : nullptr)) return 10;
+    if (remote && worker_cpu < 0) return 11;
+    if (!PinTask(0, controller_cpu)) return 12;
+    if (!remote) worker_cpu = controller_cpu;
+
+    SharedRtState* state = NewSharedRtState();
+    if (state == nullptr) return 13;
+
+    pid_t first = fork();
+    if (first < 0) return 14;
+    if (first == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'A');
+        while (__atomic_load_n(&state->sequence_index, __ATOMIC_ACQUIRE) < 2) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        RecordEvent(state, 'A');
+        _exit(0);
+    }
+    ChildGuard first_guard(first);
+    if (!WaitStopped(first) || !PinTask(first, worker_cpu) ||
+        !SetPolicy(first, SCHED_RR, 20)) {
+        return 15;
+    }
+
+    pid_t second = fork();
+    if (second < 0) return 16;
+    if (second == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'B');
+        if (mixed_fifo_peer && sched_yield() != 0) _exit(20);
+        while (__atomic_load_n(&state->sequence_index, __ATOMIC_ACQUIRE) < 3) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        _exit(0);
+    }
+    ChildGuard second_guard(second);
+    const int second_policy = mixed_fifo_peer ? SCHED_FIFO : SCHED_RR;
+    if (!WaitStopped(second) || !PinTask(second, worker_cpu) ||
+        !SetPolicy(second, second_policy, 20)) {
+        return 17;
+    }
+
+    if (!remote && !SetPolicy(0, SCHED_FIFO, 50)) return 18;
+    if (kill(first, SIGCONT) != 0 || kill(second, SIGCONT) != 0) {
+        if (!remote) (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 19;
+    }
+    if (!remote && !SetPolicy(0, SCHED_OTHER, 0)) return 21;
+
+    const int first_result = WaitForChild(first);
+    first_guard.Release();
+    const int second_result = WaitForChild(second);
+    second_guard.Release();
+    const bool ordered = SequenceIs(state, "ABA", 3);
+    munmap(state, sizeof(*state));
+    return first_result == 0 && second_result == 0 && ordered ? 0 : 22;
+}
+
+int RrRotationScenario() {
+    return OrderedRotationScenario(false, false);
+}
+
+int MixedRotationScenario() {
+    return OrderedRotationScenario(false, true);
+}
+
+int RemoteRrRotationScenario() {
+    return OrderedRotationScenario(true, false);
+}
+
+int NoPrematurePeerScenario(int first_policy, int first_priority, int second_policy,
+                            int second_priority) {
+    int cpu = -1;
+    if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 30;
+    SharedRtState* state = NewSharedRtState();
+    if (state == nullptr) return 31;
+
+    pid_t first = fork();
+    if (first < 0) return 32;
+    if (first == 0) {
+        raise(SIGSTOP);
+        const uint64_t start = ThreadCpuTimeNs();
+        if (start == UINT64_MAX) _exit(20);
+        for (;;) {
+            const uint64_t now = ThreadCpuTimeNs();
+            if (now == UINT64_MAX) _exit(21);
+            if (__atomic_load_n(&state->peer_ran_early, __ATOMIC_ACQUIRE) != 0) _exit(22);
+            if (now - start >= 300 * 1000 * 1000ULL) break;
+        }
+        __atomic_store_n(&state->first_done, 1, __ATOMIC_RELEASE);
+        _exit(0);
+    }
+    ChildGuard first_guard(first);
+    if (!WaitStopped(first) || !PinTask(first, cpu) ||
+        !SetPolicy(first, first_policy, first_priority)) {
+        return 33;
+    }
+
+    pid_t second = fork();
+    if (second < 0) return 34;
+    if (second == 0) {
+        raise(SIGSTOP);
+        if (__atomic_load_n(&state->first_done, __ATOMIC_ACQUIRE) == 0) {
+            __atomic_store_n(&state->peer_ran_early, 1, __ATOMIC_RELEASE);
+        }
+        _exit(0);
+    }
+    ChildGuard second_guard(second);
+    if (!WaitStopped(second) || !PinTask(second, cpu) ||
+        !SetPolicy(second, second_policy, second_priority)) {
+        return 35;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 50)) return 36;
+    if (kill(first, SIGCONT) != 0 || kill(second, SIGCONT) != 0) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 37;
+    }
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 38;
+
+    const int first_result = WaitForChild(first);
+    first_guard.Release();
+    const int second_result = WaitForChild(second);
+    second_guard.Release();
+    const bool correct = __atomic_load_n(&state->first_done, __ATOMIC_ACQUIRE) == 1 &&
+                         __atomic_load_n(&state->peer_ran_early, __ATOMIC_ACQUIRE) == 0;
+    munmap(state, sizeof(*state));
+    return first_result == 0 && second_result == 0 && correct ? 0 : 39;
+}
+
+int RrPriorityIsolationScenario() {
+    return NoPrematurePeerScenario(SCHED_RR, 20, SCHED_RR, 10);
+}
+
+int FifoNoTimesliceScenario() {
+    return NoPrematurePeerScenario(SCHED_FIFO, 20, SCHED_FIFO, 20);
+}
+
+int RrBlockedWakeTailScenario() {
+    int cpu = -1;
+    if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 40;
+    SharedRtState* state = NewSharedRtState();
+    if (state == nullptr) return 41;
+    int ready[2];
+    int wake[2];
+    if (pipe(ready) != 0 || pipe(wake) != 0) return 42;
+
+    pid_t blocked = fork();
+    if (blocked < 0) return 43;
+    if (blocked == 0) {
+        close(ready[0]);
+        close(wake[1]);
+        WriteByteOrExit(ready[1], 'r');
+        close(ready[1]);
+        if (!ReadByte(wake[0])) _exit(20);
+        RecordEvent(state, 'B');
+        _exit(0);
+    }
+    ChildGuard blocked_guard(blocked);
+    close(ready[1]);
+    close(wake[0]);
+    if (!ReadByteWithTimeout(ready[0], 2000) || !WaitForBlockedTask(blocked) ||
+        !PinTask(blocked, cpu) || !SetPolicy(blocked, SCHED_RR, 20)) {
+        return 44;
+    }
+    close(ready[0]);
+
+    pid_t first = fork();
+    if (first < 0) return 45;
+    if (first == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'A');
+        if (sched_yield() != 0) _exit(21);
+        _exit(0);
+    }
+    ChildGuard first_guard(first);
+    if (!WaitStopped(first) || !PinTask(first, cpu) || !SetPolicy(first, SCHED_FIFO, 20)) {
+        return 46;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 50)) return 47;
+    if (kill(first, SIGCONT) != 0 || write(wake[1], "x", 1) != 1) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 48;
+    }
+    close(wake[1]);
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 49;
+
+    const int first_result = WaitForChild(first);
+    first_guard.Release();
+    const int blocked_result = WaitForChild(blocked);
+    blocked_guard.Release();
+    const bool ordered = SequenceIs(state, "AB", 2);
+    munmap(state, sizeof(*state));
+    return first_result == 0 && blocked_result == 0 && ordered ? 0 : 50;
+}
+
+int ResetOnlyKeepsQueueOrderScenario() {
+    int cpu = -1;
+    if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 51;
+    SharedRtState* state = NewSharedRtState();
+    if (state == nullptr) return 52;
+
+    pid_t first = fork();
+    if (first < 0) return 53;
+    if (first == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'A');
+        if (sched_yield() != 0) _exit(20);
+        _exit(0);
+    }
+    ChildGuard first_guard(first);
+    if (!WaitStopped(first) || !PinTask(first, cpu) || !SetPolicy(first, SCHED_FIFO, 20)) {
+        return 54;
+    }
+
+    pid_t second = fork();
+    if (second < 0) return 55;
+    if (second == 0) {
+        raise(SIGSTOP);
+        RecordEvent(state, 'B');
+        _exit(0);
+    }
+    ChildGuard second_guard(second);
+    if (!WaitStopped(second) || !PinTask(second, cpu) || !SetPolicy(second, SCHED_FIFO, 20)) {
+        return 56;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 50)) return 57;
+    if (kill(first, SIGCONT) != 0 || kill(second, SIGCONT) != 0 ||
+        !SetPolicy(first, SCHED_FIFO | SCHED_RESET_ON_FORK, 20)) {
+        (void)SetPolicy(0, SCHED_OTHER, 0);
+        return 58;
+    }
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 59;
+
+    const int first_result = WaitForChild(first);
+    first_guard.Release();
+    const int second_result = WaitForChild(second);
+    second_guard.Release();
+    const bool ordered = SequenceIs(state, "AB", 2);
+    munmap(state, sizeof(*state));
+    return first_result == 0 && second_result == 0 && ordered ? 0 : 60;
+}
+
+int RrAffinityMigrationScenario() {
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, &worker_cpu) || worker_cpu < 0 ||
+        !PinTask(0, controller_cpu)) {
+        return 61;
+    }
+    SharedRtState* state = NewSharedRtState();
+    if (state == nullptr) return 62;
+
+    pid_t worker = fork();
+    if (worker < 0) return 63;
+    if (worker == 0) {
+        raise(SIGSTOP);
+        if (CurrentCpu() != worker_cpu) _exit(20);
+        __atomic_store_n(&state->started_on_cpu1, 1, __ATOMIC_RELEASE);
+        for (;;) {
+            const int cpu = CurrentCpu();
+            if (cpu < 0) _exit(21);
+            if (cpu == controller_cpu) {
+                __atomic_store_n(&state->seen_cpu0, 1, __ATOMIC_RELEASE);
+                _exit(0);
+            }
+        }
+    }
+    ChildGuard worker_guard(worker);
+    if (!WaitStopped(worker) || !PinTask(worker, worker_cpu) ||
+        !SetPolicy(worker, SCHED_RR, 20) || kill(worker, SIGCONT) != 0) {
+        return 64;
+    }
+
+    bool started = false;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (__atomic_load_n(&state->started_on_cpu1, __ATOMIC_ACQUIRE) != 0) {
+            started = true;
+            break;
+        }
+        usleep(10 * 1000);
+    }
+    if (!started || !PinTask(worker, controller_cpu)) return 65;
+
+    const int worker_result = WaitForChild(worker);
+    worker_guard.Release();
+    const bool migrated = __atomic_load_n(&state->seen_cpu0, __ATOMIC_ACQUIRE) == 1;
+    munmap(state, sizeof(*state));
+    return worker_result == 0 && migrated ? 0 : 66;
 }
 
 int FifoYieldScenario() {
@@ -914,7 +1358,7 @@ int FifoYieldScenario() {
     return first_result == 0 && second_result == 0 && ordered ? 0 : 19;
 }
 
-int FifoThrottlingScenario() {
+int RealtimeThrottlingScenario(int policy) {
     int cpu = -1;
     if (!PickAllowedCpus(&cpu) || !PinTask(0, cpu)) return 30;
     SharedFifoState* state = NewSharedFifoState();
@@ -932,7 +1376,7 @@ int FifoThrottlingScenario() {
         __atomic_store_n(&state->throttle_stage, 3, __ATOMIC_RELEASE);
         _exit(0);
     }
-    if (!WaitStopped(runner) || !PinTask(runner, cpu) || !SetPolicy(runner, SCHED_FIFO, 20)) {
+    if (!WaitStopped(runner) || !PinTask(runner, cpu) || !SetPolicy(runner, policy, 20)) {
         kill(runner, SIGKILL);
         return 33;
     }
@@ -976,6 +1420,14 @@ int FifoThrottlingScenario() {
     bool completed = __atomic_load_n(&state->throttle_stage, __ATOMIC_ACQUIRE) == 3;
     munmap(state, sizeof(*state));
     return runner_result == 0 && observer_result == 0 && completed ? 0 : 39;
+}
+
+int FifoThrottlingScenario() {
+    return RealtimeThrottlingScenario(SCHED_FIFO);
+}
+
+int RrThrottlingScenario() {
+    return RealtimeThrottlingScenario(SCHED_RR);
 }
 
 int FifoRemoteScenario() {
@@ -1093,6 +1545,41 @@ TEST(SchedFifoBehavior, RuntimeThrottlingLetsFairRunAndRecovers) {
     EXPECT_EQ(0, RunIsolatedScenario(FifoThrottlingScenario));
 }
 
+TEST(SchedRrBehavior, SamePriorityQuantumRotates) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrRotationScenario));
+}
+
+TEST(SchedRrBehavior, DifferentPriorityDoesNotRotate) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrPriorityIsolationScenario));
+}
+
+TEST(SchedRrBehavior, FifoDoesNotAcquireTimeslicing) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(FifoNoTimesliceScenario));
+}
+
+TEST(SchedRrBehavior, FifoAndRrSharePriorityQueue) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(MixedRotationScenario));
+}
+
+TEST(SchedRrBehavior, BlockedWakeupJoinsPriorityTail) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrBlockedWakeTailScenario));
+}
+
+TEST(SchedPolicyChange, ResetOnlyDoesNotMoveQueuedTask) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    EXPECT_EQ(0, RunIsolatedScenario(ResetOnlyKeepsQueueOrderScenario));
+}
+
+TEST(SchedRrBehavior, RuntimeThrottlingLetsFairRunAndRecovers) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrThrottlingScenario));
+}
+
 TEST(SchedFifoSmp, RemotePreemptionAndRunningTargetStress) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
     int first = -1;
@@ -1100,6 +1587,24 @@ TEST(SchedFifoSmp, RemotePreemptionAndRunningTargetStress) {
     ASSERT_TRUE(PickAllowedCpus(&first, &second));
     if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
     EXPECT_EQ(0, RunIsolatedScenario(FifoRemoteScenario));
+}
+
+TEST(SchedRrSmp, RemoteRunqueueRotatesSamePriorityTasks) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    int first = -1;
+    int second = -1;
+    ASSERT_TRUE(PickAllowedCpus(&first, &second));
+    if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
+    EXPECT_EQ(0, RunIsolatedScenario(RemoteRrRotationScenario));
+}
+
+TEST(SchedRrSmp, RunningTaskMigratesToAllowedCpu) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    int first = -1;
+    int second = -1;
+    ASSERT_TRUE(PickAllowedCpus(&first, &second));
+    if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
+    EXPECT_EQ(0, RunIsolatedScenario(RrAffinityMigrationScenario));
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -57,6 +57,10 @@ long RawGetPriorityMin(uint64_t policy) {
     return syscall(SYS_sched_get_priority_min, policy);
 }
 
+long RawRrGetInterval(pid_t tid, struct timespec* interval) {
+    return syscall(SYS_sched_rr_get_interval, tid, interval);
+}
+
 bool IsDragonOS() {
     struct utsname info {};
     return uname(&info) == 0 && strstr(info.release, "dragonos") != nullptr;
@@ -355,6 +359,27 @@ TEST(SchedGetScheduler, ProcStatusKeepsLegacyClassLabel) {
     EXPECT_STREQ("CFS", label);
 }
 
+TEST(SchedRrInterval, CurrentAndErrorsMatchLinux) {
+    struct timespec interval {-1, -1};
+    EXPECT_EQ(0, RawRrGetInterval(0, &interval)) << strerror(errno);
+    EXPECT_GE(interval.tv_sec, 0);
+    EXPECT_GE(interval.tv_nsec, 0);
+    EXPECT_LT(interval.tv_nsec, 1000 * 1000 * 1000);
+
+    errno = 0;
+    EXPECT_EQ(-1, RawRrGetInterval(-1, &interval));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawRrGetInterval(INT_MAX, nullptr));
+    EXPECT_EQ(ESRCH, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawRrGetInterval(0, nullptr));
+    EXPECT_EQ(EFAULT, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawRrGetInterval(0, reinterpret_cast<struct timespec*>(1)));
+    EXPECT_EQ(EFAULT, errno);
+}
+
 TEST(SchedClassAccounting, IdleClassTicksAdvanceWhileCallerSleeps) {
     if (!IsDragonOS()) GTEST_SKIP() << "DragonOS idle-class accounting regression";
 
@@ -494,6 +519,35 @@ TEST(SchedRrPolicy, FairFifoRrRoundTrip) {
     EXPECT_EQ(0, RunIsolatedScenario(RrRoundTripScenario));
 }
 
+int RrIntervalPolicyScenario() {
+    struct timespec interval {-1, -1};
+    if (!SetPolicy(0, SCHED_RR, 20)) return 50;
+    if (RawRrGetInterval(0, &interval) != 0 || interval.tv_sec != 0 ||
+        interval.tv_nsec != 100 * 1000 * 1000) {
+        return 51;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO, 20)) return 52;
+    interval = {-1, -1};
+    if (sched_rr_get_interval(0, &interval) != 0 || interval.tv_sec != 0 ||
+        interval.tv_nsec != 0) {
+        return 53;
+    }
+
+    if (!SetPolicy(0, SCHED_OTHER, 0)) return 54;
+    interval = {-1, -1};
+    if (RawRrGetInterval(0, &interval) != 0 || interval.tv_sec != 0 ||
+        interval.tv_nsec != 0) {
+        return 55;
+    }
+    return 0;
+}
+
+TEST(SchedRrInterval, PolicyIntervalsMatchLinux) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(RrIntervalPolicyScenario));
+}
+
 int FifoForkScenario() {
     if (!SetPolicy(0, SCHED_FIFO, 20)) return 20;
     pid_t inherited = fork();
@@ -609,6 +663,11 @@ TEST(SchedSetScheduler, OtherTidAndNestedCloneReset) {
         FAIL() << "worker did not publish its TID within 5 seconds";
     }
     const pid_t tid = state.tid.load(std::memory_order_acquire);
+    struct timespec interval {-1, -1};
+    EXPECT_EQ(0, RawRrGetInterval(tid, &interval)) << strerror(errno);
+    EXPECT_GE(interval.tv_sec, 0);
+    EXPECT_GE(interval.tv_nsec, 0);
+    EXPECT_LT(interval.tv_nsec, 1000 * 1000 * 1000);
     RawSchedParam zero {0};
     EXPECT_EQ(0, RawSetScheduler(tid, SCHED_OTHER | SCHED_RESET_ON_FORK, &zero)) << strerror(errno);
     EXPECT_EQ(SCHED_OTHER | SCHED_RESET_ON_FORK, sched_getscheduler(tid));


### PR DESCRIPTION
## Summary

- expose `SCHED_RR` through `sched_setscheduler(2)` with Linux-compatible realtime priority validation, authorization, policy queries, procfs reporting, and reset-on-fork behavior
- implement `sched_rr_get_interval(2)` with Linux-compatible TID lookup, error ordering, and the configured 100 ms RR quantum
- track a task-local 100 ms round-robin quantum and rotate only when an equal-priority realtime peer is runnable
- preserve the shared realtime runqueue, FIFO behavior, runtime bandwidth enforcement, and existing migration transaction
- keep reset-only updates in place while retaining full queue transitions for exact FIFO/RR policy changes
- extend scheduler semantics coverage for RR ordering, blocking and wakeup, throttling, remote runqueues, and affinity migration

## Design

`SCHED_FIFO` and `SCHED_RR` continue to share the existing realtime scheduling class and priority queues. Each task owns only its remaining RR quantum; the realtime tick decrements it for exact `SCHED_RR` tasks and moves an expired task to the tail only when its priority bucket contains another runnable task. This keeps the common hot path bounded and leaves FIFO tasks untouched.

Scheduler changes remain committed through `ProcessManager::set_scheduler` under the existing task and runqueue locking transaction. Exact FIFO/RR transitions use the established dequeue/update/enqueue path, while a request that changes only `SCHED_RESET_ON_FORK` updates the flag without perturbing queue order.

`sched_rr_get_interval(2)` remains a read-only ABI adapter: it resolves the target TID, snapshots the exact policy under the existing task lock, converts the scheduler-owned RR tick constant to a native 64-bit `timespec`, and performs the userspace copy afterward. It does not read the mutable remaining quantum or take a runqueue lock. No parallel runqueue, scheduler plugin layer, test-only kernel ABI, or timer workaround is introduced.

## Linux compatibility

- accept `SCHED_RR` priorities 1 through 99 and reject invalid parameters
- apply owner, `CAP_SYS_NICE`, and target `RLIMIT_RTPRIO` rules using the exact old and requested policies
- report `SCHED_RR` through scheduler query syscalls and `/proc/<pid>/status`
- return the fixed RR quantum through `sched_rr_get_interval(2)`, with Linux-compatible `EINVAL`, `ESRCH`, and `EFAULT` ordering
- reset realtime children to normal scheduling when reset-on-fork is active
- reload an expired RR quantum even without a peer, and requeue only when an equal-priority peer exists
- preserve the RR quantum across wakeup, migration, and policy/priority transactions according to Linux 6.6 behavior

## Validation

- pre-fix DragonOS reproducer: syscall 148 returned `ENOSYS`
- `make fmt`, including all-feature kernel clippy
- `make kernel` on x86_64
- `make kernel ARCH=loongarch64`
- RISC-V kernel compile and two link passes; final packaging remains blocked by the pre-existing absent DragonStub build target
- complete userspace and dunitest build
- host Linux focused interval test passed
- DragonOS 2-vCPU `sched_policy_semantics_test`: 36/36 passed
- focused interval tests repeated three times: 6/6 passed
- `git diff --check`
- adversarial reviews covering Linux semantics, concurrency, security, performance, architecture, maintainability, workaround risk, and overdesign; no remaining actionable findings

Refs #760