### PR TITLE
feat(sched): implement sched_setparam semantics

### DIFF
--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -36,6 +36,7 @@ enum SchedulerUpdate {
     Replace(SchedChangeRequest),
     Parameters {
         expected_policy: LinuxSchedPolicy,
+        expected_rt_priority: Option<i32>,
         rt_priority: Option<i32>,
     },
 }
@@ -168,18 +169,20 @@ impl ProcessManager {
     /// Atomically update only the scheduler parameters of a task whose base
     /// policy is expected to remain unchanged.
     ///
-    /// A `false` result means the policy changed before the runqueue-locked
-    /// commit point. The syscall layer must revalidate and authorize the new
-    /// policy before retrying.
+    /// A `false` result means policy or an authorization-dependent RT priority
+    /// changed before the runqueue-locked commit point. The syscall layer must
+    /// revalidate and authorize the new state before retrying.
     pub(crate) fn set_scheduler_param(
         pcb: &Arc<ProcessControlBlock>,
         expected_policy: LinuxSchedPolicy,
+        expected_rt_priority: Option<i32>,
         rt_priority: Option<i32>,
     ) -> Result<bool, SystemError> {
         Self::update_scheduler(
             pcb,
             SchedulerUpdate::Parameters {
                 expected_policy,
+                expected_rt_priority,
                 rt_priority,
             },
         )
@@ -194,12 +197,14 @@ impl ProcessManager {
             | SchedulerUpdate::Replace(SchedChangeRequest::Rr { priority, .. }) => Some(priority),
             SchedulerUpdate::Parameters {
                 expected_policy: LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr,
+                expected_rt_priority: Some(_),
                 rt_priority: Some(priority),
                 ..
             } => Some(priority),
             SchedulerUpdate::Replace(SchedChangeRequest::Normal { .. })
             | SchedulerUpdate::Parameters {
                 expected_policy: LinuxSchedPolicy::Normal,
+                expected_rt_priority: None,
                 rt_priority: None,
             } => None,
             SchedulerUpdate::Parameters { .. } => return Err(SystemError::EINVAL),
@@ -269,9 +274,12 @@ impl ProcessManager {
                 }) => (LinuxSchedPolicy::Rr, priority, reset_on_fork),
                 SchedulerUpdate::Parameters {
                     expected_policy,
+                    expected_rt_priority,
                     rt_priority,
                 } => {
-                    if old_policy != expected_policy {
+                    if old_policy != expected_policy
+                        || expected_rt_priority.is_some_and(|priority| old_normal_prio != priority)
+                    {
                         return Ok(false);
                     }
                     let priority = match expected_policy {

--- a/kernel/src/process/manager/sched.rs
+++ b/kernel/src/process/manager/sched.rs
@@ -31,6 +31,15 @@ pub(crate) enum SchedChangeRequest {
     },
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SchedulerUpdate {
+    Replace(SchedChangeRequest),
+    Parameters {
+        expected_policy: LinuxSchedPolicy,
+        rt_priority: Option<i32>,
+    },
+}
+
 impl ProcessManager {
     /// Wake up a process.
     pub fn wakeup(pcb: &Arc<ProcessControlBlock>) -> Result<(), SystemError> {
@@ -153,12 +162,52 @@ impl ProcessManager {
         pcb: &Arc<ProcessControlBlock>,
         request: SchedChangeRequest,
     ) -> Result<(), SystemError> {
-        if let SchedChangeRequest::Fifo { priority, .. } | SchedChangeRequest::Rr { priority, .. } =
-            request
+        Self::update_scheduler(pcb, SchedulerUpdate::Replace(request)).map(|_| ())
+    }
+
+    /// Atomically update only the scheduler parameters of a task whose base
+    /// policy is expected to remain unchanged.
+    ///
+    /// A `false` result means the policy changed before the runqueue-locked
+    /// commit point. The syscall layer must revalidate and authorize the new
+    /// policy before retrying.
+    pub(crate) fn set_scheduler_param(
+        pcb: &Arc<ProcessControlBlock>,
+        expected_policy: LinuxSchedPolicy,
+        rt_priority: Option<i32>,
+    ) -> Result<bool, SystemError> {
+        Self::update_scheduler(
+            pcb,
+            SchedulerUpdate::Parameters {
+                expected_policy,
+                rt_priority,
+            },
+        )
+    }
+
+    fn update_scheduler(
+        pcb: &Arc<ProcessControlBlock>,
+        update: SchedulerUpdate,
+    ) -> Result<bool, SystemError> {
+        let rt_priority = match update {
+            SchedulerUpdate::Replace(SchedChangeRequest::Fifo { priority, .. })
+            | SchedulerUpdate::Replace(SchedChangeRequest::Rr { priority, .. }) => Some(priority),
+            SchedulerUpdate::Parameters {
+                expected_policy: LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr,
+                rt_priority: Some(priority),
+                ..
+            } => Some(priority),
+            SchedulerUpdate::Replace(SchedChangeRequest::Normal { .. })
+            | SchedulerUpdate::Parameters {
+                expected_policy: LinuxSchedPolicy::Normal,
+                rt_priority: None,
+            } => None,
+            SchedulerUpdate::Parameters { .. } => return Err(SystemError::EINVAL),
+        };
+        if rt_priority
+            .is_some_and(|priority| !(0..crate::sched::prio::MAX_RT_PRIO - 1).contains(&priority))
         {
-            if !(0..crate::sched::prio::MAX_RT_PRIO - 1).contains(&priority) {
-                return Err(SystemError::EINVAL);
-            }
+            return Err(SystemError::EINVAL);
         }
 
         let _irq_guard = unsafe { CurrentIrqArch::save_and_disable_irq() };
@@ -204,20 +253,35 @@ impl ProcessManager {
             let old_prio = pcb.sched_info().prio();
             let old_normal_prio = pcb.sched_info().normal_prio();
             let old_reset = pi_guard.sched_reset_on_fork();
-            let (new_policy, new_prio, new_reset) = match request {
-                SchedChangeRequest::Normal { reset_on_fork } => (
+            let (new_policy, new_prio, new_reset) = match update {
+                SchedulerUpdate::Replace(SchedChangeRequest::Normal { reset_on_fork }) => (
                     LinuxSchedPolicy::Normal,
                     pcb.sched_info().static_prio(),
                     reset_on_fork,
                 ),
-                SchedChangeRequest::Fifo {
+                SchedulerUpdate::Replace(SchedChangeRequest::Fifo {
                     priority,
                     reset_on_fork,
-                } => (LinuxSchedPolicy::Fifo, priority, reset_on_fork),
-                SchedChangeRequest::Rr {
+                }) => (LinuxSchedPolicy::Fifo, priority, reset_on_fork),
+                SchedulerUpdate::Replace(SchedChangeRequest::Rr {
                     priority,
                     reset_on_fork,
-                } => (LinuxSchedPolicy::Rr, priority, reset_on_fork),
+                }) => (LinuxSchedPolicy::Rr, priority, reset_on_fork),
+                SchedulerUpdate::Parameters {
+                    expected_policy,
+                    rt_priority,
+                } => {
+                    if old_policy != expected_policy {
+                        return Ok(false);
+                    }
+                    let priority = match expected_policy {
+                        LinuxSchedPolicy::Normal => pcb.sched_info().static_prio(),
+                        LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr => {
+                            rt_priority.expect("RT parameter update validated before locking")
+                        }
+                    };
+                    (old_policy, priority, old_reset)
+                }
             };
             let new_class = new_policy.base_sched_class();
 
@@ -229,7 +293,7 @@ impl ProcessManager {
                 }
                 drop(rq_guard);
                 drop(pi_guard);
-                return Ok(());
+                return Ok(true);
             }
 
             let queued = *pcb.sched_info().on_rq.lock_irqsave() == OnRq::Queued;
@@ -287,7 +351,7 @@ impl ProcessManager {
 
             drop(rq_guard);
             drop(pi_guard);
-            return Ok(());
+            return Ok(true);
         }
     }
 

--- a/kernel/src/sched/syscall/mod.rs
+++ b/kernel/src/sched/syscall/mod.rs
@@ -5,6 +5,7 @@ mod sys_sched_get_priority;
 mod sys_sched_getparam;
 mod sys_sched_getscheduler;
 mod sys_sched_rr_get_interval;
+mod sys_sched_setparam;
 mod sys_sched_setscheduler;
 mod sys_sched_yield;
 mod types;

--- a/kernel/src/sched/syscall/sys_sched_setparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_setparam.rs
@@ -23,6 +23,7 @@ use super::{
 
 struct PreparedUpdate {
     policy: LinuxSchedPolicy,
+    expected_rt_priority: Option<i32>,
     rt_priority: Option<i32>,
     unprivileged_allowed: bool,
 }
@@ -30,8 +31,9 @@ struct PreparedUpdate {
 struct SysSchedSetparam;
 
 impl SysSchedSetparam {
-    /// Validate and authorize a priority update against one policy snapshot.
-    /// The manager checks that the same policy is still current at commit.
+    /// Validate and authorize a priority update against one scheduler snapshot.
+    /// The manager checks that the authorization-dependent state is still
+    /// current at commit.
     fn prepare_update(
         target: &Arc<ProcessControlBlock>,
         user_priority: i32,
@@ -42,28 +44,29 @@ impl SysSchedSetparam {
 
         let pi_guard = target.sched_info().pi_lock_irqsave();
         let policy = target.sched_info().policy();
-        let (rt_priority, within_limit) = match policy {
+        let (expected_rt_priority, rt_priority, within_limit) = match policy {
             LinuxSchedPolicy::Normal => {
                 if user_priority != 0 {
                     return Err(SystemError::EINVAL);
                 }
-                (None, true)
+                (None, None, true)
             }
             LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr => {
                 let priority =
                     PrioUtil::user_rt_prio_to_internal(user_priority).ok_or(SystemError::EINVAL)?;
+                let old_rt_priority = target.sched_info().normal_prio();
                 let old_user_priority =
-                    PrioUtil::internal_rt_prio_to_user(target.sched_info().normal_prio())
-                        .ok_or(SystemError::EIO)?;
+                    PrioUtil::internal_rt_prio_to_user(old_rt_priority).ok_or(SystemError::EIO)?;
                 let within_limit =
                     user_priority <= old_user_priority || user_priority as u64 <= rtprio_limit;
-                (Some(priority), within_limit)
+                (Some(old_rt_priority), Some(priority), within_limit)
             }
         };
         drop(pi_guard);
 
         Ok(PreparedUpdate {
             policy,
+            expected_rt_priority,
             rt_priority,
             unprivileged_allowed: same_owner && within_limit,
         })
@@ -98,8 +101,12 @@ impl Syscall for SysSchedSetparam {
             if !prepared.unprivileged_allowed && !capable(CAPFlags::CAP_SYS_NICE) {
                 return Err(SystemError::EPERM);
             }
-            if ProcessManager::set_scheduler_param(&target, prepared.policy, prepared.rt_priority)?
-            {
+            if ProcessManager::set_scheduler_param(
+                &target,
+                prepared.policy,
+                prepared.expected_rt_priority,
+                prepared.rt_priority,
+            )? {
                 return Ok(0);
             }
         }

--- a/kernel/src/sched/syscall/sys_sched_setparam.rs
+++ b/kernel/src/sched/syscall/sys_sched_setparam.rs
@@ -1,0 +1,116 @@
+use alloc::{string::ToString, sync::Arc, vec::Vec};
+
+use system_error::SystemError;
+
+use crate::{
+    arch::{interrupt::TrapFrame, syscall::nr::SYS_SCHED_SETPARAM},
+    process::{
+        cred::{capable, CAPFlags},
+        resource::RLimitID,
+        ProcessControlBlock, ProcessManager,
+    },
+    sched::{prio::PrioUtil, LinuxSchedPolicy},
+    syscall::{
+        table::{FormattedSyscallParam, Syscall},
+        user_access::UserBufferReader,
+    },
+};
+
+use super::{
+    types::KernelSchedParam,
+    util::{find_sched_target, same_sched_owner},
+};
+
+struct PreparedUpdate {
+    policy: LinuxSchedPolicy,
+    rt_priority: Option<i32>,
+    unprivileged_allowed: bool,
+}
+
+struct SysSchedSetparam;
+
+impl SysSchedSetparam {
+    /// Validate and authorize a priority update against one policy snapshot.
+    /// The manager checks that the same policy is still current at commit.
+    fn prepare_update(
+        target: &Arc<ProcessControlBlock>,
+        user_priority: i32,
+    ) -> Result<PreparedUpdate, SystemError> {
+        let current = ProcessManager::current_pcb();
+        let same_owner = same_sched_owner(&current.cred(), &target.cred());
+        let rtprio_limit = target.get_rlimit(RLimitID::Rtprio).rlim_cur;
+
+        let pi_guard = target.sched_info().pi_lock_irqsave();
+        let policy = target.sched_info().policy();
+        let (rt_priority, within_limit) = match policy {
+            LinuxSchedPolicy::Normal => {
+                if user_priority != 0 {
+                    return Err(SystemError::EINVAL);
+                }
+                (None, true)
+            }
+            LinuxSchedPolicy::Fifo | LinuxSchedPolicy::Rr => {
+                let priority =
+                    PrioUtil::user_rt_prio_to_internal(user_priority).ok_or(SystemError::EINVAL)?;
+                let old_user_priority =
+                    PrioUtil::internal_rt_prio_to_user(target.sched_info().normal_prio())
+                        .ok_or(SystemError::EIO)?;
+                let within_limit =
+                    user_priority <= old_user_priority || user_priority as u64 <= rtprio_limit;
+                (Some(priority), within_limit)
+            }
+        };
+        drop(pi_guard);
+
+        Ok(PreparedUpdate {
+            policy,
+            rt_priority,
+            unprivileged_allowed: same_owner && within_limit,
+        })
+    }
+}
+
+impl Syscall for SysSchedSetparam {
+    fn num_args(&self) -> usize {
+        2
+    }
+
+    fn handle(&self, args: &[usize], frame: &mut TrapFrame) -> Result<usize, SystemError> {
+        let pid = args[0] as i32;
+        let param = args[1] as *const KernelSchedParam;
+
+        if pid < 0 || param.is_null() {
+            return Err(SystemError::EINVAL);
+        }
+
+        // Linux copies exactly one legacy sched_param before target lookup or
+        // priority validation, which determines EFAULT/ESRCH/EINVAL ordering.
+        let reader = UserBufferReader::new(
+            param,
+            core::mem::size_of::<KernelSchedParam>(),
+            frame.is_from_user(),
+        )?;
+        let sched_param: KernelSchedParam = reader.buffer_protected(0)?.read_one(0)?;
+        let target = find_sched_target(pid)?;
+
+        loop {
+            let prepared = Self::prepare_update(&target, sched_param.sched_priority)?;
+            if !prepared.unprivileged_allowed && !capable(CAPFlags::CAP_SYS_NICE) {
+                return Err(SystemError::EPERM);
+            }
+            if ProcessManager::set_scheduler_param(&target, prepared.policy, prepared.rt_priority)?
+            {
+                return Ok(0);
+            }
+        }
+    }
+
+    fn entry_format(&self, args: &[usize]) -> Vec<FormattedSyscallParam> {
+        vec![
+            FormattedSyscallParam::new("pid", (args[0] as i32).to_string()),
+            FormattedSyscallParam::new("param", format!("{:#x}", args[1])),
+        ]
+    }
+}
+
+syscall_table_macros::declare_syscall!(SYS_SCHED_SETPARAM, SysSchedSetparam);

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -1166,6 +1166,73 @@ TEST(SchedSetParam, UnprivilegedRlimitRaiseLowerAndNoop) {
     EXPECT_EQ(0, RunIsolatedScenario(SetParamRlimitScenario));
 }
 
+struct SetParamPriorityRaceState {
+    std::atomic<int> ready {0};
+    std::atomic<int> start {0};
+    pid_t target = -1;
+};
+
+struct SetParamPriorityRaceWriter {
+    SetParamPriorityRaceState* state = nullptr;
+    int priority = 0;
+    int result = -1;
+};
+
+void* SetParamPriorityRaceWorker(void* arg) {
+    auto* writer = static_cast<SetParamPriorityRaceWriter*>(arg);
+    writer->state->ready.fetch_add(1, std::memory_order_release);
+    while (writer->state->start.load(std::memory_order_acquire) == 0) sched_yield();
+
+    RawSchedParam param {writer->priority};
+    errno = 0;
+    writer->result = RawSetParam(writer->state->target, &param) == 0 ? 0 : errno;
+    return nullptr;
+}
+
+int SetParamPriorityAuthorizationRaceScenario() {
+    constexpr int kHighWriters = 16;
+    constexpr int kWriterCount = kHighWriters + 1;
+    struct rlimit high {10, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &high) != 0) return 10 + errno;
+    if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) return 20 + errno;
+    if (!SetPolicy(0, SCHED_RR, 10)) return 30 + errno;
+
+    struct rlimit zero {0, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &zero) != 0) return 40 + errno;
+
+    SetParamPriorityRaceState state;
+    state.target = static_cast<pid_t>(syscall(SYS_gettid));
+    pthread_t threads[kWriterCount] {};
+    SetParamPriorityRaceWriter writers[kWriterCount] {};
+    for (int index = 0; index < kWriterCount; ++index) {
+        writers[index].state = &state;
+        writers[index].priority = index == kHighWriters ? 1 : 10;
+        if (pthread_create(&threads[index], nullptr, SetParamPriorityRaceWorker,
+                           &writers[index]) != 0) {
+            return 50 + index;
+        }
+    }
+
+    while (state.ready.load(std::memory_order_acquire) != kWriterCount) sched_yield();
+    state.start.store(1, std::memory_order_release);
+    for (int index = 0; index < kWriterCount; ++index) {
+        if (pthread_join(threads[index], nullptr) != 0) return 80 + index;
+    }
+
+    if (writers[kHighWriters].result != 0) return 110 + writers[kHighWriters].result;
+    for (int index = 0; index < kHighWriters; ++index) {
+        if (writers[index].result != 0 && writers[index].result != EPERM) return 140 + index;
+    }
+    return ReadPolicyAndPriority(0, SCHED_RR, 1) ? 0 : 170;
+}
+
+TEST(SchedSetParam, ConcurrentPriorityChangeRetriesAuthorization) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    for (int attempt = 0; attempt < 16; ++attempt) {
+        ASSERT_EQ(0, RunIsolatedScenario(SetParamPriorityAuthorizationRaceScenario));
+    }
+}
+
 struct SharedFifoState {
     int sequence_index;
     char sequence[4];

--- a/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/sched_policy_semantics.cc
@@ -49,6 +49,10 @@ long RawSetScheduler(pid_t tid, int policy, const RawSchedParam* param) {
     return syscall(SYS_sched_setscheduler, tid, policy, param);
 }
 
+long RawSetParam(pid_t tid, const RawSchedParam* param) {
+    return syscall(SYS_sched_setparam, tid, param);
+}
+
 long RawGetPriorityMax(uint64_t policy) {
     return syscall(SYS_sched_get_priority_max, policy);
 }
@@ -285,6 +289,34 @@ TEST(SchedParamAbi, GetParamWritesExactlyFourBytes) {
     for (uint8_t byte : value.canary) EXPECT_EQ(0xa5, byte);
 }
 
+TEST(SchedSetParam, CurrentOtherPriorityZero) {
+    RawSchedParam param {0};
+    EXPECT_EQ(0, RawSetParam(0, &param)) << strerror(errno);
+    EXPECT_TRUE(ReadPolicyAndPriority(0, SCHED_OTHER, 0));
+}
+
+TEST(SchedSetParam, ErrorOrderingMatchesLinux) {
+    RawSchedParam zero {0};
+    RawSchedParam invalid {INT_MAX};
+    constexpr pid_t kMissingTid = INT_MAX;
+
+    errno = 0;
+    EXPECT_EQ(-1, RawSetParam(-1, &zero));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetParam(0, nullptr));
+    EXPECT_EQ(EINVAL, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetParam(kMissingTid, reinterpret_cast<RawSchedParam*>(-1)));
+    EXPECT_EQ(EFAULT, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetParam(kMissingTid, &invalid));
+    EXPECT_EQ(ESRCH, errno);
+    errno = 0;
+    EXPECT_EQ(-1, RawSetParam(0, &invalid));
+    EXPECT_EQ(EINVAL, errno);
+}
+
 TEST(SchedParamAbi, SetParamReadsExactlyFourBytes) {
     const long page_size = sysconf(_SC_PAGESIZE);
     ASSERT_GT(page_size, 0);
@@ -299,7 +331,8 @@ TEST(SchedParamAbi, SetParamReadsExactlyFourBytes) {
     pid_t child = fork();
     ASSERT_GE(child, 0) << strerror(errno);
     if (child == 0) {
-        _exit(RawSetScheduler(0, SCHED_OTHER | SCHED_RESET_ON_FORK, param) == 0 ? 0 : errno);
+        if (RawSetScheduler(0, SCHED_OTHER | SCHED_RESET_ON_FORK, param) != 0) _exit(errno);
+        _exit(RawSetParam(0, param) == 0 ? 0 : errno);
     }
     EXPECT_EQ(0, WaitForChild(child));
     EXPECT_EQ(0, munmap(mapping, static_cast<size_t>(page_size) * 2));
@@ -312,10 +345,11 @@ TEST(SchedParamAbi, LibcWrapperInterop) {
         struct sched_param param {};
         param.sched_priority = 0;
         if (sched_setscheduler(0, SCHED_OTHER | SCHED_RESET_ON_FORK, &param) != 0) _exit(10);
+        if (sched_setparam(0, &param) != 0) _exit(11);
         struct sched_param out {};
         memset(&out, 0xa5, sizeof(out));
-        if (sched_getparam(0, &out) != 0 || out.sched_priority != 0) _exit(11);
-        if (sched_getscheduler(0) != (SCHED_OTHER | SCHED_RESET_ON_FORK)) _exit(12);
+        if (sched_getparam(0, &out) != 0 || out.sched_priority != 0) _exit(12);
+        if (sched_getscheduler(0) != (SCHED_OTHER | SCHED_RESET_ON_FORK)) _exit(13);
         _exit(0);
     }
     EXPECT_EQ(0, WaitForChild(child));
@@ -548,6 +582,49 @@ TEST(SchedRrInterval, PolicyIntervalsMatchLinux) {
     EXPECT_EQ(0, RunIsolatedScenario(RrIntervalPolicyScenario));
 }
 
+int SetParamStateScenario() {
+    RawSchedParam zero {0};
+    if (!SetPolicy(0, SCHED_OTHER | SCHED_RESET_ON_FORK, 0)) return 10 + errno;
+    if (RawSetParam(0, &zero) != 0 ||
+        !ReadPolicyAndPriority(0, SCHED_OTHER | SCHED_RESET_ON_FORK, 0)) {
+        return 20 + errno;
+    }
+
+    if (!SetPolicy(0, SCHED_FIFO | SCHED_RESET_ON_FORK, 10)) return 50 + errno;
+    constexpr int priorities[] = {1, 99};
+    for (int priority : priorities) {
+        RawSchedParam param {priority};
+        if (RawSetParam(0, &param) != 0 ||
+            !ReadPolicyAndPriority(0, SCHED_FIFO | SCHED_RESET_ON_FORK, priority)) {
+            return 60 + errno;
+        }
+    }
+    struct timespec interval {-1, -1};
+    if (RawRrGetInterval(0, &interval) != 0 || interval.tv_sec != 0 ||
+        interval.tv_nsec != 0) {
+        return 70 + errno;
+    }
+
+    if (!SetPolicy(0, SCHED_RR | SCHED_RESET_ON_FORK, 20)) return 80 + errno;
+    RawSchedParam rr {30};
+    if (RawSetParam(0, &rr) != 0 ||
+        !ReadPolicyAndPriority(0, SCHED_RR | SCHED_RESET_ON_FORK, 30)) {
+        return 90 + errno;
+    }
+    interval = {-1, -1};
+    if (RawRrGetInterval(0, &interval) != 0 || interval.tv_sec != 0 ||
+        interval.tv_nsec != 100 * 1000 * 1000) {
+        return 100 + errno;
+    }
+
+    return SetPolicy(0, SCHED_OTHER, 0) ? 0 : 110 + errno;
+}
+
+TEST(SchedSetParam, PreservesPolicyResetAndConfiguredQuantum) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RT support";
+    EXPECT_EQ(0, RunIsolatedScenario(SetParamStateScenario));
+}
+
 int FifoForkScenario() {
     if (!SetPolicy(0, SCHED_FIFO, 20)) return 20;
     pid_t inherited = fork();
@@ -680,6 +757,30 @@ TEST(SchedSetScheduler, OtherTidAndNestedCloneReset) {
     EXPECT_EQ(ESRCH, errno);
 }
 
+TEST(SchedSetParam, OtherTidPreservesResetFlag) {
+    WorkerState state;
+    pthread_t worker;
+    ASSERT_EQ(0, pthread_create(&worker, nullptr, FlagWorker, &state));
+    for (int attempt = 0;
+         attempt < 500 && state.tid.load(std::memory_order_acquire) == 0; ++attempt) {
+        usleep(10 * 1000);
+    }
+    const pid_t tid = state.tid.load(std::memory_order_acquire);
+    if (tid <= 0) {
+        state.proceed.store(1, std::memory_order_release);
+        pthread_join(worker, nullptr);
+        FAIL() << "worker did not publish its TID within 5 seconds";
+    }
+
+    RawSchedParam zero {0};
+    EXPECT_EQ(0, RawSetScheduler(tid, SCHED_OTHER | SCHED_RESET_ON_FORK, &zero)) << strerror(errno);
+    EXPECT_EQ(0, RawSetParam(tid, &zero)) << strerror(errno);
+    EXPECT_EQ(SCHED_OTHER | SCHED_RESET_ON_FORK, sched_getscheduler(tid));
+    state.proceed.store(1, std::memory_order_release);
+    ASSERT_EQ(0, pthread_join(worker, nullptr));
+    EXPECT_EQ(0, state.result);
+}
+
 int RunCredentialCaller(pid_t target, uid_t ruid, uid_t euid, bool set_flag,
                         int expected_errno, bool expect_get_success) {
     pid_t caller = fork();
@@ -695,6 +796,20 @@ int RunCredentialCaller(pid_t target, uid_t ruid, uid_t euid, bool set_flag,
         errno = 0;
         long result = RawSetScheduler(
             target, set_flag ? SCHED_OTHER | SCHED_RESET_ON_FORK : SCHED_OTHER, &zero);
+        if (expected_errno == 0) _exit(result == 0 ? 0 : 30 + errno);
+        _exit(result == -1 && errno == expected_errno ? 0 : 60 + errno);
+    }
+    return WaitForChild(caller);
+}
+
+int RunSetParamCredentialCaller(pid_t target, uid_t ruid, uid_t euid, int expected_errno) {
+    pid_t caller = fork();
+    if (caller < 0) return 200;
+    if (caller == 0) {
+        if (setresuid(ruid, euid, euid) != 0) _exit(100 + errno);
+        RawSchedParam zero {0};
+        errno = 0;
+        const long result = RawSetParam(target, &zero);
         if (expected_errno == 0) _exit(result == 0 ? 0 : 30 + errno);
         _exit(result == -1 && errno == expected_errno ? 0 : 60 + errno);
     }
@@ -727,6 +842,10 @@ TEST(SchedPermission, OwnerCapabilityAndProtectedClearMatrix) {
 
     // Cross-owner queries are unrestricted, while setters require owner or
     // CAP_SYS_NICE. Matching only current real UID must not authorize.
+    EXPECT_EQ(0, RunSetParamCredentialCaller(target, 1002, 1002, EPERM));
+    EXPECT_EQ(0, RunSetParamCredentialCaller(target, 1002, 1001, 0));
+    RawSchedParam zero {0};
+    EXPECT_EQ(0, RawSetParam(target, &zero)) << strerror(errno);
     EXPECT_EQ(0, RunCredentialCaller(target, 1002, 1002, true, EPERM, true));
     EXPECT_EQ(0, RunCredentialCaller(target, 1001, 1002, true, EPERM, true));
 
@@ -737,7 +856,6 @@ TEST(SchedPermission, OwnerCapabilityAndProtectedClearMatrix) {
     EXPECT_EQ(SCHED_OTHER | SCHED_RESET_ON_FORK, sched_getscheduler(target));
 
     // The root parent has CAP_SYS_NICE in the initial namespace and may clear.
-    RawSchedParam zero {0};
     EXPECT_EQ(0, RawSetScheduler(target, SCHED_OTHER, &zero)) << strerror(errno);
     EXPECT_EQ(SCHED_OTHER, sched_getscheduler(target));
 
@@ -1011,6 +1129,41 @@ int RrRlimitScenario() {
 TEST(SchedRrRlimit, PriorityAndExactPolicyRules) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
     EXPECT_EQ(0, RunIsolatedScenario(RrRlimitScenario));
+}
+
+int SetParamRlimitScenario() {
+    struct rlimit high {10, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &high) != 0) return 10 + errno;
+    if (syscall(SYS_setresuid, 1001, 1001, 1001) != 0) return 20 + errno;
+    if (!SetPolicy(0, SCHED_RR, 10)) return 30 + errno;
+
+    RawSchedParam raised {11};
+    errno = 0;
+    if (RawSetParam(0, &raised) == 0 || errno != EPERM ||
+        !ReadPolicyAndPriority(0, SCHED_RR, 10)) {
+        return 40 + errno;
+    }
+
+    struct rlimit low {0, 10};
+    if (setrlimit(RLIMIT_RTPRIO, &low) != 0) return 50 + errno;
+    RawSchedParam lowered {1};
+    if (RawSetParam(0, &lowered) != 0 ||
+        !ReadPolicyAndPriority(0, SCHED_RR, 1)) {
+        return 60 + errno;
+    }
+    RawSchedParam increase {2};
+    errno = 0;
+    if (RawSetParam(0, &increase) == 0 || errno != EPERM ||
+        !ReadPolicyAndPriority(0, SCHED_RR, 1)) {
+        return 70 + errno;
+    }
+    if (RawSetParam(0, &lowered) != 0) return 80 + errno;
+    return SetPolicy(0, SCHED_OTHER, 0) ? 0 : 90 + errno;
+}
+
+TEST(SchedSetParam, UnprivilegedRlimitRaiseLowerAndNoop) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RR support";
+    EXPECT_EQ(0, RunIsolatedScenario(SetParamRlimitScenario));
 }
 
 struct SharedFifoState {
@@ -1301,8 +1454,10 @@ int ResetOnlyKeepsQueueOrderScenario() {
     }
 
     if (!SetPolicy(0, SCHED_FIFO, 50)) return 57;
+    RawSchedParam unchanged {20};
     if (kill(first, SIGCONT) != 0 || kill(second, SIGCONT) != 0 ||
-        !SetPolicy(first, SCHED_FIFO | SCHED_RESET_ON_FORK, 20)) {
+        !SetPolicy(first, SCHED_FIFO | SCHED_RESET_ON_FORK, 20) ||
+        RawSetParam(first, &unchanged) != 0) {
         (void)SetPolicy(0, SCHED_OTHER, 0);
         return 58;
     }
@@ -1594,6 +1749,120 @@ int FifoRemoteScenario() {
     return stress_result == 0 ? 0 : 54;
 }
 
+int SetParamRemoteRunningScenario() {
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, &worker_cpu) || worker_cpu < 0 ||
+        !PinTask(0, controller_cpu)) {
+        return 60;
+    }
+    SharedFifoState* state = NewSharedFifoState();
+    if (state == nullptr) return 61;
+
+    pid_t worker = fork();
+    if (worker < 0) return 62;
+    if (worker == 0) {
+        if (!PinTask(0, worker_cpu) || !SetPolicy(0, SCHED_FIFO, 10)) _exit(20);
+        __atomic_store_n(&state->stress_started, 1, __ATOMIC_RELEASE);
+        while (__atomic_load_n(&state->stress_release, __ATOMIC_ACQUIRE) == 0) {
+            __atomic_signal_fence(__ATOMIC_SEQ_CST);
+        }
+        _exit(0);
+    }
+    ChildGuard worker_guard(worker);
+    bool started = false;
+    for (int attempt = 0; attempt < 200; ++attempt) {
+        if (__atomic_load_n(&state->stress_started, __ATOMIC_ACQUIRE) == 1) {
+            started = true;
+            break;
+        }
+        usleep(10 * 1000);
+    }
+    if (!started) return 63;
+
+    for (int round = 0; round < 64; ++round) {
+        const int priority = (round & 1) == 0 ? 1 : 99;
+        RawSchedParam param {priority};
+        if (RawSetParam(worker, &param) != 0 ||
+            !ReadPolicyAndPriority(worker, SCHED_FIFO, priority)) {
+            return 64 + errno;
+        }
+    }
+    __atomic_store_n(&state->stress_release, 1, __ATOMIC_RELEASE);
+    const int worker_result = WaitForChild(worker);
+    worker_guard.Release();
+    munmap(state, sizeof(*state));
+    return worker_result == 0 ? 0 : 65;
+}
+
+struct SetParamPolicyRaceState {
+    std::atomic<int> tid {0};
+    std::atomic<int> start {0};
+    std::atomic<int> stop {0};
+    int worker_cpu = -1;
+    int result = -1;
+};
+
+void* SetParamPolicyRaceWorker(void* arg) {
+    auto* state = static_cast<SetParamPolicyRaceState*>(arg);
+    if (!PinTask(0, state->worker_cpu) || !SetPolicy(0, SCHED_RR, 10)) {
+        state->result = 10 + errno;
+        state->tid.store(-1, std::memory_order_release);
+        return nullptr;
+    }
+    state->tid.store(static_cast<int>(syscall(SYS_gettid)), std::memory_order_release);
+    while (state->start.load(std::memory_order_acquire) == 0) sched_yield();
+
+    int round = 0;
+    while (state->stop.load(std::memory_order_acquire) == 0) {
+        RawSchedParam param {(round++ & 1) == 0 ? 1 : 99};
+        if (RawSetParam(0, &param) != 0) {
+            state->result = 20 + errno;
+            return nullptr;
+        }
+        sched_yield();
+    }
+    state->result = SetPolicy(0, SCHED_OTHER, 0) ? 0 : 30 + errno;
+    return nullptr;
+}
+
+int SetParamPolicyRaceScenario() {
+    int controller_cpu = -1;
+    int worker_cpu = -1;
+    if (!PickAllowedCpus(&controller_cpu, &worker_cpu) || worker_cpu < 0 ||
+        !PinTask(0, controller_cpu)) {
+        return 70;
+    }
+
+    SetParamPolicyRaceState state;
+    state.worker_cpu = worker_cpu;
+    pthread_t worker;
+    if (pthread_create(&worker, nullptr, SetParamPolicyRaceWorker, &state) != 0) return 71;
+    for (int attempt = 0; attempt < 200 && state.tid.load(std::memory_order_acquire) == 0;
+         ++attempt) {
+        usleep(10 * 1000);
+    }
+    const int tid = state.tid.load(std::memory_order_acquire);
+    if (tid <= 0) {
+        state.start.store(1, std::memory_order_release);
+        pthread_join(worker, nullptr);
+        return 72;
+    }
+
+    state.start.store(1, std::memory_order_release);
+    for (int round = 0; round < 256; ++round) {
+        const int policy = (round & 1) == 0 ? SCHED_FIFO : SCHED_RR;
+        if (!SetPolicy(tid, policy, 20)) {
+            state.stop.store(1, std::memory_order_release);
+            pthread_join(worker, nullptr);
+            return 73 + errno;
+        }
+    }
+    state.stop.store(1, std::memory_order_release);
+    if (pthread_join(worker, nullptr) != 0) return 74;
+    return state.result;
+}
+
 TEST(SchedFifoBehavior, SamePriorityYieldMovesCurrentToTail) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
     EXPECT_EQ(0, RunIsolatedScenario(FifoYieldScenario));
@@ -1629,7 +1898,7 @@ TEST(SchedRrBehavior, BlockedWakeupJoinsPriorityTail) {
     EXPECT_EQ(0, RunIsolatedScenario(RrBlockedWakeTailScenario));
 }
 
-TEST(SchedPolicyChange, ResetOnlyDoesNotMoveQueuedTask) {
+TEST(SchedPolicyChange, ResetAndSetParamNoopDoNotMoveQueuedTask) {
     if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
     EXPECT_EQ(0, RunIsolatedScenario(ResetOnlyKeepsQueueOrderScenario));
 }
@@ -1646,6 +1915,24 @@ TEST(SchedFifoSmp, RemotePreemptionAndRunningTargetStress) {
     ASSERT_TRUE(PickAllowedCpus(&first, &second));
     if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
     EXPECT_EQ(0, RunIsolatedScenario(FifoRemoteScenario));
+}
+
+TEST(SchedSetParam, RemoteRunningTaskPriorityStress) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace FIFO support";
+    int first = -1;
+    int second = -1;
+    ASSERT_TRUE(PickAllowedCpus(&first, &second));
+    if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
+    EXPECT_EQ(0, RunIsolatedScenario(SetParamRemoteRunningScenario));
+}
+
+TEST(SchedSetParam, PolicyChangeRaceRetriesWithFreshValidation) {
+    if (!IsDragonOS()) GTEST_SKIP() << "requires DragonOS userspace RT support";
+    int first = -1;
+    int second = -1;
+    ASSERT_TRUE(PickAllowedCpus(&first, &second));
+    if (second < 0) GTEST_SKIP() << "requires at least two allowed CPUs";
+    EXPECT_EQ(0, RunIsolatedScenario(SetParamPolicyRaceScenario));
 }
 
 TEST(SchedRrSmp, RemoteRunqueueRotatesSamePriorityTasks) {


### PR DESCRIPTION
## Summary

- implement `sched_setparam(2)` with Linux-compatible parameter validation, TID lookup, error ordering, ownership, capability, and `RLIMIT_RTPRIO` authorization
- preserve the target scheduling policy, reset-on-fork state, configured RR quantum, and remaining RR slice during parameter-only updates
- retry preparation and authorization when a concurrent policy transition invalidates the expected policy
- extend scheduler semantics coverage for ABI boundaries, permissions, remote running tasks, queue ordering, and concurrent FIFO/RR transitions
- retain and cross-check the already merged `sched_rr_get_interval(2)` behavior without duplicating its implementation

## Architecture

The syscall layer owns legacy ABI decoding and authorization. `ProcessManager` owns the atomic scheduler mutation under the existing task PI-lock and stable runqueue-lock transaction. Parameter-only updates reuse that transaction through a small private update enum, while the existing `set_scheduler` interface remains unchanged.

A prepared parameter update records the expected policy. The commit compares it under the stable scheduler locks before changing priority; a mismatch returns to the syscall layer for fresh validation and authorization. Same-effective-priority updates avoid dequeue and enqueue operations, preserving queue order and avoiding unnecessary rescheduling.

## Linux compatibility

- copy the exact four-byte `sched_param` before target lookup and priority validation
- require priority 0 for normal scheduling and priorities 1 through 99 for FIFO/RR
- allow same-owner unprivileged lowering and `RLIMIT_RTPRIO`-bounded realtime raises
- require `CAP_SYS_NICE` when ownership and resource-limit rules do not authorize the change
- preserve policy and reset-on-fork state, including across concurrent policy changes
- preserve the configured and remaining RR time slice

## Validation

- `make fmt`, including kernel clippy
- `make kernel`
- DragonOS QEMU SMP scheduler semantics suite: 44/44 passed
- ABI boundary, permission, queue-order, remote-running-task, and concurrent policy-transition coverage passed
- `git diff --check`
- adversarial correctness, concurrency, security, architecture, performance, and maintainability review completed with no remaining findings

Refs #760
