### PR TITLE
refactor(net): unify link mutations across rtnetlink and ioctl

### DIFF
--- a/kernel/Cargo.lock
+++ b/kernel/Cargo.lock
@@ -1561,7 +1561,7 @@ checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
 [[package]]
 name = "smoltcp"
 version = "0.12.0"
-source = "git+https://github.com/DragonOS-Community/smoltcp?rev=1f1172a#1f1172a7ac88b46d443982bbd8779866eee68c9d"
+source = "git+https://github.com/DragonOS-Community/smoltcp?rev=ebeaec6#ebeaec612ccdd36239588e4d8987fc14d623a52b"
 dependencies = [
  "bitflags 1.3.2",
  "byteorder",

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -62,7 +62,7 @@ linkme = "=0.3.27"
 num = { version = "=0.4.0", default-features = false }
 num-derive = "=0.3"
 num-traits = { git = "https://git.mirrors.dragonos.org.cn/DragonOS-Community/num-traits.git", rev = "1597c1c", default-features = false }
-smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/smoltcp", rev = "1f1172a", default-features = false, features = [
+smoltcp = { version = "=0.12.0", git = "https://github.com/DragonOS-Community/smoltcp", rev = "ebeaec6", default-features = false, features = [
     "alloc",
     "medium-ethernet",
     "socket-raw",

--- a/kernel/crates/napi-state/src/lib.rs
+++ b/kernel/crates/napi-state/src/lib.rs
@@ -5,18 +5,27 @@ use core::sync::atomic::{AtomicU32, Ordering};
 pub const SCHED: u32 = 1 << 0;
 pub const MISSED: u32 = 1 << 1;
 pub const DISABLE: u32 = 1 << 2;
+pub const PAUSED: u32 = 1 << 10;
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum CompleteState {
     Completed,
     Missed,
     Disabled,
+    Paused,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ScheduleState {
     Acquired,
     Missed,
+    Disabled,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ResumeState {
+    Acquired,
+    Owned,
     Disabled,
 }
 
@@ -27,7 +36,7 @@ pub enum ScheduleState {
 pub fn schedule_prep(state: &AtomicU32) -> ScheduleState {
     let mut current = state.load(Ordering::Acquire);
     loop {
-        if current & DISABLE != 0 {
+        if current & (DISABLE | PAUSED) != 0 {
             return ScheduleState::Disabled;
         }
 
@@ -57,6 +66,17 @@ pub fn complete(state: &AtomicU32) -> CompleteState {
         }
         debug_assert_ne!(current & SCHED, 0, "completing an unscheduled NAPI");
 
+        if current & PAUSED != 0 {
+            let next = current & !(SCHED | MISSED);
+            match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+                Ok(_) => return CompleteState::Paused,
+                Err(observed) => {
+                    current = observed;
+                    continue;
+                }
+            }
+        }
+
         let mut next = current & !(SCHED | MISSED);
         let result = if current & MISSED != 0 {
             next |= SCHED;
@@ -79,6 +99,47 @@ pub fn complete(state: &AtomicU32) -> CompleteState {
 /// in which a concurrent scheduler can acquire an owner that nobody publishes.
 pub fn disable(state: &AtomicU32) {
     state.store(DISABLE, Ordering::Release);
+}
+
+/// Reversibly stop new scheduling without stealing an existing poll owner.
+pub fn pause(state: &AtomicU32) {
+    state.fetch_or(PAUSED, Ordering::AcqRel);
+}
+
+/// Release a queued owner while administrative pause is still in effect.
+/// `false` means resume won the race, so the caller must keep the owner.
+pub fn complete_paused(state: &AtomicU32) -> bool {
+    let mut current = state.load(Ordering::Acquire);
+    loop {
+        if current & PAUSED == 0 {
+            return false;
+        }
+        debug_assert_ne!(current & SCHED, 0, "pausing an unscheduled NAPI owner");
+        let next = current & !(SCHED | MISSED);
+        match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return true,
+            Err(observed) => current = observed,
+        }
+    }
+}
+
+/// Resume a paused instance without creating a second queued/active owner.
+pub fn resume(state: &AtomicU32) -> ResumeState {
+    let mut current = state.load(Ordering::Acquire);
+    loop {
+        if current & DISABLE != 0 {
+            return ResumeState::Disabled;
+        }
+        let (next, result) = if current & SCHED != 0 {
+            ((current & !PAUSED) | MISSED, ResumeState::Owned)
+        } else {
+            ((current & !PAUSED) | SCHED, ResumeState::Acquired)
+        };
+        match state.compare_exchange_weak(current, next, Ordering::AcqRel, Ordering::Acquire) {
+            Ok(_) => return result,
+            Err(observed) => current = observed,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -108,6 +169,46 @@ mod tests {
         let state = AtomicU32::new(DISABLE);
         assert_eq!(schedule_prep(&state), ScheduleState::Disabled);
         assert_eq!(state.load(Ordering::Relaxed), DISABLE);
+    }
+
+    #[test]
+    fn pause_rejects_schedule_until_resume_acquires_owner() {
+        let state = AtomicU32::new(0);
+        pause(&state);
+        assert_eq!(schedule_prep(&state), ScheduleState::Disabled);
+        assert_eq!(resume(&state), ResumeState::Acquired);
+        assert_eq!(state.load(Ordering::Relaxed), SCHED);
+    }
+
+    #[test]
+    fn paused_queued_owner_is_released_without_losing_pause() {
+        let state = AtomicU32::new(SCHED | MISSED);
+        pause(&state);
+        assert!(complete_paused(&state));
+        assert_eq!(state.load(Ordering::Relaxed), PAUSED);
+    }
+
+    #[test]
+    fn resume_of_active_owner_records_missed() {
+        let state = AtomicU32::new(SCHED | PAUSED);
+        assert_eq!(resume(&state), ResumeState::Owned);
+        assert_eq!(state.load(Ordering::Relaxed), SCHED | MISSED);
+        assert_eq!(complete(&state), CompleteState::Missed);
+    }
+
+    #[test]
+    fn completion_during_pause_releases_active_owner() {
+        let state = AtomicU32::new(SCHED | PAUSED);
+        assert_eq!(complete(&state), CompleteState::Paused);
+        assert_eq!(state.load(Ordering::Relaxed), PAUSED);
+    }
+
+    #[test]
+    fn resume_wins_queued_owner_race() {
+        let state = AtomicU32::new(SCHED | PAUSED);
+        assert_eq!(resume(&state), ResumeState::Owned);
+        assert!(!complete_paused(&state));
+        assert_eq!(state.load(Ordering::Relaxed), SCHED | MISSED);
     }
 
     #[test]

--- a/kernel/src/driver/base/device_rename.rs
+++ b/kernel/src/driver/base/device_rename.rs
@@ -1,0 +1,90 @@
+use alloc::{string::String, sync::Arc};
+
+use system_error::SystemError;
+
+use crate::{
+    driver::base::kobject::{KObject, KObjectState},
+    filesystem::{
+        kernfs::{KernFSInode, KernFSRenameSpec, PreparedKernFSRename},
+        sysfs::sysfs_instance,
+        vfs::IndexNode,
+    },
+    libs::casting::DowncastArc,
+};
+
+use super::device::Device;
+
+/// Driver-core projection of a device rename. `rename` is absent for devices
+/// which were deliberately registered without sysfs.
+pub(crate) struct PreparedDeviceSysfsRename {
+    rename: Option<PreparedKernFSRename>,
+    old_devpath: Option<String>,
+}
+
+impl PreparedDeviceSysfsRename {
+    pub(crate) fn commit(self) -> Result<Option<String>, SystemError> {
+        if let Some(rename) = self.rename {
+            rename.commit()?;
+        }
+        Ok(self.old_devpath)
+    }
+}
+
+/// Prepares the identity-preserving directory and class-link re-key for one
+/// class device. The device's logical name is published by its owning control
+/// transaction after this structural commit succeeds.
+pub(crate) fn prepare_class_device_sysfs_rename(
+    device: &Arc<dyn Device>,
+    new_name: String,
+) -> Result<PreparedDeviceSysfsRename, SystemError> {
+    let registered = device.kobj_state().contains(KObjectState::IN_SYSFS);
+    let device_inode = device.inode();
+    if !registered {
+        return if device_inode.is_none() {
+            Ok(PreparedDeviceSysfsRename {
+                rename: None,
+                old_devpath: None,
+            })
+        } else {
+            Err(SystemError::EIO)
+        };
+    }
+
+    let device_inode = device_inode.ok_or(SystemError::EIO)?;
+    let device_parent = device_inode.parent().ok_or(SystemError::EIO)?;
+    let old_sysfs_name = device_inode.try_name()?;
+    let class = device.class().ok_or(SystemError::EIO)?;
+    let class_kobject = class.subsystem().subsys() as Arc<dyn KObject>;
+    let class_parent = class_kobject.inode().ok_or(SystemError::EIO)?;
+    let class_link = class_parent
+        .find(&old_sysfs_name)
+        .map_err(|_| SystemError::EIO)?
+        .downcast_arc::<KernFSInode>()
+        .ok_or(SystemError::EIO)?;
+    if !class_link
+        .symlink_target()
+        .is_some_and(|target| Arc::ptr_eq(&target, &device_inode))
+    {
+        return Err(SystemError::EIO);
+    }
+
+    let target_path = sysfs_instance().child_absolute_path(&device_parent, new_name.as_str())?;
+    let old_devpath = sysfs_instance().try_kernfs_path(&device_inode)?;
+    let class_name = try_copy_string(&new_name)?;
+    let device_spec = KernFSRenameSpec::new(device_inode, new_name);
+    let class_spec = KernFSRenameSpec::new(class_link, class_name)
+        .with_symlink_target_absolute_path(target_path);
+    Ok(PreparedDeviceSysfsRename {
+        rename: Some(PreparedKernFSRename::prepare(device_spec, class_spec)?),
+        old_devpath: Some(old_devpath),
+    })
+}
+
+fn try_copy_string(source: &str) -> Result<String, SystemError> {
+    let mut result = String::new();
+    result
+        .try_reserve_exact(source.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    result.push_str(source);
+    Ok(result)
+}

--- a/kernel/src/driver/base/kobject.rs
+++ b/kernel/src/driver/base/kobject.rs
@@ -7,7 +7,6 @@ use core::{
 };
 
 use alloc::{
-    format,
     string::String,
     sync::{Arc, Weak},
     vec::Vec,
@@ -31,7 +30,10 @@ use crate::{
         kobject::message::KobjectUeventMessage,
         table::{NetlinkKobjectUeventProtocol, SupportedNetlinkProtocol},
     },
-    process::{namespace::net_namespace::INIT_NET_NAMESPACE, ProcessManager},
+    process::{
+        namespace::net_namespace::{NetNamespace, INIT_NET_NAMESPACE},
+        ProcessManager,
+    },
 };
 
 use system_error::SystemError;
@@ -93,29 +95,55 @@ impl dyn KObject {
         Self::emit_uevent(action, &devpath, extra_env)
     }
 
+    /// Emits a kobject event into an explicitly selected network namespace.
+    ///
+    /// Most kobjects are not namespace-aware and use [`Self::kobject_uevent`].
+    /// Namespaced object classes, such as network devices, must select the
+    /// namespace from the object rather than from the calling task.
+    pub fn kobject_uevent_in_netns(
+        kobj: &Arc<dyn KObject>,
+        action: &str,
+        extra_env: &[(&str, String)],
+        netns: Arc<NetNamespace>,
+    ) -> Result<(), SystemError> {
+        let devpath = Self::devpath(kobj)?;
+        Self::emit_uevent_in_netns(action, &devpath, extra_env, netns)
+    }
+
     pub fn emit_uevent(
         action: &str,
         devpath: &str,
         extra_env: &[(&str, String)],
     ) -> Result<(), SystemError> {
-        let mut payload = Vec::new();
-        push_env_field(&mut payload, &format!("{action}@{devpath}"));
-        push_env_field(&mut payload, &format!("ACTION={action}"));
-        push_env_field(&mut payload, &format!("DEVPATH={devpath}"));
-        for (key, value) in extra_env {
-            push_env_field(&mut payload, &format!("{key}={value}"));
-        }
-        let seqnum = UEVENT_SEQNUM.fetch_add(1, Ordering::Relaxed);
-        push_env_field(&mut payload, &format!("SEQNUM={seqnum}"));
-
         let netns = if ProcessManager::initialized() {
             ProcessManager::current_netns()
         } else {
             INIT_NET_NAMESPACE.clone()
         };
+        Self::emit_uevent_in_netns(action, devpath, extra_env, netns)
+    }
+
+    pub fn emit_uevent_in_netns(
+        action: &str,
+        devpath: &str,
+        extra_env: &[(&str, String)],
+        netns: Arc<NetNamespace>,
+    ) -> Result<(), SystemError> {
+        let mut payload = Vec::new();
+        try_push_env_components(&mut payload, &[action.as_bytes(), b"@", devpath.as_bytes()])?;
+        try_push_env_components(&mut payload, &[b"ACTION=", action.as_bytes()])?;
+        try_push_env_components(&mut payload, &[b"DEVPATH=", devpath.as_bytes()])?;
+        for (key, value) in extra_env {
+            try_push_env_components(&mut payload, &[key.as_bytes(), b"=", value.as_bytes()])?;
+        }
+        let seqnum = UEVENT_SEQNUM.fetch_add(1, Ordering::Relaxed);
+        let mut digits = [0u8; 20];
+        let seqnum = decimal_bytes(seqnum, &mut digits);
+        try_push_env_components(&mut payload, &[b"SEQNUM=", seqnum])?;
+
         NetlinkKobjectUeventProtocol::multicast(
             GroupIdSet::new(1),
-            KobjectUeventMessage::new(&payload),
+            KobjectUeventMessage::try_from_vec(payload)?,
             netns,
         )
     }
@@ -131,9 +159,30 @@ impl DowncastArc for dyn KObject {
     }
 }
 
-fn push_env_field(payload: &mut Vec<u8>, field: &str) {
-    payload.extend_from_slice(field.as_bytes());
+fn try_push_env_components(payload: &mut Vec<u8>, components: &[&[u8]]) -> Result<(), SystemError> {
+    let length = components.iter().try_fold(1usize, |length, component| {
+        length.checked_add(component.len())
+    });
+    payload
+        .try_reserve(length.ok_or(SystemError::ENOMEM)?)
+        .map_err(|_| SystemError::ENOMEM)?;
+    for component in components {
+        payload.extend_from_slice(component);
+    }
     payload.push(0);
+    Ok(())
+}
+
+fn decimal_bytes(mut value: u64, storage: &mut [u8; 20]) -> &[u8] {
+    let mut start = storage.len();
+    loop {
+        start -= 1;
+        storage[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            return &storage[start..];
+        }
+    }
 }
 
 fn kobject_devpath(kobj: &Arc<dyn KObject>) -> Result<String, SystemError> {

--- a/kernel/src/driver/base/mod.rs
+++ b/kernel/src/driver/base/mod.rs
@@ -3,6 +3,7 @@ pub mod char;
 pub mod class;
 pub mod cpu;
 pub mod device;
+pub(crate) mod device_rename;
 pub mod firmware;
 pub mod hypervisor;
 pub mod init;

--- a/kernel/src/driver/net/e1000e/e1000e.rs
+++ b/kernel/src/driver/net/e1000e/e1000e.rs
@@ -65,6 +65,7 @@ const E1000E_RECV_VECTOR: IrqNumber = IrqNumber::new(57);
 
 // napi队列中暂时存储的buffer个数
 const E1000E_RECV_NAPI: usize = 1024;
+const E1000E_RUNTIME_RX_INTERRUPTS: u32 = E1000E_IMS_RXT0 | E1000E_IMS_RXDMT0 | E1000E_IMS_OTHER;
 
 // 收/发包的描述符结构 pp.24 Table 3-1
 #[repr(C)]
@@ -512,6 +513,49 @@ impl E1000EDevice {
         buffer.set_length(packet_len);
         // debug!("e1000e: receive packet");
         return Some(buffer);
+    }
+
+    /// Stop runtime RX production before NAPI is quiesced. Descriptor memory
+    /// remains owned by the driver throughout the administrative transition.
+    pub fn suspend_runtime_rx(&mut self) {
+        unsafe {
+            volwrite!(self.interrupt_regs, imc, E1000E_IMC_CLEAR);
+            let rctl = volread!(self.rctl_regs, rctl) & !E1000E_RCTL_EN;
+            volwrite!(self.rctl_regs, rctl, rctl);
+            let _ = volread!(self.general_regs, status);
+        }
+        compiler_fence(Ordering::SeqCst);
+    }
+
+    /// Return completions from the stopped receiver without allocating new
+    /// DMA buffers.
+    pub fn discard_rx_completions(&mut self) {
+        for _ in 0..self.recv_desc_ring.len() {
+            let mut rdt = unsafe { volread!(self.receive_regs, rdt0) } as usize;
+            let index = (rdt + 1) % self.recv_desc_ring.len();
+            let desc = &mut self.recv_desc_ring[index];
+            if (desc.status & E1000E_RXD_STATUS_DD) == 0 {
+                break;
+            }
+            desc.status = 0;
+            desc.len = 0;
+            rdt = index;
+            unsafe { volwrite!(self.receive_regs, rdt0, rdt as u32) };
+        }
+        self.e1000e_intr();
+    }
+
+    pub fn resume_runtime_rx(&mut self) {
+        unsafe {
+            let rctl = volread!(self.rctl_regs, rctl) | E1000E_RCTL_EN;
+            volwrite!(self.rctl_regs, rctl, rctl);
+            let _ = volread!(self.general_regs, status);
+            let mut interrupts = E1000E_IMS_LSC | E1000E_RUNTIME_RX_INTERRUPTS;
+            if self.tx_completion_interrupt_armed {
+                interrupts |= E1000E_IMS_TXDW;
+            }
+            volwrite!(self.interrupt_regs, ims, interrupts);
+        }
     }
 
     pub fn e1000e_can_transmit(&self) -> bool {

--- a/kernel/src/driver/net/e1000e/e1000e_driver.rs
+++ b/kernel/src/driver/net/e1000e/e1000e_driver.rs
@@ -10,7 +10,7 @@ use crate::{
         },
         net::{
             napi::NapiStruct, register_netdevice, types::InterfaceFlags, Iface, IfaceCommon,
-            NetDeivceState, NetDeviceCommonData, Operstate,
+            MtuBounds, NetDeivceState, NetDeviceCommonData, Operstate,
         },
     },
     libs::{
@@ -523,6 +523,33 @@ impl Iface for E1000EInterface {
 
     fn mtu(&self) -> usize {
         self.common.mtu()
+    }
+
+    fn mtu_bounds(&self) -> MtuBounds {
+        MtuBounds {
+            min: 68,
+            max: E1000E_IP_MTU,
+        }
+    }
+
+    fn begin_admin_down(&self) {
+        self.driver.inner.lock_irqsave().suspend_runtime_rx();
+    }
+
+    fn quiesce_admin_down(&self) {
+        // Intel documents a 10 ms drain interval after clearing RCTL.EN. Do
+        // not hold the device spinlock or FIB writer while hardware settles.
+        let deadline = Instant::now().total_micros().saturating_add(10_000);
+        while Instant::now().total_micros() < deadline {
+            crate::sched::sched_yield();
+        }
+        self.driver.inner.lock_irqsave().discard_rx_completions();
+    }
+
+    fn publish_admin_state(&self, is_up: bool) {
+        if is_up {
+            self.driver.inner.lock_irqsave().resume_runtime_rx();
+        }
     }
 }
 

--- a/kernel/src/driver/net/iface.rs
+++ b/kernel/src/driver/net/iface.rs
@@ -49,6 +49,16 @@ pub enum Operstate {
     IF_OPER_UP = 6,
 }
 
+/// Runtime IP-MTU limits supported by one interface implementation.
+///
+/// The control plane owns validation; drivers only describe the bounds that
+/// their current buffers and the smoltcp projection can safely represent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MtuBounds {
+    pub min: usize,
+    pub max: usize,
+}
+
 /// Control-plane metadata attached to one configured interface address.
 ///
 /// `label == None` means the interface's current primary name. Keeping that
@@ -462,6 +472,26 @@ pub trait Iface: crate::driver::base::device::Device {
 
     fn mtu(&self) -> usize;
 
+    /// Inclusive runtime IP-MTU limits for this device.
+    fn mtu_bounds(&self) -> MtuBounds;
+
+    /// Stop new device notifications or software ingress admission before the
+    /// shared NAPI owner is paused. This must not fail, allocate, or block.
+    fn begin_admin_down(&self) {}
+
+    /// Wait for device-private ingress which started before administrative
+    /// DOWN to finish, then discard queued software ingress. The shared link
+    /// core invokes this after pausing NAPI and before taking the FIB writer,
+    /// so implementations may block but must not acquire RTNL.
+    fn quiesce_admin_down(&self) {}
+
+    /// Publishes device-private data-path state for a real administrative
+    /// UP/DOWN transition. Implementations must not allocate, fail, sleep, or
+    /// acquire RTNL/FIB/smoltcp locks: the caller holds RTNL and the FIB writer
+    /// after all preparation has succeeded. NAPI lifecycle is managed by the
+    /// shared link core rather than by this driver hook.
+    fn publish_admin_state(&self, _is_up: bool) {}
+
     /// # 获取当前iface的napi结构体
     /// 默认返回None，表示不支持napi
     fn napi_struct(&self) -> Option<Arc<napi::NapiStruct>> {
@@ -524,18 +554,31 @@ pub(super) fn register_netdevice(
     // Register driver-core/sysfs first. Until PRESENT and the namespace/FIB
     // transaction both commit, the object is provisional and unannounced.
     netdev_register_kobject(dev.clone())?;
-    dev.set_net_state(NetDeivceState::__LINK_STATE_PRESENT);
-
-    if let Err(error) = netns.add_device(dev.clone()) {
+    if let Err(error) = register_netdevice_in_namespace(netns, dev.clone()) {
         // No add uevent has been sent, so rollback is structural and must not
         // allocate notification state before removing the provisional object.
-        dev.clear_net_state(NetDeivceState::__LINK_STATE_PRESENT);
         netdev_unregister_kobject(dev);
         return Err(error);
     }
 
     netdev_emit_uevent(dev, "add");
 
+    Ok(())
+}
+
+/// Publishes a netdevice in one network namespace without creating a global
+/// sysfs projection. This is the common registration lifecycle used by
+/// per-netns devices: PRESENT is owned here and rolled back if topology/FIB
+/// insertion fails.
+pub(crate) fn register_netdevice_in_namespace(
+    netns: &Arc<NetNamespace>,
+    dev: Arc<dyn Iface>,
+) -> Result<(), SystemError> {
+    dev.set_net_state(NetDeivceState::__LINK_STATE_PRESENT);
+    if let Err(error) = netns.add_device(dev.clone()) {
+        dev.clear_net_state(NetDeivceState::__LINK_STATE_PRESENT);
+        return Err(error);
+    }
     Ok(())
 }
 

--- a/kernel/src/driver/net/iface.rs
+++ b/kernel/src/driver/net/iface.rs
@@ -257,6 +257,9 @@ pub trait Iface: crate::driver::base::device::Device {
         let smoltcp::wire::IpAddress::Ipv4(next_hop) = *next_hop else {
             return Err(SystemError::EAFNOSUPPORT);
         };
+        if ip_packet.len() > self.mtu() {
+            return Err(SystemError::EMSGSIZE);
+        }
         let napi = self.napi_struct();
         let owner_netns = self.net_namespace();
         let scheduler_netns = napi.is_none().then(|| owner_netns.clone()).flatten();

--- a/kernel/src/driver/net/iface.rs
+++ b/kernel/src/driver/net/iface.rs
@@ -475,6 +475,17 @@ pub trait Iface: crate::driver::base::device::Device {
     /// Inclusive runtime IP-MTU limits for this device.
     fn mtu_bounds(&self) -> MtuBounds;
 
+    /// Project a userspace-visible device MTU into the shared network stack.
+    ///
+    /// Most devices have an identity projection. Implementations whose ABI
+    /// MTU exceeds a protocol limit supported by the stack may derive a
+    /// smaller value here; the configured MTU remains the sole stored state.
+    /// Every value accepted by `mtu_bounds()` must project to a value accepted
+    /// by this interface's smoltcp device capabilities.
+    fn stack_mtu(&self, configured_mtu: usize) -> usize {
+        configured_mtu
+    }
+
     /// Stop new device notifications or software ingress admission before the
     /// shared NAPI owner is paused. This must not fail, allocate, or block.
     fn begin_admin_down(&self) {}

--- a/kernel/src/driver/net/iface_common.rs
+++ b/kernel/src/driver/net/iface_common.rs
@@ -503,173 +503,176 @@ impl IfaceCommon {
     where
         D: smoltcp::phy::Device + ?Sized,
     {
-        let scope = self.poll_scope();
-        match scope {
-            IfacePollScope::None => return false,
-            IfacePollScope::LocalOnly | IfacePollScope::Full => {}
-        }
+        let mut force_authoritative = force_authoritative;
+        loop {
+            let scope = self.poll_scope();
+            match scope {
+                IfacePollScope::None => return false,
+                IfacePollScope::LocalOnly | IfacePollScope::Full => {}
+            }
 
-        let netns = self.net_namespace();
-        let authoritative_ipv4_output = force_authoritative
-            || netns
+            let netns = self.net_namespace();
+            let authoritative_ipv4_output = force_authoritative
+                || netns
+                    .as_ref()
+                    .is_some_and(|netns| netns.router().requires_authoritative_ipv4_output());
+            let configured_ipv4_output = netns
                 .as_ref()
-                .is_some_and(|netns| netns.router().requires_authoritative_ipv4_output());
-        let configured_ipv4_output = netns
-            .as_ref()
-            .is_some_and(crate::net::neighbor::has_ipv4_entries);
-        let needs_routed_poll = self.needs_namespace_routing()
-            || scope == IfacePollScope::LocalOnly
-            || authoritative_ipv4_output
-            || configured_ipv4_output;
-        let router = if needs_routed_poll {
-            netns.as_ref().map(|netns| netns.router())
-        } else {
-            None
-        };
-        let route_policy = router.as_ref().and_then(|router| {
-            netns
-                .as_ref()
-                .map(|netns| crate::net::route::lock_output_routes(router, netns.device_list()))
-        });
-        let routed_this_round = route_policy.is_some();
-        let owner_is_up = scope == IfacePollScope::Full;
+                .is_some_and(crate::net::neighbor::has_ipv4_entries);
+            let needs_routed_poll = self.needs_namespace_routing()
+                || scope == IfacePollScope::LocalOnly
+                || authoritative_ipv4_output
+                || configured_ipv4_output;
+            let router = if needs_routed_poll {
+                netns.as_ref().map(|netns| netns.router())
+            } else {
+                None
+            };
+            let route_policy = router.as_ref().and_then(|router| {
+                netns
+                    .as_ref()
+                    .map(|netns| crate::net::route::lock_output_routes(router, netns.device_list()))
+            });
+            let routed_this_round = route_policy.is_some();
+            let owner_is_up = scope == IfacePollScope::Full;
 
-        let timestamp = crate::time::Instant::now().into();
-        let mut sockets = self.sockets.lock();
-        let mut interface = self.smol_iface.lock();
-        if self.poll_scope() != scope {
-            drop(interface);
-            drop(sockets);
-            drop(route_policy);
-            drop(router);
-            return self.poll_with_authoritative_mode(device, force_authoritative);
-        }
-        let configured_neighbors = netns.as_ref().and_then(|netns| {
-            crate::net::neighbor::has_ipv4_entries(netns).then(|| crate::net::neighbor::read(netns))
-        });
+            let timestamp = crate::time::Instant::now().into();
+            let mut sockets = self.sockets.lock();
+            let mut interface = self.smol_iface.lock();
+            if self.poll_scope() != scope {
+                drop(interface);
+                drop(sockets);
+                drop(route_policy);
+                drop(router);
+                continue;
+            }
+            let configured_neighbors = netns.as_ref().and_then(|netns| {
+                crate::net::neighbor::has_ipv4_entries(netns)
+                    .then(|| crate::net::neighbor::read(netns))
+            });
 
-        // Reservations and route-mode changes publish before SocketSet
-        // mutation. Recheck after serialization and restart before processing
-        // any packet if the initial backend snapshot became stale.
-        let restart = self.recheck_poll_mode(
-            netns.as_ref(),
-            needs_routed_poll,
-            authoritative_ipv4_output,
-            configured_ipv4_output,
-        );
-        if restart != PollModeRecheck::Current {
+            // Reservations and route-mode changes publish before SocketSet
+            // mutation. Recheck after serialization and restart before processing
+            // any packet if the initial backend snapshot became stale.
+            let restart = self.recheck_poll_mode(
+                netns.as_ref(),
+                needs_routed_poll,
+                authoritative_ipv4_output,
+                configured_ipv4_output,
+            );
+            if restart != PollModeRecheck::Current {
+                drop(configured_neighbors);
+                drop(interface);
+                drop(sockets);
+                drop(route_policy);
+                drop(router);
+                force_authoritative |= restart == PollModeRecheck::Authoritative;
+                continue;
+            }
+            let backend_policy = route_policy.as_ref().map(|routes| OutputBackendPolicy {
+                routes,
+                configured_neighbors: configured_neighbors.as_ref(),
+                owner_ifindex: self.iface_id as u32,
+                owner_is_up,
+                authoritative_ipv4_output,
+            });
+
+            // 刷新 listener 缓存：必须在持有 sockets 锁的前提下进行，且不得额外分配。
+            self.tcp_listener_backlog
+                .refresh_listen_socket_present(&sockets);
+
+            let (has_events, poll_again, deadline_rearm) = {
+                let local_result = if routed_this_round
+                    && (self.has_local_input() || scope == IfacePollScope::LocalOnly)
+                {
+                    let mut local_device =
+                        LocalInputDevice::new(device, self, backend_policy.unwrap());
+                    Some(interface.poll(timestamp, &mut local_device, &mut sockets))
+                } else {
+                    None
+                };
+                let poll_result = if scope == IfacePollScope::Full {
+                    if routed_this_round {
+                        let mut routed_device = RoutedTxDevice {
+                            device,
+                            queue: &self.local_input_queue,
+                            backend_policy: backend_policy.unwrap(),
+                        };
+                        Some(interface.poll(timestamp, &mut routed_device, &mut sockets))
+                    } else {
+                        Some(interface.poll(timestamp, device, &mut sockets))
+                    }
+                } else {
+                    None
+                };
+
+                // Reclaim/advance orphaned TCP sockets after smoltcp has processed ingress.
+                // If this aborts an orphan, compute poll_at afterwards so the pending RST is
+                // scheduled immediately instead of waiting for an unrelated future poll.
+                self.tcp_close_defer.reap_closed(timestamp, &mut sockets);
+
+                self.release_resolved_routed_outputs(
+                    &mut interface,
+                    timestamp,
+                    configured_neighbors.as_ref(),
+                );
+                self.retain_namespace_routing_for_pending_fragments(&interface);
+
+                let poll_at = interface.poll_at(timestamp, &sockets);
+                let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
+                (
+                    local_result.is_some_and(|result| {
+                        matches!(result, smoltcp::iface::PollResult::SocketStateChanged)
+                    }) || poll_result.is_some_and(|result| {
+                        matches!(result, smoltcp::iface::PollResult::SocketStateChanged)
+                    }),
+                    poll_again || self.has_local_input(),
+                    deadline_rearm,
+                )
+            };
+
+            // Publish the deadline while the smoltcp serialization locks are held,
+            // but notify the namespace only after dropping them.
+            // Lock order is smoltcp -> configured-neighbor read. Release in the
+            // reverse order before output draining may acquire another smoltcp
+            // lock; RTNL delete deliberately uses smoltcp -> table write.
             drop(configured_neighbors);
             drop(interface);
             drop(sockets);
             drop(route_policy);
             drop(router);
-            return self.poll_with_authoritative_mode(
-                device,
-                force_authoritative || restart == PollModeRecheck::Authoritative,
-            );
+            let output_drain = self.drain_local_outputs(device, Self::LOCAL_OUTPUT_POLL_BUDGET);
+            self.clear_namespace_routing_if_idle();
+            self.notify_deadline_rearm(deadline_rearm);
+
+            // 注意：不要在持有 bounds 读锁(且 irqsave)期间调用 socket.notify()。
+            // 否则会形成典型锁顺序反转死锁：
+            // - poll 路径：bounds.read_irqsave() -> socket.notify() -> socket.inner(RwLock)
+            // - connect/bind/close 路径：socket.inner(RwLock) -> bounds.write()
+            // 因此这里先快照一份 bound sockets，再逐个 notify。
+            //
+            // IMPORTANT: 对于 loopback 场景（如 gVisor BlockingLargeWrite 测试），始终需要唤醒所有
+            // 等待的 socket。原因：smoltcp 在处理 ACK 后可能不返回 SocketStateChanged，但发送端的
+            // can_send() 已经变为 true。如果只在 has_events 时唤醒，发送端会永远等待。
+            // 唤醒后 socket 会重新检查条件，如果条件不满足会继续等待，所以不会造成忙等待。
+            self.notify_all_bound_sockets();
+
+            // TODO: remove closed sockets
+            // let closed_sockets = self
+            //     .closing_sockets
+            //     .lock_irq_disabled()
+            //     .extract_if(|closing_socket| closing_socket.is_closed())
+            //     .collect::<Vec<_>>();
+            // drop(closed_sockets);
+            // `Iface::poll()` 的返回值不仅用于“这轮有没有状态变化”，还会被
+            // `poll_iface_until_quiescent()` 当作“是否还需要立刻再 poll 一轮”的判据。
+            //
+            // smoltcp 会通过 `poll_at() == Now` 表示还有立即可推进的工作
+            // （例如 loopback 二次往返、ACK/window update、仅 egress 前进等）。
+            // 如果这里只返回 `has_events`，快路径会过早停止，剩余工作只能等下一次外部事件，
+            // 在 blocking TCP 大包场景就会表现为 send/recv 偶发永久卡住。
+            return has_events || poll_again || output_drain.needs_immediate_poll();
         }
-        let backend_policy = route_policy.as_ref().map(|routes| OutputBackendPolicy {
-            routes,
-            configured_neighbors: configured_neighbors.as_ref(),
-            owner_ifindex: self.iface_id as u32,
-            owner_is_up,
-            authoritative_ipv4_output,
-        });
-
-        // 刷新 listener 缓存：必须在持有 sockets 锁的前提下进行，且不得额外分配。
-        self.tcp_listener_backlog
-            .refresh_listen_socket_present(&sockets);
-
-        let (has_events, poll_again, deadline_rearm) = {
-            let local_result = if routed_this_round
-                && (self.has_local_input() || scope == IfacePollScope::LocalOnly)
-            {
-                let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
-                Some(interface.poll(timestamp, &mut local_device, &mut sockets))
-            } else {
-                None
-            };
-            let poll_result = if scope == IfacePollScope::Full {
-                if routed_this_round {
-                    let mut routed_device = RoutedTxDevice {
-                        device,
-                        queue: &self.local_input_queue,
-                        backend_policy: backend_policy.unwrap(),
-                    };
-                    Some(interface.poll(timestamp, &mut routed_device, &mut sockets))
-                } else {
-                    Some(interface.poll(timestamp, device, &mut sockets))
-                }
-            } else {
-                None
-            };
-
-            // Reclaim/advance orphaned TCP sockets after smoltcp has processed ingress.
-            // If this aborts an orphan, compute poll_at afterwards so the pending RST is
-            // scheduled immediately instead of waiting for an unrelated future poll.
-            self.tcp_close_defer.reap_closed(timestamp, &mut sockets);
-
-            self.release_resolved_routed_outputs(
-                &mut interface,
-                timestamp,
-                configured_neighbors.as_ref(),
-            );
-            self.retain_namespace_routing_for_pending_fragments(&interface);
-
-            let poll_at = interface.poll_at(timestamp, &sockets);
-            let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
-            (
-                local_result.is_some_and(|result| {
-                    matches!(result, smoltcp::iface::PollResult::SocketStateChanged)
-                }) || poll_result.is_some_and(|result| {
-                    matches!(result, smoltcp::iface::PollResult::SocketStateChanged)
-                }),
-                poll_again || self.has_local_input(),
-                deadline_rearm,
-            )
-        };
-
-        // Publish the deadline while the smoltcp serialization locks are held,
-        // but notify the namespace only after dropping them.
-        // Lock order is smoltcp -> configured-neighbor read. Release in the
-        // reverse order before output draining may acquire another smoltcp
-        // lock; RTNL delete deliberately uses smoltcp -> table write.
-        drop(configured_neighbors);
-        drop(interface);
-        drop(sockets);
-        drop(route_policy);
-        drop(router);
-        let output_drain = self.drain_local_outputs(device, Self::LOCAL_OUTPUT_POLL_BUDGET);
-        self.clear_namespace_routing_if_idle();
-        self.notify_deadline_rearm(deadline_rearm);
-
-        // 注意：不要在持有 bounds 读锁(且 irqsave)期间调用 socket.notify()。
-        // 否则会形成典型锁顺序反转死锁：
-        // - poll 路径：bounds.read_irqsave() -> socket.notify() -> socket.inner(RwLock)
-        // - connect/bind/close 路径：socket.inner(RwLock) -> bounds.write()
-        // 因此这里先快照一份 bound sockets，再逐个 notify。
-        //
-        // IMPORTANT: 对于 loopback 场景（如 gVisor BlockingLargeWrite 测试），始终需要唤醒所有
-        // 等待的 socket。原因：smoltcp 在处理 ACK 后可能不返回 SocketStateChanged，但发送端的
-        // can_send() 已经变为 true。如果只在 has_events 时唤醒，发送端会永远等待。
-        // 唤醒后 socket 会重新检查条件，如果条件不满足会继续等待，所以不会造成忙等待。
-        self.notify_all_bound_sockets();
-
-        // TODO: remove closed sockets
-        // let closed_sockets = self
-        //     .closing_sockets
-        //     .lock_irq_disabled()
-        //     .extract_if(|closing_socket| closing_socket.is_closed())
-        //     .collect::<Vec<_>>();
-        // drop(closed_sockets);
-        // `Iface::poll()` 的返回值不仅用于“这轮有没有状态变化”，还会被
-        // `poll_iface_until_quiescent()` 当作“是否还需要立刻再 poll 一轮”的判据。
-        //
-        // smoltcp 会通过 `poll_at() == Now` 表示还有立即可推进的工作
-        // （例如 loopback 二次往返、ACK/window update、仅 egress 前进等）。
-        // 如果这里只返回 `has_events`，快路径会过早停止，剩余工作只能等下一次外部事件，
-        // 在 blocking TCP 大包场景就会表现为 send/recv 偶发永久卡住。
-        has_events || poll_again || output_drain.needs_immediate_poll()
     }
 
     /// NAPI 使用的 bounded poll：最多处理 `budget` 个 ingress 包，然后推进一次 egress。
@@ -691,223 +694,227 @@ impl IfaceCommon {
     where
         D: smoltcp::phy::Device + ?Sized,
     {
-        let scope = self.poll_scope();
-        match scope {
-            IfacePollScope::None => return napi::NapiPollResult::idle(),
-            IfacePollScope::LocalOnly | IfacePollScope::Full => {}
-        }
+        let mut force_authoritative = force_authoritative;
+        loop {
+            let scope = self.poll_scope();
+            match scope {
+                IfacePollScope::None => return napi::NapiPollResult::idle(),
+                IfacePollScope::LocalOnly | IfacePollScope::Full => {}
+            }
 
-        let netns = self.net_namespace();
-        let authoritative_ipv4_output = force_authoritative
-            || netns
+            let netns = self.net_namespace();
+            let authoritative_ipv4_output = force_authoritative
+                || netns
+                    .as_ref()
+                    .is_some_and(|netns| netns.router().requires_authoritative_ipv4_output());
+            let configured_ipv4_output = netns
                 .as_ref()
-                .is_some_and(|netns| netns.router().requires_authoritative_ipv4_output());
-        let configured_ipv4_output = netns
-            .as_ref()
-            .is_some_and(crate::net::neighbor::has_ipv4_entries);
-        let needs_routed_poll = self.needs_namespace_routing()
-            || scope == IfacePollScope::LocalOnly
-            || authoritative_ipv4_output
-            || configured_ipv4_output;
-        let router = if needs_routed_poll {
-            netns.as_ref().map(|netns| netns.router())
-        } else {
-            None
-        };
-        let route_policy = router.as_ref().and_then(|router| {
-            netns
-                .as_ref()
-                .map(|netns| crate::net::route::lock_output_routes(router, netns.device_list()))
-        });
-        let routed_this_round = route_policy.is_some();
-        let owner_is_up = scope == IfacePollScope::Full;
+                .is_some_and(crate::net::neighbor::has_ipv4_entries);
+            let needs_routed_poll = self.needs_namespace_routing()
+                || scope == IfacePollScope::LocalOnly
+                || authoritative_ipv4_output
+                || configured_ipv4_output;
+            let router = if needs_routed_poll {
+                netns.as_ref().map(|netns| netns.router())
+            } else {
+                None
+            };
+            let route_policy = router.as_ref().and_then(|router| {
+                netns
+                    .as_ref()
+                    .map(|netns| crate::net::route::lock_output_routes(router, netns.device_list()))
+            });
+            let routed_this_round = route_policy.is_some();
+            let owner_is_up = scope == IfacePollScope::Full;
 
-        let timestamp = crate::time::Instant::now().into();
-        let mut sockets = self.sockets.lock();
-        let mut interface = self.smol_iface.lock();
-        if self.poll_scope() != scope {
-            drop(interface);
-            drop(sockets);
-            drop(route_policy);
-            drop(router);
-            return self.poll_napi_with_authoritative_mode(device, budget, force_authoritative);
-        }
-        let configured_neighbors = netns.as_ref().and_then(|netns| {
-            crate::net::neighbor::has_ipv4_entries(netns).then(|| crate::net::neighbor::read(netns))
-        });
+            let timestamp = crate::time::Instant::now().into();
+            let mut sockets = self.sockets.lock();
+            let mut interface = self.smol_iface.lock();
+            if self.poll_scope() != scope {
+                drop(interface);
+                drop(sockets);
+                drop(route_policy);
+                drop(router);
+                continue;
+            }
+            let configured_neighbors = netns.as_ref().and_then(|netns| {
+                crate::net::neighbor::has_ipv4_entries(netns)
+                    .then(|| crate::net::neighbor::read(netns))
+            });
 
-        let restart = self.recheck_poll_mode(
-            netns.as_ref(),
-            needs_routed_poll,
-            authoritative_ipv4_output,
-            configured_ipv4_output,
-        );
-        if restart != PollModeRecheck::Current {
+            let restart = self.recheck_poll_mode(
+                netns.as_ref(),
+                needs_routed_poll,
+                authoritative_ipv4_output,
+                configured_ipv4_output,
+            );
+            if restart != PollModeRecheck::Current {
+                drop(configured_neighbors);
+                drop(interface);
+                drop(sockets);
+                drop(route_policy);
+                drop(router);
+                force_authoritative |= restart == PollModeRecheck::Authoritative;
+                continue;
+            }
+            let backend_policy = route_policy.as_ref().map(|routes| OutputBackendPolicy {
+                routes,
+                configured_neighbors: configured_neighbors.as_ref(),
+                owner_ifindex: self.iface_id as u32,
+                owner_is_up,
+                authoritative_ipv4_output,
+            });
+
+            // 刷新 listener 缓存：必须在持有 sockets 锁的前提下进行，且不得额外分配。
+            self.tcp_listener_backlog
+                .refresh_listen_socket_present(&sockets);
+
+            let mut processed = 0usize;
+            let mut had_packet = false;
+
+            // Local output is packet work too: it performs route/neighbor
+            // classification and transmission rather than merely reaping TX
+            // completions. Reserve half the shared NAPI budget when it is already
+            // backlogged, then let either side consume unused capacity.
+            let ingress_budget = if self.local_input_queue.has_ready_output(timestamp) {
+                budget.div_ceil(2)
+            } else {
+                budget
+            };
+
+            // Reserve at most half of the first pass for namespace-local handoff,
+            // then poll the hardware/device queue. If the device has no work, use
+            // the remaining budget for local input. This keeps both sources
+            // progressing without reducing throughput when only one is active.
+            let local_first_budget = if scope == IfacePollScope::Full {
+                ingress_budget.div_ceil(2)
+            } else {
+                ingress_budget
+            };
+            if routed_this_round {
+                let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
+                for _ in 0..local_first_budget {
+                    match interface.poll_ingress_single(timestamp, &mut local_device, &mut sockets)
+                    {
+                        smoltcp::iface::PollIngressSingleResult::None => break,
+                        smoltcp::iface::PollIngressSingleResult::PacketProcessed
+                        | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
+                            had_packet = true;
+                            processed += 1;
+                        }
+                    }
+                }
+            }
+
+            let device_budget = if scope == IfacePollScope::Full {
+                ingress_budget - processed
+            } else {
+                0
+            };
+            let mut device_processed = 0usize;
+            if routed_this_round {
+                let mut routed_device = RoutedTxDevice {
+                    device,
+                    queue: &self.local_input_queue,
+                    backend_policy: backend_policy.unwrap(),
+                };
+                for _ in 0..device_budget {
+                    match interface.poll_ingress_single(timestamp, &mut routed_device, &mut sockets)
+                    {
+                        smoltcp::iface::PollIngressSingleResult::None => break,
+                        smoltcp::iface::PollIngressSingleResult::PacketProcessed
+                        | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
+                            had_packet = true;
+                            processed += 1;
+                            device_processed += 1;
+                        }
+                    }
+                }
+            } else {
+                for _ in 0..device_budget {
+                    match interface.poll_ingress_single(timestamp, device, &mut sockets) {
+                        smoltcp::iface::PollIngressSingleResult::None => break,
+                        smoltcp::iface::PollIngressSingleResult::PacketProcessed
+                        | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
+                            had_packet = true;
+                            processed += 1;
+                            device_processed += 1;
+                        }
+                    }
+                }
+            }
+
+            let remaining = device_budget - device_processed;
+            if routed_this_round && remaining > 0 && self.has_local_input() {
+                let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
+                for _ in 0..remaining {
+                    match interface.poll_ingress_single(timestamp, &mut local_device, &mut sockets)
+                    {
+                        smoltcp::iface::PollIngressSingleResult::None => break,
+                        smoltcp::iface::PollIngressSingleResult::PacketProcessed
+                        | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
+                            had_packet = true;
+                            processed += 1;
+                        }
+                    }
+                }
+            }
+
+            // 推进发送路径（smoltcp 保证 bounded work）。
+            if routed_this_round && owner_is_up {
+                let mut routed_device = RoutedTxDevice {
+                    device,
+                    queue: &self.local_input_queue,
+                    backend_policy: backend_policy.unwrap(),
+                };
+                let _ = interface.poll_egress(timestamp, &mut routed_device, &mut sockets);
+            } else if routed_this_round {
+                let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
+                let _ = interface.poll_egress(timestamp, &mut local_device, &mut sockets);
+            } else {
+                let _ = interface.poll_egress(timestamp, device, &mut sockets);
+            }
+
+            self.release_resolved_routed_outputs(
+                &mut interface,
+                timestamp,
+                configured_neighbors.as_ref(),
+            );
+            self.retain_namespace_routing_for_pending_fragments(&interface);
+
+            let poll_at = interface.poll_at(timestamp, &sockets);
+            let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
+
+            // 解锁后唤醒/通知 socket（沿用原 poll() 的 Linux-like 语义）。
+            // Preserve the same smoltcp -> neighbor lock order as the direct poll
+            // path before draining may enter a target interface.
             drop(configured_neighbors);
             drop(interface);
             drop(sockets);
             drop(route_policy);
             drop(router);
-            return self.poll_napi_with_authoritative_mode(
-                device,
-                budget,
-                force_authoritative || restart == PollModeRecheck::Authoritative,
+            let output_drain = self.drain_local_outputs(device, budget - processed);
+            self.clear_namespace_routing_if_idle();
+            self.notify_deadline_rearm(deadline_rearm);
+            self.notify_all_bound_sockets();
+
+            // NAPI 语义：只要“还有立即可推进的工作”，就应继续留在 poll_list。
+            //
+            // 除了 ingress backlog 超过 budget 之外，egress/ACK 路径也可能要求立刻再次 poll：
+            // smoltcp 会通过 `poll_at() == Now`（这里被 clamp 成 `Some(timestamp)`）表达这一点。
+            // 如果忽略这个条件，loopback/TCP 大流量场景可能出现：
+            // - 已处理完当前 ingress batch；
+            // - 但仍有 ACK / window update / 后续 egress 需要立即发送；
+            // - NAPI 线程却错误睡眠，直到下一次外部事件才继续推进，
+            //   导致 send done 后 recv 端偶发卡住。
+            return napi::NapiPollResult::new(
+                processed + output_drain.work_done,
+                (had_packet && processed == ingress_budget)
+                    || poll_again
+                    || self.has_local_input()
+                    || output_drain.needs_immediate_poll(),
             );
         }
-        let backend_policy = route_policy.as_ref().map(|routes| OutputBackendPolicy {
-            routes,
-            configured_neighbors: configured_neighbors.as_ref(),
-            owner_ifindex: self.iface_id as u32,
-            owner_is_up,
-            authoritative_ipv4_output,
-        });
-
-        // 刷新 listener 缓存：必须在持有 sockets 锁的前提下进行，且不得额外分配。
-        self.tcp_listener_backlog
-            .refresh_listen_socket_present(&sockets);
-
-        let mut processed = 0usize;
-        let mut had_packet = false;
-
-        // Local output is packet work too: it performs route/neighbor
-        // classification and transmission rather than merely reaping TX
-        // completions. Reserve half the shared NAPI budget when it is already
-        // backlogged, then let either side consume unused capacity.
-        let ingress_budget = if self.local_input_queue.has_ready_output(timestamp) {
-            budget.div_ceil(2)
-        } else {
-            budget
-        };
-
-        // Reserve at most half of the first pass for namespace-local handoff,
-        // then poll the hardware/device queue. If the device has no work, use
-        // the remaining budget for local input. This keeps both sources
-        // progressing without reducing throughput when only one is active.
-        let local_first_budget = if scope == IfacePollScope::Full {
-            ingress_budget.div_ceil(2)
-        } else {
-            ingress_budget
-        };
-        if routed_this_round {
-            let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
-            for _ in 0..local_first_budget {
-                match interface.poll_ingress_single(timestamp, &mut local_device, &mut sockets) {
-                    smoltcp::iface::PollIngressSingleResult::None => break,
-                    smoltcp::iface::PollIngressSingleResult::PacketProcessed
-                    | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
-                        had_packet = true;
-                        processed += 1;
-                    }
-                }
-            }
-        }
-
-        let device_budget = if scope == IfacePollScope::Full {
-            ingress_budget - processed
-        } else {
-            0
-        };
-        let mut device_processed = 0usize;
-        if routed_this_round {
-            let mut routed_device = RoutedTxDevice {
-                device,
-                queue: &self.local_input_queue,
-                backend_policy: backend_policy.unwrap(),
-            };
-            for _ in 0..device_budget {
-                match interface.poll_ingress_single(timestamp, &mut routed_device, &mut sockets) {
-                    smoltcp::iface::PollIngressSingleResult::None => break,
-                    smoltcp::iface::PollIngressSingleResult::PacketProcessed
-                    | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
-                        had_packet = true;
-                        processed += 1;
-                        device_processed += 1;
-                    }
-                }
-            }
-        } else {
-            for _ in 0..device_budget {
-                match interface.poll_ingress_single(timestamp, device, &mut sockets) {
-                    smoltcp::iface::PollIngressSingleResult::None => break,
-                    smoltcp::iface::PollIngressSingleResult::PacketProcessed
-                    | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
-                        had_packet = true;
-                        processed += 1;
-                        device_processed += 1;
-                    }
-                }
-            }
-        }
-
-        let remaining = device_budget - device_processed;
-        if routed_this_round && remaining > 0 && self.has_local_input() {
-            let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
-            for _ in 0..remaining {
-                match interface.poll_ingress_single(timestamp, &mut local_device, &mut sockets) {
-                    smoltcp::iface::PollIngressSingleResult::None => break,
-                    smoltcp::iface::PollIngressSingleResult::PacketProcessed
-                    | smoltcp::iface::PollIngressSingleResult::SocketStateChanged => {
-                        had_packet = true;
-                        processed += 1;
-                    }
-                }
-            }
-        }
-
-        // 推进发送路径（smoltcp 保证 bounded work）。
-        if routed_this_round && owner_is_up {
-            let mut routed_device = RoutedTxDevice {
-                device,
-                queue: &self.local_input_queue,
-                backend_policy: backend_policy.unwrap(),
-            };
-            let _ = interface.poll_egress(timestamp, &mut routed_device, &mut sockets);
-        } else if routed_this_round {
-            let mut local_device = LocalInputDevice::new(device, self, backend_policy.unwrap());
-            let _ = interface.poll_egress(timestamp, &mut local_device, &mut sockets);
-        } else {
-            let _ = interface.poll_egress(timestamp, device, &mut sockets);
-        }
-
-        self.release_resolved_routed_outputs(
-            &mut interface,
-            timestamp,
-            configured_neighbors.as_ref(),
-        );
-        self.retain_namespace_routing_for_pending_fragments(&interface);
-
-        let poll_at = interface.poll_at(timestamp, &sockets);
-        let (poll_again, deadline_rearm) = self.publish_poll_deadline(timestamp, poll_at);
-
-        // 解锁后唤醒/通知 socket（沿用原 poll() 的 Linux-like 语义）。
-        // Preserve the same smoltcp -> neighbor lock order as the direct poll
-        // path before draining may enter a target interface.
-        drop(configured_neighbors);
-        drop(interface);
-        drop(sockets);
-        drop(route_policy);
-        drop(router);
-        let output_drain = self.drain_local_outputs(device, budget - processed);
-        self.clear_namespace_routing_if_idle();
-        self.notify_deadline_rearm(deadline_rearm);
-        self.notify_all_bound_sockets();
-
-        // NAPI 语义：只要“还有立即可推进的工作”，就应继续留在 poll_list。
-        //
-        // 除了 ingress backlog 超过 budget 之外，egress/ACK 路径也可能要求立刻再次 poll：
-        // smoltcp 会通过 `poll_at() == Now`（这里被 clamp 成 `Some(timestamp)`）表达这一点。
-        // 如果忽略这个条件，loopback/TCP 大流量场景可能出现：
-        // - 已处理完当前 ingress batch；
-        // - 但仍有 ACK / window update / 后续 egress 需要立即发送；
-        // - NAPI 线程却错误睡眠，直到下一次外部事件才继续推进，
-        //   导致 send done 后 recv 端偶发卡住。
-        napi::NapiPollResult::new(
-            processed + output_drain.work_done,
-            (had_packet && processed == ingress_budget)
-                || poll_again
-                || self.has_local_input()
-                || output_drain.needs_immediate_poll(),
-        )
     }
 
     fn drain_local_outputs<D>(&self, device: &mut D, budget: usize) -> LocalOutputDrainResult

--- a/kernel/src/driver/net/iface_common.rs
+++ b/kernel/src/driver/net/iface_common.rs
@@ -535,6 +535,13 @@ impl IfaceCommon {
         let timestamp = crate::time::Instant::now().into();
         let mut sockets = self.sockets.lock();
         let mut interface = self.smol_iface.lock();
+        if self.poll_scope() != scope {
+            drop(interface);
+            drop(sockets);
+            drop(route_policy);
+            drop(router);
+            return self.poll_with_authoritative_mode(device, force_authoritative);
+        }
         let configured_neighbors = netns.as_ref().and_then(|netns| {
             crate::net::neighbor::has_ipv4_entries(netns).then(|| crate::net::neighbor::read(netns))
         });
@@ -716,6 +723,13 @@ impl IfaceCommon {
         let timestamp = crate::time::Instant::now().into();
         let mut sockets = self.sockets.lock();
         let mut interface = self.smol_iface.lock();
+        if self.poll_scope() != scope {
+            drop(interface);
+            drop(sockets);
+            drop(route_policy);
+            drop(router);
+            return self.poll_napi_with_authoritative_mode(device, budget, force_authoritative);
+        }
         let configured_neighbors = netns.as_ref().and_then(|netns| {
             crate::net::neighbor::has_ipv4_entries(netns).then(|| crate::net::neighbor::read(netns))
         });
@@ -1339,11 +1353,11 @@ impl IfaceCommon {
     }
 
     pub fn mtu(&self) -> usize {
-        self.mtu.load(Ordering::Relaxed)
+        self.mtu.load(Ordering::Acquire)
     }
 
     pub fn set_mtu(&self, mtu: usize) {
-        self.mtu.store(mtu, Ordering::Relaxed);
+        self.mtu.store(mtu, Ordering::Release);
     }
 
     pub(crate) fn address_metadata(&self) -> &Mutex<Vec<AddressMetadata>> {

--- a/kernel/src/driver/net/iface_common.rs
+++ b/kernel/src/driver/net/iface_common.rs
@@ -6,6 +6,7 @@ pub struct IfaceCommon {
     pub(super) flags: AtomicU32,
     pub(super) mtu: AtomicUsize,
     pub(super) type_: InterfaceType,
+    tx_admission: tx_admission::TxAdmission,
     pub(super) smol_iface: Mutex<smoltcp::iface::Interface>,
     /// 存smoltcp网卡的套接字集
     pub(super) sockets: Mutex<smoltcp::iface::SocketSet<'static>>,
@@ -118,6 +119,7 @@ impl IfaceCommon {
             flags: AtomicU32::new(flags.bits()),
             mtu: AtomicUsize::new(mtu),
             type_,
+            tx_admission: tx_admission::TxAdmission::new(flags.contains(InterfaceFlags::UP)),
             napi_struct: RwLock::new(None),
             local_input_queue: LocalInputQueue::new(),
             address_metadata: Mutex::new(address_metadata),
@@ -1354,6 +1356,18 @@ impl IfaceCommon {
 
     pub fn mtu(&self) -> usize {
         self.mtu.load(Ordering::Acquire)
+    }
+
+    pub(crate) fn try_acquire_tx(&self) -> Option<tx_admission::TxAdmissionGuard<'_>> {
+        self.tx_admission.try_enter()
+    }
+
+    pub(crate) fn close_tx_and_wait(&self) {
+        self.tx_admission.close_and_wait();
+    }
+
+    pub(crate) fn open_tx(&self) {
+        self.tx_admission.open();
     }
 
     pub fn set_mtu(&self, mtu: usize) {

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -36,6 +36,12 @@ use super::{register_netdevice, NetDeivceState, NetDeviceCommonData, Operstate};
 use super::{Iface, IfaceCommon, MtuBounds};
 
 const DEVICE_NAME: &str = "loopback";
+/// Linux's userspace-visible loopback MTU and packet-buffer capacity.
+const LOOPBACK_MTU: usize = 64 * 1024;
+/// smoltcp currently shares one MTU across IPv4 and IPv6. Keep its projection
+/// within IPv4's 16-bit total-length field while the device retains Linux's
+/// 64 KiB administrative MTU and packet-buffer capacity.
+const LOOPBACK_STACK_MTU: usize = u16::MAX as usize;
 
 /// ## 环回接收令牌
 /// 用于储存lo网卡接收到的数据
@@ -190,10 +196,11 @@ impl phy::Device for LoopbackDriver {
     where
         Self: 'a;
     /// ## 返回设备的物理层特性。
-    /// lo设备的最大传输单元为65535，最大突发大小为1，传输介质默认为Ethernet
+    /// smoltcp 的共享 IPv4/IPv6 MTU 能力使用 IPv4 可表示上限；
+    /// Linux 可见的 64 KiB loopback MTU 由 `LoopbackInterface` 单独公布。
     fn capabilities(&self) -> phy::DeviceCapabilities {
         let mut result = phy::DeviceCapabilities::default();
-        result.max_transmission_unit = 65535;
+        result.max_transmission_unit = LOOPBACK_STACK_MTU;
         result.max_burst_size = Some(1);
         result.medium = smoltcp::phy::Medium::Ip;
         return result;
@@ -253,8 +260,6 @@ impl phy::Device for LoopbackDriver {
 }
 
 impl LoopbackDriver {
-    const MAX_PACKET_LEN: usize = 65535;
-
     pub fn set_iface(&self, iface: Weak<dyn Iface>) {
         *self.iface.lock() = Some(iface);
     }
@@ -268,7 +273,7 @@ impl LoopbackDriver {
     }
 
     fn submit_frame(&self, frame: Vec<u8>) -> Result<(), SystemError> {
-        if frame.len() > Self::MAX_PACKET_LEN {
+        if frame.len() > LOOPBACK_MTU {
             return Err(SystemError::EMSGSIZE);
         }
         self.inner.lock().loopback_transmit(frame);
@@ -283,7 +288,7 @@ impl LoopbackDriver {
     }
 
     pub fn try_raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {
-        if frame.len() > Self::MAX_PACKET_LEN {
+        if frame.len() > LOOPBACK_MTU {
             return Err(SystemError::EMSGSIZE);
         }
         self.submit_frame(frame.to_vec())
@@ -335,8 +340,6 @@ impl LoopbackInterface {
 
     /// 在指定网络命名空间中创建 loopback，使用给定的 per-netns ifindex（Linux 新 netns 中 lo 通常为 1）。
     pub fn new_with_ifindex(mut driver: LoopbackDriver, ifindex: usize) -> Arc<Self> {
-        use smoltcp::phy::Device;
-
         let iface_id = ifindex;
 
         // let hardware_addr = HardwareAddress::Ethernet(smoltcp::wire::EthernetAddress([
@@ -371,7 +374,7 @@ impl LoopbackInterface {
         // device-intrinsic flag. Registration owns PRESENT, administrative
         // policy owns UP, and user_visible_flags() derives runtime flags.
         let flags = InterfaceFlags::LOOPBACK;
-        let mtu = driver.capabilities().max_transmission_unit;
+        let mtu = LOOPBACK_MTU;
 
         let iface = Arc::new(LoopbackInterface {
             driver,
@@ -631,10 +634,15 @@ impl Iface for LoopbackInterface {
 
     fn mtu_bounds(&self) -> MtuBounds {
         MtuBounds {
-            // smoltcp's IPv4/IPv6 TCP paths require room for their headers.
+            // Match Linux's standard loopback MTU while retaining the
+            // protocol-safe smoltcp projection in stack_mtu().
             min: 68,
-            max: 65535,
+            max: LOOPBACK_MTU,
         }
+    }
+
+    fn stack_mtu(&self, configured_mtu: usize) -> usize {
+        configured_mtu.min(LOOPBACK_STACK_MTU)
     }
 }
 

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -651,6 +651,7 @@ pub fn generate_loopback_iface_default() -> Arc<LoopbackInterface> {
     iface.common.publish_configured_flags(prepared);
     iface.set_net_state(NetDeivceState::__LINK_STATE_START);
     iface.set_operstate(Operstate::IF_OPER_UP);
+    iface.common.open_tx();
 
     iface
 }

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -38,6 +38,10 @@ use super::{Iface, IfaceCommon, MtuBounds};
 const DEVICE_NAME: &str = "loopback";
 /// Linux's userspace-visible loopback MTU and packet-buffer capacity.
 const LOOPBACK_MTU: usize = 64 * 1024;
+/// IPv4 requires room for its minimum header. smoltcp also uses this lower
+/// bound for its shared IPv4/IPv6 MTU, independently of Linux's administrative
+/// loopback MTU range.
+const LOOPBACK_STACK_MIN_MTU: usize = 68;
 /// smoltcp currently shares one MTU across IPv4 and IPv6. Keep its projection
 /// within IPv4's 16-bit total-length field while the device retains Linux's
 /// 64 KiB administrative MTU and packet-buffer capacity.
@@ -272,10 +276,21 @@ impl LoopbackDriver {
         !self.inner.lock().queue.is_empty()
     }
 
-    fn submit_frame(&self, frame: Vec<u8>) -> Result<(), SystemError> {
-        if frame.len() > LOOPBACK_MTU {
+    fn packet_len_limit(&self) -> usize {
+        self.iface().map_or(LOOPBACK_MTU, |iface| iface.mtu())
+    }
+
+    fn validate_frame_len(&self, len: usize) -> Result<(), SystemError> {
+        if len > self.packet_len_limit() {
             return Err(SystemError::EMSGSIZE);
         }
+        Ok(())
+    }
+
+    fn submit_frame(&self, frame: Vec<u8>) -> Result<(), SystemError> {
+        // Recheck immediately before enqueueing: the configured MTU can change
+        // after a caller's pre-allocation check.
+        self.validate_frame_len(frame.len())?;
         self.inner.lock().loopback_transmit(frame);
         if let Some(iface) = self.iface() {
             if let Some(napi) = iface.napi_struct() {
@@ -288,9 +303,7 @@ impl LoopbackDriver {
     }
 
     pub fn try_raw_transmit(&self, frame: &[u8]) -> Result<(), SystemError> {
-        if frame.len() > LOOPBACK_MTU {
-            return Err(SystemError::EMSGSIZE);
-        }
+        self.validate_frame_len(frame.len())?;
         self.submit_frame(frame.to_vec())
     }
 }
@@ -591,6 +604,9 @@ impl Iface for LoopbackInterface {
         _next_hop: &smoltcp::wire::IpAddress,
         ip_packet: &[u8],
     ) -> Result<(), super::RouteSendError> {
+        if ip_packet.len() > self.mtu() {
+            return Err(SystemError::EMSGSIZE.into());
+        }
         self.inject_local_ipv4_packet(self.nic_id() as u32, self.mac(), ip_packet, false)
             .map_err(Into::into)
     }
@@ -636,13 +652,13 @@ impl Iface for LoopbackInterface {
         MtuBounds {
             // Match Linux's standard loopback MTU while retaining the
             // protocol-safe smoltcp projection in stack_mtu().
-            min: 68,
+            min: 0,
             max: LOOPBACK_MTU,
         }
     }
 
     fn stack_mtu(&self, configured_mtu: usize) -> usize {
-        configured_mtu.min(LOOPBACK_STACK_MTU)
+        configured_mtu.clamp(LOOPBACK_STACK_MIN_MTU, LOOPBACK_STACK_MTU)
     }
 }
 

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -33,7 +33,7 @@ use crate::libs::once::Once;
 
 use super::{register_netdevice, NetDeivceState, NetDeviceCommonData, Operstate};
 
-use super::{Iface, IfaceCommon};
+use super::{Iface, IfaceCommon, MtuBounds};
 
 const DEVICE_NAME: &str = "loopback";
 
@@ -367,10 +367,10 @@ impl LoopbackInterface {
             ip_addrs.push(cidr6).expect("Push ipCidr failed: full");
         });
 
-        let flags = InterfaceFlags::LOOPBACK
-            | InterfaceFlags::UP
-            | InterfaceFlags::RUNNING
-            | InterfaceFlags::LOWER_UP;
+        // Like Linux's gen_lo_setup(), construction records only the
+        // device-intrinsic flag. Registration owns PRESENT, administrative
+        // policy owns UP, and user_visible_flags() derives runtime flags.
+        let flags = InterfaceFlags::LOOPBACK;
         let mtu = driver.capabilities().max_transmission_unit;
 
         let iface = Arc::new(LoopbackInterface {
@@ -628,12 +628,29 @@ impl Iface for LoopbackInterface {
     fn mtu(&self) -> usize {
         self.common.mtu()
     }
+
+    fn mtu_bounds(&self) -> MtuBounds {
+        MtuBounds {
+            // smoltcp's IPv4/IPv6 TCP paths require room for their headers.
+            min: 68,
+            max: 65535,
+        }
+    }
 }
 
 pub fn generate_loopback_iface_default() -> Arc<LoopbackInterface> {
     let iface = LoopbackInterface::new(LoopbackDriver::default());
-    // 标识网络设备已经启动
+
+    // Preserve DragonOS's initial-netns bootstrap policy explicitly. Fresh
+    // network namespaces follow Linux and leave lo administratively down;
+    // neither policy belongs in the device constructor.
+    let prepared = iface
+        .common
+        .prepare_configured_flags(InterfaceFlags::UP, InterfaceFlags::UP)
+        .expect("initial loopback flags must be representable");
+    iface.common.publish_configured_flags(prepared);
     iface.set_net_state(NetDeivceState::__LINK_STATE_START);
+    iface.set_operstate(Operstate::IF_OPER_UP);
 
     iface
 }

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -43,6 +43,7 @@ mod iface_common;
 mod iface_deadline;
 mod local_output;
 mod local_queue;
+mod tx_admission;
 
 pub use iface::*;
 pub use iface_common::IfaceCommon;

--- a/kernel/src/driver/net/napi.rs
+++ b/kernel/src/driver/net/napi.rs
@@ -9,8 +9,8 @@ use alloc::collections::VecDeque;
 use alloc::string::ToString;
 use alloc::sync::{Arc, Weak};
 use core::sync::atomic::AtomicU32;
-use napi_state::CompleteState;
 pub(crate) use napi_state::ScheduleState;
+use napi_state::{CompleteState, ResumeState};
 use system_error::SystemError;
 use unified_init::macros::unified_init;
 
@@ -110,6 +110,8 @@ bitflags! {
         /// 一个可选的高级功能，表示此NAPI由专用内核线程处理。
         const THREADED          = 1 << 8;
         const SCHED_THREADED    = 1 << 9;
+        /// Reversible administrative pause, separate from teardown DISABLE.
+        const PAUSED            = 1 << 10;
     }
 }
 
@@ -175,6 +177,9 @@ fn net_rx_action() {
             if napi_is_disabled(&napi) {
                 continue;
             }
+            if napi_state::complete_paused(&napi.state) {
+                continue;
+            }
 
             let Some((iface, result)) = napi.poll(budget) else {
                 // A registered NAPI must not outlive its interface. Clear the state to avoid
@@ -224,6 +229,27 @@ pub(crate) fn napi_complete_state(napi: &NapiStruct) -> CompleteState {
 /// Complete a NAPI instance which has no device-specific callback handshake.
 pub fn napi_complete(napi: Arc<NapiStruct>) {
     if napi_complete_state(&napi) == CompleteState::Missed {
+        __napi_schedule(napi);
+    }
+}
+
+/// Reversibly pause polling for an administratively down interface.
+fn napi_pause(napi: &NapiStruct) {
+    napi_state::pause(&napi.state);
+}
+
+/// Pause new scheduling and wait until the queued or active owner observes it.
+/// Callers must not hold a lock needed by the poll path.
+pub(crate) fn napi_pause_and_wait(napi: &NapiStruct) {
+    napi_pause(napi);
+    while napi.state.load(core::sync::atomic::Ordering::Acquire) & napi_state::SCHED != 0 {
+        crate::sched::sched_yield();
+    }
+}
+
+/// Resume polling while preserving the unique queued/active owner.
+pub(crate) fn napi_resume(napi: Arc<NapiStruct>) {
+    if napi_state::resume(&napi.state) == ResumeState::Acquired {
         __napi_schedule(napi);
     }
 }
@@ -292,7 +318,7 @@ pub fn napi_schedule(napi: Arc<NapiStruct>) -> NapiScheduleResult {
         return NapiScheduleResult::Detached;
     };
     iface.napi_poll_begin();
-    if napi_is_disabled(&napi) {
+    if napi_is_disabled(&napi) || napi_state::complete_paused(&napi.state) {
         return NapiScheduleResult::Disabled;
     }
     __napi_schedule(napi);

--- a/kernel/src/driver/net/sysfs.rs
+++ b/kernel/src/driver/net/sysfs.rs
@@ -1,7 +1,9 @@
+pub(crate) use crate::driver::base::device_rename::PreparedDeviceSysfsRename;
 use crate::{
     driver::base::{
         class::Class,
         device::{device_manager, Device},
+        device_rename::prepare_class_device_sysfs_rename,
         kobject::KObject,
     },
     filesystem::{
@@ -13,6 +15,7 @@ use crate::{
     },
 };
 use alloc::sync::Arc;
+use alloc::{string::String, vec::Vec};
 use intertrait::cast::CastArc;
 use log::{error, warn};
 use system_error::SystemError;
@@ -59,26 +62,90 @@ pub fn netdev_unregister_kobject(dev: Arc<dyn Iface>) {
     device_manager().remove(&(dev as Arc<dyn Device>));
 }
 
+/// Prepares the sysfs half of a netdevice rename without changing the logical
+/// interface name. Non-initial namespaces deliberately have no sysfs object.
+pub(crate) fn prepare_netdev_sysfs_rename(
+    dev: &Arc<dyn Iface>,
+    new_name: String,
+) -> Result<PreparedDeviceSysfsRename, SystemError> {
+    prepare_class_device_sysfs_rename(&(dev.clone() as Arc<dyn Device>), new_name)
+}
+
+/// Emits the best-effort kobject move notification after the sysfs and logical
+/// netdevice names have committed.
+pub(crate) fn netdev_emit_move_uevent(dev: Arc<dyn Iface>, old_devpath: String) {
+    netdev_emit_uevent_with_env(dev, "move", Some(("DEVPATH_OLD", old_devpath)));
+}
+
 /// Emit a netdevice lifecycle event after the corresponding structural state
 /// has been committed. Notification delivery is best effort, like Linux
 /// kobject and rtnetlink multicast: listener backpressure must not roll back a
 /// registered device or prevent an unregistered device from being removed.
 pub fn netdev_emit_uevent(dev: Arc<dyn Iface>, action: &'static str) {
-    let ifname = dev.iface_name();
-    if let Err(error) = <dyn KObject>::kobject_uevent(
-        &(dev.clone() as Arc<dyn KObject>),
-        action,
-        &[
-            ("SUBSYSTEM", "net".into()),
-            ("DEVNAME", ifname.clone()),
-            ("INTERFACE", ifname.clone()),
-        ],
-    ) {
-        warn!(
-            "failed to emit '{}' uevent for netdevice '{}': {:?}",
-            action, ifname, error
-        );
+    netdev_emit_uevent_with_env(dev, action, None);
+}
+
+/// Builds the Linux netdevice-specific environment in one place and routes
+/// the event according to the device's namespace ownership. Event-specific
+/// fields are appended without duplicating the stable identity fields.
+fn netdev_emit_uevent_with_env(
+    dev: Arc<dyn Iface>,
+    action: &'static str,
+    action_env: Option<(&'static str, String)>,
+) {
+    let result = try_emit_netdev_uevent(&dev, action, action_env);
+    if let Err(error) = result {
+        warn!("failed to emit '{}' netdevice uevent: {:?}", action, error);
     }
+}
+
+fn try_emit_netdev_uevent(
+    dev: &Arc<dyn Iface>,
+    action: &'static str,
+    action_env: Option<(&'static str, String)>,
+) -> Result<(), SystemError> {
+    let ifname = dev.common().with_iface_name(try_copy_string)?;
+    let Some(netns) = dev.net_namespace() else {
+        return Err(SystemError::ENODEV);
+    };
+    let inode = dev.inode().ok_or(SystemError::ENOENT)?;
+    let devpath = crate::filesystem::sysfs::sysfs_instance().try_kernfs_path(&inode)?;
+    let mut env = Vec::new();
+    env.try_reserve_exact(4 + usize::from(action_env.is_some()))
+        .map_err(|_| SystemError::ENOMEM)?;
+    env.push(("SUBSYSTEM", try_copy_string("net")?));
+    env.push(("DEVNAME", try_copy_string(&ifname)?));
+    env.push(("INTERFACE", ifname));
+    env.push(("IFINDEX", try_decimal_string(dev.nic_id())?));
+    if let Some(field) = action_env {
+        env.push(field);
+    }
+
+    <dyn KObject>::emit_uevent_in_netns(action, &devpath, &env, netns)
+}
+
+fn try_copy_string(source: &str) -> Result<String, SystemError> {
+    let mut result = String::new();
+    result
+        .try_reserve_exact(source.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    result.push_str(source);
+    Ok(result)
+}
+
+fn try_decimal_string(mut value: usize) -> Result<String, SystemError> {
+    let mut digits = [0u8; 20];
+    let mut start = digits.len();
+    loop {
+        start -= 1;
+        digits[start] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    let value = core::str::from_utf8(&digits[start..]).map_err(|_| SystemError::EINVAL)?;
+    try_copy_string(value)
 }
 
 // 参考：https://code.dragonos.org.cn/xref/linux-6.6.21/net/core/net-sysfs.c

--- a/kernel/src/driver/net/tx_admission.rs
+++ b/kernel/src/driver/net/tx_admission.rs
@@ -1,0 +1,63 @@
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+const CLOSED: usize = 1usize << (usize::BITS - 1);
+const ACTIVE_MASK: usize = !CLOSED;
+
+/// Serializes the final device-TX admission point with administrative DOWN.
+///
+/// Callers acquire a guard only around the synchronous raw-TX path; user
+/// copies and packet construction must happen before admission. Closing the
+/// gate prevents new submissions and waits for already admitted ones.
+pub(super) struct TxAdmission {
+    state: AtomicUsize,
+}
+
+pub(crate) struct TxAdmissionGuard<'a> {
+    admission: &'a TxAdmission,
+}
+
+impl TxAdmission {
+    pub(super) fn new(enabled: bool) -> Self {
+        Self {
+            state: AtomicUsize::new(if enabled { 0 } else { CLOSED }),
+        }
+    }
+
+    pub(super) fn try_enter(&self) -> Option<TxAdmissionGuard<'_>> {
+        let mut state = self.state.load(Ordering::Acquire);
+        loop {
+            if state & CLOSED != 0 || state & ACTIVE_MASK == ACTIVE_MASK {
+                return None;
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Some(TxAdmissionGuard { admission: self }),
+                Err(current) => state = current,
+            }
+        }
+    }
+
+    pub(super) fn close_and_wait(&self) {
+        let previous = self.state.fetch_or(CLOSED, Ordering::AcqRel);
+        debug_assert_eq!(previous & CLOSED, 0);
+        while self.state.load(Ordering::Acquire) != CLOSED {
+            crate::sched::sched_yield();
+        }
+    }
+
+    pub(super) fn open(&self) {
+        debug_assert_eq!(self.state.load(Ordering::Acquire), CLOSED);
+        self.state.store(0, Ordering::Release);
+    }
+}
+
+impl Drop for TxAdmissionGuard<'_> {
+    fn drop(&mut self) {
+        let previous = self.admission.state.fetch_sub(1, Ordering::Release);
+        debug_assert_ne!(previous & ACTIVE_MASK, 0);
+    }
+}

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -1,5 +1,5 @@
 use super::bridge::BridgeEnableDevice;
-use super::{BootstrapRoute, Iface, IfaceCommon, IfacePollScope};
+use super::{BootstrapRoute, Iface, IfaceCommon, IfacePollScope, MtuBounds};
 use super::{NetDeivceState, NetDeviceCommonData, Operstate};
 use crate::arch::rand::rand;
 use crate::driver::base::class::Class;
@@ -42,9 +42,13 @@ pub struct Veth {
     /// Frames awaiting bridge/routing classification. Classification may
     /// consult the authoritative FIB and therefore must run outside smoltcp's
     /// interface lock.
-    pending_rx_queue: VecDeque<Vec<u8>>,
+    pending_rx_queue: VecDeque<PendingVethFrame>,
     /// Frames classified for local smoltcp delivery.
     local_rx_queue: VecDeque<Vec<u8>>,
+    /// Serialized with peer enqueue so DOWN both rejects new external ingress
+    /// and drains everything accepted before the transition.
+    peer_ingress_enabled: bool,
+    ingress_generation: u64,
     /// 对端的 `VethInterface`，在完成数据发送的时候会使用到
     peer: Weak<VethInterface>,
     self_iface_ref: Weak<VethInterface>,
@@ -56,6 +60,8 @@ impl Veth {
             name,
             pending_rx_queue: VecDeque::new(),
             local_rx_queue: VecDeque::new(),
+            peer_ingress_enabled: true,
+            ingress_generation: 0,
             peer: Weak::new(),
             self_iface_ref: Weak::new(),
         }
@@ -72,7 +78,13 @@ impl Veth {
     fn to_peer_owned(peer: &Arc<VethInterface>, data: Vec<u8>) -> Result<(), SystemError> {
         let napi = peer.napi_struct().ok_or(SystemError::ENOBUFS)?;
         let mut peer_veth = peer.driver.inner.lock();
-        peer_veth.pending_rx_queue.push_back(data);
+        if !peer_veth.peer_ingress_enabled {
+            return Ok(());
+        }
+        let generation = peer_veth.ingress_generation;
+        peer_veth
+            .pending_rx_queue
+            .push_back(PendingVethFrame { generation, data });
 
         // {
         //     let ether = EthernetFrame::new_checked(data).unwrap();
@@ -154,6 +166,11 @@ enum IngressDisposition {
     Local,
 }
 
+struct PendingVethFrame {
+    generation: u64,
+    data: Vec<u8>,
+}
+
 impl VethDriver {
     /// Classifies a bounded batch before smoltcp locks its interface. Routed
     /// and bridged frames are consumed here; local frames move to the queue
@@ -162,19 +179,22 @@ impl VethDriver {
         let _classification_guard = self.ingress_classification_lock.lock();
         let mut scanned = 0;
         for _ in 0..scan_budget {
-            let data = {
+            let frame = {
                 let mut veth = self.inner.lock();
                 veth.pending_rx_queue.pop_front()
             };
-            let Some(data) = data else {
+            let Some(frame) = frame else {
                 break;
             };
             scanned += 1;
 
-            match self.classify_and_consume(&data) {
+            match self.classify_and_consume(&frame.data) {
                 IngressDisposition::Consumed => {}
                 IngressDisposition::Local => {
-                    self.inner.lock().local_rx_queue.push_back(data);
+                    let mut inner = self.inner.lock();
+                    if inner.peer_ingress_enabled && inner.ingress_generation == frame.generation {
+                        inner.local_rx_queue.push_back(frame.data);
+                    }
                 }
             }
         }
@@ -685,6 +705,39 @@ impl Iface for VethInterface {
 
     fn mtu(&self) -> usize {
         self.common.mtu()
+    }
+
+    fn mtu_bounds(&self) -> MtuBounds {
+        MtuBounds {
+            min: 68,
+            max: VETH_IP_MTU,
+        }
+    }
+
+    fn begin_admin_down(&self) {
+        let mut driver = self.driver.inner.lock();
+        driver.peer_ingress_enabled = false;
+        driver.ingress_generation = driver.ingress_generation.wrapping_add(1);
+    }
+
+    fn quiesce_admin_down(&self) {
+        // Serialize with the complete dequeue/classify/commit section. Once
+        // this returns, no frame accepted in the old generation can still
+        // produce bridge, routing, packet-socket, or local-stack side effects.
+        let classification_guard = self.driver.ingress_classification_lock.lock();
+        let mut driver = self.driver.inner.lock();
+        let pending = core::mem::take(&mut driver.pending_rx_queue);
+        let local = core::mem::take(&mut driver.local_rx_queue);
+        drop(driver);
+        drop(classification_guard);
+        drop(pending);
+        drop(local);
+    }
+
+    fn publish_admin_state(&self, is_up: bool) {
+        if is_up {
+            self.driver.inner.lock().peer_ingress_enabled = true;
+        }
     }
 }
 

--- a/kernel/src/driver/net/virtio_net.rs
+++ b/kernel/src/driver/net/virtio_net.rs
@@ -18,7 +18,7 @@ use virtio_drivers::{
     PhysAddr,
 };
 
-use super::{Iface, NetDeivceState, NetDeviceCommonData, Operstate};
+use super::{Iface, MtuBounds, NetDeivceState, NetDeviceCommonData, Operstate};
 use crate::{
     arch::rand::rand,
     driver::{
@@ -1295,7 +1295,15 @@ impl Iface for VirtioInterface {
         };
 
         match napi_complete_state(&napi) {
-            CompleteState::Disabled => {}
+            CompleteState::Disabled | CompleteState::Paused => {
+                // Administrative DOWN may race an in-flight poll after its
+                // completion path tentatively re-enabled callbacks.
+                self.device_inner
+                    .inner
+                    .lock_irqsave()
+                    .inner
+                    .disable_interrupts();
+            }
             CompleteState::Missed => {
                 self.device_inner
                     .inner
@@ -1386,6 +1394,21 @@ impl Iface for VirtioInterface {
 
     fn mtu(&self) -> usize {
         self.iface_common.mtu()
+    }
+
+    fn mtu_bounds(&self) -> MtuBounds {
+        MtuBounds {
+            min: 68,
+            max: VIRTIO_NET_IP_MTU,
+        }
+    }
+
+    fn begin_admin_down(&self) {
+        self.device_inner
+            .inner
+            .lock_irqsave()
+            .inner
+            .disable_interrupts();
     }
 }
 

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -27,6 +27,9 @@ use super::vfs::{
 };
 
 pub mod callback;
+mod rename;
+
+pub use rename::{KernFSRenameSpec, PreparedKernFSRename};
 
 #[derive(Debug)]
 pub struct KernFS {
@@ -106,8 +109,8 @@ impl KernFS {
             flags: InodeFlags::empty(),
         };
         let root_inode = Arc::new_cyclic(|self_ref| KernFSInode {
-            name: String::from(""),
             inner: RwSem::new(InnerKernFSInode {
+                name: String::from(""),
                 parent: Weak::new(),
                 metadata,
                 symlink_target: None,
@@ -118,6 +121,7 @@ impl KernFS {
             private_data: Mutex::new(None),
             callback: None,
             children: Mutex::new(HashMap::new()),
+            child_mutation: Mutex::new(()),
             inode_type: KernInodeType::Dir,
             lazy_list: Mutex::new(HashMap::new()),
             lazy_build_lock: Mutex::new(()),
@@ -140,10 +144,11 @@ pub struct KernFSInode {
     callback: Option<&'static dyn KernFSCallback>,
     /// 子Inode
     children: Mutex<HashMap<String, Arc<KernFSInode>>>,
+    /// Serializes every mutation of `children` and `lazy_list` for this
+    /// directory. Readers keep using the map locks directly.
+    child_mutation: Mutex<()>,
     /// Inode类型
     inode_type: KernInodeType,
-    /// Inode名称
-    name: String,
     /// lazy list
     lazy_list: Mutex<HashMap<String, fn() -> KernFSInodeArgs>>,
     /// Serializes lazy entry materialization without holding entry maps.
@@ -160,6 +165,9 @@ pub struct KernFSInodeArgs {
 
 #[derive(Debug)]
 pub struct InnerKernFSInode {
+    /// The name is changed together with its parent's map key by a prepared
+    /// kernfs rename transaction.
+    name: String,
     parent: Weak<KernFSInode>,
 
     /// 当前inode的元数据
@@ -363,7 +371,7 @@ impl IndexNode for KernFSInode {
     }
 
     fn dname(&self) -> Result<DName, SystemError> {
-        Ok(self.name.clone().into())
+        Ok(self.name().into())
     }
 
     fn read_at(
@@ -455,8 +463,8 @@ impl KernFSInode {
         metadata.file_type = inode_type.into();
 
         let inode = Arc::new_cyclic(|self_ref| KernFSInode {
-            name,
             inner: RwSem::new(InnerKernFSInode {
+                name,
                 parent: parent.as_ref().map_or(Weak::new(), Arc::downgrade),
                 metadata,
                 symlink_target: None,
@@ -467,6 +475,7 @@ impl KernFSInode {
             private_data: Mutex::new(private_data),
             callback,
             children: Mutex::new(HashMap::new()),
+            child_mutation: Mutex::new(()),
             inode_type,
             lazy_list: Mutex::new(HashMap::new()),
             lazy_build_lock: Mutex::new(()),
@@ -575,6 +584,7 @@ impl KernFSInode {
             return Err(SystemError::ENOTDIR);
         }
 
+        let _mutation = self.child_mutation.lock();
         let children = self.children.lock();
         let mut lazy_list = self.lazy_list.lock();
         if children.contains_key(&name) || lazy_list.contains_key(&name) {
@@ -609,6 +619,7 @@ impl KernFSInode {
             args.callback,
         );
 
+        let _mutation = self.child_mutation.lock();
         let mut children = self.children.lock();
         if let Some(child) = children.get(name).cloned() {
             return Ok(child);
@@ -632,6 +643,7 @@ impl KernFSInode {
         private_data: Option<KernInodePrivateData>,
         callback: Option<&'static dyn KernFSCallback>,
     ) -> Result<Arc<KernFSInode>, SystemError> {
+        let _mutation = self.child_mutation.lock();
         let mut children = self.children.lock();
         let lazy_list = self.lazy_list.lock();
         if children.contains_key(&name) || lazy_list.contains_key(&name) {
@@ -709,6 +721,7 @@ impl KernFSInode {
             return Err(SystemError::ENOTDIR);
         }
 
+        let _mutation = self.child_mutation.lock();
         let mut children = self.children.lock();
         let inode = children.get(name).ok_or(SystemError::ENOENT)?;
         if inode.children.lock().is_empty() {
@@ -751,8 +764,27 @@ impl KernFSInode {
         return Ok(inode);
     }
 
-    pub fn name(&self) -> &str {
-        return &self.name;
+    pub fn name(&self) -> String {
+        self.inner.read().name.clone()
+    }
+
+    /// Borrows the inode name while holding its read guard. This keeps
+    /// comparisons and fallible path construction allocation-free at the
+    /// call site without exposing the mutable inode internals.
+    pub(crate) fn with_name<R>(&self, f: impl FnOnce(&str) -> R) -> R {
+        let inner = self.inner.read();
+        f(&inner.name)
+    }
+
+    pub(crate) fn try_name(&self) -> Result<String, SystemError> {
+        self.with_name(|name| {
+            let mut result = String::new();
+            result
+                .try_reserve_exact(name.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+            result.push_str(name);
+            Ok(result)
+        })
     }
 
     pub fn parent(&self) -> Option<Arc<KernFSInode>> {
@@ -770,9 +802,16 @@ impl KernFSInode {
 
     /// remove a kernfs_node recursively
     pub fn remove_recursive(&self) {
-        let mut children = self.children.lock().drain().collect::<Vec<_>>();
+        let mut children = {
+            let _mutation = self.child_mutation.lock();
+            self.children.lock().drain().collect::<Vec<_>>()
+        };
         while let Some((_, child)) = children.pop() {
-            children.append(&mut child.children.lock().drain().collect::<Vec<_>>());
+            let mut descendants = {
+                let _mutation = child.child_mutation.lock();
+                child.children.lock().drain().collect::<Vec<_>>()
+            };
+            children.append(&mut descendants);
         }
     }
 
@@ -781,7 +820,9 @@ impl KernFSInode {
     pub fn remove_inode_include_self(&self) {
         let parent = self.parent();
         if let Some(parent) = parent {
-            parent.children.lock().remove(self.name());
+            let name = self.name();
+            let _mutation = parent.child_mutation.lock();
+            parent.children.lock().remove(&name);
         }
         self.remove_recursive();
     }

--- a/kernel/src/filesystem/kernfs/rename.rs
+++ b/kernel/src/filesystem/kernfs/rename.rs
@@ -1,0 +1,287 @@
+use alloc::{string::String, sync::Arc};
+
+use hashbrown::HashMap;
+use system_error::SystemError;
+
+use super::{KernFS, KernFSInode, KernInodeType};
+
+/// One inode re-key requested as part of a two-node kernfs rename.
+///
+/// All strings are owned before commit so publication never allocates.
+pub struct KernFSRenameSpec {
+    inode: Arc<KernFSInode>,
+    new_name: String,
+    symlink_target_absolute_path: Option<String>,
+}
+
+impl KernFSRenameSpec {
+    pub fn new(inode: Arc<KernFSInode>, new_name: String) -> Self {
+        Self {
+            inode,
+            new_name,
+            symlink_target_absolute_path: None,
+        }
+    }
+
+    pub fn with_symlink_target_absolute_path(mut self, path: String) -> Self {
+        self.symlink_target_absolute_path = Some(path);
+        self
+    }
+}
+
+struct PreparedRenameEntry {
+    parent: Arc<KernFSInode>,
+    inode: Arc<KernFSInode>,
+    old_name: String,
+    new_key: String,
+    new_inode_name: String,
+    symlink_target_absolute_path: Option<String>,
+}
+
+impl PreparedRenameEntry {
+    fn prepare(spec: KernFSRenameSpec) -> Result<Self, SystemError> {
+        validate_name(&spec.new_name)?;
+        if spec.symlink_target_absolute_path.is_some()
+            && spec.inode.inode_type != KernInodeType::SymLink
+        {
+            return Err(SystemError::EINVAL);
+        }
+
+        let parent = spec.inode.parent().ok_or(SystemError::ENOENT)?;
+        let old_name = spec.inode.try_name()?;
+        let new_inode_name = try_copy_string(&spec.new_name)?;
+        Ok(Self {
+            parent,
+            inode: spec.inode,
+            old_name,
+            new_key: spec.new_name,
+            new_inode_name,
+            symlink_target_absolute_path: spec.symlink_target_absolute_path,
+        })
+    }
+
+    fn parent_id(&self) -> u64 {
+        self.parent.inner.read().metadata.inode_id.data() as u64
+    }
+
+    fn validate(
+        &self,
+        children: &HashMap<String, Arc<KernFSInode>>,
+        lazy: &HashMap<String, fn() -> super::KernFSInodeArgs>,
+    ) -> Result<(), SystemError> {
+        let current = children.get(&self.old_name).ok_or(SystemError::ESTALE)?;
+        if !Arc::ptr_eq(current, &self.inode) || !self.inode.with_name(|name| name == self.old_name)
+        {
+            return Err(SystemError::ESTALE);
+        }
+        if self.new_key != self.old_name
+            && (children.contains_key(&self.new_key) || lazy.contains_key(&self.new_key))
+        {
+            return Err(SystemError::EEXIST);
+        }
+        Ok(())
+    }
+
+    fn publish(self, children: &mut HashMap<String, Arc<KernFSInode>>) {
+        let inode = children
+            .remove(&self.old_name)
+            .expect("prepared kernfs rename source disappeared under mutation gate");
+        children.insert(self.new_key, inode);
+
+        let mut inner = self.inode.inner.write();
+        inner.name = self.new_inode_name;
+        if let Some(path) = self.symlink_target_absolute_path {
+            inner.symlink_target_absolute_path = Some(path);
+        }
+    }
+}
+
+/// A bounded transaction that re-keys two existing kernfs inodes without
+/// replacing either inode object.
+pub struct PreparedKernFSRename {
+    entries: [PreparedRenameEntry; 2],
+}
+
+impl PreparedKernFSRename {
+    pub fn prepare(first: KernFSRenameSpec, second: KernFSRenameSpec) -> Result<Self, SystemError> {
+        if Arc::ptr_eq(&first.inode, &second.inode) {
+            return Err(SystemError::EINVAL);
+        }
+        let mut entries = [
+            PreparedRenameEntry::prepare(first)?,
+            PreparedRenameEntry::prepare(second)?,
+        ];
+        if entries[1].parent_id() < entries[0].parent_id() {
+            entries.swap(0, 1);
+        }
+        Ok(Self { entries })
+    }
+
+    /// Revalidates and reserves both parent maps before changing either one.
+    pub fn commit(self) -> Result<(), SystemError> {
+        let [first, second] = self.entries;
+        if Arc::ptr_eq(&first.parent, &second.parent) {
+            return commit_same_parent(first, second);
+        }
+
+        let first_parent = first.parent.clone();
+        let second_parent = second.parent.clone();
+        let _first_gate = first_parent.child_mutation.lock();
+        let _second_gate = second_parent.child_mutation.lock();
+        let mut first_children = first_parent.children.lock();
+        let mut second_children = second_parent.children.lock();
+        let first_lazy = first_parent.lazy_list.lock();
+        let second_lazy = second_parent.lazy_list.lock();
+
+        first.validate(&first_children, &first_lazy)?;
+        second.validate(&second_children, &second_lazy)?;
+        first_children
+            .try_reserve(1)
+            .map_err(|_| SystemError::ENOMEM)?;
+        second_children
+            .try_reserve(1)
+            .map_err(|_| SystemError::ENOMEM)?;
+
+        drop(first_lazy);
+        drop(second_lazy);
+        first.publish(&mut first_children);
+        second.publish(&mut second_children);
+        Ok(())
+    }
+}
+
+fn commit_same_parent(
+    first: PreparedRenameEntry,
+    second: PreparedRenameEntry,
+) -> Result<(), SystemError> {
+    if first.new_key == second.new_key {
+        return Err(SystemError::EEXIST);
+    }
+    let parent = first.parent.clone();
+    let _gate = parent.child_mutation.lock();
+    let mut children = parent.children.lock();
+    let lazy = parent.lazy_list.lock();
+    first.validate(&children, &lazy)?;
+    second.validate(&children, &lazy)?;
+    children.try_reserve(2).map_err(|_| SystemError::ENOMEM)?;
+
+    drop(lazy);
+    first.publish(&mut children);
+    second.publish(&mut children);
+    Ok(())
+}
+
+fn validate_name(name: &str) -> Result<(), SystemError> {
+    if name.is_empty() || name == "." || name == ".." || name.contains('/') {
+        return Err(SystemError::EINVAL);
+    }
+    if name.len() > KernFS::MAX_NAMELEN {
+        return Err(SystemError::ENAMETOOLONG);
+    }
+    Ok(())
+}
+
+fn try_copy_string(source: &str) -> Result<String, SystemError> {
+    let mut result = String::new();
+    result
+        .try_reserve_exact(source.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    result.push_str(source);
+    Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::{string::ToString, sync::Arc};
+
+    use super::*;
+    use crate::filesystem::vfs::InodeMode;
+
+    fn test_tree() -> (
+        Arc<KernFSInode>,
+        Arc<KernFSInode>,
+        Arc<KernFSInode>,
+        Arc<KernFSInode>,
+    ) {
+        let root = KernFS::create_root_inode();
+        let mode = InodeMode::from_bits_truncate(0o755);
+        let devices = root
+            .add_dir("devices".to_string(), mode, None, None)
+            .unwrap();
+        let class = root.add_dir("class".to_string(), mode, None, None).unwrap();
+        let device = devices
+            .add_dir("eth0".to_string(), mode, None, None)
+            .unwrap();
+        let link = class
+            .add_link("eth0".to_string(), &device, "/sys/devices/eth0".to_string())
+            .unwrap();
+        (devices, class, device, link)
+    }
+
+    #[test]
+    fn two_parent_rename_preserves_inode_identity_and_updates_link_path() {
+        let (devices, class, device, link) = test_tree();
+        let plan = PreparedKernFSRename::prepare(
+            KernFSRenameSpec::new(device.clone(), "eth1".to_string()),
+            KernFSRenameSpec::new(link.clone(), "eth1".to_string())
+                .with_symlink_target_absolute_path("/sys/devices/eth1".to_string()),
+        )
+        .unwrap();
+
+        plan.commit().unwrap();
+
+        assert!(!devices.children.lock().contains_key("eth0"));
+        assert!(!class.children.lock().contains_key("eth0"));
+        assert!(Arc::ptr_eq(
+            devices.children.lock().get("eth1").unwrap(),
+            &device
+        ));
+        assert!(Arc::ptr_eq(
+            class.children.lock().get("eth1").unwrap(),
+            &link
+        ));
+        assert_eq!(device.name(), "eth1");
+        assert_eq!(link.name(), "eth1");
+        assert_eq!(
+            link.inner.read().symlink_target_absolute_path.as_deref(),
+            Some("/sys/devices/eth1")
+        );
+    }
+
+    #[test]
+    fn conflict_leaves_both_names_and_link_path_unchanged() {
+        let (devices, class, device, link) = test_tree();
+        class
+            .add_dir(
+                "eth1".to_string(),
+                InodeMode::from_bits_truncate(0o755),
+                None,
+                None,
+            )
+            .unwrap();
+        let plan = PreparedKernFSRename::prepare(
+            KernFSRenameSpec::new(device.clone(), "eth1".to_string()),
+            KernFSRenameSpec::new(link.clone(), "eth1".to_string())
+                .with_symlink_target_absolute_path("/sys/devices/eth1".to_string()),
+        )
+        .unwrap();
+
+        assert_eq!(plan.commit(), Err(SystemError::EEXIST));
+
+        assert!(Arc::ptr_eq(
+            devices.children.lock().get("eth0").unwrap(),
+            &device
+        ));
+        assert!(Arc::ptr_eq(
+            class.children.lock().get("eth0").unwrap(),
+            &link
+        ));
+        assert!(!devices.children.lock().contains_key("eth1"));
+        assert_eq!(device.name(), "eth0");
+        assert_eq!(link.name(), "eth0");
+        assert_eq!(
+            link.inner.read().symlink_target_absolute_path.as_deref(),
+            Some("/sys/devices/eth0")
+        );
+    }
+}

--- a/kernel/src/filesystem/sysfs/dir.rs
+++ b/kernel/src/filesystem/sysfs/dir.rs
@@ -166,6 +166,68 @@ impl SysFS {
         return path;
     }
 
+    /// Builds the absolute path cached by a sysfs symlink before a child is
+    /// renamed. All fallible allocation belongs to the prepare phase.
+    pub(crate) fn child_absolute_path(
+        &self,
+        parent: &Arc<KernFSInode>,
+        child_name: &str,
+    ) -> Result<String, SystemError> {
+        let parent_path = self.try_kernfs_path(parent)?;
+        let mut path = String::new();
+        let capacity = "/sys"
+            .len()
+            .checked_add(parent_path.len())
+            .and_then(|length| length.checked_add(1))
+            .and_then(|length| length.checked_add(child_name.len()))
+            .ok_or(SystemError::ENOMEM)?;
+        path.try_reserve_exact(capacity)
+            .map_err(|_| SystemError::ENOMEM)?;
+        path.push_str("/sys");
+        path.push_str(&parent_path);
+        path.push('/');
+        path.push_str(child_name);
+        Ok(path)
+    }
+
+    /// Fallible counterpart used by prepared control-plane transactions.
+    /// Existing display-only callers retain `kernfs_path`; mutation prepare
+    /// must be able to report ENOMEM rather than enter the allocator handler.
+    pub(crate) fn try_kernfs_path(&self, inode: &Arc<KernFSInode>) -> Result<String, SystemError> {
+        let mut current = inode.clone();
+        let mut names = Vec::new();
+        let root = self.root_inode();
+        let mut detached = false;
+        while !Arc::ptr_eq(&current, root) {
+            names.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+            names.push(current.try_name()?);
+            let Some(parent) = current.parent() else {
+                detached = true;
+                break;
+            };
+            current = parent;
+        }
+
+        let mut length = if detached { "(null)".len() } else { 0 };
+        for name in &names {
+            length = length
+                .checked_add(1)
+                .and_then(|value| value.checked_add(name.len()))
+                .ok_or(SystemError::ENOMEM)?;
+        }
+        let mut path = String::new();
+        path.try_reserve_exact(length)
+            .map_err(|_| SystemError::ENOMEM)?;
+        if detached {
+            path.push_str("(null)");
+        }
+        for name in names.iter().rev() {
+            path.push('/');
+            path.push_str(name);
+        }
+        Ok(path)
+    }
+
     /// 从sysfs中删除一个kobject对应的目录（包括目录自身以及目录下的所有文件、文件夹）
     pub fn remove_dir(&self, kobj: &Arc<dyn KObject>) {
         let kobj_inode = kobj.inode();

--- a/kernel/src/net/address.rs
+++ b/kernel/src/net/address.rs
@@ -14,6 +14,9 @@ use crate::{
     net::rtnl::RtnlGuard,
 };
 
+const IPV4_MIN_MTU: usize = 68;
+const IPV6_MIN_MTU: usize = 1280;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AddressMutation {
     Add(IpCidr),
@@ -31,6 +34,17 @@ pub(crate) enum AddressMutationOutcome {
 pub(in crate::net) struct AddressMutationCommit {
     pub outcome: AddressMutationOutcome,
     pub route_changes: crate::net::route::RouteNotifications,
+}
+
+pub(crate) struct RemovedAddress {
+    pub cidr: IpCidr,
+    pub label: CString,
+}
+
+pub(in crate::net) struct PreparedMtuAddressChange {
+    routes: crate::net::route::PreparedAddressRouteCommit,
+    removed: Vec<RemovedAddress>,
+    renamed_ipv4: Vec<IpCidr>,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -134,59 +148,8 @@ impl PreparedAddressLabelRename {
         iface: &Arc<dyn Iface>,
         new_name: &str,
     ) -> Result<Self, SystemError> {
-        const IFNAME_MAX: usize = 15;
-
-        let mut metadata = try_clone_metadata(&iface.common().address_metadata().lock(), 0)?;
-        let ipv4_count = metadata
-            .iter()
-            .filter(|entry| matches!(entry.cidr, IpCidr::Ipv4(_)))
-            .count();
-        let mut renamed_ipv4 = Vec::new();
-        renamed_ipv4
-            .try_reserve_exact(ipv4_count)
-            .map_err(|_| SystemError::ENOMEM)?;
-
-        // Interface names are bounded by IFNAMSIZ. Copy the old name to the
-        // stack so the name lock is never held across label allocation.
-        let mut old_name = [0u8; IFNAME_MAX + 1];
-        let old_name_len = iface.common().with_iface_name(|name| {
-            let copied = name.len().min(old_name.len());
-            old_name[..copied].copy_from_slice(&name.as_bytes()[..copied]);
-            copied
-        });
-        let old_name = &old_name[..old_name_len];
-
-        let mut ordinal = 0usize;
-        for entry in metadata
-            .iter_mut()
-            .filter(|entry| matches!(entry.cidr, IpCidr::Ipv4(_)))
-        {
-            ordinal += 1;
-            renamed_ipv4.push(entry.cidr);
-            if ordinal == 1 {
-                entry.label = None;
-                continue;
-            }
-
-            let old_label = entry
-                .label
-                .as_ref()
-                .map(|label| label.as_bytes())
-                .unwrap_or(old_name);
-            let mut generated_suffix = [0u8; 1 + 3 * core::mem::size_of::<usize>()];
-            let suffix = match old_label.iter().position(|byte| *byte == b':') {
-                Some(index) => &old_label[index..],
-                None => decimal_alias_suffix(ordinal, &mut generated_suffix),
-            };
-            let suffix = if suffix.len() > IFNAME_MAX {
-                &suffix[suffix.len() - IFNAME_MAX..]
-            } else {
-                suffix
-            };
-            let prefix_len = new_name.len().min(IFNAME_MAX - suffix.len());
-            entry.label = Some(try_build_label(&new_name.as_bytes()[..prefix_len], suffix)?);
-        }
-
+        let metadata = try_clone_metadata(&iface.common().address_metadata().lock(), 0)?;
+        let (metadata, renamed_ipv4) = prepare_renamed_metadata(iface, new_name, metadata)?;
         Ok(Self {
             metadata,
             renamed_ipv4,
@@ -200,6 +163,196 @@ impl PreparedAddressLabelRename {
             .publish_name_and_address_metadata(new_name, self.metadata);
         self.renamed_ipv4
     }
+}
+
+fn prepare_renamed_metadata(
+    iface: &Arc<dyn Iface>,
+    new_name: &str,
+    mut metadata: Vec<AddressMetadata>,
+) -> Result<(Vec<AddressMetadata>, Vec<IpCidr>), SystemError> {
+    const IFNAME_MAX: usize = 15;
+
+    let ipv4_count = metadata
+        .iter()
+        .filter(|entry| matches!(entry.cidr, IpCidr::Ipv4(_)))
+        .count();
+    let mut renamed_ipv4 = Vec::new();
+    renamed_ipv4
+        .try_reserve_exact(ipv4_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+
+    // Interface names are bounded by IFNAMSIZ. Copy the old name to the
+    // stack so the name lock is never held across label allocation.
+    let mut old_name = [0u8; IFNAME_MAX + 1];
+    let old_name_len = iface.common().with_iface_name(|name| {
+        let copied = name.len().min(old_name.len());
+        old_name[..copied].copy_from_slice(&name.as_bytes()[..copied]);
+        copied
+    });
+    let old_name = &old_name[..old_name_len];
+
+    let mut ordinal = 0usize;
+    for entry in metadata
+        .iter_mut()
+        .filter(|entry| matches!(entry.cidr, IpCidr::Ipv4(_)))
+    {
+        ordinal += 1;
+        renamed_ipv4.push(entry.cidr);
+        if ordinal == 1 {
+            entry.label = None;
+            continue;
+        }
+
+        let old_label = entry
+            .label
+            .as_ref()
+            .map(|label| label.as_bytes())
+            .unwrap_or(old_name);
+        let mut generated_suffix = [0u8; 1 + 3 * core::mem::size_of::<usize>()];
+        let suffix = match old_label.iter().position(|byte| *byte == b':') {
+            Some(index) => &old_label[index..],
+            None => decimal_alias_suffix(ordinal, &mut generated_suffix),
+        };
+        let suffix = if suffix.len() > IFNAME_MAX {
+            &suffix[suffix.len() - IFNAME_MAX..]
+        } else {
+            suffix
+        };
+        let prefix_len = new_name.len().min(IFNAME_MAX - suffix.len());
+        entry.label = Some(try_build_label(&new_name.as_bytes()[..prefix_len], suffix)?);
+    }
+
+    Ok((metadata, renamed_ipv4))
+}
+
+pub(in crate::net) fn prepare_mtu_address_change(
+    _rtnl: &RtnlGuard,
+    netns: &Arc<crate::process::namespace::net_namespace::NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    mtu: usize,
+    renamed_to: Option<&str>,
+    was_up: bool,
+    is_up: bool,
+) -> Result<Option<PreparedMtuAddressChange>, SystemError> {
+    let mirror = iface.router_common().ip_addrs.read();
+    let before = try_clone_copy_slice(&mirror, 0)?;
+    let mut after = try_clone_copy_slice(&mirror, 0)?;
+    drop(mirror);
+
+    let removal_count = after
+        .iter()
+        .filter(|cidr| match cidr {
+            IpCidr::Ipv4(_) => mtu < IPV4_MIN_MTU,
+            IpCidr::Ipv6(_) => mtu < IPV6_MIN_MTU,
+        })
+        .count();
+    if removal_count == 0 {
+        return Ok(None);
+    }
+
+    let mut metadata = try_clone_metadata(&iface.common().address_metadata().lock(), 0)?;
+    let default_label = try_default_label(iface)?;
+    let mut removed = Vec::new();
+    removed
+        .try_reserve_exact(removal_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+    let mut deleted_addresses = Vec::new();
+    deleted_addresses
+        .try_reserve_exact(removal_count)
+        .map_err(|_| SystemError::ENOMEM)?;
+
+    let mut index = 0;
+    while index < after.len() {
+        let cidr = after[index];
+        let remove = match cidr {
+            IpCidr::Ipv4(_) => mtu < IPV4_MIN_MTU,
+            IpCidr::Ipv6(_) => mtu < IPV6_MIN_MTU,
+        };
+        if !remove {
+            index += 1;
+            continue;
+        }
+        after.remove(index);
+        deleted_addresses.push(cidr.address());
+        let label =
+            if let Some(metadata_index) = metadata.iter().position(|entry| entry.cidr == cidr) {
+                let entry = metadata.remove(metadata_index);
+                match entry.label {
+                    Some(label) => label,
+                    None => try_clone_cstring(&default_label)?,
+                }
+            } else {
+                try_clone_cstring(&default_label)?
+            };
+        removed.push(RemovedAddress { cidr, label });
+    }
+
+    let (metadata, renamed_ipv4) = if let Some(new_name) = renamed_to {
+        prepare_renamed_metadata(iface, new_name, metadata)?
+    } else {
+        (metadata, Vec::new())
+    };
+    let routes = crate::net::route::prepare_address_link_change(
+        netns,
+        iface,
+        crate::net::route::AddressLinkChange {
+            before: &before,
+            after: &after,
+            metadata,
+            deleted_addresses: &deleted_addresses,
+            was_up,
+            is_up,
+        },
+    )?;
+    Ok(Some(PreparedMtuAddressChange {
+        routes,
+        removed,
+        renamed_ipv4,
+    }))
+}
+
+impl PreparedMtuAddressChange {
+    pub(in crate::net) fn publish(
+        self,
+        netns: &Arc<crate::process::namespace::net_namespace::NetNamespace>,
+        iface: &Arc<dyn Iface>,
+        renamed_to: Option<String>,
+        publish_mtu: impl FnOnce(),
+        is_up: bool,
+        publish_link_state: impl FnOnce(),
+    ) -> (
+        Vec<RemovedAddress>,
+        Vec<IpCidr>,
+        crate::net::route::RouteNotifications,
+    ) {
+        let Self {
+            routes,
+            removed,
+            renamed_ipv4,
+        } = self;
+        let route_changes = routes.publish_link_change(
+            netns,
+            iface,
+            renamed_to,
+            publish_mtu,
+            publish_link_state,
+            is_up,
+        );
+        (removed, renamed_ipv4, route_changes)
+    }
+}
+
+fn try_default_label(iface: &Arc<dyn Iface>) -> Result<CString, SystemError> {
+    iface.common().with_iface_name(|name| {
+        let allocation_len = name.len().checked_add(1).ok_or(SystemError::ENOMEM)?;
+        let mut bytes = Vec::new();
+        bytes
+            .try_reserve_exact(allocation_len)
+            .map_err(|_| SystemError::ENOMEM)?;
+        bytes.extend_from_slice(name.as_bytes());
+        bytes.push(0);
+        CString::from_vec_with_nul(bytes).map_err(|_| SystemError::EINVAL)
+    })
 }
 
 fn decimal_alias_suffix(mut ordinal: usize, storage: &mut [u8]) -> &[u8] {
@@ -328,6 +481,7 @@ fn commit_published(
             if find_for_new_or_replace(&after, cidr).is_some() {
                 return Err(SystemError::EEXIST);
             }
+            validate_published_address_addition(iface, cidr)?;
             insert_address_candidate(&mut after, cidr);
             metadata.push(AddressMetadata {
                 cidr,
@@ -345,6 +499,7 @@ fn commit_published(
             if let Some(index) = find_for_new_or_replace(&after, cidr) {
                 AddressMutationOutcome::Replaced(after[index])
             } else {
+                validate_published_address_addition(iface, cidr)?;
                 insert_address_candidate(&mut after, cidr);
                 metadata.push(AddressMetadata {
                     cidr,
@@ -365,6 +520,20 @@ fn commit_published(
         outcome,
         route_changes,
     })
+}
+
+fn validate_published_address_addition(
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+) -> Result<(), SystemError> {
+    // Linux destroys the IPv4 in_device once MTU drops below the protocol
+    // minimum. A later address add cannot recreate it until the MTU is valid.
+    // IPv6 differs: Linux permits an explicit add below 1280, so keep this
+    // admission rule IPv4-specific.
+    if matches!(cidr, IpCidr::Ipv4(_)) && iface.mtu() < IPV4_MIN_MTU {
+        return Err(SystemError::ENOBUFS);
+    }
+    Ok(())
 }
 
 fn insert_address_candidate(addresses: &mut Vec<IpCidr>, cidr: IpCidr) {

--- a/kernel/src/net/address.rs
+++ b/kernel/src/net/address.rs
@@ -10,8 +10,9 @@ use smoltcp::wire::{IpAddress, IpCidr, Ipv4Address};
 use system_error::SystemError;
 
 use crate::{
-    driver::net::{AddressMetadata, Iface},
+    driver::net::{types::InterfaceFlags, AddressMetadata, Iface},
     net::rtnl::RtnlGuard,
+    process::namespace::net_namespace::NetNamespace,
 };
 
 const IPV4_MIN_MTU: usize = 68;
@@ -693,6 +694,63 @@ pub(crate) fn iface_has_address(iface: &Arc<dyn Iface>, address: IpAddress) -> b
         .any(|cidr| cidr.address() == address)
 }
 
+/// Returns whether Linux would treat `address` as local on `iface` for bind
+/// and fixed-source output validation.
+///
+/// Most addresses require an exact configured entry. IPv4 loopback devices
+/// additionally own every address in each configured prefix; this is the
+/// shared rule used by socket placement and route-source validation.
+pub(crate) fn iface_accepts_local_address(iface: &Arc<dyn Iface>, address: IpAddress) -> bool {
+    let addresses = iface.common().ip_addrs();
+    iface_accepts_local_address_from(iface, &addresses, address)
+}
+
+/// Returns whether `address` is an IPv4 broadcast address on `iface`.
+///
+/// This covers both the limited broadcast address and subnet-directed
+/// broadcasts derived from the interface's configured prefixes.
+pub(crate) fn iface_accepts_broadcast_address(iface: &Arc<dyn Iface>, address: IpAddress) -> bool {
+    let IpAddress::Ipv4(address) = address else {
+        return false;
+    };
+    address.is_broadcast()
+        || iface.common().ip_addrs().iter().any(|cidr| match cidr {
+            IpCidr::Ipv4(cidr) => cidr
+                .broadcast()
+                .is_some_and(|broadcast| broadcast == address),
+            IpCidr::Ipv6(_) => false,
+        })
+}
+
+pub(crate) fn netns_accepts_broadcast_address(
+    netns: &Arc<NetNamespace>,
+    address: IpAddress,
+) -> bool {
+    matches!(address, IpAddress::Ipv4(address) if address.is_broadcast())
+        || netns
+            .device_list()
+            .values()
+            .any(|iface| iface_accepts_broadcast_address(iface, address))
+}
+
+fn iface_accepts_local_address_from(
+    iface: &Arc<dyn Iface>,
+    addresses: &[IpCidr],
+    address: IpAddress,
+) -> bool {
+    if addresses.iter().any(|cidr| cidr.address() == address) {
+        return true;
+    }
+    let IpAddress::Ipv4(address) = address else {
+        return false;
+    };
+    iface.flags().contains(InterfaceFlags::LOOPBACK)
+        && addresses.iter().any(|cidr| match cidr {
+            IpCidr::Ipv4(cidr) => cidr.contains_addr(&address),
+            IpCidr::Ipv6(_) => false,
+        })
+}
+
 /// Selects the IPv4 source that Linux's `inet_select_addr()` would use for an
 /// output route on this interface.
 ///
@@ -747,7 +805,10 @@ pub(crate) fn source_address_usable_on_iface(
     if source_address_requires_iface(address) {
         iface_has_address(iface, address)
     } else {
-        netns_has_address(netns, address)
+        netns
+            .device_list()
+            .values()
+            .any(|iface| iface_accepts_local_address(iface, address))
     }
 }
 
@@ -776,14 +837,13 @@ impl<'a> CandidateAddressOwnership<'a> {
         }
     }
 
-    fn iface_has_address(&self, iface: &Arc<dyn Iface>, address: IpAddress) -> bool {
-        if Arc::ptr_eq(iface, self.changed_iface) {
+    fn iface_accepts_local_address(&self, iface: &Arc<dyn Iface>, address: IpAddress) -> bool {
+        let addresses = if Arc::ptr_eq(iface, self.changed_iface) {
             self.changed_addresses
-                .iter()
-                .any(|cidr| cidr.address() == address)
         } else {
-            iface_has_address(iface, address)
-        }
+            return iface_accepts_local_address(iface, address);
+        };
+        iface_accepts_local_address_from(iface, addresses, address)
     }
 
     pub(crate) fn source_usable_on_oif(&self, oif: u32, address: IpAddress) -> bool {
@@ -791,11 +851,11 @@ impl<'a> CandidateAddressOwnership<'a> {
             return false;
         };
         if source_address_requires_iface(address) {
-            self.iface_has_address(egress_iface, address)
+            self.iface_accepts_local_address(egress_iface, address)
         } else {
             self.devices
                 .values()
-                .any(|iface| self.iface_has_address(iface, address))
+                .any(|iface| self.iface_accepts_local_address(iface, address))
         }
     }
 }

--- a/kernel/src/net/link.rs
+++ b/kernel/src/net/link.rs
@@ -202,10 +202,11 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
         };
 
         if let Some(mtu) = mtu {
+            let stack_mtu = iface.stack_mtu(mtu);
             iface
                 .smol_iface()
                 .lock()
-                .set_ip_mtu(mtu)
+                .set_ip_mtu(stack_mtu)
                 .expect("validated interface MTU must be representable by smoltcp");
             iface.common().set_mtu(mtu);
         }

--- a/kernel/src/net/link.rs
+++ b/kernel/src/net/link.rs
@@ -1,0 +1,529 @@
+//! ABI-independent network-link mutation core.
+//!
+//! Rtnetlink and legacy socket ioctls translate their wire formats into these
+//! types. RTNL remains the outer writer lock; all fallible preparation is
+//! completed before authoritative interface state is published.
+
+use alloc::{string::String, sync::Arc, vec::Vec};
+use core::fmt::Write;
+
+use system_error::SystemError;
+
+use crate::{
+    arch::MMArch,
+    driver::{
+        base::device_rename::PreparedDeviceSysfsRename,
+        net::{
+            napi::{napi_pause_and_wait, napi_resume, napi_schedule},
+            sysfs::prepare_netdev_sysfs_rename,
+            types::InterfaceFlags,
+            Iface, NetDeivceState, Operstate, PreparedConfiguredFlags,
+        },
+    },
+    mm::MemoryManagementArch,
+    process::namespace::net_namespace::NetNamespace,
+};
+
+use super::{
+    address::PreparedAddressLabelRename,
+    neighbor::{self, NeighborEntry, PreparedConfiguredNeighborPurge},
+    route::{self, PreparedLinkStateChange, RouteNotifications},
+    rtnl::RtnlGuard,
+};
+
+const IFNAMSIZ: usize = 16;
+
+const USER_SETTABLE_FLAGS: InterfaceFlags = InterfaceFlags::from_bits_truncate(
+    InterfaceFlags::UP.bits()
+        | InterfaceFlags::DEBUG.bits()
+        | InterfaceFlags::NOTRAILERS.bits()
+        | InterfaceFlags::NOARP.bits()
+        | InterfaceFlags::PROMISC.bits()
+        | InterfaceFlags::ALLMULTI.bits()
+        | InterfaceFlags::DYNAMIC.bits()
+        | InterfaceFlags::MULTICAST.bits()
+        | InterfaceFlags::PORTSEL.bits()
+        | InterfaceFlags::AUTOMEDIA.bits(),
+);
+
+pub(crate) enum LinkTarget<'a> {
+    Index(u32),
+    Name(&'a str),
+}
+
+#[derive(Default)]
+pub(crate) struct LinkUpdate {
+    pub new_name: Option<String>,
+    pub mtu: Option<LinkMtuUpdate>,
+    pub flags: Option<LinkFlagsUpdate>,
+}
+
+pub(crate) enum LinkMtuUpdate {
+    Rtnetlink(u32),
+    Ioctl(i32),
+}
+
+pub(crate) enum LinkFlagsUpdate {
+    Replace(InterfaceFlags),
+    Masked {
+        requested: InterfaceFlags,
+        change: InterfaceFlags,
+    },
+}
+
+bitflags! {
+    pub(crate) struct LinkChanges: u8 {
+        const NAME = 1 << 0;
+        const MTU = 1 << 1;
+        const FLAGS = 1 << 2;
+    }
+}
+
+pub(crate) struct LinkMutationCommit {
+    pub iface: Arc<dyn Iface>,
+    pub changes: LinkChanges,
+    pub renamed_ipv4: Vec<smoltcp::wire::IpCidr>,
+    pub route_changes: Option<RouteNotifications>,
+    pub removed_neighbors: Vec<NeighborEntry>,
+    pub rename_old_devpath: Option<String>,
+}
+
+struct PreparedLinkRename {
+    name: String,
+    labels: PreparedAddressLabelRename,
+    sysfs: PreparedDeviceSysfsRename,
+}
+
+struct PreparedLinkMutation<'rtnl> {
+    _rtnl: &'rtnl RtnlGuard,
+    iface: Arc<dyn Iface>,
+    netns: Arc<NetNamespace>,
+    mtu: Option<usize>,
+    rename: Option<PreparedLinkRename>,
+    flags: Option<PreparedConfiguredFlags>,
+    routes: Option<PreparedLinkStateChange<'rtnl>>,
+    neighbors: Option<PreparedConfiguredNeighborPurge<'rtnl>>,
+    changes: LinkChanges,
+    was_up: bool,
+    is_up: bool,
+    noarp_changed: bool,
+}
+
+pub(crate) fn mutate_link(
+    rtnl: &RtnlGuard,
+    netns: &Arc<NetNamespace>,
+    target: LinkTarget<'_>,
+    update: LinkUpdate,
+) -> Result<LinkMutationCommit, SystemError> {
+    let iface = resolve_iface(netns, target)?;
+    PreparedLinkMutation::prepare(rtnl, netns.clone(), iface, update)?.commit()
+}
+
+impl<'rtnl> PreparedLinkMutation<'rtnl> {
+    fn prepare(
+        rtnl: &'rtnl RtnlGuard,
+        netns: Arc<NetNamespace>,
+        iface: Arc<dyn Iface>,
+        update: LinkUpdate,
+    ) -> Result<Self, SystemError> {
+        // Keep Linux do_setlink()'s externally observable validation order.
+        let mtu = prepare_mtu(&iface, update.mtu)?;
+        let rename = prepare_rename(rtnl, &netns, &iface, update.new_name)?;
+
+        let (flags, was_up, is_up, noarp_changed) = prepare_flags(&iface, update.flags)?;
+        let link_down = was_up && !is_up;
+        let routes = if was_up != is_up {
+            Some(route::prepare_link_state_change(
+                rtnl, &netns, &iface, is_up,
+            )?)
+        } else {
+            None
+        };
+        let neighbors = if link_down || (noarp_changed && is_up) {
+            Some(neighbor::prepare_configured_iface_purge(
+                rtnl,
+                &netns,
+                iface.nic_id() as u32,
+            )?)
+        } else {
+            None
+        };
+
+        let mut changes = LinkChanges::empty();
+        if mtu.is_some() {
+            changes.insert(LinkChanges::MTU);
+        }
+        if rename.is_some() {
+            changes.insert(LinkChanges::NAME);
+        }
+        if flags.is_some_and(|prepared| prepared.old_flags() != prepared.new_flags()) {
+            changes.insert(LinkChanges::FLAGS);
+        }
+
+        Ok(Self {
+            _rtnl: rtnl,
+            iface,
+            netns,
+            mtu,
+            rename,
+            flags,
+            routes,
+            neighbors,
+            changes,
+            was_up,
+            is_up,
+            noarp_changed,
+        })
+    }
+
+    fn commit(self) -> Result<LinkMutationCommit, SystemError> {
+        let Self {
+            _rtnl: _,
+            iface,
+            netns,
+            mtu,
+            rename,
+            flags,
+            routes,
+            neighbors,
+            changes,
+            was_up,
+            is_up,
+            noarp_changed,
+        } = self;
+
+        // The kernfs transaction performs its final conflict/generation check
+        // before any logical link state is changed.
+        let (rename, rename_old_devpath) = if let Some(rename) = rename {
+            let old_devpath = rename.sysfs.commit()?;
+            (Some((rename.name, rename.labels)), old_devpath)
+        } else {
+            (None, None)
+        };
+
+        if let Some(mtu) = mtu {
+            iface
+                .smol_iface()
+                .lock()
+                .set_ip_mtu(mtu)
+                .expect("validated interface MTU must be representable by smoltcp");
+            iface.common().set_mtu(mtu);
+        }
+
+        let renamed_ipv4 = if let Some((name, labels)) = rename {
+            labels.publish(&iface, name)
+        } else {
+            Vec::new()
+        };
+
+        if noarp_changed {
+            iface
+                .smol_iface()
+                .lock()
+                .set_neighbor_discovery_enabled(!is_noarp(flags));
+        }
+
+        let link_down = was_up && !is_up;
+        if neighbors.is_some() && !link_down {
+            iface.smol_iface().lock().flush_neighbor_cache();
+        }
+
+        if link_down {
+            iface.begin_admin_down();
+            if let Some(napi) = iface.napi_struct() {
+                napi_pause_and_wait(&napi);
+            }
+            // This can wait for device-private ingress. It deliberately runs
+            // before the FIB writer so a classifier holding a FIB reader can
+            // finish instead of deadlocking the control-plane transaction.
+            iface.quiesce_admin_down();
+        }
+
+        let route_changes = if let Some(routes) = routes {
+            Some(routes.publish(&netns, is_up, || {
+                publish_link_flags_and_state(&iface, flags, is_up);
+                if link_down {
+                    // The route transaction holds the FIB writer here. Pollers
+                    // which observed the old UP generation have drained before
+                    // this final device/L2 invalidation, and later pollers see
+                    // DOWN, so no learned mapping can cross the transition.
+                    iface.smol_iface().lock().flush_neighbor_cache();
+                }
+            }))
+        } else {
+            if let Some(flags) = flags {
+                iface.common().publish_configured_flags(flags);
+            }
+            None
+        };
+
+        let removed_neighbors = neighbors.map(|plan| plan.publish()).unwrap_or_default();
+
+        // A NOARP transition changes whether an unresolved destination can be
+        // sent immediately. Wake the owner so packets waiting on the previous
+        // discovery policy are re-evaluated without waiting for an old retry
+        // deadline.
+        let link_state_changed = was_up != is_up;
+        if link_state_changed && is_up {
+            if iface.napi_struct().is_none() {
+                netns.wakeup_poll_thread();
+            }
+        } else if noarp_changed {
+            if let Some(napi) = iface.napi_struct() {
+                napi_schedule(napi);
+            } else {
+                netns.wakeup_poll_thread();
+            }
+        }
+        if noarp_changed || link_state_changed {
+            netns.notify_deadline_changed();
+        }
+
+        Ok(LinkMutationCommit {
+            iface,
+            changes,
+            renamed_ipv4,
+            route_changes,
+            removed_neighbors,
+            rename_old_devpath,
+        })
+    }
+}
+
+fn resolve_iface(
+    netns: &Arc<NetNamespace>,
+    target: LinkTarget<'_>,
+) -> Result<Arc<dyn Iface>, SystemError> {
+    let devices = netns.device_list();
+    let iface = match target {
+        LinkTarget::Index(index) => devices.get(&(index as usize)).cloned(),
+        LinkTarget::Name(name) => devices
+            .values()
+            .find(|iface| iface.common().with_iface_name(|current| current == name))
+            .cloned(),
+    }
+    .ok_or(SystemError::ENODEV)?;
+    drop(devices);
+
+    if !iface
+        .net_namespace()
+        .is_some_and(|owner| Arc::ptr_eq(&owner, netns))
+        || !iface
+            .net_state()
+            .contains(NetDeivceState::__LINK_STATE_PRESENT)
+    {
+        return Err(SystemError::ENODEV);
+    }
+    Ok(iface)
+}
+
+fn prepare_mtu(
+    iface: &Arc<dyn Iface>,
+    requested: Option<LinkMtuUpdate>,
+) -> Result<Option<usize>, SystemError> {
+    let Some(requested) = requested else {
+        return Ok(None);
+    };
+    let requested = match requested {
+        LinkMtuUpdate::Rtnetlink(value) => usize::try_from(value),
+        LinkMtuUpdate::Ioctl(value) => usize::try_from(value),
+    }
+    .map_err(|_| SystemError::EINVAL)?;
+    let bounds = iface.mtu_bounds();
+    if requested < bounds.min || requested > bounds.max {
+        return Err(SystemError::EINVAL);
+    }
+    Ok((requested != iface.mtu()).then_some(requested))
+}
+
+fn prepare_rename(
+    rtnl: &RtnlGuard,
+    netns: &Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    requested: Option<String>,
+) -> Result<Option<PreparedLinkRename>, SystemError> {
+    let Some(template) = requested else {
+        return Ok(None);
+    };
+    let name = allocate_link_name(netns, iface, &template)?;
+    if iface
+        .common()
+        .with_iface_name(|current| current == name.as_str())
+    {
+        return Ok(None);
+    }
+
+    let labels = PreparedAddressLabelRename::prepare(rtnl, iface, &name)?;
+    let sysfs = prepare_netdev_sysfs_rename(iface, try_copy_string(&name)?)?;
+    Ok(Some(PreparedLinkRename {
+        name,
+        labels,
+        sysfs,
+    }))
+}
+
+fn allocate_link_name(
+    netns: &Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    template: &str,
+) -> Result<String, SystemError> {
+    validate_name_bytes(template)?;
+    let percent = template.as_bytes().iter().position(|byte| *byte == b'%');
+    let Some(percent) = percent else {
+        if name_is_used(netns, iface, template) {
+            return Err(SystemError::EEXIST);
+        }
+        return try_copy_string(template);
+    };
+    if template.as_bytes().get(percent + 1) != Some(&b'd')
+        || template.as_bytes()[percent + 2..].contains(&b'%')
+    {
+        return Err(SystemError::EINVAL);
+    }
+
+    let prefix = &template[..percent];
+    let suffix = &template[percent + 2..];
+    let limit = 8 * <MMArch as MemoryManagementArch>::PAGE_SIZE;
+    let mut used = Vec::new();
+    let words = limit.div_ceil(u64::BITS as usize);
+    used.try_reserve_exact(words)
+        .map_err(|_| SystemError::ENOMEM)?;
+    used.resize(words, 0u64);
+    for other in netns.device_list().values() {
+        other.common().with_iface_name(|current| {
+            if let Some(ordinal) = template_ordinal(current, prefix, suffix, limit) {
+                used[ordinal / u64::BITS as usize] |= 1u64 << (ordinal % u64::BITS as usize);
+            }
+        });
+    }
+    for ordinal in 0..limit {
+        let digits = decimal_digits(ordinal);
+        if prefix.len() + digits + suffix.len() >= IFNAMSIZ {
+            continue;
+        }
+        if used[ordinal / u64::BITS as usize] & (1u64 << (ordinal % u64::BITS as usize)) != 0 {
+            continue;
+        }
+        let mut candidate = String::new();
+        candidate
+            .try_reserve_exact(IFNAMSIZ - 1)
+            .map_err(|_| SystemError::ENOMEM)?;
+        candidate.push_str(prefix);
+        write!(&mut candidate, "{ordinal}").map_err(|_| SystemError::ENOMEM)?;
+        candidate.push_str(suffix);
+        return Ok(candidate);
+    }
+    Err(SystemError::ENFILE)
+}
+
+fn template_ordinal(name: &str, prefix: &str, suffix: &str, limit: usize) -> Option<usize> {
+    let middle = name.strip_prefix(prefix)?.strip_suffix(suffix)?;
+    if middle.is_empty()
+        || (middle.len() > 1 && middle.starts_with('0'))
+        || !middle.bytes().all(|byte| byte.is_ascii_digit())
+    {
+        return None;
+    }
+    let ordinal = middle.parse::<usize>().ok()?;
+    (ordinal < limit).then_some(ordinal)
+}
+
+fn decimal_digits(mut value: usize) -> usize {
+    let mut digits = 1;
+    while value >= 10 {
+        value /= 10;
+        digits += 1;
+    }
+    digits
+}
+
+fn validate_name_bytes(name: &str) -> Result<(), SystemError> {
+    if name.is_empty()
+        || name.len() >= IFNAMSIZ
+        || name == "."
+        || name == ".."
+        || name
+            .bytes()
+            .any(|byte| byte == b'/' || byte == b':' || byte.is_ascii_whitespace())
+    {
+        return Err(SystemError::EINVAL);
+    }
+    Ok(())
+}
+
+fn name_is_used(netns: &Arc<NetNamespace>, iface: &Arc<dyn Iface>, name: &str) -> bool {
+    netns.device_list().values().any(|other| {
+        !Arc::ptr_eq(other, iface) && other.common().with_iface_name(|current| current == name)
+    })
+}
+
+fn prepare_flags(
+    iface: &Arc<dyn Iface>,
+    update: Option<LinkFlagsUpdate>,
+) -> Result<(Option<PreparedConfiguredFlags>, bool, bool, bool), SystemError> {
+    let Some(update) = update else {
+        let up = iface
+            .common()
+            .configured_flags()
+            .contains(InterfaceFlags::UP);
+        return Ok((None, up, up, false));
+    };
+    let (requested, change) = match update {
+        LinkFlagsUpdate::Replace(requested) => (requested, USER_SETTABLE_FLAGS),
+        LinkFlagsUpdate::Masked { requested, change } => {
+            let change = if change.is_empty() {
+                USER_SETTABLE_FLAGS
+            } else {
+                change & USER_SETTABLE_FLAGS
+            };
+            (requested, change)
+        }
+    };
+    let prepared = iface.common().prepare_configured_flags(requested, change)?;
+    let old = prepared.old_flags();
+    let new = prepared.new_flags();
+    Ok((
+        Some(prepared),
+        old.contains(InterfaceFlags::UP),
+        new.contains(InterfaceFlags::UP),
+        old.contains(InterfaceFlags::NOARP) != new.contains(InterfaceFlags::NOARP),
+    ))
+}
+
+fn is_noarp(flags: Option<PreparedConfiguredFlags>) -> bool {
+    flags.is_some_and(|prepared| prepared.new_flags().contains(InterfaceFlags::NOARP))
+}
+
+fn publish_link_flags_and_state(
+    iface: &Arc<dyn Iface>,
+    flags: Option<PreparedConfiguredFlags>,
+    is_up: bool,
+) {
+    if is_up {
+        iface.publish_admin_state(true);
+        if let Some(flags) = flags {
+            iface.common().publish_configured_flags(flags);
+        }
+        iface.set_operstate(Operstate::IF_OPER_UP);
+        iface.set_net_state(NetDeivceState::__LINK_STATE_START);
+        if let Some(napi) = iface.napi_struct() {
+            napi_resume(napi);
+        }
+    } else {
+        iface.publish_admin_state(false);
+        if let Some(flags) = flags {
+            iface.common().publish_configured_flags(flags);
+        }
+        iface.clear_net_state(NetDeivceState::__LINK_STATE_START);
+        iface.set_operstate(Operstate::IF_OPER_DOWN);
+    }
+}
+
+fn try_copy_string(source: &str) -> Result<String, SystemError> {
+    let mut result = String::new();
+    result
+        .try_reserve_exact(source.len())
+        .map_err(|_| SystemError::ENOMEM)?;
+    result.push_str(source);
+    Ok(result)
+}

--- a/kernel/src/net/link.rs
+++ b/kernel/src/net/link.rs
@@ -229,6 +229,7 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
         }
 
         if link_down {
+            iface.common().close_tx_and_wait();
             iface.begin_admin_down();
             if let Some(napi) = iface.napi_struct() {
                 napi_pause_and_wait(&napi);
@@ -506,6 +507,7 @@ fn publish_link_flags_and_state(
         }
         iface.set_operstate(Operstate::IF_OPER_UP);
         iface.set_net_state(NetDeivceState::__LINK_STATE_START);
+        iface.common().open_tx();
         if let Some(napi) = iface.napi_struct() {
             napi_resume(napi);
         }

--- a/kernel/src/net/link.rs
+++ b/kernel/src/net/link.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 use super::{
-    address::PreparedAddressLabelRename,
+    address::{PreparedAddressLabelRename, PreparedMtuAddressChange, RemovedAddress},
     neighbor::{self, NeighborEntry, PreparedConfiguredNeighborPurge},
     route::{self, PreparedLinkStateChange, RouteNotifications},
     rtnl::RtnlGuard,
@@ -83,6 +83,7 @@ pub(crate) struct LinkMutationCommit {
     pub iface: Arc<dyn Iface>,
     pub changes: LinkChanges,
     pub renamed_ipv4: Vec<smoltcp::wire::IpCidr>,
+    pub removed_addresses: Vec<RemovedAddress>,
     pub route_changes: Option<RouteNotifications>,
     pub removed_neighbors: Vec<NeighborEntry>,
     pub rename_old_devpath: Option<String>,
@@ -90,7 +91,7 @@ pub(crate) struct LinkMutationCommit {
 
 struct PreparedLinkRename {
     name: String,
-    labels: PreparedAddressLabelRename,
+    labels: Option<PreparedAddressLabelRename>,
     sysfs: PreparedDeviceSysfsRename,
 }
 
@@ -102,6 +103,7 @@ struct PreparedLinkMutation<'rtnl> {
     rename: Option<PreparedLinkRename>,
     flags: Option<PreparedConfiguredFlags>,
     routes: Option<PreparedLinkStateChange<'rtnl>>,
+    address_change: Option<PreparedMtuAddressChange>,
     neighbors: Option<PreparedConfiguredNeighborPurge<'rtnl>>,
     changes: LinkChanges,
     was_up: bool,
@@ -132,7 +134,27 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
 
         let (flags, was_up, is_up, noarp_changed) = prepare_flags(&iface, update.flags)?;
         let link_down = was_up && !is_up;
-        let routes = if was_up != is_up {
+        let address_change = mtu
+            .map(|mtu| {
+                super::address::prepare_mtu_address_change(
+                    rtnl,
+                    &netns,
+                    &iface,
+                    mtu,
+                    rename.as_ref().map(|rename| rename.name.as_str()),
+                    was_up,
+                    is_up,
+                )
+            })
+            .transpose()?
+            .flatten();
+        let mut rename = rename;
+        if address_change.is_some() {
+            if let Some(rename) = rename.as_mut() {
+                rename.labels = None;
+            }
+        }
+        let routes = if address_change.is_none() && was_up != is_up {
             Some(route::prepare_link_state_change(
                 rtnl, &netns, &iface, is_up,
             )?)
@@ -168,6 +190,7 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             rename,
             flags,
             routes,
+            address_change,
             neighbors,
             changes,
             was_up,
@@ -185,6 +208,7 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             rename,
             flags,
             routes,
+            address_change,
             neighbors,
             changes,
             was_up,
@@ -201,7 +225,7 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             (None, None)
         };
 
-        if let Some(mtu) = mtu {
+        if let Some(mtu) = mtu.filter(|_| address_change.is_none()) {
             let stack_mtu = iface.stack_mtu(mtu);
             iface
                 .smol_iface()
@@ -211,11 +235,15 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             iface.common().set_mtu(mtu);
         }
 
-        let renamed_ipv4 = if let Some((name, labels)) = rename {
-            labels.publish(&iface, name)
-        } else {
-            Vec::new()
-        };
+        let mut rename = rename;
+        let mut renamed_ipv4 = Vec::new();
+        if address_change.is_none() {
+            if let Some((name, labels)) = rename.take() {
+                renamed_ipv4 = labels
+                    .expect("rename without an address transaction owns its label plan")
+                    .publish(&iface, name);
+            }
+        }
 
         if noarp_changed {
             iface
@@ -241,7 +269,42 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             iface.quiesce_admin_down();
         }
 
-        let route_changes = if let Some(routes) = routes {
+        let mut removed_addresses = Vec::new();
+        let route_changes = if let Some(address_change) = address_change {
+            let renamed_to = rename.take().map(|(name, labels)| {
+                debug_assert!(labels.is_none());
+                name
+            });
+            let (removed, renamed, route_changes) = address_change.publish(
+                &netns,
+                &iface,
+                renamed_to,
+                || {
+                    let mtu = mtu.expect("address teardown requires an MTU update");
+                    let stack_mtu = iface.stack_mtu(mtu);
+                    iface
+                        .smol_iface()
+                        .lock()
+                        .set_ip_mtu(stack_mtu)
+                        .expect("validated interface MTU must be representable by smoltcp");
+                    iface.common().set_mtu(mtu);
+                },
+                is_up,
+                || {
+                    if was_up != is_up {
+                        publish_link_flags_and_state(&iface, flags, is_up);
+                    } else if let Some(flags) = flags {
+                        iface.common().publish_configured_flags(flags);
+                    }
+                    if link_down {
+                        iface.smol_iface().lock().flush_neighbor_cache();
+                    }
+                },
+            );
+            removed_addresses = removed;
+            renamed_ipv4 = renamed;
+            Some(route_changes)
+        } else if let Some(routes) = routes {
             Some(routes.publish(&netns, is_up, || {
                 publish_link_flags_and_state(&iface, flags, is_up);
                 if link_down {
@@ -285,6 +348,7 @@ impl<'rtnl> PreparedLinkMutation<'rtnl> {
             iface,
             changes,
             renamed_ipv4,
+            removed_addresses,
             route_changes,
             removed_neighbors,
             rename_old_devpath,
@@ -359,7 +423,7 @@ fn prepare_rename(
     let sysfs = prepare_netdev_sysfs_rename(iface, try_copy_string(&name)?)?;
     Ok(Some(PreparedLinkRename {
         name,
-        labels,
+        labels: Some(labels),
         sysfs,
     }))
 }

--- a/kernel/src/net/mod.rs
+++ b/kernel/src/net/mod.rs
@@ -7,6 +7,7 @@ use core::sync::atomic::AtomicUsize;
 use crate::driver::net::Iface;
 
 pub(crate) mod address;
+pub(crate) mod link;
 pub mod neighbor;
 pub mod posix;
 pub(crate) mod route;

--- a/kernel/src/net/neighbor/mod.rs
+++ b/kernel/src/net/neighbor/mod.rs
@@ -118,6 +118,38 @@ pub(crate) fn has_ipv4_entries(netns: &Arc<NetNamespace>) -> bool {
     netns.neighbor_table().has_ipv4_entries()
 }
 
+/// Allocation-complete removal of all configured neighbors owned by one
+/// interface. Holding the borrowed RTNL guard keeps the prepared table
+/// generation stable until publication.
+pub(crate) struct PreparedConfiguredNeighborPurge<'rtnl> {
+    rtnl: &'rtnl RtnlGuard,
+    netns: Arc<NetNamespace>,
+    prepared: table::PreparedNeighborPurge,
+}
+
+impl PreparedConfiguredNeighborPurge<'_> {
+    /// Publishes the purge without allocating and returns the removed entries
+    /// for post-commit rtnetlink notifications.
+    pub(crate) fn publish(self) -> Vec<NeighborEntry> {
+        self.netns
+            .neighbor_table()
+            .publish_iface_purge(self.rtnl, self.prepared)
+    }
+}
+
+pub(crate) fn prepare_configured_iface_purge<'rtnl>(
+    rtnl: &'rtnl RtnlGuard,
+    netns: &Arc<NetNamespace>,
+    ifindex: u32,
+) -> Result<PreparedConfiguredNeighborPurge<'rtnl>, SystemError> {
+    let prepared = netns.neighbor_table().prepare_iface_purge(rtnl, ifindex)?;
+    Ok(PreparedConfiguredNeighborPurge {
+        rtnl,
+        netns: netns.clone(),
+        prepared,
+    })
+}
+
 pub(crate) fn remove_iface(rtnl: &RtnlGuard, netns: &Arc<NetNamespace>, ifindex: u32) {
     netns.neighbor_table().remove_iface(rtnl, ifindex);
 }

--- a/kernel/src/net/neighbor/table.rs
+++ b/kernel/src/net/neighbor/table.rs
@@ -43,6 +43,19 @@ pub(crate) struct NeighborSnapshot {
     entries: Vec<NeighborEntry>,
 }
 
+/// An RTNL-serialized, allocation-complete purge of one interface's configured
+/// neighbors.
+///
+/// The copied entries are both the eventual notification payload and proof of
+/// the table generation prepared for publication. Configured-neighbor writers
+/// all require RTNL, so the matching table range cannot change between
+/// `prepare_iface_purge` and `publish_iface_purge` while the caller retains the
+/// same guard.
+pub(super) struct PreparedNeighborPurge {
+    ifindex: u32,
+    removed: Vec<NeighborEntry>,
+}
+
 impl NeighborSnapshot {
     pub(crate) fn empty() -> Self {
         Self {
@@ -63,13 +76,7 @@ impl NeighborSnapshot {
     }
 
     pub(crate) fn for_iface(&self, ifindex: u32) -> &[NeighborEntry] {
-        let start = self
-            .entries
-            .partition_point(|entry| entry.ifindex < ifindex);
-        let end = self
-            .entries
-            .partition_point(|entry| entry.ifindex <= ifindex);
-        &self.entries[start..end]
+        &self.entries[iface_range(&self.entries, ifindex)]
     }
 }
 
@@ -205,21 +212,63 @@ impl NeighborTable {
         self.ipv4_entries.load(AtomicOrdering::Acquire) != 0
     }
 
+    pub(super) fn prepare_iface_purge(
+        &self,
+        _rtnl: &RtnlGuard,
+        ifindex: u32,
+    ) -> Result<PreparedNeighborPurge, SystemError> {
+        let entries = self.entries.read();
+        let range = iface_range(&entries, ifindex);
+        let mut removed = Vec::new();
+        removed
+            .try_reserve_exact(range.len())
+            .map_err(|_| SystemError::ENOMEM)?;
+        removed.extend_from_slice(&entries[range]);
+        Ok(PreparedNeighborPurge { ifindex, removed })
+    }
+
+    pub(super) fn publish_iface_purge(
+        &self,
+        _rtnl: &RtnlGuard,
+        prepared: PreparedNeighborPurge,
+    ) -> Vec<NeighborEntry> {
+        let PreparedNeighborPurge { ifindex, removed } = prepared;
+        if removed.is_empty() {
+            return removed;
+        }
+
+        let mut entries = self.entries.write();
+        let range = iface_range(&entries, ifindex);
+        debug_assert_eq!(&entries[range.clone()], removed.as_slice());
+        self.remove_iface_entries(&mut entries, range);
+        removed
+    }
+
     /// Purges device-owned entries during an RTNL-serialized topology removal.
     /// Shrinking a vector is non-fallible, which lets device teardown finish
     /// after its fallible route preparation has succeeded.
     pub(super) fn remove_iface(&self, _rtnl: &RtnlGuard, ifindex: u32) {
         let mut entries = self.entries.write();
-        let removed_ipv4 = entries
+        let range = iface_range(&entries, ifindex);
+        self.remove_iface_entries(&mut entries, range);
+    }
+
+    fn remove_iface_entries(
+        &self,
+        entries: &mut Vec<NeighborEntry>,
+        range: core::ops::Range<usize>,
+    ) {
+        let removed_ipv4 = entries[range.clone()]
             .iter()
             .filter(|entry| {
-                entry.ifindex == ifindex
-                    && entry.ethernet_output
-                    && matches!(entry.destination, IpAddress::Ipv4(_))
+                entry.ethernet_output && matches!(entry.destination, IpAddress::Ipv4(_))
             })
             .count();
-        entries.retain(|entry| entry.ifindex != ifindex);
+        entries.drain(range);
         if removed_ipv4 != 0 {
+            // Keep a stale-positive gate until the mappings are gone. A packet
+            // may take the slow path unnecessarily, but can never miss a
+            // configured mapping that is still published.
             self.ipv4_entries
                 .fetch_sub(removed_ipv4, AtomicOrdering::Release);
         }
@@ -240,6 +289,12 @@ fn validate_supported_capabilities(update: NeighborUpdate) -> Result<(), SystemE
 
 fn find(entries: &[NeighborEntry], ifindex: u32, destination: IpAddress) -> Result<usize, usize> {
     entries.binary_search_by(|entry| compare_key(entry, ifindex, destination))
+}
+
+fn iface_range(entries: &[NeighborEntry], ifindex: u32) -> core::ops::Range<usize> {
+    let start = entries.partition_point(|entry| entry.ifindex < ifindex);
+    let end = entries.partition_point(|entry| entry.ifindex <= ifindex);
+    start..end
 }
 
 fn compare_key(entry: &NeighborEntry, ifindex: u32, destination: IpAddress) -> Ordering {

--- a/kernel/src/net/route/fib.rs
+++ b/kernel/src/net/route/fib.rs
@@ -161,7 +161,7 @@ impl<'a> FibEditor<'a> {
         before_routes: &[RouteEntry],
         after_routes: &[RouteEntry],
         ifindex: u32,
-        deleted_address: Option<IpAddress>,
+        deleted_addresses: &[IpAddress],
         preferred_source_remains_usable: F,
     ) -> Result<PreferredSourceTransitions, SystemError>
     where
@@ -171,15 +171,18 @@ impl<'a> FibEditor<'a> {
         // still untouched; subsequent edits keep the candidate's index in
         // lockstep with its authoritative route vector.
         self.record(ifindex)?;
-        if let Some(deleted) = deleted_address {
+        if !deleted_addresses.is_empty() {
             let mut affected_oifs = Vec::new();
             affected_oifs
                 .try_reserve_exact(self.fib.entries.len())
                 .map_err(|_| SystemError::ENOMEM)?;
             for entry in self.fib.entries.iter().copied() {
-                if entry.preferred_source == Some(deleted)
+                if entry
+                    .preferred_source
+                    .is_some_and(|source| deleted_addresses.contains(&source))
                     && !preferred_source_remains_usable(entry)
-                    && (!is_ipv4(deleted) || entry.table == super::RT_TABLE_MAIN)
+                    && (!entry.preferred_source.is_some_and(is_ipv4)
+                        || entry.table == super::RT_TABLE_MAIN)
                     && !affected_oifs.contains(&entry.oif)
                 {
                     affected_oifs.push(entry.oif);
@@ -192,7 +195,7 @@ impl<'a> FibEditor<'a> {
         self.fib.reconcile_address_routes(
             before_routes,
             after_routes,
-            deleted_address,
+            deleted_addresses,
             preferred_source_remains_usable,
         )
     }
@@ -700,7 +703,7 @@ impl FibTable {
         &mut self,
         before_routes: &[RouteEntry],
         after_routes: &[RouteEntry],
-        deleted_address: Option<IpAddress>,
+        deleted_addresses: &[IpAddress],
         preferred_source_remains_usable: F,
     ) -> Result<PreferredSourceTransitions, SystemError>
     where
@@ -734,13 +737,18 @@ impl FibTable {
         }
 
         let mut transitions = PreferredSourceTransitions::default();
-        if let Some(deleted) = deleted_address {
+        if !deleted_addresses.is_empty() {
             let mut index = 0;
             while index < self.entries.len() {
                 let entry = self.entries[index];
-                if entry.preferred_source == Some(deleted)
-                    && !preferred_source_remains_usable(entry)
-                {
+                let Some(deleted) = entry
+                    .preferred_source
+                    .filter(|source| deleted_addresses.contains(source))
+                else {
+                    index += 1;
+                    continue;
+                };
+                if !preferred_source_remains_usable(entry) {
                     if is_ipv4(deleted) {
                         // fib_sync_down_addr() only invalidates the L3
                         // domain's forwarding table. DragonOS has no VRF/L3

--- a/kernel/src/net/route/lifecycle.rs
+++ b/kernel/src/net/route/lifecycle.rs
@@ -28,13 +28,20 @@ pub(crate) fn register_iface(
 ) -> Result<(), SystemError> {
     let addresses = try_clone_slice(&iface.common().ip_addrs())?;
     let staged = iface.common().take_bootstrap_routes();
+    // Construction may preload addresses before the device is visible, but a
+    // DOWN device must not publish those addresses into the FIB merely by
+    // being registered. Explicit address changes after registration use the
+    // address transaction path and remain independent of this rule.
+    let defer_constructor_address_routes = !iface.flags().contains(InterfaceFlags::UP);
     iface
         .smol_iface()
         .lock()
         .set_route_table_includes_connected_prefixes(true);
     let result = transact_with_devices(rtnl, netns, devices, |candidate| {
-        for route in derived_address_entries(iface, &addresses)? {
-            candidate.insert_derived(route)?;
+        if !defer_constructor_address_routes {
+            for route in derived_address_entries(iface, &addresses)? {
+                candidate.insert_derived(route)?;
+            }
         }
         for route in staged.iter().copied() {
             let route = RouteEntry {
@@ -124,11 +131,11 @@ pub(crate) fn prepare_link_state_change<'rtnl>(
             for entry in
                 derived_address_entries_for_link_state(iface, &iface.common().ip_addrs(), true)?
             {
-                if (!is_ipv4(entry.destination.address())
-                    || entry.table == RT_TABLE_MAIN
-                    || entry.kind == RTN_BROADCAST)
-                    && candidate.insert_derived(entry)?
-                {
+                // insert_derived() is the lifecycle authority here: the first
+                // UP publishes every deferred constructor address route,
+                // while later UP transitions only restore entries actually
+                // removed on DOWN.
+                if candidate.insert_derived(entry)? {
                     added.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
                     added.push(entry);
                 }

--- a/kernel/src/net/route/lifecycle.rs
+++ b/kernel/src/net/route/lifecycle.rs
@@ -1,4 +1,4 @@
-use alloc::{sync::Arc, vec::Vec};
+use alloc::{string::String, sync::Arc, vec::Vec};
 
 use smoltcp::{
     iface::Route as SmolRoute,
@@ -167,7 +167,7 @@ pub(crate) fn prepare_link_state_change<'rtnl>(
 /// A fully prepared address/FIB commit. Construction may fail; publication is
 /// intentionally non-fallible and keeps addresses, projection and FIB atomic
 /// under the established RTNL -> FIB -> smoltcp lock order.
-struct PreparedAddressRouteCommit {
+pub(crate) struct PreparedAddressRouteCommit {
     before: FibTable,
     candidate: FibTable,
     projection: Vec<SmolRoute>,
@@ -177,6 +177,15 @@ struct PreparedAddressRouteCommit {
     metadata: Vec<AddressMetadata>,
 }
 
+pub(crate) struct AddressLinkChange<'a> {
+    pub before: &'a [IpCidr],
+    pub after: &'a [IpCidr],
+    pub metadata: Vec<AddressMetadata>,
+    pub deleted_addresses: &'a [IpAddress],
+    pub was_up: bool,
+    pub is_up: bool,
+}
+
 impl PreparedAddressRouteCommit {
     fn prepare(
         netns: &Arc<NetNamespace>,
@@ -184,13 +193,43 @@ impl PreparedAddressRouteCommit {
         before_addresses: &[IpCidr],
         after_addresses: &[IpCidr],
         metadata: Vec<AddressMetadata>,
-        deleted_address: Option<IpAddress>,
+        deleted_addresses: &[IpAddress],
     ) -> Result<Self, SystemError> {
+        let is_up = iface.flags().contains(InterfaceFlags::UP);
+        Self::prepare_for_link(
+            netns,
+            iface,
+            AddressLinkChange {
+                before: before_addresses,
+                after: after_addresses,
+                metadata,
+                deleted_addresses,
+                was_up: is_up,
+                is_up,
+            },
+        )
+    }
+
+    fn prepare_for_link(
+        netns: &Arc<NetNamespace>,
+        iface: &Arc<dyn Iface>,
+        change: AddressLinkChange<'_>,
+    ) -> Result<Self, SystemError> {
+        let AddressLinkChange {
+            before: before_addresses,
+            after: after_addresses,
+            metadata,
+            deleted_addresses,
+            was_up,
+            is_up,
+        } = change;
         let ifindex = iface.nic_id() as u32;
         let before = netns.router().fib.read().try_clone()?;
         let mut candidate = before.try_clone()?;
-        let before_routes = derived_address_entries(iface, before_addresses)?;
-        let after_routes = derived_address_entries(iface, after_addresses)?;
+        let before_routes =
+            derived_address_entries_for_link_state(iface, before_addresses, was_up)?;
+        let after_address_routes =
+            derived_address_entries_for_link_state(iface, after_addresses, was_up)?;
         let device_list = netns.device_list();
         let mut devices = Vec::new();
         devices
@@ -202,9 +241,9 @@ impl PreparedAddressRouteCommit {
             let ownership = CandidateAddressOwnership::new(&device_list, iface, after_addresses);
             editor.reconcile_address_routes(
                 &before_routes,
-                &after_routes,
+                &after_address_routes,
                 ifindex,
-                deleted_address,
+                deleted_addresses,
                 |entry| {
                     ownership.source_usable_on_oif(
                         entry.oif,
@@ -215,8 +254,44 @@ impl PreparedAddressRouteCommit {
                 },
             )
         }?;
+        let mut affected_oifs = editor.finish()?;
+        let address_removed = if was_up && !is_up {
+            candidate.delta_from(&before)?.removed
+        } else {
+            Vec::new()
+        };
+        if was_up && !is_up {
+            let mut state_editor = FibEditor::new(&mut candidate);
+            state_editor.remove_where(|entry| {
+                entry.oif == ifindex
+                    && !(is_ipv4(entry.destination.address())
+                        && entry.table == RT_TABLE_LOCAL
+                        && entry.kind == RTN_LOCAL
+                        && entry.scope == RT_SCOPE_HOST)
+            })?;
+            for oif in state_editor.finish()? {
+                if !affected_oifs.contains(&oif) {
+                    affected_oifs
+                        .try_reserve(1)
+                        .map_err(|_| SystemError::ENOMEM)?;
+                    affected_oifs.push(oif);
+                }
+            }
+        } else if !was_up && is_up {
+            let mut state_editor = FibEditor::new(&mut candidate);
+            for entry in derived_address_entries_for_link_state(iface, after_addresses, true)? {
+                state_editor.insert_derived(entry)?;
+            }
+            for oif in state_editor.finish()? {
+                if !affected_oifs.contains(&oif) {
+                    affected_oifs
+                        .try_reserve(1)
+                        .map_err(|_| SystemError::ENOMEM)?;
+                    affected_oifs.push(oif);
+                }
+            }
+        }
         drop(device_list);
-        let affected_oifs = editor.finish()?;
 
         let mut address_capacity = 0;
         iface
@@ -236,6 +311,14 @@ impl PreparedAddressRouteCommit {
         let other_projections =
             ProjectionPlan::prepare(&before, &candidate, &other_oifs, &devices)?;
         let mut notifications = candidate.delta_from(&before)?.into_notifications();
+        if was_up && !is_up {
+            // NETDEV_DOWN silently flushes ordinary IPv4 routes. Routes
+            // removed by the preceding MTU address teardown retain their
+            // normal address-lifecycle notifications.
+            notifications.removed.retain(|entry| {
+                !is_ipv4(entry.destination.address()) || address_removed.contains(entry)
+            });
+        }
         silent.removed.sort_unstable();
         silent.added.sort_unstable();
         notifications
@@ -256,6 +339,18 @@ impl PreparedAddressRouteCommit {
     }
 
     fn publish(self, netns: &Arc<NetNamespace>, iface: &Arc<dyn Iface>) -> RouteNotifications {
+        self.publish_link_change(netns, iface, None, || {}, || {}, false)
+    }
+
+    pub(crate) fn publish_link_change(
+        self,
+        netns: &Arc<NetNamespace>,
+        iface: &Arc<dyn Iface>,
+        renamed_to: Option<String>,
+        publish_mtu: impl FnOnce(),
+        publish_link_state: impl FnOnce(),
+        is_up: bool,
+    ) -> RouteNotifications {
         let Self {
             before,
             candidate,
@@ -267,6 +362,13 @@ impl PreparedAddressRouteCommit {
         } = self;
         let router = netns.router();
         let mut current = router.fib_write();
+        publish_mtu();
+        let mut publish_link_state = Some(publish_link_state);
+        if !is_up {
+            publish_link_state
+                .take()
+                .expect("link state publisher runs once")();
+        }
         debug_assert_eq!(*current, before);
         let mut smol_iface = iface.smol_iface().lock();
         smol_iface.update_ip_addrs(|addresses| {
@@ -282,12 +384,31 @@ impl PreparedAddressRouteCommit {
         });
         drop(smol_iface);
         other_projections.publish();
-        *iface.common().address_metadata().lock() = metadata;
+        if let Some(name) = renamed_to {
+            iface
+                .common()
+                .publish_name_and_address_metadata(name, metadata);
+        } else {
+            *iface.common().address_metadata().lock() = metadata;
+        }
         let mut mirror = iface.router_common().ip_addrs.write();
         *mirror = after_addresses;
         *current = candidate;
+        if is_up {
+            publish_link_state
+                .take()
+                .expect("link state publisher runs once")();
+        }
         notifications
     }
+}
+
+pub(crate) fn prepare_address_link_change(
+    netns: &Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    change: AddressLinkChange<'_>,
+) -> Result<PreparedAddressRouteCommit, SystemError> {
+    PreparedAddressRouteCommit::prepare_for_link(netns, iface, change)
 }
 
 pub(crate) fn commit_addresses(
@@ -299,13 +420,14 @@ pub(crate) fn commit_addresses(
     metadata: Vec<AddressMetadata>,
     deleted_address: Option<IpAddress>,
 ) -> Result<RouteNotifications, SystemError> {
+    let deleted_addresses = deleted_address.as_slice();
     let prepared = PreparedAddressRouteCommit::prepare(
         netns,
         iface,
         before,
         after,
         metadata,
-        deleted_address,
+        deleted_addresses,
     )?;
     Ok(prepared.publish(netns, iface))
 }

--- a/kernel/src/net/route/mod.rs
+++ b/kernel/src/net/route/mod.rs
@@ -26,8 +26,8 @@ use crate::{
 use fib::FibEditor;
 pub(in crate::net) use fib::FibTable;
 pub(crate) use lifecycle::{
-    commit_addresses, prepare_link_state_change, register_iface, unregister_iface,
-    PreparedLinkStateChange,
+    commit_addresses, prepare_address_link_change, prepare_link_state_change, register_iface,
+    unregister_iface, AddressLinkChange, PreparedAddressRouteCommit, PreparedLinkStateChange,
 };
 pub(crate) use source::{resolve_ipv4_output_flow, resolve_ipv4_route, Ipv4OutputFlow};
 use transaction::{

--- a/kernel/src/net/route/source.rs
+++ b/kernel/src/net/route/source.rs
@@ -54,12 +54,7 @@ pub(crate) fn resolve_ipv4_route(
         fixed_source.and_then(|source| {
             (!source.is_unspecified()).then_some(())?;
             devices.iter().find_map(|(ifindex, candidate)| {
-                candidate
-                    .router_common()
-                    .ip_addrs
-                    .read()
-                    .iter()
-                    .any(|cidr| cidr.address() == source)
+                crate::net::address::iface_accepts_local_address(candidate, source)
                     .then(|| u32::try_from(*ifindex).ok())
                     .flatten()
             })
@@ -77,14 +72,9 @@ pub(crate) fn resolve_ipv4_route(
     }
 
     let source_is_local = |source: IpAddress| {
-        devices.values().any(|candidate| {
-            candidate
-                .router_common()
-                .ip_addrs
-                .read()
-                .iter()
-                .any(|cidr| cidr.address() == source)
-        })
+        devices
+            .values()
+            .any(|candidate| crate::net::address::iface_accepts_local_address(candidate, source))
     };
     let source = if let Some(source) = fixed_source {
         if !matches!(source, IpAddress::Ipv4(_)) || !source_is_local(source) {

--- a/kernel/src/net/socket/inet/common/mod.rs
+++ b/kernel/src/net/socket/inet/common/mod.rs
@@ -332,7 +332,9 @@ pub(crate) fn get_iface_for_local_bind(
     if let smoltcp::wire::IpAddress::Ipv4(v4_addr) = ip_addr {
         let device_list = netns.device_list();
         return device_list.iter().find_map(|(_, iface)| {
-            loopback_iface_contains_v4(iface, *v4_addr).then(|| iface.clone())
+            (iface.flags().contains(InterfaceFlags::LOOPBACK)
+                && crate::net::address::iface_accepts_local_address(iface, (*v4_addr).into()))
+            .then(|| iface.clone())
         });
     }
 
@@ -347,13 +349,12 @@ pub fn get_iface_to_bind(
     let device_list = netns.device_list();
 
     // Subnet-directed broadcast should prefer the iface whose configured subnet matches.
-    if let smoltcp::wire::IpAddress::Ipv4(target_broadcast) = ip_addr {
-        if target_broadcast.is_broadcast() {
-            if let Some(iface) = device_list.iter().find_map(|(_, iface)| {
-                iface_matches_directed_broadcast(iface, *target_broadcast).then(|| iface.clone())
-            }) {
-                return Some(iface);
-            }
+    if matches!(ip_addr, smoltcp::wire::IpAddress::Ipv4(_)) {
+        if let Some(iface) = device_list.iter().find_map(|(_, iface)| {
+            crate::net::address::iface_accepts_broadcast_address(iface, *ip_addr)
+                .then(|| iface.clone())
+        }) {
+            return Some(iface);
         }
     }
 
@@ -365,18 +366,11 @@ pub fn get_iface_to_bind(
     }
 
     if let Some(iface) = device_list
-        .iter()
-        .find(|(_, iface)| iface.smol_iface().lock().has_ip_addr(*ip_addr))
-        .map(|(_, iface)| iface.clone())
+        .values()
+        .find(|iface| crate::net::address::iface_accepts_local_address(iface, *ip_addr))
+        .cloned()
     {
         return Some(iface);
-    }
-
-    // Linux-like loopback behavior for IPv4: lo considers the whole configured subnet local.
-    if let smoltcp::wire::IpAddress::Ipv4(v4_addr) = ip_addr {
-        return device_list.iter().find_map(|(_, iface)| {
-            loopback_iface_contains_v4(iface, *v4_addr).then(|| iface.clone())
-        });
     }
 
     // IPv6 loopback destinations (::1 etc.) are delivered via the loopback interface.
@@ -387,35 +381,6 @@ pub fn get_iface_to_bind(
     }
 
     None
-}
-
-#[inline]
-fn iface_matches_directed_broadcast(
-    iface: &Arc<dyn Iface>,
-    target_broadcast: smoltcp::wire::Ipv4Address,
-) -> bool {
-    let smol_iface = iface.smol_iface().lock();
-    smol_iface.ip_addrs().iter().any(|cidr| match cidr {
-        smoltcp::wire::IpCidr::Ipv4(v4_cidr) => {
-            v4_cidr.broadcast().is_some_and(|b| b == target_broadcast)
-        }
-        _ => false,
-    })
-}
-
-#[inline]
-pub(super) fn loopback_iface_contains_v4(
-    iface: &Arc<dyn Iface>,
-    v4_addr: smoltcp::wire::Ipv4Address,
-) -> bool {
-    if !iface.flags().contains(InterfaceFlags::LOOPBACK) {
-        return false;
-    }
-    let smol_iface = iface.smol_iface().lock();
-    smol_iface.ip_addrs().iter().any(|cidr| match cidr {
-        smoltcp::wire::IpCidr::Ipv4(v4_cidr) => v4_cidr.contains_addr(&v4_addr),
-        _ => false,
-    })
 }
 
 #[inline]

--- a/kernel/src/net/socket/inet/datagram/mod.rs
+++ b/kernel/src/net/socket/inet/datagram/mod.rs
@@ -521,8 +521,6 @@ impl UdpSocket {
             remote,
             required_oif,
             multicast_source,
-            remote.is_multicast(),
-            remote.is_broadcast(),
         )?;
         let flow_target = output_flow
             .map(|flow| output_flow::ephemeral_target(self, flow))
@@ -1027,8 +1025,6 @@ impl UdpSocket {
                     dest.addr,
                     required_oif,
                     connected_source.or(multicast_source),
-                    dest.addr.is_multicast(),
-                    dest.addr.is_broadcast(),
                 )?
             }
             None => None,

--- a/kernel/src/net/socket/inet/datagram/output_flow.rs
+++ b/kernel/src/net/socket/inet/datagram/output_flow.rs
@@ -58,15 +58,8 @@ pub(super) fn ephemeral_target(
     )
 }
 
-fn needs_flow(
-    local: IpListenEndpoint,
-    destination: IpAddress,
-    is_multicast: bool,
-    is_broadcast: bool,
-) -> bool {
+fn needs_flow(destination: IpAddress) -> bool {
     matches!(destination, IpAddress::Ipv4(_))
-        && !is_broadcast
-        && (local.addr.is_none() || is_multicast)
 }
 
 pub(super) fn resolve_ipv4_send_flow(
@@ -75,10 +68,8 @@ pub(super) fn resolve_ipv4_send_flow(
     destination: IpAddress,
     required_oif: Option<u32>,
     fixed_source: Option<IpAddress>,
-    is_multicast: bool,
-    is_broadcast: bool,
 ) -> Result<Option<Ipv4OutputFlow>, SystemError> {
-    if !needs_flow(local, destination, is_multicast, is_broadcast) {
+    if !needs_flow(destination) {
         return Ok(None);
     }
     let fixed_source = local
@@ -112,42 +103,15 @@ pub(super) fn local_source_endpoint(
 
 #[cfg(test)]
 mod tests {
-    use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
+    use smoltcp::wire::IpAddress;
 
     use super::needs_flow;
 
     #[test]
-    fn wildcard_ipv4_is_distinct_from_fixed_and_ipv6_endpoints() {
-        let wildcard = IpListenEndpoint::from(12345);
-        assert!(needs_flow(
-            wildcard,
-            IpAddress::v4(203, 0, 113, 1),
-            false,
-            false
-        ));
-        assert!(!needs_flow(
-            wildcard,
-            IpAddress::v6(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1),
-            false,
-            false
-        ));
-        assert!(!needs_flow(
-            IpListenEndpoint::from(IpEndpoint::new(IpAddress::v4(192, 0, 2, 1), 12345)),
-            IpAddress::v4(203, 0, 113, 1),
-            false,
-            false
-        ));
-        assert!(needs_flow(
-            wildcard,
-            IpAddress::v4(239, 1, 2, 3),
-            true,
-            false
-        ));
-        assert!(needs_flow(
-            IpListenEndpoint::from(IpEndpoint::new(IpAddress::v4(192, 0, 2, 1), 12345)),
-            IpAddress::v4(239, 1, 2, 3),
-            true,
-            false
-        ));
+    fn every_ipv4_send_requires_a_current_flow() {
+        assert!(needs_flow(IpAddress::v4(203, 0, 113, 1)));
+        assert!(needs_flow(IpAddress::v4(239, 1, 2, 3)));
+        assert!(needs_flow(IpAddress::v4(255, 255, 255, 255)));
+        assert!(!needs_flow(IpAddress::v6(0x2001, 0xdb8, 0, 0, 0, 0, 0, 1)));
     }
 }

--- a/kernel/src/net/socket/inet/datagram/output_flow.rs
+++ b/kernel/src/net/socket/inet/datagram/output_flow.rs
@@ -62,6 +62,23 @@ fn needs_flow(destination: IpAddress) -> bool {
     matches!(destination, IpAddress::Ipv4(_))
 }
 
+/// Converts the receive-side bind address into an output source constraint.
+///
+/// Linux keeps separate receive and transmit addresses for IPv4 sockets:
+/// multicast and broadcast bind addresses select received traffic, while the
+/// transmit source remains route-selected. Keep that distinction here instead
+/// of teaching the FIB that non-unicast addresses are locally owned sources.
+fn bound_source_constraint(
+    netns: &Arc<NetNamespace>,
+    local: IpListenEndpoint,
+) -> Option<IpAddress> {
+    local.addr.filter(|address| {
+        !address.is_unspecified()
+            && !address.is_multicast()
+            && !crate::net::address::netns_accepts_broadcast_address(netns, *address)
+    })
+}
+
 pub(super) fn resolve_ipv4_send_flow(
     netns: &Arc<NetNamespace>,
     local: IpListenEndpoint,
@@ -72,10 +89,7 @@ pub(super) fn resolve_ipv4_send_flow(
     if !needs_flow(destination) {
         return Ok(None);
     }
-    let fixed_source = local
-        .addr
-        .filter(|address| !address.is_unspecified())
-        .or(fixed_source);
+    let fixed_source = bound_source_constraint(netns, local).or(fixed_source);
     crate::net::route::resolve_ipv4_output_flow(netns, destination, required_oif, fixed_source)
         .map(Some)
 }
@@ -88,9 +102,7 @@ pub(super) fn local_source_endpoint(
     output_flow: Option<Ipv4OutputFlow>,
     unspecified: IpAddress,
 ) -> IpEndpoint {
-    let address = local
-        .addr
-        .filter(|address| !address.is_unspecified())
+    let address = bound_source_constraint(netns, local)
         .or_else(|| output_flow.map(|flow| flow.source))
         .or_else(|| {
             let ifindex = usize::try_from(local_delivery_ifindex?).ok()?;

--- a/kernel/src/net/socket/inet/datagram/socket_impl.rs
+++ b/kernel/src/net/socket/inet/datagram/socket_impl.rs
@@ -125,8 +125,6 @@ impl Socket for UdpSocket {
                     remote.addr,
                     required_oif,
                     multicast_source,
-                    remote.addr.is_multicast(),
-                    remote.addr.is_broadcast(),
                 )?
                 .map(|flow| flow.source);
                 match self.inner.read().as_ref() {

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -12,8 +12,8 @@ use system_error::SystemError;
 
 use super::{
     ioctl::{
-        handle_netdev_query, handle_siocgifconf, SIOCGIFCONF, SIOCGIFFLAGS, SIOCGIFHWADDR,
-        SIOCGIFINDEX, SIOCGIFMTU,
+        handle_netdev_mutation, handle_netdev_query, handle_siocgifconf, SIOCGIFCONF, SIOCGIFFLAGS,
+        SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMTU, SIOCSIFFLAGS, SIOCSIFMTU,
     },
     Socket,
 };
@@ -157,6 +157,7 @@ impl<T: Socket + 'static> IndexNode for T {
             SIOCGIFINDEX | SIOCGIFFLAGS | SIOCGIFMTU | SIOCGIFHWADDR => {
                 handle_netdev_query(self.netns(), cmd, data)
             }
+            SIOCSIFFLAGS | SIOCSIFMTU => handle_netdev_mutation(self.netns(), cmd, data),
             FIONREAD /* TIOCINQ */ => {
                 // Get number of bytes available to read
                 let bytes_available = self.recv_bytes_available();

--- a/kernel/src/net/socket/ioctl.rs
+++ b/kernel/src/net/socket/ioctl.rs
@@ -1,10 +1,9 @@
-//! Linux-compatible network-device query ioctls shared by all socket families.
+//! Linux-compatible network-device ioctls shared by all socket families.
 //!
 //! Query commands read the namespace captured by the socket at creation time,
-//! matching Linux `sock_net(sk)`. They intentionally do not acquire RTNL: each
-//! command returns one device property through the `ifreq` union. Mutation
-//! ioctls belong to the RTNL control core and must not be added here as direct
-//! `Iface` writes.
+//! matching Linux `sock_net(sk)`. Query commands return one device property
+//! through the `ifreq` union. Mutation commands only translate the ABI and
+//! delegate to the same RTNL-serialized link core as rtnetlink.
 
 use alloc::{sync::Arc, vec::Vec};
 use core::mem::size_of;
@@ -12,15 +11,24 @@ use core::mem::size_of;
 use system_error::SystemError;
 
 use crate::{
-    driver::net::Iface,
-    net::{posix::SockAddrIn, socket::IFNAMSIZ},
-    process::namespace::net_namespace::NetNamespace,
+    driver::net::{types::InterfaceFlags, Iface},
+    net::{
+        link::{LinkFlagsUpdate, LinkMtuUpdate, LinkTarget, LinkUpdate},
+        posix::SockAddrIn,
+        socket::IFNAMSIZ,
+    },
+    process::{
+        cred::{ns_capable, CAPFlags},
+        namespace::net_namespace::NetNamespace,
+    },
     syscall::user_access::{UserBufferReader, UserBufferWriter},
 };
 
 pub(super) const SIOCGIFCONF: u32 = 0x8912;
 pub(super) const SIOCGIFFLAGS: u32 = 0x8913;
+pub(super) const SIOCSIFFLAGS: u32 = 0x8914;
 pub(super) const SIOCGIFMTU: u32 = 0x8921;
+pub(super) const SIOCSIFMTU: u32 = 0x8922;
 pub(super) const SIOCGIFHWADDR: u32 = 0x8927;
 pub(super) const SIOCGIFINDEX: u32 = 0x8933;
 
@@ -44,7 +52,7 @@ impl Default for IfReq {
 }
 
 impl IfReq {
-    fn lookup_name(&mut self) -> Result<&str, SystemError> {
+    fn canonical_name_bytes(&mut self) -> &[u8] {
         self.ifr_name[IFNAMSIZ - 1] = 0;
         let nul = self
             .ifr_name
@@ -53,7 +61,12 @@ impl IfReq {
             .unwrap_or(IFNAMSIZ);
         let name = &self.ifr_name[..nul];
         let alias = name.iter().position(|byte| *byte == b':').unwrap_or(nul);
-        let name = core::str::from_utf8(&name[..alias]).map_err(|_| SystemError::ENODEV)?;
+        &name[..alias]
+    }
+
+    fn lookup_name(&mut self) -> Result<&str, SystemError> {
+        let name =
+            core::str::from_utf8(self.canonical_name_bytes()).map_err(|_| SystemError::ENODEV)?;
         if name.is_empty() {
             return Err(SystemError::ENODEV);
         }
@@ -62,6 +75,23 @@ impl IfReq {
 
     fn set_i32(&mut self, value: i32) {
         self.ifr_ifru[..size_of::<i32>()].copy_from_slice(&value.to_ne_bytes());
+    }
+
+    fn get_i32(&self) -> i32 {
+        i32::from_ne_bytes(
+            self.ifr_ifru[..size_of::<i32>()]
+                .try_into()
+                .expect("ifreq union contains an i32"),
+        )
+    }
+
+    fn get_flags(&self) -> InterfaceFlags {
+        let value = i16::from_ne_bytes(
+            self.ifr_ifru[..size_of::<i16>()]
+                .try_into()
+                .expect("ifreq union contains an i16"),
+        );
+        InterfaceFlags::from_bits_truncate((value as u16) as u32)
     }
 
     fn set_flags(&mut self, flags: u32) {
@@ -128,6 +158,46 @@ pub(super) fn handle_netdev_query(
     }
 
     write_ifreq(data, &ifreq)?;
+    Ok(0)
+}
+
+pub(super) fn handle_netdev_mutation(
+    netns: Arc<NetNamespace>,
+    cmd: u32,
+    data: usize,
+) -> Result<usize, SystemError> {
+    // Linux copies the whole ifreq before the capability check, so EFAULT has
+    // precedence over EPERM and device lookup errors.
+    let mut ifreq = read_ifreq(data)?;
+    let mut name_storage = [0u8; IFNAMSIZ];
+    let name_len = {
+        let name = ifreq.canonical_name_bytes();
+        name_storage[..name.len()].copy_from_slice(name);
+        name.len()
+    };
+    if !ns_capable(netns.user_ns(), CAPFlags::CAP_NET_ADMIN) {
+        return Err(SystemError::EPERM);
+    }
+    let name = core::str::from_utf8(&name_storage[..name_len]).map_err(|_| SystemError::ENODEV)?;
+    if name.is_empty() {
+        return Err(SystemError::ENODEV);
+    }
+
+    let update = match cmd {
+        SIOCSIFFLAGS => LinkUpdate {
+            flags: Some(LinkFlagsUpdate::Replace(ifreq.get_flags())),
+            ..Default::default()
+        },
+        SIOCSIFMTU => LinkUpdate {
+            mtu: Some(LinkMtuUpdate::Ioctl(ifreq.get_i32())),
+            ..Default::default()
+        },
+        _ => return Err(SystemError::ENOTTY),
+    };
+
+    let rtnl = crate::net::rtnl::lock();
+    let committed = crate::net::link::mutate_link(&rtnl, &netns, LinkTarget::Name(name), update)?;
+    super::netlink::notify_link_commit(&netns, committed);
     Ok(0)
 }
 

--- a/kernel/src/net/socket/netlink/kobject/message.rs
+++ b/kernel/src/net/socket/netlink/kobject/message.rs
@@ -5,13 +5,13 @@ use crate::net::socket::netlink::table::MulticastMessage;
 
 #[derive(Debug, Clone)]
 pub struct KobjectUeventMessage {
-    bytes: Arc<[u8]>,
+    bytes: Arc<Vec<u8>>,
 }
 
 impl KobjectUeventMessage {
     pub fn new(payload: &[u8]) -> Self {
         Self {
-            bytes: Arc::from(payload),
+            bytes: Arc::new(payload.to_vec()),
         }
     }
 
@@ -21,15 +21,19 @@ impl KobjectUeventMessage {
             .try_reserve(payload.len())
             .map_err(|_| SystemError::ENOMEM)?;
         bytes.extend_from_slice(payload);
-        Ok(Self {
-            bytes: Arc::from(bytes),
-        })
+        Self::try_from_vec(bytes)
     }
 
     pub fn from_vec(bytes: Vec<u8>) -> Self {
         Self {
-            bytes: Arc::from(bytes),
+            bytes: Arc::new(bytes),
         }
+    }
+
+    pub fn try_from_vec(bytes: Vec<u8>) -> Result<Self, SystemError> {
+        Ok(Self {
+            bytes: Arc::try_new(bytes).map_err(|_| SystemError::ENOMEM)?,
+        })
     }
 
     pub fn as_bytes(&self) -> &[u8] {

--- a/kernel/src/net/socket/netlink/mod.rs
+++ b/kernel/src/net/socket/netlink/mod.rs
@@ -54,6 +54,13 @@ pub fn create_netlink_socket(
     Ok(inode)
 }
 
+pub(crate) fn notify_link_commit(
+    netns: &Arc<crate::process::namespace::net_namespace::NetNamespace>,
+    committed: crate::net::link::LinkMutationCommit,
+) {
+    route::kern::notify_link_commit(netns, committed);
+}
+
 pub(crate) fn notify_link_change(iface: &Arc<dyn crate::driver::net::Iface>) {
     route::kern::notify_link_change(iface);
 }

--- a/kernel/src/net/socket/netlink/receiver.rs
+++ b/kernel/src/net/socket/netlink/receiver.rs
@@ -25,7 +25,9 @@ impl<Message> MessageQueue<Message> {
 
     fn enqueue(&self, message: Message) -> Result<(), SystemError> {
         // FIXME: 确保消息队列不会超过最大长度
-        self.0.lock().push_back(message);
+        let mut queue = self.0.lock();
+        queue.try_reserve(1).map_err(|_| SystemError::ENOMEM)?;
+        queue.push_back(message);
         Ok(())
     }
 }

--- a/kernel/src/net/socket/netlink/route/kern/addr.rs
+++ b/kernel/src/net/socket/netlink/route/kern/addr.rs
@@ -446,6 +446,15 @@ pub(super) fn notify_address_change(
     notify_one(netns, iface, cidr, CSegmentType::NEWADDR, None);
 }
 
+pub(super) fn notify_removed_address(
+    netns: Arc<NetNamespace>,
+    iface: &Arc<dyn Iface>,
+    cidr: IpCidr,
+    label: &CString,
+) {
+    notify_one(netns, iface, cidr, CSegmentType::DELADDR, Some(label));
+}
+
 fn notify_address_outcome_with_label(
     netns: Arc<NetNamespace>,
     iface: &Arc<dyn Iface>,

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -232,6 +232,7 @@ pub(crate) fn notify_link_commit(netns: &Arc<NetNamespace>, committed: LinkMutat
         iface,
         changes,
         renamed_ipv4,
+        removed_addresses,
         route_changes,
         removed_neighbors,
         rename_old_devpath,
@@ -241,6 +242,9 @@ pub(crate) fn notify_link_commit(netns: &Arc<NetNamespace>, committed: LinkMutat
     }
     if !changes.is_empty() {
         notify_link_change(&iface);
+    }
+    for removed in removed_addresses {
+        super::addr::notify_removed_address(netns.clone(), &iface, removed.cidr, &removed.label);
     }
     for cidr in renamed_ipv4 {
         super::addr::notify_address_change(netns.clone(), &iface, cidr);

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -1,9 +1,9 @@
 use crate::{
     driver::net::{
-        napi::napi_schedule,
         types::{InterfaceFlags, InterfaceType},
-        Iface, Operstate,
+        Iface,
     },
+    net::link::{LinkFlagsUpdate, LinkMtuUpdate, LinkMutationCommit, LinkTarget, LinkUpdate},
     net::socket::{
         netlink::{
             message::segment::{
@@ -185,11 +185,35 @@ pub(super) fn do_del_link(
     request_segment: &LinkSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let iface = find_iface_for_setlink(request_segment, netns)?;
+    let iface = find_iface_for_link(request_segment, &netns)?;
     if iface.type_() == InterfaceType::LOOPBACK {
         return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
     }
     Err(SystemError::EOPNOTSUPP_OR_ENOTSUP)
+}
+
+fn find_iface_for_link(
+    request_segment: &LinkSegment,
+    netns: &Arc<NetNamespace>,
+) -> Result<Arc<dyn Iface>, SystemError> {
+    if let Some(index) = request_segment.body().index {
+        return netns
+            .device_list()
+            .get(&(index.get() as usize))
+            .cloned()
+            .ok_or(SystemError::ENODEV);
+    }
+    let name = request_segment.attrs().iter().find_map(|attr| match attr {
+        LinkAttr::Name(name) => name.to_str().ok(),
+        _ => None,
+    });
+    let name = name.ok_or(SystemError::EINVAL)?;
+    netns
+        .device_list()
+        .values()
+        .find(|iface| iface.common().with_iface_name(|current| current == name))
+        .cloned()
+        .ok_or(SystemError::ENODEV)
 }
 
 pub(super) fn do_set_link(
@@ -197,178 +221,35 @@ pub(super) fn do_set_link(
     request_segment: &LinkSegment,
     netns: Arc<NetNamespace>,
 ) -> Result<Vec<RouteNlSegment>, SystemError> {
-    let iface = find_iface_for_setlink(request_segment, netns.clone())?;
-    let updates = validate_setlink_request(request_segment, iface.as_ref())?;
-    let committed =
-        PreparedSetLink::prepare(rtnl, request_segment, netns.clone(), iface.clone(), updates)?
-            .commit();
-
-    notify_link_change(&iface);
-    for cidr in committed.renamed_ipv4 {
-        super::addr::notify_address_change(netns.clone(), &iface, cidr);
-    }
-    if let Some(changes) = committed.route_changes {
-        notify_link_route_changes(&netns, changes);
-    }
-
+    let (target, update) = parse_setlink_request(request_segment)?;
+    let committed = crate::net::link::mutate_link(rtnl, &netns, target, update)?;
+    notify_link_commit(&netns, committed);
     Ok(Vec::new())
 }
 
-struct PreparedLinkRename {
-    name: String,
-    labels: crate::net::address::PreparedAddressLabelRename,
-}
-
-/// A SETLINK mutation whose validation and allocations have completed.
-///
-/// This statically composes the concrete name/address, flag, and route plans;
-/// a generic transaction framework would obscure their different publication
-/// ordering without improving the single SETLINK call site.
-struct PreparedSetLink<'rtnl> {
-    _rtnl: &'rtnl crate::net::rtnl::RtnlGuard,
-    iface: Arc<dyn Iface>,
-    netns: Arc<NetNamespace>,
-    mtu: Option<u32>,
-    rename: Option<PreparedLinkRename>,
-    flags: crate::driver::net::PreparedConfiguredFlags,
-    routes: Option<crate::net::route::PreparedLinkStateChange<'rtnl>>,
-    changes_up: bool,
-    was_up: bool,
-    is_up: bool,
-}
-
-struct CommittedSetLink {
-    renamed_ipv4: Vec<smoltcp::wire::IpCidr>,
-    route_changes: Option<crate::net::route::RouteNotifications>,
-}
-
-impl<'rtnl> PreparedSetLink<'rtnl> {
-    fn prepare(
-        rtnl: &'rtnl crate::net::rtnl::RtnlGuard,
-        request_segment: &LinkSegment,
-        netns: Arc<NetNamespace>,
-        iface: Arc<dyn Iface>,
-        updates: SetLinkUpdates,
-    ) -> Result<Self, SystemError> {
-        let rename = if let Some(name) = updates.name {
-            let duplicate = netns.device_list().values().any(|other| {
-                !Arc::ptr_eq(other, &iface)
-                    && other
-                        .common()
-                        .with_iface_name(|current| current == name.as_str())
-            });
-            if duplicate {
-                return Err(SystemError::EEXIST);
-            }
-            let labels =
-                crate::net::address::PreparedAddressLabelRename::prepare(rtnl, &iface, &name)?;
-            Some(PreparedLinkRename { name, labels })
-        } else {
-            None
-        };
-
-        let change_mask = InterfaceFlags::from_bits_truncate(request_segment.body().change.bits());
-        let requested_flags =
-            InterfaceFlags::from_bits_truncate(request_segment.body().flags.bits());
-        let flags = iface
-            .common()
-            .prepare_configured_flags(requested_flags, change_mask)?;
-        let was_up = flags.old_flags().contains(InterfaceFlags::UP);
-        let is_up = flags.new_flags().contains(InterfaceFlags::UP);
-        let changes_up = change_mask.contains(InterfaceFlags::UP);
-        let routes = if changes_up && was_up != is_up {
-            Some(crate::net::route::prepare_link_state_change(
-                rtnl, &netns, &iface, is_up,
-            )?)
-        } else {
-            None
-        };
-
-        Ok(Self {
-            _rtnl: rtnl,
-            iface,
-            netns,
-            mtu: updates.mtu,
-            rename,
-            flags,
-            routes,
-            changes_up,
-            was_up,
-            is_up,
-        })
+pub(crate) fn notify_link_commit(netns: &Arc<NetNamespace>, committed: LinkMutationCommit) {
+    let LinkMutationCommit {
+        iface,
+        changes,
+        renamed_ipv4,
+        route_changes,
+        removed_neighbors,
+        rename_old_devpath,
+    } = committed;
+    if let Some(old_devpath) = rename_old_devpath {
+        crate::driver::net::sysfs::netdev_emit_move_uevent(iface.clone(), old_devpath);
     }
-
-    fn commit(self) -> CommittedSetLink {
-        let Self {
-            _rtnl: _,
-            iface,
-            netns,
-            mtu,
-            rename,
-            flags,
-            routes,
-            changes_up,
-            was_up,
-            is_up,
-        } = self;
-
-        // Linux applies MTU and rename before dev_change_flags(). All
-        // fallible work is already owned by this plan, so publication cannot
-        // strand a half-prepared SETLINK request.
-        if let Some(mtu) = mtu {
-            iface.common().set_mtu(mtu as usize);
-        }
-        let renamed_ipv4 = if let Some(rename) = rename {
-            rename.labels.publish(&iface, rename.name)
-        } else {
-            Vec::new()
-        };
-
-        let route_changes = if let Some(routes) = routes {
-            Some(routes.publish(&netns, is_up, || {
-                publish_link_flags_and_state(&iface, flags, is_up);
-            }))
-        } else {
-            // Linux applies an idempotent IFF_UP request to the runtime
-            // lifecycle too; only FIB publication requires a transition.
-            if changes_up {
-                publish_link_flags_and_state(&iface, flags, is_up);
-            } else {
-                iface.common().publish_configured_flags(flags);
-            }
-            None
-        };
-
-        if changes_up && was_up != is_up {
-            if is_up {
-                if let Some(napi) = iface.napi_struct() {
-                    napi_schedule(napi);
-                } else {
-                    netns.wakeup_poll_thread();
-                }
-            }
-            netns.notify_deadline_changed();
-        }
-
-        CommittedSetLink {
-            renamed_ipv4,
-            route_changes,
-        }
+    if !changes.is_empty() {
+        notify_link_change(&iface);
     }
-}
-
-fn publish_link_flags_and_state(
-    iface: &Arc<dyn Iface>,
-    prepared_flags: crate::driver::net::PreparedConfiguredFlags,
-    is_up: bool,
-) {
-    iface.common().publish_configured_flags(prepared_flags);
-    if is_up {
-        iface.set_operstate(Operstate::IF_OPER_UP);
-        iface.set_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_START);
-    } else {
-        iface.clear_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_START);
-        iface.set_operstate(Operstate::IF_OPER_DOWN);
+    for cidr in renamed_ipv4 {
+        super::addr::notify_address_change(netns.clone(), &iface, cidr);
+    }
+    if let Some(changes) = route_changes {
+        notify_link_route_changes(netns, changes);
+    }
+    for entry in removed_neighbors {
+        super::neigh::notify_removed_entry(netns, entry);
     }
 }
 
@@ -388,78 +269,54 @@ fn notify_link_route_changes(
     }
 }
 
-fn find_iface_for_setlink(
+fn parse_setlink_request(
     request_segment: &LinkSegment,
-    netns: Arc<NetNamespace>,
-) -> Result<Arc<dyn Iface>, SystemError> {
-    if let Some(index) = request_segment.body().index {
-        return netns
-            .device_list()
-            .get(&(index.get() as usize))
-            .cloned()
-            .ok_or(SystemError::ENODEV);
-    }
-
-    let requested_name = request_segment.attrs().iter().find_map(|attr| {
-        if let LinkAttr::Name(name) = attr {
-            name.to_str().ok()
-        } else {
-            None
-        }
-    });
-
-    if let Some(name) = requested_name {
-        return netns
-            .device_list()
-            .iter()
-            .find(|(_, iface)| iface.common().with_iface_name(|current| current == name))
-            .map(|(_, iface)| iface.clone())
-            .ok_or(SystemError::ENODEV);
-    }
-
-    Err(SystemError::EINVAL)
-}
-
-struct SetLinkUpdates {
-    name: Option<String>,
-    mtu: Option<u32>,
-}
-
-fn validate_setlink_request(
-    request_segment: &LinkSegment,
-    iface: &dyn Iface,
-) -> Result<SetLinkUpdates, SystemError> {
-    let body = request_segment.body();
-    if body.pad.is_some() {
+) -> Result<(LinkTarget<'_>, LinkUpdate), SystemError> {
+    if request_segment.body().pad.is_some() {
         return Err(SystemError::EINVAL);
     }
+    // nla_parse() keeps the last attribute of a given type.
+    let requested_name = request_segment
+        .attrs()
+        .iter()
+        .filter_map(|attr| {
+            if let LinkAttr::Name(name) = attr {
+                name.to_str().ok()
+            } else {
+                None
+            }
+        })
+        .next_back();
+    if let Some(index) = request_segment.body().index {
+        let mut update = LinkUpdate::default();
+        if let Some(name) = requested_name {
+            update.new_name = Some(try_string_from_str(name)?);
+        }
+        parse_setlink_attrs(request_segment, &mut update, true)?;
+        update.flags = parse_flags(request_segment);
+        return Ok((LinkTarget::Index(index.get()), update));
+    }
+    let name = requested_name.ok_or(SystemError::EINVAL)?;
+    let mut update = LinkUpdate::default();
+    parse_setlink_attrs(request_segment, &mut update, false)?;
+    update.flags = parse_flags(request_segment);
+    Ok((LinkTarget::Name(name), update))
+}
 
-    let mut updates = SetLinkUpdates {
-        name: None,
-        mtu: None,
-    };
+fn parse_setlink_attrs(
+    request_segment: &LinkSegment,
+    update: &mut LinkUpdate,
+    name_is_mutation: bool,
+) -> Result<(), SystemError> {
     for attr in request_segment.attrs() {
         match attr {
             LinkAttr::Name(name) => {
-                let name = try_string_from_str(name.to_str().map_err(|_| SystemError::EINVAL)?)?;
-                if name.is_empty() {
-                    return Err(SystemError::EINVAL);
-                }
-                if !iface
-                    .common()
-                    .with_iface_name(|current| current == name.as_str())
-                {
-                    updates.name = Some(name);
+                name.to_str().map_err(|_| SystemError::EINVAL)?;
+                if name_is_mutation {
+                    // Already copied above; keep parsing focused on policy.
                 }
             }
-            LinkAttr::Mtu(mtu) => {
-                if *mtu == 0 {
-                    return Err(SystemError::EINVAL);
-                }
-                if *mtu != iface.mtu() as u32 {
-                    updates.mtu = Some(*mtu);
-                }
-            }
+            LinkAttr::Mtu(mtu) => update.mtu = Some(LinkMtuUpdate::Rtnetlink(*mtu)),
             LinkAttr::Allmulti(_) => return Err(SystemError::EINVAL),
             LinkAttr::Promiscuity(_)
             | LinkAttr::TxqLen(_)
@@ -468,8 +325,18 @@ fn validate_setlink_request(
             _ => return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP),
         }
     }
+    Ok(())
+}
 
-    Ok(updates)
+fn parse_flags(request_segment: &LinkSegment) -> Option<LinkFlagsUpdate> {
+    let body = request_segment.body();
+    if body.flags.is_empty() && body.change.is_empty() {
+        return None;
+    }
+    Some(LinkFlagsUpdate::Masked {
+        requested: InterfaceFlags::from_bits_truncate(body.flags.bits()),
+        change: InterfaceFlags::from_bits_truncate(body.change.bits()),
+    })
 }
 
 fn try_string_from_str(source: &str) -> Result<String, SystemError> {

--- a/kernel/src/net/socket/netlink/route/kern/mod.rs
+++ b/kernel/src/net/socket/netlink/route/kern/mod.rs
@@ -28,7 +28,7 @@ mod neigh;
 mod route;
 mod utils;
 
-pub(crate) use link::notify_link_change;
+pub(crate) use link::{notify_link_change, notify_link_commit};
 
 /// Per-send authorization and routing state for userspace rtnetlink requests.
 ///

--- a/kernel/src/net/socket/netlink/route/kern/neigh.rs
+++ b/kernel/src/net/socket/netlink/route/kern/neigh.rs
@@ -403,6 +403,10 @@ fn notify_entry(
     }
 }
 
+pub(super) fn notify_removed_entry(netns: &Arc<NetNamespace>, entry: NeighborEntry) {
+    notify_entry(netns, entry, CSegmentType::DELNEIGH, true);
+}
+
 fn neigh_to_segment(
     request_header: &CMsgSegHdr,
     entry: NeighborEntry,

--- a/kernel/src/net/socket/packet/mod.rs
+++ b/kernel/src/net/socket/packet/mod.rs
@@ -318,8 +318,21 @@ impl Socket for PacketSocket {
     fn send_to(&self, b: &[u8], f: PMSG, a: Endpoint) -> Result<usize, SystemError> {
         self.send_endpoint(b, f, a)
     }
-    fn validate_send_buffer_len(&self, l: usize, _: Option<&Endpoint>) -> Result<(), SystemError> {
-        self.validate_packet_len(l)
+    fn validate_send_buffer_len(
+        &self,
+        len: usize,
+        address: Option<&Endpoint>,
+    ) -> Result<(), SystemError> {
+        self.validate_packet_send_len(len, address)
+    }
+    fn send_user_buffer(
+        &self,
+        reader: &crate::syscall::user_access::UserBufferReader<'_>,
+        len: usize,
+        flags: PMSG,
+        address: Option<Endpoint>,
+    ) -> Result<usize, SystemError> {
+        self.send_packet_user_buffer(reader, len, flags, address)
     }
     fn recv(&self, b: &mut [u8], f: PMSG) -> Result<usize, SystemError> {
         self.recv_packet(b, f)

--- a/kernel/src/net/socket/packet/tx.rs
+++ b/kernel/src/net/socket/packet/tx.rs
@@ -1,7 +1,10 @@
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-use crate::driver::net::{types::InterfaceFlags, Iface};
+use crate::driver::net::{
+    types::{InterfaceFlags, InterfaceType},
+    Iface,
+};
 use crate::filesystem::vfs::iov::IoVecs;
 use crate::net::posix::SockAddr;
 use crate::net::socket::endpoint::Endpoint;
@@ -9,13 +12,25 @@ use crate::net::socket::PMSG;
 
 use super::{PacketSocket, PacketSocketType, SockAddrLl};
 
+const ETHERNET_HEADER_LEN: usize = 14;
+const VLAN_HEADER_LEN: usize = 4;
+const IEEE_8021Q_TPID: u16 = 0x8100;
+
+fn extra_vlan_len_allowed(iface: &dyn Iface, protocol: u16) -> bool {
+    iface.type_() == InterfaceType::ETHER && protocol == IEEE_8021Q_TPID
+}
+
+struct PreparedPacketSend {
+    iface: alloc::sync::Arc<dyn Iface>,
+    kind: PreparedPacketKind,
+}
+
+enum PreparedPacketKind {
+    Raw,
+    Dgram { dest: SockAddrLl, protocol: u16 },
+}
+
 impl PacketSocket {
-    pub(super) fn validate_packet_len(&self, len: usize) -> Result<(), SystemError> {
-        if len > u16::MAX as usize {
-            return Err(SystemError::EMSGSIZE);
-        }
-        Ok(())
-    }
     fn destination_iface(
         &self,
         dest: Option<&SockAddrLl>,
@@ -33,29 +48,24 @@ impl PacketSocket {
             .clone()
             .ok_or(SystemError::EDESTADDRREQ)
     }
-    fn try_send(&self, buf: &[u8], dest: Option<SockAddrLl>) -> Result<usize, SystemError> {
-        self.validate_packet_len(buf.len())?;
+
+    fn prepare_send(
+        &self,
+        len: usize,
+        dest: Option<SockAddrLl>,
+    ) -> Result<PreparedPacketSend, SystemError> {
         let iface = self.destination_iface(dest.as_ref())?;
         if !iface.user_visible_flags().contains(InterfaceFlags::UP) {
             return Err(SystemError::ENETDOWN);
         }
-        match self.sock_type {
-            PacketSocketType::Raw => {
-                if buf.len() < 14 {
-                    return Err(SystemError::EINVAL);
-                }
-                iface.raw_transmit(buf)?;
-                Ok(buf.len())
-            }
+
+        let kind = match self.sock_type {
+            PacketSocketType::Raw => PreparedPacketKind::Raw,
             PacketSocketType::Dgram => {
                 let addr = dest.ok_or(SystemError::EDESTADDRREQ)?;
                 if addr.sll_halen < 6 {
                     return Err(SystemError::EINVAL);
                 }
-                let total = 14usize
-                    .checked_add(buf.len())
-                    .ok_or(SystemError::EMSGSIZE)?;
-                self.validate_packet_len(total)?;
                 let protocol = if addr.sll_protocol != 0 {
                     addr.sll_protocol
                 } else {
@@ -64,18 +74,131 @@ impl PacketSocket {
                 if protocol == 0 {
                     return Err(SystemError::EINVAL);
                 }
+                PreparedPacketKind::Dgram {
+                    dest: addr,
+                    protocol,
+                }
+            }
+        };
+        let coarse_overhead = match &kind {
+            PreparedPacketKind::Raw => ETHERNET_HEADER_LEN + VLAN_HEADER_LEN,
+            PreparedPacketKind::Dgram { .. } => VLAN_HEADER_LEN,
+        };
+        let coarse_limit = iface
+            .mtu()
+            .checked_add(coarse_overhead)
+            .ok_or(SystemError::EMSGSIZE)?;
+        if len > coarse_limit {
+            return Err(SystemError::EMSGSIZE);
+        }
+
+        Ok(PreparedPacketSend { iface, kind })
+    }
+
+    fn finish_send(&self, prepared: PreparedPacketSend, buf: &[u8]) -> Result<usize, SystemError> {
+        let PreparedPacketSend { iface, kind } = prepared;
+        match kind {
+            PreparedPacketKind::Raw => {
+                if buf.len() < ETHERNET_HEADER_LEN {
+                    return Err(SystemError::EINVAL);
+                }
+                let protocol = u16::from_be_bytes([buf[12], buf[13]]);
+                let l2_len = if extra_vlan_len_allowed(iface.as_ref(), protocol) {
+                    ETHERNET_HEADER_LEN + VLAN_HEADER_LEN
+                } else {
+                    ETHERNET_HEADER_LEN
+                };
+                let max_len = iface
+                    .mtu()
+                    .checked_add(l2_len)
+                    .ok_or(SystemError::EMSGSIZE)?;
+                if buf.len() > max_len {
+                    return Err(SystemError::EMSGSIZE);
+                }
+                let _tx = iface
+                    .common()
+                    .try_acquire_tx()
+                    .ok_or(SystemError::ENETDOWN)?;
+                iface.raw_transmit(buf)?;
+                Ok(buf.len())
+            }
+            PreparedPacketKind::Dgram { dest, protocol } => {
+                let total = 14usize
+                    .checked_add(buf.len())
+                    .ok_or(SystemError::EMSGSIZE)?;
+                let max_payload = iface
+                    .mtu()
+                    .checked_add(if extra_vlan_len_allowed(iface.as_ref(), protocol) {
+                        VLAN_HEADER_LEN
+                    } else {
+                        0
+                    })
+                    .ok_or(SystemError::EMSGSIZE)?;
+                if buf.len() > max_payload {
+                    return Err(SystemError::EMSGSIZE);
+                }
                 let mut frame = Vec::new();
                 frame
                     .try_reserve_exact(total)
                     .map_err(|_| SystemError::ENOMEM)?;
-                frame.extend_from_slice(&addr.sll_addr[..6]);
+                frame.extend_from_slice(&dest.sll_addr[..6]);
                 frame.extend_from_slice(iface.mac().as_bytes());
                 frame.extend_from_slice(&protocol.to_be_bytes());
                 frame.extend_from_slice(buf);
+                let _tx = iface
+                    .common()
+                    .try_acquire_tx()
+                    .ok_or(SystemError::ENETDOWN)?;
                 iface.raw_transmit(&frame)?;
                 Ok(buf.len())
             }
         }
+    }
+
+    fn try_send(&self, buf: &[u8], dest: Option<SockAddrLl>) -> Result<usize, SystemError> {
+        let prepared = self.prepare_send(buf.len(), dest)?;
+        self.finish_send(prepared, buf)
+    }
+
+    pub(super) fn validate_packet_send_len(
+        &self,
+        len: usize,
+        address: Option<&Endpoint>,
+    ) -> Result<(), SystemError> {
+        let dest = address.map(Self::endpoint_to_sockaddr).transpose()?;
+        self.prepare_send(len, dest).map(|_| ())
+    }
+
+    pub(super) fn send_packet_user_buffer(
+        &self,
+        reader: &crate::syscall::user_access::UserBufferReader<'_>,
+        len: usize,
+        flags: PMSG,
+        address: Option<Endpoint>,
+    ) -> Result<usize, SystemError> {
+        Self::validate_send_flags(flags)?;
+        let dest = address
+            .as_ref()
+            .map(Self::endpoint_to_sockaddr)
+            .transpose()?;
+        let prepared = self.prepare_send(len, dest)?;
+        let data = crate::net::socket::base::copy_user_buffer_to_vec(reader, len)?;
+        self.finish_send(prepared, &data)
+    }
+
+    fn endpoint_to_sockaddr(address: &Endpoint) -> Result<SockAddrLl, SystemError> {
+        let Endpoint::LinkLayer(ll) = address else {
+            return Err(SystemError::EINVAL);
+        };
+        Ok(SockAddrLl {
+            sll_family: 17,
+            sll_protocol: ll.protocol,
+            sll_ifindex: ll.interface as i32,
+            sll_hatype: ll.hatype,
+            sll_pkttype: ll.pkttype,
+            sll_halen: ll.halen,
+            sll_addr: ll.addr,
+        })
     }
     fn validate_send_flags(flags: PMSG) -> Result<(), SystemError> {
         let allowed = PMSG::DONTWAIT | PMSG::DONTROUTE | PMSG::NOSIGNAL | PMSG::MORE;
@@ -99,22 +222,7 @@ impl PacketSocket {
         flags: PMSG,
         address: Endpoint,
     ) -> Result<usize, SystemError> {
-        let Endpoint::LinkLayer(ll) = address else {
-            return Err(SystemError::EINVAL);
-        };
-        self.send_packet(
-            buf,
-            flags,
-            Some(SockAddrLl {
-                sll_family: 17,
-                sll_protocol: ll.protocol,
-                sll_ifindex: ll.interface as i32,
-                sll_hatype: ll.hatype,
-                sll_pkttype: ll.pkttype,
-                sll_halen: ll.halen,
-                sll_addr: ll.addr,
-            }),
-        )
+        self.send_packet(buf, flags, Some(Self::endpoint_to_sockaddr(&address)?))
     }
     pub(super) fn send_packet_msg(
         &self,
@@ -127,29 +235,18 @@ impl PacketSocket {
         if total == usize::MAX {
             return Err(SystemError::EMSGSIZE);
         }
-        self.validate_packet_len(total)?;
-        let data = iovs.gather()?;
         // A partial user copy is not a shorter datagram.
-        if data.len() != total {
-            return Err(SystemError::EFAULT);
-        }
         let dest = if !msg.msg_name.is_null() && msg.msg_namelen > 0 {
             let endpoint = SockAddr::to_endpoint(msg.msg_name as *const SockAddr, msg.msg_namelen)?;
-            let Endpoint::LinkLayer(ll) = endpoint else {
-                return Err(SystemError::EINVAL);
-            };
-            Some(SockAddrLl {
-                sll_family: 17,
-                sll_protocol: ll.protocol,
-                sll_ifindex: ll.interface as i32,
-                sll_hatype: ll.hatype,
-                sll_pkttype: ll.pkttype,
-                sll_halen: ll.halen,
-                sll_addr: ll.addr,
-            })
+            Some(Self::endpoint_to_sockaddr(&endpoint)?)
         } else {
             None
         };
-        self.try_send(&data, dest)
+        let prepared = self.prepare_send(total, dest)?;
+        let data = iovs.gather()?;
+        if data.len() != total {
+            return Err(SystemError::EFAULT);
+        }
+        self.finish_send(prepared, &data)
     }
 }

--- a/kernel/src/net/socket/packet/tx.rs
+++ b/kernel/src/net/socket/packet/tx.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use system_error::SystemError;
 
-use crate::driver::net::Iface;
+use crate::driver::net::{types::InterfaceFlags, Iface};
 use crate::filesystem::vfs::iov::IoVecs;
 use crate::net::posix::SockAddr;
 use crate::net::socket::endpoint::Endpoint;
@@ -36,6 +36,9 @@ impl PacketSocket {
     fn try_send(&self, buf: &[u8], dest: Option<SockAddrLl>) -> Result<usize, SystemError> {
         self.validate_packet_len(buf.len())?;
         let iface = self.destination_iface(dest.as_ref())?;
+        if !iface.user_visible_flags().contains(InterfaceFlags::UP) {
+            return Err(SystemError::ENETDOWN);
+        }
         match self.sock_type {
             PacketSocketType::Raw => {
                 if buf.len() < 14 {

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -527,7 +527,6 @@ impl NetNamespace {
             crate::driver::net::loopback::LoopbackDriver::default(),
             crate::net::LOOPBACK_IFINDEX,
         );
-
         let inner = InnerNetNamespace {
             router: Router::new(format!("netns_router_{}", counter)),
         };
@@ -564,7 +563,11 @@ impl NetNamespace {
         // 否则像 lo 这样的设备在 Tx 后仅通过 wakeup_poll_thread() 触发下一次 poll，
         // 若此处不记录 pcb，后续将无法唤醒，从而导致 TCP connect/accept 等卡死。
         Self::create_polling_thread(netns.clone(), format!("netns_{}", counter));
-        netns.add_device(loopback)?;
+        // Per-netns loopback has no global sysfs projection. The shared
+        // registration lifecycle makes it PRESENT; as in Linux's
+        // loopback_net_init(), it remains administratively down until
+        // userspace opens the link.
+        crate::driver::net::register_netdevice_in_namespace(&netns, loopback)?;
 
         Ok(netns)
     }

--- a/user/apps/tests/dunitest/no_skip.txt
+++ b/user/apps/tests/dunitest/no_skip.txt
@@ -18,5 +18,6 @@ normal/rtnetlink_serialization_semantics
 normal/rtnetlink_neigh_semantics
 normal/socket_getsockopt_semantics
 normal/socket_ioctl_netdev_query
+normal/socket_ioctl_netdev_mutation
 normal/tcp_self_connect_semantics
 normal/poll_timeout_semantics

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_addr_semantics.cc
@@ -197,6 +197,15 @@ int SetLinkUp(int fd, uint32_t ifindex, uint32_t sequence) {
     return SendAndReceiveAck(fd, request);
 }
 
+int SetLinkMtu(int fd, uint32_t ifindex, uint32_t mtu, uint32_t sequence) {
+    auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, sequence);
+    auto* message = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
+    message->ifi_family = AF_UNSPEC;
+    message->ifi_index = static_cast<int>(ifindex);
+    AddAttr(&request, IFLA_MTU, &mtu, sizeof(mtu));
+    return SendAndReceiveAck(fd, request);
+}
+
 int SetLinkName(int fd, uint32_t ifindex, const char* name, uint32_t sequence) {
     auto request = NewRequest<ifinfomsg>(RTM_SETLINK, NLM_F_REQUEST | NLM_F_ACK, sequence);
     auto* message = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(request.data()));
@@ -852,7 +861,7 @@ int RunCombinedRenameAndLinkState() {
 
     // A later invalid attribute must reject the whole combined request before
     // publishing either the requested name or administrative state.
-    if (SetLinkNameAndState(fd.Get(), ifindex, "bad0", false, ++sequence, 0) != EINVAL ||
+    if (SetLinkNameAndState(fd.Get(), ifindex, "bad0", false, ++sequence, UINT32_MAX) != EINVAL ||
         if_nametoindex("lo") != ifindex || if_nametoindex("bad0") != 0 ||
         LinkIsUp("lo") != std::optional<bool>(true)) {
         return 4420;
@@ -879,6 +888,35 @@ int RunCombinedRenameAndLinkState() {
         CountAddressNotifications(notifications.Get(), RTM_NEWADDR, generated, "txn1:3") != 1) {
         return 4440;
     }
+    return 0;
+}
+
+int RunLowMtuIpv4Admission() {
+    FdGuard fd;
+    uint32_t ifindex = 0;
+    uint32_t sequence = 1900;
+    if (const int error = PrepareNamespace(&fd, &ifindex, &sequence); error != 0) return error;
+
+    const AddressSpec address = MakeAddress(AF_INET, "192.0.2.61", 24, ifindex);
+    const RouteSpec connected{Ipv4("192.0.2.0"), 24, ifindex};
+    if (SetLinkMtu(fd.Get(), ifindex, 67, ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true,
+                      true, ++sequence) != ENOBUFS ||
+        CountAddress(fd.Get(), address, ++sequence) != 0 ||
+        CountRoute(fd.Get(), connected, ++sequence) != 0) {
+        return 4500;
+    }
+
+    if (SetLinkMtu(fd.Get(), ifindex, 68, ++sequence) != 0 ||
+        ChangeAddress(fd.Get(), RTM_NEWADDR,
+                      NLM_F_REQUEST | NLM_F_ACK | NLM_F_CREATE | NLM_F_EXCL, address, true,
+                      true, ++sequence) != 0 ||
+        CountAddress(fd.Get(), address, ++sequence) != 1 ||
+        CountRoute(fd.Get(), connected, ++sequence) < 1) {
+        return 4510;
+    }
+    if (const int error = VerifyBoundUdpDelivery(address); error != 0) return 4520 + error;
     return 0;
 }
 
@@ -1290,6 +1328,11 @@ TEST(RtnetlinkAddressSemantics, DuplicateReplaceDeleteAndParserSemanticsMatchLin
 TEST(RtnetlinkAddressSemantics, CombinedRenameAndLinkStatePublishesOnePreparedGeneration) {
     ExpectSuccessfulChild(RunWithWatchdog(RunCombinedRenameAndLinkState),
                           "combined link rename/state transaction deadlocked");
+}
+
+TEST(RtnetlinkAddressSemantics, LowMtuRejectsIpv4UntilProtocolCanBeRecreated) {
+    ExpectSuccessfulChild(RunWithWatchdog(RunLowMtuIpv4Admission),
+                          "low-MTU IPv4 admission or recovery deadlocked");
 }
 
 TEST(RtnetlinkAddressSemantics, InvalidAddressCannotPanicKernel) {

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -5,9 +5,11 @@
 #include <linux/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
+#include <poll.h>
 #include <sched.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
+#include <sys/stat.h>
 #include <sys/time.h>
 #include <sys/utsname.h>
 #include <sys/wait.h>
@@ -15,10 +17,12 @@
 
 #include <array>
 #include <cerrno>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -66,6 +70,116 @@ int OpenRouteSocket() {
     return fd;
 }
 
+int OpenUeventSocket() {
+    int fd = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_KOBJECT_UEVENT);
+    if (fd < 0) return -1;
+
+    sockaddr_nl address {};
+    address.nl_family = AF_NETLINK;
+    address.nl_groups = 1;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&address), sizeof(address)) < 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+bool UeventHasField(const unsigned char* payload, size_t length, std::string_view expected) {
+    size_t offset = 0;
+    while (offset < length) {
+        const char* field = reinterpret_cast<const char*>(payload + offset);
+        const size_t remaining = length - offset;
+        const size_t field_length = strnlen(field, remaining);
+        if (field_length == remaining) return false;
+        if (std::string_view(field, field_length) == expected) return true;
+        offset += field_length + 1;
+    }
+    return false;
+}
+
+bool UeventHasNonemptyField(const unsigned char* payload, size_t length,
+                           std::string_view prefix) {
+    size_t offset = 0;
+    while (offset < length) {
+        const char* field = reinterpret_cast<const char*>(payload + offset);
+        const size_t remaining = length - offset;
+        const size_t field_length = strnlen(field, remaining);
+        if (field_length == remaining) return false;
+        const std::string_view value(field, field_length);
+        if (value.size() > prefix.size() && value.substr(0, prefix.size()) == prefix) {
+            return true;
+        }
+        offset += field_length + 1;
+    }
+    return false;
+}
+
+bool IsExpectedMoveUevent(const unsigned char* payload, size_t length,
+                          const std::string& interface, int ifindex) {
+    return UeventHasField(payload, length, "ACTION=move") &&
+           UeventHasField(payload, length, "SUBSYSTEM=net") &&
+           UeventHasField(payload, length, "INTERFACE=" + interface) &&
+           UeventHasField(payload, length, "IFINDEX=" + std::to_string(ifindex));
+}
+
+std::optional<bool> ReceiveExpectedMoveUevent(int fd, const std::string& interface,
+                                             int ifindex) {
+    std::array<unsigned char, 8192> payload {};
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(2);
+    // A unique temporary interface name filters unrelated host uevents. Bound
+    // both the scan and total wall time so sustained noise cannot hang CI.
+    for (int attempts = 0; attempts < 64; ++attempts) {
+        const auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(
+            deadline - std::chrono::steady_clock::now());
+        if (remaining.count() <= 0) return std::nullopt;
+        pollfd descriptor {fd, POLLIN, 0};
+        const int ready = poll(&descriptor, 1, static_cast<int>(remaining.count()));
+        if (ready == 0) return std::nullopt;
+        if (ready < 0) {
+            if (errno == EINTR) {
+                --attempts;
+                continue;
+            }
+            return false;
+        }
+        if ((descriptor.revents & POLLIN) == 0) return false;
+
+        const ssize_t received =
+            recv(fd, payload.data(), payload.size(), MSG_DONTWAIT);
+        if (received < 0) {
+            if (errno == EINTR) {
+                --attempts;
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return std::nullopt;
+            return false;
+        }
+        if (!IsExpectedMoveUevent(payload.data(), received, interface, ifindex)) continue;
+        return UeventHasNonemptyField(payload.data(), received, "DEVPATH_OLD=");
+    }
+    return std::nullopt;
+}
+
+std::optional<bool> HasExpectedMoveUeventQueued(int fd, const std::string& interface,
+                                               int ifindex) {
+    std::array<unsigned char, 8192> payload {};
+    for (int attempts = 0; attempts < 64; ++attempts) {
+        const ssize_t received = recv(fd, payload.data(), payload.size(), MSG_DONTWAIT);
+        if (received < 0) {
+            if (errno == EINTR) {
+                --attempts;
+                continue;
+            }
+            if (errno == EAGAIN || errno == EWOULDBLOCK) return false;
+            return std::nullopt;
+        }
+        if (IsExpectedMoveUevent(payload.data(), received, interface, ifindex)) return true;
+    }
+    return std::nullopt;
+}
+
 int RecvAck(int fd, uint32_t seq) {
     std::array<unsigned char, 4096> buffer {};
     for (;;) {
@@ -80,6 +194,117 @@ int RecvAck(int fd, uint32_t seq) {
             return error->error == 0 ? 0 : -error->error;
         }
     }
+}
+
+struct LinkSnapshot {
+    uint32_t flags;
+    uint32_t mtu;
+    std::string name;
+};
+
+bool AddAttribute(nlmsghdr* header, size_t capacity, uint16_t type, const void* data,
+                  size_t length) {
+    const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
+    const size_t attribute_length = RTA_LENGTH(length);
+    const size_t next = offset + RTA_ALIGN(attribute_length);
+    if (next > capacity) return false;
+
+    auto* attribute = reinterpret_cast<rtattr*>(reinterpret_cast<unsigned char*>(header) + offset);
+    attribute->rta_type = type;
+    attribute->rta_len = attribute_length;
+    std::memcpy(RTA_DATA(attribute), data, length);
+    header->nlmsg_len = next;
+    return true;
+}
+
+int SetLink(int fd, int ifindex, uint32_t flags, uint32_t change,
+            std::optional<uint32_t> mtu, const std::optional<std::string>& name, uint32_t seq) {
+    std::array<unsigned char, 512> storage {};
+    auto* header = reinterpret_cast<nlmsghdr*>(storage.data());
+    auto* link = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(header));
+    header->nlmsg_len = NLMSG_LENGTH(sizeof(*link));
+    header->nlmsg_type = RTM_SETLINK;
+    header->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    header->nlmsg_seq = seq;
+    link->ifi_family = AF_UNSPEC;
+    link->ifi_index = ifindex;
+    link->ifi_flags = flags;
+    link->ifi_change = change;
+
+    if (mtu.has_value() &&
+        !AddAttribute(header, storage.size(), IFLA_MTU, &*mtu, sizeof(*mtu))) {
+        return EMSGSIZE;
+    }
+    if (name.has_value() &&
+        !AddAttribute(header, storage.size(), IFLA_IFNAME, name->c_str(), name->size() + 1)) {
+        return EMSGSIZE;
+    }
+    if (send(fd, header, header->nlmsg_len, 0) != static_cast<ssize_t>(header->nlmsg_len)) {
+        return errno;
+    }
+    return RecvAck(fd, seq);
+}
+
+std::optional<LinkSnapshot> QueryLink(int fd, int ifindex, uint32_t seq) {
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request {};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_GETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST;
+    request.header.nlmsg_seq = seq;
+    request.link.ifi_family = AF_UNSPEC;
+    request.link.ifi_index = ifindex;
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) {
+        return std::nullopt;
+    }
+
+    std::array<unsigned char, 4096> buffer {};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return std::nullopt;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_ERROR) return std::nullopt;
+            if (header->nlmsg_type != RTM_NEWLINK) continue;
+
+            const auto* link = reinterpret_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            if (link->ifi_index != ifindex) continue;
+            LinkSnapshot result {link->ifi_flags, 0, {}};
+            bool found_mtu = false;
+            bool found_name = false;
+            int attr_length = IFLA_PAYLOAD(header);
+            for (auto* attr = IFLA_RTA(link); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type == IFLA_MTU && RTA_PAYLOAD(attr) == sizeof(uint32_t)) {
+                    std::memcpy(&result.mtu, RTA_DATA(attr), sizeof(result.mtu));
+                    found_mtu = true;
+                } else if (attr->rta_type == IFLA_IFNAME && RTA_PAYLOAD(attr) > 0) {
+                    const auto* value = static_cast<const char*>(RTA_DATA(attr));
+                    const size_t payload = RTA_PAYLOAD(attr);
+                    const size_t length = strnlen(value, payload);
+                    if (length < payload) {
+                        result.name.assign(value, length);
+                        found_name = true;
+                    }
+                }
+            }
+            if (found_mtu && found_name) return result;
+            return std::nullopt;
+        }
+    }
+}
+
+std::optional<int> FindIfindex(const char* name) {
+    FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
+    if (fd.Get() < 0) return std::nullopt;
+    ifreq request {};
+    std::strncpy(request.ifr_name, name, IFNAMSIZ - 1);
+    if (ioctl(fd.Get(), SIOCGIFINDEX, &request) < 0) return std::nullopt;
+    return request.ifr_ifindex;
 }
 
 int SetLinkUp(int fd, int ifindex, bool up, uint32_t seq) {
@@ -100,6 +325,280 @@ int SetLinkUp(int fd, int ifindex, bool up, uint32_t seq) {
         return errno;
     }
     return RecvAck(fd, seq);
+}
+
+int RunCombinedMutationCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+    FdGuard fd(OpenRouteSocket());
+    if (fd.Get() < 0) return 10;
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+
+    uint32_t seq = 1;
+    const auto original = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!original.has_value()) return 12;
+    const uint32_t changed_mtu = original->mtu == 1500 ? 1400 : 1500;
+    const bool changed_up = (original->flags & IFF_UP) == 0;
+    const uint32_t changed_flags = changed_up ? IFF_UP : 0;
+    if (SetLink(fd.Get(), *ifindex, changed_flags, IFF_UP, changed_mtu, std::nullopt,
+                seq++) != 0) {
+        return 13;
+    }
+    const auto changed = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!changed.has_value() || changed->mtu != changed_mtu ||
+        ((changed->flags & IFF_UP) != 0) != changed_up ||
+        (changed->flags & IFF_LOOPBACK) == 0) {
+        return 14;
+    }
+
+    const uint32_t original_up = original->flags & IFF_UP;
+    if (SetLink(fd.Get(), *ifindex, original_up, IFF_UP, original->mtu, std::nullopt,
+                seq++) != 0) {
+        return 15;
+    }
+    const auto before_failure = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!before_failure.has_value()) return 16;
+    const uint32_t failed_mtu = before_failure->mtu == 1600 ? 1400 : 1600;
+    const uint32_t failed_up = (before_failure->flags & IFF_UP) == 0 ? IFF_UP : 0;
+    const int error = SetLink(fd.Get(), *ifindex, failed_up, IFF_UP, failed_mtu,
+                              std::string("bad/name"), seq++);
+    if (error == 0) return 17;
+    const auto after_failure = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!after_failure.has_value() || after_failure->name != before_failure->name) return 18;
+
+    // DragonOS intentionally gives the shared transaction stronger failure
+    // atomicity than Linux do_setlink(), which has already changed MTU when a
+    // later rename fails. Keep the host path useful without asserting the
+    // stronger DragonOS guarantee there.
+    if (IsDragonOS() &&
+        (after_failure->mtu != before_failure->mtu ||
+         (after_failure->flags & IFF_UP) != (before_failure->flags & IFF_UP))) {
+        return 19;
+    }
+    if (SetLink(fd.Get(), *ifindex, before_failure->flags & IFF_UP, IFF_UP,
+                before_failure->mtu, std::nullopt, seq++) != 0) {
+        return 20;
+    }
+    return 0;
+}
+
+int RunReplaceFlagsCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+    FdGuard fd(OpenRouteSocket());
+    if (fd.Get() < 0) return 10;
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+
+    uint32_t seq = 1;
+    const auto original = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!original.has_value()) return 12;
+    if (SetLink(fd.Get(), *ifindex, IFF_UP | IFF_NOARP, IFF_UP | IFF_NOARP,
+                std::nullopt, std::nullopt, seq++) != 0) {
+        return 13;
+    }
+    const auto prepared = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!prepared.has_value() || (prepared->flags & (IFF_UP | IFF_NOARP)) !=
+                                     (IFF_UP | IFF_NOARP)) {
+        return 14;
+    }
+
+    // Linux treats ifi_change == 0 as a full replace for compatibility. The
+    // omitted configurable NOARP bit is cleared, while device/volatile bits
+    // cannot be overwritten by userspace.
+    if (SetLink(fd.Get(), *ifindex, IFF_UP, 0, std::nullopt, std::nullopt, seq++) != 0) {
+        return 15;
+    }
+    const auto replaced = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!replaced.has_value() || (replaced->flags & IFF_UP) == 0 ||
+        (replaced->flags & IFF_NOARP) != 0) {
+        return 16;
+    }
+    constexpr uint32_t kVolatileAndDevice =
+        IFF_LOOPBACK | IFF_POINTOPOINT | IFF_BROADCAST | IFF_ECHO | IFF_MASTER |
+        IFF_SLAVE | IFF_RUNNING | IFF_LOWER_UP | IFF_DORMANT;
+    if ((replaced->flags & kVolatileAndDevice) != (prepared->flags & kVolatileAndDevice)) {
+        return 17;
+    }
+
+    const uint32_t restore_flags = original->flags & (IFF_UP | IFF_NOARP);
+    if (SetLink(fd.Get(), *ifindex, restore_flags, IFF_UP | IFF_NOARP, std::nullopt,
+                std::nullopt, seq++) != 0) {
+        return 18;
+    }
+    return 0;
+}
+
+int RunRenameValidationCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+    FdGuard fd(OpenRouteSocket());
+    if (fd.Get() < 0) return 10;
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+
+    uint32_t seq = 1;
+    const auto original = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!original.has_value()) return 12;
+    const std::array<std::string, 9> invalid_names = {
+        ".", "..", "bad/name", "bad:name", "bad name", "abcdefghijklmnop", "bad%x",
+        "bad%", "bad%d%d"};
+    for (const auto& invalid : invalid_names) {
+        if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, invalid, seq++) == 0) return 13;
+        const auto unchanged = QueryLink(fd.Get(), *ifindex, seq++);
+        if (!unchanged.has_value() || unchanged->name != original->name) return 14;
+    }
+
+    const std::string renamed = "dunitlo0";
+    struct stat old_target {};
+    const std::string old_path = "/sys/class/net/" + original->name;
+    const std::string new_path = "/sys/class/net/" + renamed;
+    const bool has_sysfs_projection = stat(old_path.c_str(), &old_target) == 0;
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, renamed, seq++) != 0) return 15;
+    const auto after_rename = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!after_rename.has_value() || after_rename->name != renamed) return 16;
+    int projection_result = 0;
+    if (has_sysfs_projection) {
+        struct stat new_target {};
+        struct stat old_after {};
+        const bool new_visible = stat(new_path.c_str(), &new_target) == 0;
+        const bool old_visible = stat(old_path.c_str(), &old_after) == 0;
+        if (IsDragonOS()) {
+            // DragonOS intentionally has no sysfs projection for the fresh
+            // namespace. Renaming its lo must not touch the initial-netns
+            // inode visible through this mount.
+            if (new_visible || !old_visible || old_after.st_ino != old_target.st_ino) {
+                projection_result = 17;
+            }
+        } else if (new_visible) {
+            if (old_visible || new_target.st_ino != old_target.st_ino) projection_result = 17;
+        } else if (!old_visible || old_after.st_ino != old_target.st_ino) {
+            // This sysfs mount remains bound to the parent network namespace
+            // after unshare(CLONE_NEWNET), so it legitimately continues to
+            // expose the parent namespace's lo on both Linux and DragonOS.
+            projection_result = 17;
+        }
+    }
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, original->name, seq++) != 0) {
+        return 18;
+    }
+    if (projection_result != 0) return projection_result;
+
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, std::string("du%d"), seq++) != 0) {
+        return 19;
+    }
+    const auto formatted = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!formatted.has_value() || formatted->name != "du0") return 20;
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, original->name, seq++) != 0) {
+        return 21;
+    }
+    return 0;
+}
+
+int RunDragonOsSysfsRenameCase() {
+    FdGuard fd(OpenRouteSocket());
+    if (fd.Get() < 0) return 10;
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+
+    uint32_t seq = 1;
+    const auto original = QueryLink(fd.Get(), *ifindex, seq++);
+    if (!original.has_value()) return 12;
+    const std::string renamed = "dunitlo0";
+    const std::string old_path = "/sys/class/net/" + original->name;
+    const std::string new_path = "/sys/class/net/" + renamed;
+    struct stat old_link {};
+    struct stat old_target {};
+    if (lstat(old_path.c_str(), &old_link) != 0 || stat(old_path.c_str(), &old_target) != 0) {
+        return 13;
+    }
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, renamed, seq++) != 0) return 14;
+
+    int result = 0;
+    struct stat new_link {};
+    struct stat new_target {};
+    struct stat ignored {};
+    if (lstat(old_path.c_str(), &ignored) == 0 || errno != ENOENT ||
+        lstat(new_path.c_str(), &new_link) != 0 || stat(new_path.c_str(), &new_target) != 0) {
+        result = 15;
+    } else if (new_link.st_ino != old_link.st_ino || new_target.st_ino != old_target.st_ino) {
+        result = 16;
+    }
+
+    // Always restore the globally visible initial-namespace loopback before
+    // reporting a failed assertion.
+    if (SetLink(fd.Get(), *ifindex, 0, 0, std::nullopt, original->name, seq++) != 0) {
+        return 17;
+    }
+    if (lstat(old_path.c_str(), &ignored) != 0 || lstat(new_path.c_str(), &ignored) == 0 ||
+        errno != ENOENT) {
+        return 18;
+    }
+    return result;
+}
+
+int RunOwnerNetnsMoveUeventCase() {
+    // Netlink sockets retain the network namespace in which they were opened.
+    // Keep both owner sockets alive across unshare so the mutation and its
+    // kobject event still target the initial namespace.
+    FdGuard owner_route(OpenRouteSocket());
+    FdGuard owner_uevent(OpenUeventSocket());
+    if (owner_route.Get() < 0 || owner_uevent.Get() < 0) return 10;
+
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+    uint32_t seq = 1;
+    const auto original = QueryLink(owner_route.Get(), *ifindex, seq++);
+    if (!original.has_value()) return 12;
+
+    // Retain the initial user namespace and its CAP_NET_ADMIN while changing
+    // only the current network namespace. Linux checks current credentials
+    // when a request is sent on the retained owner RTNL socket.
+    if (unshare(CLONE_NEWNET) != 0) return 77;
+    FdGuard foreign_uevent(OpenUeventSocket());
+    if (foreign_uevent.Get() < 0) return 13;
+
+    const std::string renamed = "dunitloev0";
+    const int rename_error = SetLink(owner_route.Get(), *ifindex, 0, 0, std::nullopt,
+                                     renamed, seq++);
+    if (rename_error != 0) {
+        if (rename_error == EPERM && !IsDragonOS()) return 77;
+        return 14;
+    }
+
+    int result = 0;
+    const auto owner_event =
+        ReceiveExpectedMoveUevent(owner_uevent.Get(), renamed, *ifindex);
+    if (!owner_event.has_value()) {
+        result = 15;
+    } else if (!*owner_event) {
+        result = 16;
+    }
+
+    const auto foreign_event =
+        HasExpectedMoveUeventQueued(foreign_uevent.Get(), renamed, *ifindex);
+    if (!foreign_event.has_value()) {
+        if (result == 0) result = 17;
+    } else if (*foreign_event && result == 0) {
+        result = 18;
+    }
+
+    // Always restore the initial namespace's globally visible loopback name,
+    // including when event validation fails.
+    if (SetLink(owner_route.Get(), *ifindex, 0, 0, std::nullopt, original->name,
+                seq++) != 0) {
+        return 19;
+    }
+    const auto restored = QueryLink(owner_route.Get(), *ifindex, seq++);
+    if (!restored.has_value() || restored->name != original->name) return 20;
+    return result;
+}
+
+int RunChild(int (*test_case)()) {
+    const pid_t child = fork();
+    if (child < 0) return 255;
+    if (child == 0) _exit(test_case());
+    int status = 0;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status)) return 254;
+    return WEXITSTATUS(status);
 }
 
 std::optional<short> QueryIoctlFlags(int fd, const char* name) {
@@ -219,6 +718,32 @@ TEST(RtnetlinkLinkSemantics, VirtioEthernetReportsStandardIpMtu) {
     EXPECT_EQ(*mtu, 1500U);
 }
 
+int RunFreshNetnsLoopbackLifecycleCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
+
+    FdGuard ioctl_fd(socket(AF_INET, SOCK_DGRAM, 0));
+    FdGuard route_fd(OpenRouteSocket());
+    if (ioctl_fd.Get() < 0 || route_fd.Get() < 0) return 10;
+
+    const auto ifindex = FindIfindex("lo");
+    if (!ifindex.has_value()) return 11;
+    const auto ioctl_flags = QueryIoctlFlags(ioctl_fd.Get(), "lo");
+    const auto rtnl_flags = QueryLinkFlags(route_fd.Get(), *ifindex, 1);
+    if (!ioctl_flags.has_value() || !rtnl_flags.has_value()) return 12;
+
+    // Existence through both APIs proves that lo is registered. Linux creates
+    // a fresh netns with lo administratively down; volatile runtime flags must
+    // not leak from construction either.
+    constexpr uint32_t kRtnlDownMask = IFF_UP | IFF_RUNNING | IFF_LOWER_UP | IFF_DORMANT;
+    if ((static_cast<uint16_t>(*ioctl_flags) & (IFF_UP | IFF_RUNNING)) != 0) return 13;
+    if ((*rtnl_flags & kRtnlDownMask) != 0) return 14;
+    if ((static_cast<uint16_t>(*ioctl_flags) & IFF_LOOPBACK) == 0 ||
+        (*rtnl_flags & IFF_LOOPBACK) == 0) {
+        return 15;
+    }
+    return 0;
+}
+
 int RunVisibleFlagsCase() {
     if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) return 77;
 
@@ -276,6 +801,51 @@ TEST(RtnetlinkLinkSemantics, VisibleFlagsFollowAdministrativeAndRuntimeState) {
     const int result = WEXITSTATUS(status);
     if (result == 77 && !IsDragonOS()) {
         GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, FreshNetworkNamespaceLoopbackIsPresentButDown) {
+    const int result = RunChild(RunFreshNetnsLoopbackLifecycleCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, SharedTransactionCommitsTogetherAndRejectsPartialFailure) {
+    const int result = RunChild(RunCombinedMutationCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, ZeroChangeMaskReplacesOnlyConfigurableFlags) {
+    const int result = RunChild(RunReplaceFlagsCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, RenameValidatesNamesFormatsAndProjectedIdentity) {
+    const int result = RunChild(RunRenameValidationCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, DragonOsInitialNetnsRenamePreservesSysfsInodes) {
+    if (!IsDragonOS()) GTEST_SKIP() << "initial-netns sysfs projection is DragonOS coverage";
+    EXPECT_EQ(RunChild(RunDragonOsSysfsRenameCase), 0);
+}
+
+TEST(RtnetlinkLinkSemantics, MoveUeventIsDeliveredOnlyToOwningNetworkNamespace) {
+    const int result = RunChild(RunOwnerNetnsMoveUeventCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host cannot create a privileged network namespace";
     }
     EXPECT_EQ(result, 0);
 }

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -202,6 +202,91 @@ struct LinkSnapshot {
     std::string name;
 };
 
+struct RouteProbe {
+    uint8_t family;
+    uint8_t prefix_len;
+    uint8_t table;
+    uint8_t type;
+    uint32_t ifindex;
+    std::array<uint8_t, 16> destination;
+};
+
+int CountRoute(int fd, const RouteProbe& probe, uint32_t seq) {
+    struct {
+        nlmsghdr header;
+        rtmsg route;
+    } request {};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(rtmsg));
+    request.header.nlmsg_type = RTM_GETROUTE;
+    request.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    request.header.nlmsg_seq = seq;
+    request.route.rtm_family = probe.family;
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) {
+        return -errno;
+    }
+
+    const size_t address_length = probe.family == AF_INET ? 4 : 16;
+    int count = 0;
+    std::array<unsigned char, 16384> buffer {};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return -errno;
+
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return count;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? count : error->error;
+            }
+            if (header->nlmsg_type != RTM_NEWROUTE) continue;
+
+            const auto* route = reinterpret_cast<const rtmsg*>(NLMSG_DATA(header));
+            if (route->rtm_family != probe.family || route->rtm_dst_len != probe.prefix_len ||
+                route->rtm_table != probe.table || route->rtm_type != probe.type) {
+                continue;
+            }
+
+            uint32_t ifindex = 0;
+            std::array<uint8_t, 16> destination {};
+            bool has_destination = false;
+            int attr_length = RTM_PAYLOAD(header);
+            for (auto* attr = RTM_RTA(route); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type == RTA_DST && RTA_PAYLOAD(attr) == address_length) {
+                    std::memcpy(destination.data(), RTA_DATA(attr), address_length);
+                    has_destination = true;
+                } else if (attr->rta_type == RTA_OIF &&
+                           RTA_PAYLOAD(attr) == sizeof(ifindex)) {
+                    std::memcpy(&ifindex, RTA_DATA(attr), sizeof(ifindex));
+                }
+            }
+            if (has_destination && ifindex == probe.ifindex &&
+                std::memcmp(destination.data(), probe.destination.data(), address_length) == 0) {
+                ++count;
+            }
+        }
+    }
+}
+
+int SendIpv4LoopbackDatagram() {
+    FdGuard fd(socket(AF_INET, SOCK_DGRAM, 0));
+    if (fd.Get() < 0) return errno;
+
+    sockaddr_in destination {};
+    destination.sin_family = AF_INET;
+    destination.sin_port = htons(9);
+    if (inet_pton(AF_INET, "127.0.0.1", &destination.sin_addr) != 1) return EINVAL;
+    const char payload = 'x';
+    if (sendto(fd.Get(), &payload, sizeof(payload), 0,
+               reinterpret_cast<const sockaddr*>(&destination), sizeof(destination)) < 0) {
+        return errno;
+    }
+    return 0;
+}
+
 bool AddAttribute(nlmsghdr* header, size_t capacity, uint16_t type, const void* data,
                   size_t length) {
     const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
@@ -728,7 +813,8 @@ int RunFreshNetnsLoopbackLifecycleCase() {
     const auto ifindex = FindIfindex("lo");
     if (!ifindex.has_value()) return 11;
     const auto ioctl_flags = QueryIoctlFlags(ioctl_fd.Get(), "lo");
-    const auto rtnl_flags = QueryLinkFlags(route_fd.Get(), *ifindex, 1);
+    uint32_t seq = 1;
+    const auto rtnl_flags = QueryLinkFlags(route_fd.Get(), *ifindex, seq++);
     if (!ioctl_flags.has_value() || !rtnl_flags.has_value()) return 12;
 
     // Existence through both APIs proves that lo is registered. Linux creates
@@ -740,6 +826,55 @@ int RunFreshNetnsLoopbackLifecycleCase() {
     if ((static_cast<uint16_t>(*ioctl_flags) & IFF_LOOPBACK) == 0 ||
         (*rtnl_flags & IFF_LOOPBACK) == 0) {
         return 15;
+    }
+
+    RouteProbe connected_v4 {AF_INET, 8, RT_TABLE_LOCAL, RTN_LOCAL,
+                             static_cast<uint32_t>(*ifindex), {}};
+    RouteProbe local_v4 {AF_INET, 32, RT_TABLE_LOCAL, RTN_LOCAL,
+                         static_cast<uint32_t>(*ifindex), {}};
+    RouteProbe broadcast_v4 {AF_INET, 32, RT_TABLE_LOCAL, RTN_BROADCAST,
+                             static_cast<uint32_t>(*ifindex), {}};
+    RouteProbe local_v6 {AF_INET6, 128, RT_TABLE_LOCAL, RTN_LOCAL,
+                         static_cast<uint32_t>(*ifindex), {}};
+    if (inet_pton(AF_INET, "127.0.0.0", connected_v4.destination.data()) != 1 ||
+        inet_pton(AF_INET, "127.0.0.1", local_v4.destination.data()) != 1 ||
+        inet_pton(AF_INET, "127.255.255.255", broadcast_v4.destination.data()) != 1 ||
+        inet_pton(AF_INET6, "::1", local_v6.destination.data()) != 1) {
+        return 16;
+    }
+
+    if (CountRoute(route_fd.Get(), connected_v4, seq++) != 0 ||
+        CountRoute(route_fd.Get(), local_v4, seq++) != 0 ||
+        CountRoute(route_fd.Get(), broadcast_v4, seq++) != 0 ||
+        CountRoute(route_fd.Get(), local_v6, seq++) != 0) {
+        return 17;
+    }
+    if (SendIpv4LoopbackDatagram() != ENETUNREACH) return 18;
+
+    if (SetLinkUp(route_fd.Get(), *ifindex, true, seq++) != 0) return 19;
+    if (CountRoute(route_fd.Get(), connected_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), local_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), broadcast_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), local_v6, seq++) != 1) {
+        return 20;
+    }
+    if (SendIpv4LoopbackDatagram() != 0) return 21;
+
+    if (SetLinkUp(route_fd.Get(), *ifindex, false, seq++) != 0) return 22;
+    if (CountRoute(route_fd.Get(), connected_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), local_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), broadcast_v4, seq++) != 0 ||
+        CountRoute(route_fd.Get(), local_v6, seq++) != 0) {
+        return 23;
+    }
+    if (SendIpv4LoopbackDatagram() != 0) return 24;
+
+    if (SetLinkUp(route_fd.Get(), *ifindex, true, seq++) != 0) return 25;
+    if (CountRoute(route_fd.Get(), connected_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), local_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), broadcast_v4, seq++) != 1 ||
+        CountRoute(route_fd.Get(), local_v6, seq++) != 1) {
+        return 26;
     }
     return 0;
 }

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
@@ -265,6 +265,21 @@ int RecvAck(int fd, uint32_t seq) {
     }
 }
 
+int SetRtnlMtu(int fd, int ifindex, uint32_t mtu, uint32_t seq) {
+    std::array<unsigned char, 256> request{};
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    auto* link = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(header));
+    header->nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    header->nlmsg_type = RTM_SETLINK;
+    header->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK;
+    header->nlmsg_seq = seq;
+    link->ifi_family = AF_UNSPEC;
+    link->ifi_index = ifindex;
+    AddAttr(header, request.size(), IFLA_MTU, &mtu, sizeof(mtu));
+    if (send(fd, request.data(), header->nlmsg_len, 0) != header->nlmsg_len) return errno;
+    return RecvAck(fd, seq);
+}
+
 int MutatePermanentNeighbor(int fd, uint16_t type, uint16_t flags, int ifindex,
                             uint32_t destination, const std::array<uint8_t, 6>* mac,
                             uint32_t seq) {
@@ -437,6 +452,59 @@ TEST(SocketIoctlNetdevMutation, FlagsAndMtuAreSharedWithRtnetlinkAndRestored) {
         if (rtnl.mtu != static_cast<uint32_t>(original_mtu) ||
             (rtnl.flags & IFF_UP) != (static_cast<uint32_t>(original_flags) & IFF_UP)) {
             return Failure(25, static_cast<int>(rtnl.mtu));
+        }
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, LoopbackAcceptsLinuxStandardMtu) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard inet(OpenInetSocket());
+        FdGuard route(OpenRouteSocket());
+        if (inet.Get() < 0 || route.Get() < 0) return Failure(1, errno);
+
+        int ifindex = 0;
+        if (int error = QueryIfindex(inet.Get(), "lo", &ifindex)) return Failure(2, error);
+        constexpr int kLinuxLoopbackMtu = 65536;
+        int ioctl_mtu = 0;
+        LinkState rtnl{};
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(3, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 199, &rtnl)) {
+            return Failure(4, error);
+        }
+        if (ioctl_mtu != kLinuxLoopbackMtu || rtnl.mtu != kLinuxLoopbackMtu) {
+            return Failure(5, ioctl_mtu);
+        }
+
+        constexpr int kAlternateMtu = kLinuxLoopbackMtu - 1;
+        if (int error = SetMtu(inet.Get(), "lo", kAlternateMtu, true)) {
+            return Failure(6, error);
+        }
+        if (int error = SetMtu(inet.Get(), "lo", kLinuxLoopbackMtu, true)) {
+            return Failure(7, error);
+        }
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(8, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 200, &rtnl)) {
+            return Failure(9, error);
+        }
+        if (ioctl_mtu != kLinuxLoopbackMtu || rtnl.mtu != kLinuxLoopbackMtu) {
+            return Failure(10, ioctl_mtu);
+        }
+
+        if (int error = SetRtnlMtu(route.Get(), ifindex, kAlternateMtu, 201)) {
+            return Failure(11, error);
+        }
+        if (int error = SetRtnlMtu(route.Get(), ifindex, kLinuxLoopbackMtu, 202)) {
+            return Failure(12, error);
+        }
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(13, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 203, &rtnl)) {
+            return Failure(14, error);
+        }
+        if (ioctl_mtu != kLinuxLoopbackMtu || rtnl.mtu != kLinuxLoopbackMtu) {
+            return Failure(15, ioctl_mtu);
         }
         return Success();
     });

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
@@ -1,0 +1,690 @@
+#include <gtest/gtest.h>
+
+#include <arpa/inet.h>
+#include <linux/capability.h>
+#include <linux/if_link.h>
+#include <linux/if_ether.h>
+#include <linux/if_packet.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <net/if.h>
+#include <net/if_arp.h>
+#include <sched.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/syscall.h>
+#include <sys/time.h>
+#include <sys/utsname.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <array>
+#include <cerrno>
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace {
+
+constexpr unsigned char kSentinel = 0xa5;
+constexpr int kNamespaceUnavailable = 77;
+constexpr int kNeighborScenarioUnavailable = 78;
+
+class FdGuard {
+  public:
+    explicit FdGuard(int fd = -1) : fd_(fd) {}
+    FdGuard(const FdGuard&) = delete;
+    FdGuard& operator=(const FdGuard&) = delete;
+    ~FdGuard() {
+        if (fd_ >= 0) close(fd_);
+    }
+
+    int Get() const { return fd_; }
+
+  private:
+    int fd_;
+};
+
+struct ChildResult {
+    int stage;
+    int actual;
+};
+
+struct LinkState {
+    uint32_t flags;
+    uint32_t mtu;
+};
+
+ChildResult Success() { return {0, 0}; }
+ChildResult Failure(int stage, int actual) { return {stage, actual}; }
+
+bool IsDragonOS() {
+    utsname uts{};
+    return uname(&uts) == 0 && std::strstr(uts.release, "dragonos") != nullptr;
+}
+
+void ExpectIsolatedChild(const std::function<ChildResult()>& child_fn) {
+    int result_pipe[2];
+    ASSERT_EQ(pipe(result_pipe), 0) << std::strerror(errno);
+
+    const pid_t child = fork();
+    ASSERT_GE(child, 0) << std::strerror(errno);
+    if (child == 0) {
+        close(result_pipe[0]);
+        ChildResult result = child_fn();
+        const ssize_t ignored = write(result_pipe[1], &result, sizeof(result));
+        (void)ignored;
+        close(result_pipe[1]);
+        _exit(result.stage == 0 ? 0 : 1);
+    }
+
+    close(result_pipe[1]);
+    ChildResult result{-1, 0};
+    const ssize_t bytes = read(result_pipe[0], &result, sizeof(result));
+    close(result_pipe[0]);
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_EQ(bytes, static_cast<ssize_t>(sizeof(result)));
+    ASSERT_TRUE(WIFEXITED(status));
+
+    if (result.stage == kNamespaceUnavailable && !IsDragonOS()) {
+        GTEST_SKIP() << "host does not permit user/network namespace creation: "
+                     << std::strerror(result.actual);
+    }
+    if (result.stage == kNeighborScenarioUnavailable && !IsDragonOS()) {
+        GTEST_SKIP() << "isolated host loopback cannot expose a keyed permanent neighbor";
+    }
+    EXPECT_EQ(result.stage, 0) << "stage=" << result.stage << " actual=" << result.actual
+                               << " (" << std::strerror(result.actual) << ")";
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
+ChildResult EnterIsolatedNetwork() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET) != 0) {
+        return Failure(kNamespaceUnavailable, errno);
+    }
+    return Success();
+}
+
+int OpenInetSocket() { return socket(AF_INET, SOCK_DGRAM, 0); }
+
+int OpenRouteSocket() {
+    int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+    if (fd < 0) return -1;
+
+    timeval timeout{};
+    timeout.tv_sec = 3;
+    if (setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout)) != 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    sockaddr_nl local{};
+    local.nl_family = AF_NETLINK;
+    if (bind(fd, reinterpret_cast<sockaddr*>(&local), sizeof(local)) != 0) {
+        const int saved = errno;
+        close(fd);
+        errno = saved;
+        return -1;
+    }
+    return fd;
+}
+
+void InitIfreq(ifreq* request, const char* name) {
+    std::memset(request, kSentinel, sizeof(*request));
+    std::memset(request->ifr_name, 0, IFNAMSIZ);
+    std::strncpy(request->ifr_name, name, IFNAMSIZ - 1);
+}
+
+int QueryIoctlFlags(int fd, const char* name, short* flags) {
+    ifreq request{};
+    InitIfreq(&request, name);
+    if (ioctl(fd, SIOCGIFFLAGS, &request) != 0) return errno;
+    *flags = request.ifr_flags;
+    return 0;
+}
+
+int QueryIoctlMtu(int fd, const char* name, int* mtu) {
+    ifreq request{};
+    InitIfreq(&request, name);
+    if (ioctl(fd, SIOCGIFMTU, &request) != 0) return errno;
+    *mtu = request.ifr_mtu;
+    return 0;
+}
+
+int QueryIfindex(int fd, const char* name, int* ifindex) {
+    ifreq request{};
+    InitIfreq(&request, name);
+    if (ioctl(fd, SIOCGIFINDEX, &request) != 0) return errno;
+    *ifindex = request.ifr_ifindex;
+    return 0;
+}
+
+int QueryRtnlState(int fd, int ifindex, uint32_t seq, LinkState* state) {
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request{};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_GETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST;
+    request.header.nlmsg_seq = seq;
+    request.link.ifi_family = AF_UNSPEC;
+    request.link.ifi_index = ifindex;
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) return errno;
+
+    std::array<unsigned char, 8192> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? EPROTO : -error->error;
+            }
+            if (header->nlmsg_type != RTM_NEWLINK ||
+                header->nlmsg_len < NLMSG_LENGTH(sizeof(ifinfomsg))) {
+                continue;
+            }
+            const auto* link = reinterpret_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            if (link->ifi_index != ifindex) continue;
+            state->flags = link->ifi_flags;
+            bool found_mtu = false;
+            int attr_length = IFLA_PAYLOAD(header);
+            for (auto* attr = IFLA_RTA(link); RTA_OK(attr, attr_length);
+                 attr = RTA_NEXT(attr, attr_length)) {
+                if (attr->rta_type != IFLA_MTU || RTA_PAYLOAD(attr) != sizeof(uint32_t)) continue;
+                std::memcpy(&state->mtu, RTA_DATA(attr), sizeof(state->mtu));
+                found_mtu = true;
+            }
+            return found_mtu ? 0 : ENOMSG;
+        }
+    }
+}
+
+int SetFlags(int fd, const char* name, short flags, bool verify_no_copyout) {
+    ifreq request{};
+    InitIfreq(&request, name);
+    request.ifr_flags = flags;
+    const ifreq before = request;
+    if (ioctl(fd, SIOCSIFFLAGS, &request) != 0) return errno;
+    if (verify_no_copyout && std::memcmp(&request, &before, sizeof(request)) != 0) return EIO;
+    return 0;
+}
+
+int SetMtu(int fd, const char* name, int mtu, bool verify_no_copyout) {
+    ifreq request{};
+    InitIfreq(&request, name);
+    request.ifr_mtu = mtu;
+    const ifreq before = request;
+    if (ioctl(fd, SIOCSIFMTU, &request) != 0) return errno;
+    if (verify_no_copyout && std::memcmp(&request, &before, sizeof(request)) != 0) return EIO;
+    return 0;
+}
+
+bool DropAllCapabilities() {
+    __user_cap_header_struct header{};
+    std::array<__user_cap_data_struct, 2> data{};
+    header.version = _LINUX_CAPABILITY_VERSION_3;
+    header.pid = 0;
+    return syscall(SYS_capset, &header, data.data()) == 0;
+}
+
+void AddAttr(nlmsghdr* header, size_t capacity, uint16_t type, const void* data, size_t length) {
+    const size_t offset = NLMSG_ALIGN(header->nlmsg_len);
+    const size_t attr_length = RTA_LENGTH(length);
+    const size_t end = offset + RTA_ALIGN(attr_length);
+    if (end > capacity) return;
+    auto* attr = reinterpret_cast<rtattr*>(reinterpret_cast<unsigned char*>(header) + offset);
+    attr->rta_type = type;
+    attr->rta_len = attr_length;
+    if (length != 0) std::memcpy(RTA_DATA(attr), data, length);
+    header->nlmsg_len = end;
+}
+
+int RecvAck(int fd, uint32_t seq) {
+    std::array<unsigned char, 4096> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq || header->nlmsg_type != NLMSG_ERROR) continue;
+            const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+            return error->error == 0 ? 0 : -error->error;
+        }
+    }
+}
+
+int MutatePermanentNeighbor(int fd, uint16_t type, uint16_t flags, int ifindex,
+                            uint32_t destination, const std::array<uint8_t, 6>* mac,
+                            uint32_t seq) {
+    alignas(nlmsghdr) std::array<unsigned char, 256> request{};
+    auto* header = reinterpret_cast<nlmsghdr*>(request.data());
+    auto* message = reinterpret_cast<ndmsg*>(NLMSG_DATA(header));
+    header->nlmsg_len = NLMSG_LENGTH(sizeof(ndmsg));
+    header->nlmsg_type = type;
+    header->nlmsg_flags = NLM_F_REQUEST | NLM_F_ACK | flags;
+    header->nlmsg_seq = seq;
+    message->ndm_family = AF_INET;
+    message->ndm_ifindex = ifindex;
+    message->ndm_state = NUD_PERMANENT;
+    message->ndm_type = RTN_UNICAST;
+    AddAttr(header, request.size(), NDA_DST, &destination, sizeof(destination));
+    if (mac != nullptr) AddAttr(header, request.size(), NDA_LLADDR, mac->data(), mac->size());
+    if (send(fd, request.data(), header->nlmsg_len, 0) != header->nlmsg_len) return errno;
+    return RecvAck(fd, seq);
+}
+
+int HasPermanentNeighbor(int fd, int ifindex, uint32_t destination, uint32_t seq, bool* found) {
+    struct {
+        nlmsghdr header;
+        ndmsg message;
+    } request{};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ndmsg));
+    request.header.nlmsg_type = RTM_GETNEIGH;
+    request.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    request.header.nlmsg_seq = seq;
+    request.message.ndm_family = AF_INET;
+    if (send(fd, &request, request.header.nlmsg_len, 0) != request.header.nlmsg_len) return errno;
+
+    *found = false;
+    std::array<unsigned char, 8192> buffer{};
+    for (;;) {
+        const ssize_t received = recv(fd, buffer.data(), buffer.size(), 0);
+        if (received < 0) return errno;
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            if (header->nlmsg_seq != seq) continue;
+            if (header->nlmsg_type == NLMSG_DONE) return 0;
+            if (header->nlmsg_type == NLMSG_ERROR) {
+                const auto* error = reinterpret_cast<const nlmsgerr*>(NLMSG_DATA(header));
+                return error->error == 0 ? EPROTO : -error->error;
+            }
+            if (header->nlmsg_type != RTM_NEWNEIGH ||
+                header->nlmsg_len < NLMSG_LENGTH(sizeof(ndmsg))) {
+                continue;
+            }
+            const auto* message = reinterpret_cast<const ndmsg*>(NLMSG_DATA(header));
+            if (message->ndm_ifindex != ifindex || !(message->ndm_state & NUD_PERMANENT)) continue;
+            int attr_length = static_cast<int>(header->nlmsg_len - NLMSG_LENGTH(sizeof(ndmsg)));
+            for (auto* attr = reinterpret_cast<const rtattr*>(
+                     reinterpret_cast<const unsigned char*>(message) + NLMSG_ALIGN(sizeof(ndmsg)));
+                 RTA_OK(attr, attr_length); attr = RTA_NEXT(attr, attr_length)) {
+                uint32_t dumped = 0;
+                if (attr->rta_type == NDA_DST && RTA_PAYLOAD(attr) >= sizeof(dumped)) {
+                    std::memcpy(&dumped, RTA_DATA(attr), sizeof(dumped));
+                    *found |= dumped == destination;
+                }
+            }
+        }
+    }
+}
+
+std::optional<std::string> FindEthernetName(int fd) {
+    struct if_nameindex* interfaces = if_nameindex();
+    if (interfaces == nullptr) return std::nullopt;
+
+    std::optional<std::string> result;
+    for (const struct if_nameindex* interface = interfaces; interface->if_index != 0;
+         ++interface) {
+        ifreq request{};
+        InitIfreq(&request, interface->if_name);
+        if (ioctl(fd, SIOCGIFHWADDR, &request) == 0 &&
+            request.ifr_hwaddr.sa_family == ARPHRD_ETHER) {
+            result = interface->if_name;
+            break;
+        }
+    }
+    if_freenameindex(interfaces);
+    return result;
+}
+
+class NeighborMutationCleanup {
+  public:
+    NeighborMutationCleanup(int inet_fd, int route_fd, std::string name, int ifindex,
+                            short original_flags, uint32_t destination,
+                            const std::array<uint8_t, 6>* mac)
+        : inet_fd_(inet_fd),
+          route_fd_(route_fd),
+          name_(std::move(name)),
+          ifindex_(ifindex),
+          original_flags_(original_flags),
+          destination_(destination),
+          mac_(mac) {}
+
+    ~NeighborMutationCleanup() {
+        (void)MutatePermanentNeighbor(route_fd_, RTM_DELNEIGH, 0, ifindex_, destination_, mac_,
+                                      902);
+        (void)SetFlags(inet_fd_, name_.c_str(), original_flags_, false);
+    }
+
+  private:
+    int inet_fd_;
+    int route_fd_;
+    std::string name_;
+    int ifindex_;
+    short original_flags_;
+    uint32_t destination_;
+    const std::array<uint8_t, 6>* mac_;
+};
+
+TEST(SocketIoctlNetdevMutation, FlagsAndMtuAreSharedWithRtnetlinkAndRestored) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard inet(OpenInetSocket());
+        FdGuard route(OpenRouteSocket());
+        if (inet.Get() < 0 || route.Get() < 0) return Failure(1, errno);
+
+        int ifindex = 0;
+        short original_flags = 0;
+        int original_mtu = 0;
+        if (int error = QueryIfindex(inet.Get(), "lo", &ifindex)) return Failure(2, error);
+        if (int error = QueryIoctlFlags(inet.Get(), "lo", &original_flags)) {
+            return Failure(3, error);
+        }
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &original_mtu)) return Failure(4, error);
+        if (original_mtu <= 128) return Failure(5, original_mtu);
+
+        const short changed_flags = original_flags ^ IFF_UP;
+        if (int error = SetFlags(inet.Get(), "lo", changed_flags, true)) return Failure(6, error);
+        short ioctl_flags = 0;
+        if (int error = QueryIoctlFlags(inet.Get(), "lo", &ioctl_flags)) return Failure(7, error);
+        LinkState rtnl{};
+        if (int error = QueryRtnlState(route.Get(), ifindex, 100, &rtnl)) return Failure(8, error);
+        if ((ioctl_flags & IFF_UP) != (changed_flags & IFF_UP)) return Failure(9, ioctl_flags);
+        if (static_cast<uint16_t>(ioctl_flags) != static_cast<uint16_t>(rtnl.flags)) {
+            return Failure(10, static_cast<int>(rtnl.flags));
+        }
+
+        const int changed_mtu = original_mtu - 1;
+        if (int error = SetMtu(inet.Get(), "lo", changed_mtu, true)) return Failure(11, error);
+        int ioctl_mtu = 0;
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(12, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 101, &rtnl)) return Failure(13, error);
+        if (ioctl_mtu != changed_mtu || rtnl.mtu != static_cast<uint32_t>(changed_mtu)) {
+            return Failure(14, ioctl_mtu);
+        }
+
+        if (int error = SetMtu(inet.Get(), "lo", -1, false); error != EINVAL) {
+            return Failure(15, error);
+        }
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(16, error);
+        if (ioctl_mtu != changed_mtu) return Failure(17, ioctl_mtu);
+        if (int error = SetMtu(inet.Get(), "no-such-netdev", -1, false); error != ENODEV) {
+            return Failure(18, error);
+        }
+
+        if (int error = SetMtu(inet.Get(), "lo", original_mtu, false)) return Failure(19, error);
+        if (int error = SetFlags(inet.Get(), "lo", original_flags, false)) return Failure(20, error);
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(21, error);
+        if (int error = QueryIoctlFlags(inet.Get(), "lo", &ioctl_flags)) return Failure(22, error);
+        if (ioctl_mtu != original_mtu || (ioctl_flags & IFF_UP) != (original_flags & IFF_UP)) {
+            return Failure(23, ioctl_mtu);
+        }
+        if (int error = QueryRtnlState(route.Get(), ifindex, 102, &rtnl)) return Failure(24, error);
+        if (rtnl.mtu != static_cast<uint32_t>(original_mtu) ||
+            (rtnl.flags & IFF_UP) != (static_cast<uint32_t>(original_flags) & IFF_UP)) {
+            return Failure(25, static_cast<int>(rtnl.mtu));
+        }
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, UserCopyFaultsPrecedeMutation) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard fd(OpenInetSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+
+        constexpr std::array<unsigned long, 2> commands = {SIOCSIFFLAGS, SIOCSIFMTU};
+        for (size_t i = 0; i < commands.size(); ++i) {
+            errno = 0;
+            if (ioctl(fd.Get(), commands[i], nullptr) != -1 || errno != EFAULT) {
+                return Failure(10 + static_cast<int>(i), errno);
+            }
+        }
+
+        const long page_size = sysconf(_SC_PAGESIZE);
+        if (page_size <= 0) return Failure(20, errno);
+        void* mapping = mmap(nullptr, page_size * 2, PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        if (mapping == MAP_FAILED) return Failure(21, errno);
+        if (mprotect(static_cast<char*>(mapping) + page_size, page_size, PROT_NONE) != 0) {
+            return Failure(22, errno);
+        }
+        auto* partial = reinterpret_cast<ifreq*>(static_cast<char*>(mapping) + page_size -
+                                                 sizeof(ifreq) + 1);
+        std::memset(partial, 0, sizeof(ifreq) - 1);
+        std::memcpy(partial->ifr_name, "lo", 3);
+        for (size_t i = 0; i < commands.size(); ++i) {
+            errno = 0;
+            if (ioctl(fd.Get(), commands[i], partial) != -1 || errno != EFAULT) {
+                return Failure(30 + static_cast<int>(i), errno);
+            }
+        }
+        if (mprotect(static_cast<char*>(mapping) + page_size, page_size,
+                     PROT_READ | PROT_WRITE) != 0) {
+            return Failure(40, errno);
+        }
+        if (munmap(mapping, page_size * 2) != 0) return Failure(41, errno);
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, NetAdminIsCheckedBeforeDeviceLookup) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard fd(OpenInetSocket());
+        if (fd.Get() < 0) return Failure(1, errno);
+        if (!DropAllCapabilities()) return Failure(2, errno);
+
+        constexpr std::array<unsigned long, 2> commands = {SIOCSIFFLAGS, SIOCSIFMTU};
+        constexpr std::array<const char*, 2> names = {"lo", "no-such-netdev"};
+        for (size_t command = 0; command < commands.size(); ++command) {
+            for (size_t name = 0; name < names.size(); ++name) {
+                ifreq request{};
+                InitIfreq(&request, names[name]);
+                request.ifr_flags = 0;
+                errno = 0;
+                if (ioctl(fd.Get(), commands[command], &request) != -1 || errno != EPERM) {
+                    return Failure(10 + static_cast<int>(command * 2 + name), errno);
+                }
+            }
+        }
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, PacketSendRejectsAdministrativelyDownInterface) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard inet(OpenInetSocket());
+        if (inet.Get() < 0) return Failure(1, errno);
+        int ifindex = 0;
+        if (int error = QueryIfindex(inet.Get(), "lo", &ifindex)) return Failure(2, error);
+
+        FdGuard packet(socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL)));
+        if (packet.Get() < 0) return Failure(3, errno);
+        sockaddr_ll destination{};
+        destination.sll_family = AF_PACKET;
+        destination.sll_protocol = htons(ETH_P_ALL);
+        destination.sll_ifindex = ifindex;
+        std::array<uint8_t, ETH_HLEN> frame{};
+        errno = 0;
+        if (sendto(packet.Get(), frame.data(), frame.size(), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != ENETDOWN) {
+            return Failure(4, errno);
+        }
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, NeighborPurgeDependsOnLinkLifecycle) {
+    ExpectIsolatedChild([] {
+        const bool dragonos = IsDragonOS();
+        if (!dragonos) {
+            ChildResult isolated = EnterIsolatedNetwork();
+            if (isolated.stage != 0) return isolated;
+        }
+        FdGuard inet(OpenInetSocket());
+        FdGuard route(OpenRouteSocket());
+        if (inet.Get() < 0 || route.Get() < 0) return Failure(1, errno);
+
+        const auto ethernet_name = dragonos ? FindEthernetName(inet.Get()) : std::nullopt;
+        if (dragonos && !ethernet_name.has_value()) return Failure(2, ENODEV);
+        const std::string name = ethernet_name.value_or("lo");
+        int ifindex = 0;
+        short original_flags = 0;
+        if (int error = QueryIfindex(inet.Get(), name.c_str(), &ifindex)) {
+            return Failure(3, error);
+        }
+        if (int error = QueryIoctlFlags(inet.Get(), name.c_str(), &original_flags)) {
+            return Failure(4, error);
+        }
+
+        constexpr std::array<uint8_t, 6> mac = {0x02, 0x22, 0x33, 0x44, 0x55, 0x71};
+        const auto* lladdr = ethernet_name.has_value() ? &mac : nullptr;
+        in_addr address{};
+        if (inet_pton(AF_INET, "198.18.230.44", &address) != 1) return Failure(5, errno);
+        NeighborMutationCleanup cleanup(inet.Get(), route.Get(), name, ifindex, original_flags,
+                                        address.s_addr, lladdr);
+
+        (void)MutatePermanentNeighbor(route.Get(), RTM_DELNEIGH, 0, ifindex, address.s_addr,
+                                      lladdr, 900);
+        const short arp_flags = static_cast<short>((original_flags | IFF_UP) & ~IFF_NOARP);
+        if (int error = SetFlags(inet.Get(), name.c_str(), arp_flags, false)) {
+            return Failure(6, error);
+        }
+        if (int error = MutatePermanentNeighbor(route.Get(), RTM_NEWNEIGH,
+                                                NLM_F_CREATE | NLM_F_EXCL, ifindex,
+                                                address.s_addr, lladdr, 901)) {
+            if (!dragonos) return Failure(kNeighborScenarioUnavailable, error);
+            return Failure(7, error);
+        }
+
+        bool found = false;
+        if (int error = HasPermanentNeighbor(route.Get(), ifindex, address.s_addr, 903, &found)) {
+            return Failure(8, error);
+        }
+        if (!found) {
+            if (!dragonos) return Failure(kNeighborScenarioUnavailable, 0);
+            return Failure(9, 0);
+        }
+
+        // Reapplying the current flags is a no-op and must not purge state.
+        if (int error = SetFlags(inet.Get(), name.c_str(), arp_flags, false)) {
+            return Failure(10, error);
+        }
+        if (int error = HasPermanentNeighbor(route.Get(), ifindex, address.s_addr, 904, &found)) {
+            return Failure(11, error);
+        }
+        if (!found) return Failure(12, 0);
+
+        const short down_flags = static_cast<short>(arp_flags & ~IFF_UP);
+        if (int error = SetFlags(inet.Get(), name.c_str(), down_flags, false)) {
+            return Failure(13, error);
+        }
+        if (int error = HasPermanentNeighbor(route.Get(), ifindex, address.s_addr, 905, &found)) {
+            return Failure(14, error);
+        }
+        if (found) return Failure(15, 0);
+
+        // Linux permits an administrative permanent entry to be installed
+        // while the link is down. A later NOARP-only change does not emit the
+        // NETDEV_CHANGE event that purges neighbors unless the device is up.
+        if (int error = MutatePermanentNeighbor(route.Get(), RTM_NEWNEIGH,
+                                                NLM_F_CREATE | NLM_F_EXCL, ifindex,
+                                                address.s_addr, lladdr, 906)) {
+            return Failure(16, error);
+        }
+        if (int error = HasPermanentNeighbor(route.Get(), ifindex, address.s_addr, 907, &found)) {
+            return Failure(17, error);
+        }
+        if (!found) return Failure(18, 0);
+        const short down_noarp_flags = static_cast<short>(down_flags | IFF_NOARP);
+        if (int error = SetFlags(inet.Get(), name.c_str(), down_noarp_flags, false)) {
+            return Failure(19, error);
+        }
+        if (int error = HasPermanentNeighbor(route.Get(), ifindex, address.s_addr, 908, &found)) {
+            return Failure(20, error);
+        }
+        if (!found) return Failure(21, 0);
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, SocketKeepsItsCreationNetworkNamespace) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard old_fd(OpenInetSocket());
+        FdGuard old_route(OpenRouteSocket());
+        if (old_fd.Get() < 0 || old_route.Get() < 0) return Failure(1, errno);
+
+        int old_ifindex = 0;
+        int old_original_mtu = 0;
+        if (int error = QueryIfindex(old_fd.Get(), "lo", &old_ifindex)) return Failure(2, error);
+        if (int error = QueryIoctlMtu(old_fd.Get(), "lo", &old_original_mtu)) {
+            return Failure(3, error);
+        }
+        if (old_original_mtu <= 129) return Failure(4, old_original_mtu);
+
+        if (unshare(CLONE_NEWNET) != 0) return Failure(kNamespaceUnavailable, errno);
+        FdGuard new_fd(OpenInetSocket());
+        FdGuard new_route(OpenRouteSocket());
+        if (new_fd.Get() < 0 || new_route.Get() < 0) return Failure(5, errno);
+        int new_ifindex = 0;
+        int new_original_mtu = 0;
+        if (int error = QueryIfindex(new_fd.Get(), "lo", &new_ifindex)) return Failure(6, error);
+        if (int error = QueryIoctlMtu(new_fd.Get(), "lo", &new_original_mtu)) {
+            return Failure(7, error);
+        }
+
+        const int old_changed_mtu = old_original_mtu - 2;
+        if (int error = SetMtu(old_fd.Get(), "lo", old_changed_mtu, false)) {
+            return Failure(8, error);
+        }
+        int observed = 0;
+        if (int error = QueryIoctlMtu(old_fd.Get(), "lo", &observed)) return Failure(9, error);
+        if (observed != old_changed_mtu) return Failure(10, observed);
+        if (int error = QueryIoctlMtu(new_fd.Get(), "lo", &observed)) return Failure(11, error);
+        if (observed != new_original_mtu) return Failure(12, observed);
+
+        LinkState old_state{};
+        LinkState new_state{};
+        if (int error = QueryRtnlState(old_route.Get(), old_ifindex, 200, &old_state)) {
+            return Failure(13, error);
+        }
+        if (int error = QueryRtnlState(new_route.Get(), new_ifindex, 201, &new_state)) {
+            return Failure(14, error);
+        }
+        if (old_state.mtu != static_cast<uint32_t>(old_changed_mtu) ||
+            new_state.mtu != static_cast<uint32_t>(new_original_mtu)) {
+            return Failure(15, static_cast<int>(old_state.mtu));
+        }
+        return Success();
+    });
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
@@ -535,6 +535,125 @@ TEST(SocketIoctlNetdevMutation, PacketSendRejectsAdministrativelyDownInterface) 
     });
 }
 
+TEST(SocketIoctlNetdevMutation, PacketSendHonorsRuntimeMtu) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard inet(OpenInetSocket());
+        if (inet.Get() < 0) return Failure(1, errno);
+
+        int ifindex = 0;
+        short flags = 0;
+        if (int error = QueryIfindex(inet.Get(), "lo", &ifindex)) return Failure(2, error);
+        if (int error = QueryIoctlFlags(inet.Get(), "lo", &flags)) return Failure(3, error);
+        if (int error = SetFlags(inet.Get(), "lo", static_cast<short>(flags | IFF_UP), false)) {
+            return Failure(4, error);
+        }
+        constexpr int kMtu = 1400;
+        if (int error = SetMtu(inet.Get(), "lo", kMtu, false)) return Failure(5, error);
+
+        sockaddr_ll destination{};
+        destination.sll_family = AF_PACKET;
+        destination.sll_protocol = htons(ETH_P_IP);
+        destination.sll_ifindex = ifindex;
+        destination.sll_halen = ETH_ALEN;
+
+        FdGuard raw(socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL)));
+        if (raw.Get() < 0) return Failure(6, errno);
+        std::array<uint8_t, kMtu + ETH_HLEN + 5> raw_frame{};
+        raw_frame[12] = 0x08;
+        raw_frame[13] = 0x00;
+        if (sendto(raw.Get(), raw_frame.data(), kMtu + ETH_HLEN, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) !=
+            kMtu + ETH_HLEN) {
+            return Failure(7, errno);
+        }
+        errno = 0;
+        if (sendto(raw.Get(), raw_frame.data(), kMtu + ETH_HLEN + 1, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(8, errno);
+        }
+
+        raw_frame[12] = 0x81;
+        raw_frame[13] = 0x00;
+        errno = 0;
+        if (sendto(raw.Get(), raw_frame.data(), kMtu + ETH_HLEN + 4, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(9, errno);
+        }
+        raw_frame[12] = 0x88;
+        raw_frame[13] = 0xa8;
+        errno = 0;
+        if (sendto(raw.Get(), raw_frame.data(), kMtu + ETH_HLEN + 4, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(10, errno);
+        }
+
+        FdGuard dgram(socket(AF_PACKET, SOCK_DGRAM, htons(ETH_P_IP)));
+        if (dgram.Get() < 0) return Failure(11, errno);
+        std::array<uint8_t, kMtu + 5> payload{};
+        if (sendto(dgram.Get(), payload.data(), kMtu, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != kMtu) {
+            return Failure(12, errno);
+        }
+        errno = 0;
+        if (sendto(dgram.Get(), payload.data(), kMtu + 1, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(13, errno);
+        }
+
+        destination.sll_protocol = htons(0x8100);
+        errno = 0;
+        if (sendto(dgram.Get(), payload.data(), kMtu + 4, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(14, errno);
+        }
+        destination.sll_protocol = htons(0x88a8);
+        errno = 0;
+        if (sendto(dgram.Get(), payload.data(), kMtu + 4, 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != EMSGSIZE) {
+            return Failure(15, errno);
+        }
+
+        destination.sll_protocol = htons(ETH_P_IP);
+        std::array<iovec, 2> iov{};
+        iov[0].iov_base = payload.data();
+        iov[0].iov_len = kMtu / 2;
+        iov[1].iov_base = payload.data() + kMtu / 2;
+        iov[1].iov_len = kMtu / 2;
+        msghdr message{};
+        message.msg_name = &destination;
+        message.msg_namelen = sizeof(destination);
+        message.msg_iov = iov.data();
+        message.msg_iovlen = iov.size();
+        if (sendmsg(dgram.Get(), &message, 0) != kMtu) {
+            return Failure(16, errno);
+        }
+        ++iov[1].iov_len;
+        errno = 0;
+        if (sendmsg(dgram.Get(), &message, 0) != -1 || errno != EMSGSIZE) {
+            return Failure(17, errno);
+        }
+
+        if (int error = SetFlags(inet.Get(), "lo", static_cast<short>(flags & ~IFF_UP), false)) {
+            return Failure(18, error);
+        }
+        errno = 0;
+        if (sendto(raw.Get(), raw_frame.data(), raw_frame.size(), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != ENETDOWN) {
+            return Failure(19, errno);
+        }
+        return Success();
+    });
+}
+
 TEST(SocketIoctlNetdevMutation, NeighborPurgeDependsOnLinkLifecycle) {
     ExpectIsolatedChild([] {
         const bool dragonos = IsDragonOS();

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_mutation.cc
@@ -506,6 +506,89 @@ TEST(SocketIoctlNetdevMutation, LoopbackAcceptsLinuxStandardMtu) {
         if (ioctl_mtu != kLinuxLoopbackMtu || rtnl.mtu != kLinuxLoopbackMtu) {
             return Failure(15, ioctl_mtu);
         }
+
+        if (int error = SetMtu(inet.Get(), "lo", 67, true)) return Failure(16, error);
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(17, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 204, &rtnl)) {
+            return Failure(18, error);
+        }
+        if (ioctl_mtu != 67 || rtnl.mtu != 67) return Failure(19, ioctl_mtu);
+
+        if (int error = SetRtnlMtu(route.Get(), ifindex, 1, 205)) {
+            return Failure(20, error);
+        }
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(21, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 206, &rtnl)) {
+            return Failure(22, error);
+        }
+        if (ioctl_mtu != 1 || rtnl.mtu != 1) return Failure(23, ioctl_mtu);
+
+        if (int error = SetMtu(inet.Get(), "lo", 0, true)) return Failure(24, error);
+        if (int error = QueryIoctlMtu(inet.Get(), "lo", &ioctl_mtu)) return Failure(25, error);
+        if (int error = QueryRtnlState(route.Get(), ifindex, 207, &rtnl)) {
+            return Failure(26, error);
+        }
+        if (ioctl_mtu != 0 || rtnl.mtu != 0) return Failure(27, ioctl_mtu);
+
+        if (int error = SetRtnlMtu(route.Get(), ifindex, kLinuxLoopbackMtu, 208)) {
+            return Failure(28, error);
+        }
+        return Success();
+    });
+}
+
+TEST(SocketIoctlNetdevMutation, LowMtuWithdrawsLoopbackIpv4State) {
+    ExpectIsolatedChild([] {
+        ChildResult isolated = EnterIsolatedNetwork();
+        if (isolated.stage != 0) return isolated;
+        FdGuard inet(OpenInetSocket());
+        if (inet.Get() < 0) return Failure(1, errno);
+
+        short flags = 0;
+        if (int error = QueryIoctlFlags(inet.Get(), "lo", &flags)) return Failure(2, error);
+        if (int error = SetFlags(inet.Get(), "lo", static_cast<short>(flags | IFF_UP), false)) {
+            return Failure(3, error);
+        }
+
+        sockaddr_in destination{};
+        destination.sin_family = AF_INET;
+        destination.sin_port = htons(9);
+        destination.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        const uint8_t payload = 0;
+        const int enabled = 1;
+        if (setsockopt(inet.Get(), SOL_SOCKET, SO_BROADCAST, &enabled, sizeof(enabled)) != 0) {
+            return Failure(4, errno);
+        }
+        if (sendto(inet.Get(), &payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != 1) {
+            return Failure(5, errno);
+        }
+
+        if (int error = SetMtu(inet.Get(), "lo", 67, true)) return Failure(6, error);
+        errno = 0;
+        if (sendto(inet.Get(), &payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != ENETUNREACH) {
+            return Failure(7, errno);
+        }
+        destination.sin_addr.s_addr = htonl(INADDR_BROADCAST);
+        errno = 0;
+        if (sendto(inet.Get(), &payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != ENETUNREACH) {
+            return Failure(8, errno);
+        }
+
+        // Linux destroys the IPv4 protocol state at this threshold. Raising
+        // the MTU alone therefore does not silently recreate the address.
+        if (int error = SetMtu(inet.Get(), "lo", 65536, true)) return Failure(9, error);
+        destination.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+        errno = 0;
+        if (sendto(inet.Get(), &payload, sizeof(payload), 0,
+                   reinterpret_cast<sockaddr*>(&destination), sizeof(destination)) != -1 ||
+            errno != ENETUNREACH) {
+            return Failure(10, errno);
+        }
         return Success();
     });
 }

--- a/user/apps/tests/dunitest/whitelist.txt
+++ b/user/apps/tests/dunitest/whitelist.txt
@@ -57,6 +57,7 @@ normal/udp_ipv6_send_semantics
 normal/socket_getsockopt_semantics
 normal/socket_readv_semantics
 normal/socket_ioctl_netdev_query
+normal/socket_ioctl_netdev_mutation
 normal/unix_socket_shutdown
 fuse/fuse_core
 fuse/fuse_extended

--- a/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
+++ b/user/apps/tests/syscall/gvisor/runner/src/lib_sync.rs
@@ -19,6 +19,54 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[repr(C)]
+union IfReqData {
+    flags: libc::c_short,
+    align: [libc::c_ulong; 3],
+}
+
+#[repr(C)]
+struct IfReq {
+    name: [libc::c_char; libc::IFNAMSIZ],
+    data: IfReqData,
+}
+
+/// Create the isolated network environment expected by the network tests.
+/// Linux deliberately leaves loopback down in a fresh network namespace, so
+/// the runner must bring it up after unshare rather than changing kernel
+/// namespace-construction semantics.
+fn initialize_isolated_network() -> std::io::Result<()> {
+    unsafe {
+        if libc::unshare(libc::CLONE_NEWNET) != 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let fd = libc::socket(libc::AF_INET, libc::SOCK_DGRAM | libc::SOCK_CLOEXEC, 0);
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        let mut request = IfReq {
+            name: [0; libc::IFNAMSIZ],
+            data: IfReqData { align: [0; 3] },
+        };
+        request.name[0] = b'l' as libc::c_char;
+        request.name[1] = b'o' as libc::c_char;
+        request.data.flags = libc::IFF_UP as libc::c_short;
+
+        // libc models ioctl's request argument as c_ulong for GNU targets and
+        // c_int for musl targets.  Use its UAPI constant and convert it to the
+        // target-specific request type inferred by ioctl.
+        let result = libc::ioctl(fd, libc::SIOCSIFFLAGS as _, &request);
+        let error = std::io::Error::last_os_error();
+        libc::close(fd);
+        if result != 0 {
+            return Err(error);
+        }
+        Ok(())
+    }
+}
+
 // The pinned gVisor tests are executed directly rather than through gVisor's
 // Bazel runner, so publish the DragonOS capability that the Int3 test queries.
 // Keep this list conservative: an omitted capability does not claim support.
@@ -448,10 +496,7 @@ impl TestRunner {
                     return Err(std::io::Error::last_os_error());
                 }
                 if isolate_network {
-                    let ret = libc::unshare(libc::CLONE_NEWNET);
-                    if ret != 0 {
-                        return Err(std::io::Error::last_os_error());
-                    }
+                    initialize_isolated_network()?;
                 }
                 Ok(())
             });


### PR DESCRIPTION
## Summary

- introduce one ABI-independent, RTNL-serialized link mutation transaction shared by `RTM_SETLINK`, `SIOCSIFFLAGS`, and `SIOCSIFMTU`
- implement Linux-compatible link rename, MTU, mutable flag, namespace capability, rollback, notification, and error semantics
- preserve sysfs object identity during rename and emit namespace-correct link/uevent notifications
- project runtime MTU and NOARP changes into smoltcp and invalidate route/neighbor state coherently
- make administrative DOWN reversible and race-free with NAPI pause/resume plus device-specific VirtIO, E1000, and veth lifecycle hooks
- reject AF_PACKET transmission while an interface is administratively down
- add dunitest coverage for netlink and ioctl mutation semantics, rollback, namespace ownership, sysfs identity, uevents, and data-plane gating

## Architecture

`RTM_SETLINK` and legacy mutation ioctls now decode only their respective ABIs. Both call the same typed link transaction, which validates and prepares all fallible work before committing under RTNL serialization. Driver, sysfs, FIB, neighbor, smoltcp, and notification updates therefore share one ordering contract instead of duplicating policy across front ends.

Administrative state changes use three explicit stages: stop new ingress, wait for and quiesce old data-plane work, then publish the new state and resume the unique NAPI owner when going UP. Permanent device teardown remains separate from reversible administrative DOWN.

The implementation intentionally keeps hardware policy in each driver. VirtIO follows Linux virtnet callback/NAPI close behavior, while E1000 masks interrupts, disables RX, drains completed descriptors, and restores the required RX/TX interrupt sources on reopen.

## Compatibility

- follows Linux 6.6 link mutation behavior and errno ordering where DragonOS exposes the corresponding capability
- keeps query-only ioctl behavior unchanged
- preserves intrinsic loopback flags while allowing its administrative UP bit to change
- updates the DragonOS smoltcp revision to include runtime MTU, NOARP, neighbor-cache flush, and pending fragment reset support

## Validation

- `make fmt`
- `cargo test --manifest-path kernel/crates/napi-state/Cargo.toml` (13 passed)
- `make kernel`
- `git diff --check`
- Linux-host dunitest semantics: mutation suite 5 passed with 1 capability-dependent skip; link suite 7 passed with 1 DragonOS-only skip
- DragonOS QEMU: mutation 6/6, link 8/8, query 6/6, address 6/6, and ping 2/2 passed across the final validation sequence
- three independent adversarial reviews covered architecture, Linux ABI/error behavior, concurrency/lock ordering, device lifecycle, performance, safety, maintainability, workaround risk, and over-design; no blocking issue remains

Part of #2233.
