### PR TITLE
feat(net): add namespace-aware netdevice sysfs projection

### DIFF
--- a/kernel/src/driver/base/class.rs
+++ b/kernel/src/driver/base/class.rs
@@ -43,6 +43,11 @@ pub trait Class: Debug + Send + Sync {
     /// 获取类的名称
     fn name(&self) -> &'static str;
 
+    /// Whether direct device entries in this class are keyed by a namespace.
+    fn namespace_children(&self) -> bool {
+        false
+    }
+
     /// 属于该类的设备的基本属性。
     fn dev_groups(&self) -> &'static [&'static dyn AttributeGroup] {
         return &[];
@@ -130,6 +135,13 @@ impl ClassManager {
         subsystem.set_class(Some(Arc::downgrade(class)));
 
         subsys.register()?;
+
+        if class.namespace_children() {
+            subsys
+                .inode()
+                .ok_or(SystemError::ENOENT)?
+                .enable_namespace_children()?;
+        }
 
         sysfs_instance().create_groups(&(subsys as Arc<dyn KObject>), class.class_groups())?;
 

--- a/kernel/src/driver/base/device/mod.rs
+++ b/kernel/src/driver/base/device/mod.rs
@@ -653,6 +653,22 @@ impl DeviceManager {
     #[inline(never)]
     #[allow(dead_code)]
     pub fn add_device(&self, device: Arc<dyn Device>) -> Result<(), SystemError> {
+        self.add_device_with_optional_namespace(device, None)
+    }
+
+    pub fn add_device_with_namespace(
+        &self,
+        device: Arc<dyn Device>,
+        namespace: crate::filesystem::kernfs::KernFSNamespaceTag,
+    ) -> Result<(), SystemError> {
+        self.add_device_with_optional_namespace(device, Some(namespace))
+    }
+
+    fn add_device_with_optional_namespace(
+        &self,
+        device: Arc<dyn Device>,
+        namespace: Option<crate::filesystem::kernfs::KernFSNamespaceTag>,
+    ) -> Result<(), SystemError> {
         // 在这里处理与parent相关的逻辑
         let deivce_parent = device.dev_parent().and_then(|x| x.upgrade());
         if let Some(ref dev) = deivce_parent {
@@ -676,7 +692,13 @@ impl DeviceManager {
             device.set_parent(Some(Arc::downgrade(&kobject_parent)));
         }
 
-        KObjectManager::add_kobj(device.clone() as Arc<dyn KObject>).map_err(|e| {
+        let add_result = match namespace {
+            Some(namespace) => {
+                KObjectManager::add_kobj_ns(device.clone() as Arc<dyn KObject>, namespace)
+            }
+            None => KObjectManager::add_kobj(device.clone() as Arc<dyn KObject>),
+        };
+        add_result.map_err(|e| {
             error!("add device '{:?}' failed: {:?}", device.name(), e);
             e
         })?;
@@ -759,7 +781,7 @@ impl DeviceManager {
         &self,
         class: Arc<dyn Class>,
         kobject_parent: Arc<dyn KObject>,
-    ) -> Arc<dyn KObject> {
+    ) -> Result<Arc<dyn KObject>, SystemError> {
         let mut guard = CLASS_DIR_KSET_INSTANCE.write();
         let class_name: String = class.name().to_string();
         let kobject_parent_name = kobject_parent.name();
@@ -767,7 +789,7 @@ impl DeviceManager {
 
         // 检查设备类目录是否已经存在
         if let Some(class_dir) = guard.get(&key) {
-            return class_dir.clone();
+            return Ok(class_dir.clone());
         }
 
         let class_dir: Arc<ClassDir> = ClassDir::new();
@@ -776,12 +798,21 @@ impl DeviceManager {
         class_dir.set_kobj_type(Some(&ClassKObjbectType));
         class_dir.set_parent(Some(Arc::downgrade(&kobject_parent)));
 
-        KObjectManager::add_kobj(class_dir.clone() as Arc<dyn KObject>)
-            .expect("add class dir failed");
+        KObjectManager::add_kobj(class_dir.clone() as Arc<dyn KObject>)?;
+        if class.namespace_children() {
+            let enable_result = class_dir
+                .inode()
+                .ok_or(SystemError::ENOENT)
+                .and_then(|inode| inode.enable_namespace_children());
+            if let Err(error) = enable_result {
+                KObjectManager::remove_kobj(class_dir.clone() as Arc<dyn KObject>);
+                return Err(error);
+            }
+        }
 
         guard.insert(key, class_dir.clone());
 
-        return class_dir;
+        return Ok(class_dir);
     }
 
     /// 获取设备真实的parent kobject
@@ -817,7 +848,7 @@ impl DeviceManager {
             // 是否需要glue dir?
 
             let kobject_parent =
-                self.class_dir_create_and_add(device.class().unwrap(), kobject_parent.clone());
+                self.class_dir_create_and_add(device.class().unwrap(), kobject_parent.clone())?;
 
             return Ok(Some(kobject_parent));
         }
@@ -1153,7 +1184,11 @@ impl DeviceManager {
         sysfs_instance().remove_link(&dev_kobj, "subsystem".to_string());
 
         let subsys_kobj = class.subsystem().subsys() as Arc<dyn KObject>;
-        sysfs_instance().remove_link(&subsys_kobj, dev.name());
+        sysfs_instance().remove_link_to(
+            &subsys_kobj,
+            &(dev.clone() as Arc<dyn KObject>),
+            dev.name(),
+        );
 
         for class_interface in class.subsystem().interfaces() {
             class_interface.remove_device(dev);

--- a/kernel/src/driver/base/device_rename.rs
+++ b/kernel/src/driver/base/device_rename.rs
@@ -7,7 +7,6 @@ use crate::{
     filesystem::{
         kernfs::{KernFSInode, KernFSRenameSpec, PreparedKernFSRename},
         sysfs::sysfs_instance,
-        vfs::IndexNode,
     },
     libs::casting::DowncastArc,
 };
@@ -56,8 +55,9 @@ pub(crate) fn prepare_class_device_sysfs_rename(
     let class = device.class().ok_or(SystemError::EIO)?;
     let class_kobject = class.subsystem().subsys() as Arc<dyn KObject>;
     let class_parent = class_kobject.inode().ok_or(SystemError::EIO)?;
+    let namespace = device_inode.namespace().ok_or(SystemError::EIO)?;
     let class_link = class_parent
-        .find(&old_sysfs_name)
+        .find_ns(&old_sysfs_name, namespace)
         .map_err(|_| SystemError::EIO)?
         .downcast_arc::<KernFSInode>()
         .ok_or(SystemError::EIO)?;
@@ -68,7 +68,11 @@ pub(crate) fn prepare_class_device_sysfs_rename(
         return Err(SystemError::EIO);
     }
 
-    let target_path = sysfs_instance().child_absolute_path(&device_parent, new_name.as_str())?;
+    let target_path = if class_parent.namespace_children_enabled() {
+        sysfs_instance().child_relative_path(&class_parent, &device_parent, new_name.as_str())?
+    } else {
+        sysfs_instance().child_absolute_path(&device_parent, new_name.as_str())?
+    };
     let old_devpath = sysfs_instance().try_kernfs_path(&device_inode)?;
     let class_name = try_copy_string(&new_name)?;
     let device_spec = KernFSRenameSpec::new(device_inode, new_name);

--- a/kernel/src/driver/base/kobject.rs
+++ b/kernel/src/driver/base/kobject.rs
@@ -17,7 +17,7 @@ use log::{debug, error};
 
 use crate::{
     filesystem::{
-        kernfs::KernFSInode,
+        kernfs::{KernFSInode, KernFSNamespaceTag},
         sysfs::{sysfs_instance, Attribute, AttributeGroup, SysFSOps, SysFSOpsSupport},
     },
     libs::{
@@ -336,6 +336,20 @@ impl KObjectManager {
     }
 
     pub fn add_kobj(kobj: Arc<dyn KObject>) -> Result<(), SystemError> {
+        Self::add_kobj_with_namespace(kobj, None)
+    }
+
+    pub fn add_kobj_ns(
+        kobj: Arc<dyn KObject>,
+        namespace: KernFSNamespaceTag,
+    ) -> Result<(), SystemError> {
+        Self::add_kobj_with_namespace(kobj, Some(namespace))
+    }
+
+    fn add_kobj_with_namespace(
+        kobj: Arc<dyn KObject>,
+        namespace: Option<KernFSNamespaceTag>,
+    ) -> Result<(), SystemError> {
         if let Some(kset) = kobj.kset() {
             kset.join(&kobj);
             // 如果kobject没有parent，那么就将这个kset作为parent
@@ -344,7 +358,7 @@ impl KObjectManager {
             }
         }
 
-        let r = Self::create_dir(kobj.clone());
+        let r = Self::create_dir(kobj.clone(), namespace);
 
         if let Err(e) = r {
             // https://code.dragonos.org.cn/xref/linux-6.1.9/lib/kobject.c?r=&mo=10426&fi=394#224
@@ -363,9 +377,15 @@ impl KObjectManager {
         return Ok(());
     }
 
-    fn create_dir(kobj: Arc<dyn KObject>) -> Result<(), SystemError> {
+    fn create_dir(
+        kobj: Arc<dyn KObject>,
+        namespace: Option<KernFSNamespaceTag>,
+    ) -> Result<(), SystemError> {
         // create dir in sysfs
-        sysfs_instance().create_dir(kobj.clone())?;
+        match namespace {
+            Some(namespace) => sysfs_instance().create_dir_ns(kobj.clone(), namespace)?,
+            None => sysfs_instance().create_dir(kobj.clone())?,
+        };
 
         // create default attributes in sysfs
         if let Some(ktype) = kobj.kobj_type() {

--- a/kernel/src/driver/net/class.rs
+++ b/kernel/src/driver/net/class.rs
@@ -65,6 +65,10 @@ impl Class for NetClass {
         return Self::NAME;
     }
 
+    fn namespace_children(&self) -> bool {
+        true
+    }
+
     fn dev_kobj(&self) -> Option<Arc<dyn KObject>> {
         Some(sys_dev_char_kobj() as Arc<dyn KObject>)
     }

--- a/kernel/src/driver/net/iface.rs
+++ b/kernel/src/driver/net/iface.rs
@@ -114,6 +114,13 @@ pub trait Iface: crate::driver::base::device::Device {
     /// 获取网卡的公共信息
     fn common(&self) -> &IfaceCommon;
 
+    /// Whether this software device may be destroyed when its owning
+    /// non-initial network namespace reaches final release. Devices which
+    /// require Linux-style migration back to init_net keep the default.
+    fn destroy_on_netns_exit(&self) -> bool {
+        false
+    }
+
     /// # `mac`
     /// 获取网卡的MAC地址
     ///
@@ -561,13 +568,21 @@ impl Default for NetDeviceCommonData {
 
 /// 将网络设备注册到sysfs中
 /// 参考：https://code.dragonos.org.cn/xref/linux-2.6.39/net/core/dev.c?fi=register_netdev#5373
-pub(super) fn register_netdevice(
+pub(crate) fn register_netdevice(
     netns: &Arc<NetNamespace>,
     dev: Arc<dyn Iface>,
 ) -> Result<(), SystemError> {
+    if !Arc::ptr_eq(
+        netns,
+        &crate::process::namespace::net_namespace::INIT_NET_NAMESPACE,
+    ) && !dev.destroy_on_netns_exit()
+    {
+        return Err(SystemError::EOPNOTSUPP_OR_ENOTSUP);
+    }
+
     // Register driver-core/sysfs first. Until PRESENT and the namespace/FIB
     // transaction both commit, the object is provisional and unannounced.
-    netdev_register_kobject(dev.clone())?;
+    netdev_register_kobject(netns, dev.clone())?;
     if let Err(error) = register_netdevice_in_namespace(netns, dev.clone()) {
         // No add uevent has been sent, so rollback is structural and must not
         // allocate notification state before removing the provisional object.

--- a/kernel/src/driver/net/loopback.rs
+++ b/kernel/src/driver/net/loopback.rs
@@ -552,6 +552,10 @@ impl Device for LoopbackInterface {
 }
 
 impl Iface for LoopbackInterface {
+    fn destroy_on_netns_exit(&self) -> bool {
+        true
+    }
+
     fn common(&self) -> &IfaceCommon {
         &self.common
     }

--- a/kernel/src/driver/net/mod.rs
+++ b/kernel/src/driver/net/mod.rs
@@ -7,7 +7,8 @@ use core::cell::Cell;
 use core::net::Ipv4Addr;
 use core::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
 use net_poll_state::{DeadlineClaims, DueResult, PollDeadlines, PublishResult};
-use sysfs::{netdev_emit_uevent, netdev_register_kobject, netdev_unregister_kobject};
+pub(crate) use sysfs::netdev_unregister_kobject;
+use sysfs::{netdev_emit_uevent, netdev_register_kobject};
 
 use crate::driver::net::napi::NapiStruct;
 use crate::driver::net::types::{InterfaceFlags, InterfaceType};

--- a/kernel/src/driver/net/sysfs.rs
+++ b/kernel/src/driver/net/sysfs.rs
@@ -7,6 +7,7 @@ use crate::{
         kobject::KObject,
     },
     filesystem::{
+        kernfs::KernFSNamespaceTag,
         sysfs::{
             file::sysfs_emit_str, Attribute, AttributeGroup, SysFSOpsSupport, SYSFS_ATTR_MODE_RO,
             SYSFS_ATTR_MODE_RW,
@@ -21,10 +22,14 @@ use log::{error, warn};
 use system_error::SystemError;
 
 use super::{class::sys_class_net_instance, Iface, NetDeivceState, Operstate};
+use crate::process::namespace::{net_namespace::NetNamespace, NamespaceOps};
 
 /// 将设备注册到`/sys/class/net`目录下
 /// 参考：https://code.dragonos.org.cn/xref/linux-2.6.39/net/core/net-sysfs.c?fi=netdev_register_kobject#1311
-pub fn netdev_register_kobject(dev: Arc<dyn Iface>) -> Result<(), SystemError> {
+pub fn netdev_register_kobject(
+    netns: &Arc<NetNamespace>,
+    dev: Arc<dyn Iface>,
+) -> Result<(), SystemError> {
     let device = dev.clone() as Arc<dyn Device>;
 
     // 初始化设备
@@ -38,7 +43,8 @@ pub fn netdev_register_kobject(dev: Arc<dyn Iface>) -> Result<(), SystemError> {
     // 设置设备的kobject名
     dev.set_name(dev.iface_name());
 
-    if let Err(error) = device_manager().add_device(device.clone()) {
+    let tag = KernFSNamespaceTag::new(netns.ns_common().nsid.data());
+    if let Err(error) = device_manager().add_device_with_namespace(device.clone(), tag) {
         // Driver-core currently exposes a fallible multi-stage add path. If a
         // late stage fails after publishing IN_SYSFS, use its structural
         // teardown path before returning the registration error. No uevent
@@ -63,7 +69,8 @@ pub fn netdev_unregister_kobject(dev: Arc<dyn Iface>) {
 }
 
 /// Prepares the sysfs half of a netdevice rename without changing the logical
-/// interface name. Non-initial namespaces deliberately have no sysfs object.
+/// interface name. The device inode's namespace tag selects the matching
+/// class link while preserving both inode identities.
 pub(crate) fn prepare_netdev_sysfs_rename(
     dev: &Arc<dyn Iface>,
     new_name: String,

--- a/kernel/src/driver/net/veth.rs
+++ b/kernel/src/driver/net/veth.rs
@@ -615,6 +615,10 @@ impl device::Device for VethInterface {
 }
 
 impl Iface for VethInterface {
+    fn destroy_on_netns_exit(&self) -> bool {
+        true
+    }
+
     fn common(&self) -> &IfaceCommon {
         &self.common
     }

--- a/kernel/src/exception/workqueue.rs
+++ b/kernel/src/exception/workqueue.rs
@@ -1,4 +1,12 @@
-use alloc::{boxed::Box, collections::VecDeque, string::ToString, sync::Arc};
+use alloc::{
+    boxed::Box,
+    string::ToString,
+    sync::{Arc, Weak},
+};
+use core::{
+    fmt,
+    sync::atomic::{AtomicBool, Ordering},
+};
 use lazy_static::lazy_static;
 use log;
 
@@ -13,6 +21,8 @@ use crate::{
 /// Represents a work item to be executed in a workqueue.
 pub struct Work {
     func: Box<dyn Fn() + Send + Sync>,
+    next: SpinLock<Option<Arc<Work>>>,
+    pending: AtomicBool,
 }
 
 impl Work {
@@ -21,7 +31,11 @@ impl Work {
     where
         F: Fn() + Send + Sync + 'static,
     {
-        Arc::new(Self { func: Box::new(f) })
+        Arc::new(Self {
+            func: Box::new(f),
+            next: SpinLock::new(None),
+            pending: AtomicBool::new(false),
+        })
     }
 
     /// Execute the work item.
@@ -30,9 +44,23 @@ impl Work {
     }
 }
 
+impl fmt::Debug for Work {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Work")
+            .field("pending", &self.pending.load(Ordering::Relaxed))
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Default)]
+struct WorkList {
+    head: Option<Arc<Work>>,
+    tail: Option<Weak<Work>>,
+}
+
 /// A workqueue that manages a list of works and a worker thread.
 pub struct WorkQueue {
-    queue: SpinLock<VecDeque<Arc<Work>>>,
+    queue: SpinLock<WorkList>,
     wait_queue: Arc<WaitQueue>,
     worker: SpinLock<Option<Arc<ProcessControlBlock>>>,
 }
@@ -42,7 +70,7 @@ impl WorkQueue {
     /// This will spawn a kernel thread with the given name.
     pub fn new(name: &str) -> Arc<Self> {
         let wq = Arc::new(Self {
-            queue: SpinLock::new(VecDeque::new()),
+            queue: SpinLock::new(WorkList::default()),
             wait_queue: Arc::new(WaitQueue::default()),
             worker: SpinLock::new(None),
         });
@@ -62,8 +90,39 @@ impl WorkQueue {
 
     /// Enqueue a work item to the workqueue.
     pub fn enqueue(&self, work: Arc<Work>) {
-        self.queue.lock().push_back(work);
+        let mut queue = self.queue.lock();
+        if work.pending.swap(true, Ordering::AcqRel) {
+            return;
+        }
+
+        debug_assert!(work.next.lock().is_none());
+        let new_tail = Arc::downgrade(&work);
+        if let Some(tail) = queue.tail.take().and_then(|tail| tail.upgrade()) {
+            *tail.next.lock() = Some(work);
+        } else {
+            debug_assert!(queue.head.is_none());
+            queue.head = Some(work);
+        }
+        queue.tail = Some(new_tail);
+        drop(queue);
         self.wait_queue.wakeup(None);
+    }
+
+    fn pop(&self) -> Option<Arc<Work>> {
+        let mut queue = self.queue.lock();
+        let work = queue.head.take()?;
+        queue.head = work.next.lock().take();
+        if queue.head.is_none() {
+            queue.tail = None;
+        }
+        // Clear PENDING while holding the queue lock. The work may enqueue
+        // itself once run() starts without racing this dequeue operation.
+        work.pending.store(false, Ordering::Release);
+        Some(work)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.queue.lock().head.is_none()
     }
 }
 
@@ -73,11 +132,11 @@ fn worker_loop(wq: Arc<WorkQueue>) -> i32 {
         // Wait for work
         let _ = wq
             .wait_queue
-            .wait_event_interruptible(|| !wq.queue.lock().is_empty(), None::<fn()>);
+            .wait_event_interruptible(|| !wq.is_empty(), None::<fn()>);
 
         // Process works
         loop {
-            let work = wq.queue.lock().pop_front();
+            let work = wq.pop();
             match work {
                 Some(w) => w.run(),
                 None => break,

--- a/kernel/src/filesystem/kernfs/mod.rs
+++ b/kernel/src/filesystem/kernfs/mod.rs
@@ -1,5 +1,10 @@
 use alloc::string::ToString;
-use core::{cmp::min, fmt::Debug, intrinsics::unlikely};
+use core::{
+    cmp::min,
+    fmt::Debug,
+    intrinsics::unlikely,
+    sync::atomic::{AtomicBool, Ordering},
+};
 
 use alloc::{
     string::String,
@@ -30,6 +35,130 @@ pub mod callback;
 mod rename;
 
 pub use rename::{KernFSRenameSpec, PreparedKernFSRename};
+
+/// Stable identity used to distinguish same-named children in a
+/// namespace-aware kernfs directory. It deliberately contains no namespace
+/// object reference.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct KernFSNamespaceTag(usize);
+
+impl KernFSNamespaceTag {
+    pub const fn new(value: usize) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct KernFSChildKey {
+    name: String,
+    namespace: Option<KernFSNamespaceTag>,
+}
+
+impl KernFSChildKey {
+    fn new(name: String, namespace: Option<KernFSNamespaceTag>) -> Self {
+        Self { name, namespace }
+    }
+}
+
+pub(crate) struct KernFSChildKeyRef<'a> {
+    name: &'a str,
+    namespace: Option<KernFSNamespaceTag>,
+}
+
+impl<'a> KernFSChildKeyRef<'a> {
+    pub(crate) fn new(name: &'a str, namespace: Option<KernFSNamespaceTag>) -> Self {
+        Self { name, namespace }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct KernFSChildren {
+    buckets: HashMap<Option<KernFSNamespaceTag>, HashMap<String, Arc<KernFSInode>>>,
+}
+
+impl KernFSChildren {
+    pub(crate) fn get(&self, key: &KernFSChildKeyRef<'_>) -> Option<&Arc<KernFSInode>> {
+        self.buckets
+            .get(&key.namespace)
+            .and_then(|bucket| bucket.get(key.name))
+    }
+
+    pub(crate) fn contains_key(&self, key: &KernFSChildKeyRef<'_>) -> bool {
+        self.get(key).is_some()
+    }
+
+    pub(crate) fn insert(
+        &mut self,
+        key: KernFSChildKey,
+        inode: Arc<KernFSInode>,
+    ) -> Option<Arc<KernFSInode>> {
+        self.buckets
+            .entry(key.namespace)
+            .or_default()
+            .insert(key.name, inode)
+    }
+
+    pub(crate) fn remove(&mut self, key: &KernFSChildKeyRef<'_>) -> Option<Arc<KernFSInode>> {
+        let (removed, bucket_empty) = {
+            let bucket = self.buckets.get_mut(&key.namespace)?;
+            let removed = bucket.remove(key.name);
+            (removed, bucket.is_empty())
+        };
+        if bucket_empty {
+            self.buckets.remove(&key.namespace);
+        }
+        removed
+    }
+
+    /// Re-key an existing child without removing its namespace bucket. Rename
+    /// commit relies on this operation being allocation-free after prepare.
+    pub(crate) fn rekey(
+        &mut self,
+        old_key: &KernFSChildKeyRef<'_>,
+        new_key: KernFSChildKey,
+    ) -> Option<()> {
+        if old_key.namespace != new_key.namespace {
+            return None;
+        }
+        let bucket = self.buckets.get_mut(&old_key.namespace)?;
+        let inode = bucket.remove(old_key.name)?;
+        // Removing one entry before inserting its replacement guarantees that
+        // the existing bucket has enough capacity; commit must not allocate.
+        let replaced = bucket.insert(new_key.name, inode);
+        debug_assert!(replaced.is_none());
+        Some(())
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.buckets.is_empty()
+    }
+
+    fn find_name_by_inode(&self, ino: InodeId) -> Option<String> {
+        self.buckets.values().find_map(|bucket| {
+            bucket
+                .iter()
+                .find(|(_, inode)| inode.metadata().unwrap().inode_id == ino)
+                .map(|(name, _)| name.clone())
+        })
+    }
+
+    fn namespace_len(&self, namespace: Option<KernFSNamespaceTag>) -> usize {
+        self.buckets.get(&namespace).map_or(0, HashMap::len)
+    }
+
+    fn extend_names(&self, namespace: Option<KernFSNamespaceTag>, names: &mut Vec<String>) {
+        if let Some(bucket) = self.buckets.get(&namespace) {
+            names.extend(bucket.keys().cloned());
+        }
+    }
+
+    fn drain_values(&mut self) -> Vec<Arc<KernFSInode>> {
+        self.buckets
+            .drain()
+            .flat_map(|(_, bucket)| bucket.into_values())
+            .collect()
+    }
+}
 
 #[derive(Debug)]
 pub struct KernFS {
@@ -120,7 +249,9 @@ impl KernFS {
             fs: RwSem::new(Weak::new()),
             private_data: Mutex::new(None),
             callback: None,
-            children: Mutex::new(HashMap::new()),
+            children: Mutex::new(KernFSChildren::default()),
+            namespace: None,
+            namespace_children: AtomicBool::new(false),
             child_mutation: Mutex::new(()),
             inode_type: KernInodeType::Dir,
             lazy_list: Mutex::new(HashMap::new()),
@@ -143,7 +274,11 @@ pub struct KernFSInode {
     /// 回调函数
     callback: Option<&'static dyn KernFSCallback>,
     /// 子Inode
-    children: Mutex<HashMap<String, Arc<KernFSInode>>>,
+    children: Mutex<KernFSChildren>,
+    /// Namespace identity of this inode in its parent's child map.
+    namespace: Option<KernFSNamespaceTag>,
+    /// Whether direct children must carry a namespace tag.
+    namespace_children: AtomicBool,
     /// Serializes every mutation of `children` and `lazy_list` for this
     /// directory. Readers keep using the map locks directly.
     child_mutation: Mutex<()>,
@@ -298,7 +433,11 @@ impl IndexNode for KernFSInode {
                     .ok_or(SystemError::ENOENT)?);
             }
             name => {
-                if let Some(child) = self.children.lock().get(name).cloned() {
+                if self.namespace_children.load(Ordering::Acquire) {
+                    return Err(SystemError::ENOENT);
+                }
+                let key = KernFSChildKeyRef::new(name, None);
+                if let Some(child) = self.children.lock().get(&key).cloned() {
                     return Ok(child);
                 }
 
@@ -315,10 +454,7 @@ impl IndexNode for KernFSInode {
         }
 
         let children = self.children.lock();
-        let r = children
-            .iter()
-            .find(|(_, v)| v.metadata().unwrap().inode_id == ino)
-            .map(|(k, _)| k.clone());
+        let r = children.find_name_by_inode(ino);
 
         return r.ok_or(SystemError::ENOENT);
     }
@@ -359,13 +495,14 @@ impl IndexNode for KernFSInode {
             return Err(SystemError::ENOTDIR);
         }
 
-        let mut keys: Vec<String> = Vec::new();
+        let children = self.children.lock();
+        let mut keys = Vec::with_capacity(children.namespace_len(None) + 2);
         keys.push(String::from("."));
         keys.push(String::from(".."));
-        self.children
-            .lock()
-            .keys()
-            .for_each(|x| keys.push(x.clone()));
+        if self.namespace_children.load(Ordering::Acquire) {
+            return Err(SystemError::ENOENT);
+        }
+        children.extend_names(None, &mut keys);
 
         return Ok(keys);
     }
@@ -449,16 +586,109 @@ impl IndexNode for KernFSInode {
 }
 
 impl KernFSInode {
+    pub fn namespace(&self) -> Option<KernFSNamespaceTag> {
+        self.namespace
+    }
+
+    pub fn namespace_children_enabled(&self) -> bool {
+        self.namespace_children.load(Ordering::Acquire)
+    }
+
+    /// Make direct children namespace-aware. Like Linux kernfs, this is an
+    /// irreversible directory property and is only valid before children or
+    /// lazy entries are published.
+    pub fn enable_namespace_children(&self) -> Result<(), SystemError> {
+        if self.inode_type != KernInodeType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+        let _mutation = self.child_mutation.lock();
+        if !self.children.lock().is_empty() || !self.lazy_list.lock().is_empty() {
+            return Err(SystemError::ENOTEMPTY);
+        }
+        self.namespace_children.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    pub fn find_ns(
+        &self,
+        name: &str,
+        namespace: KernFSNamespaceTag,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        if name.len() > KernFS::MAX_NAMELEN {
+            return Err(SystemError::ENAMETOOLONG);
+        }
+        if self.inode_type != KernInodeType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+        match name {
+            "" | "." => self
+                .self_ref
+                .upgrade()
+                .map(|inode| inode as Arc<dyn IndexNode>)
+                .ok_or(SystemError::ENOENT),
+            ".." => self
+                .inner
+                .read()
+                .parent
+                .upgrade()
+                .map(|inode| inode as Arc<dyn IndexNode>)
+                .ok_or(SystemError::ENOENT),
+            name if self.namespace_children.load(Ordering::Acquire) => self
+                .children
+                .lock()
+                .get(&KernFSChildKeyRef::new(name, Some(namespace)))
+                .cloned()
+                .map(|inode| inode as Arc<dyn IndexNode>)
+                .ok_or(SystemError::ENOENT),
+            name => self.find(name),
+        }
+    }
+
+    pub fn list_ns(&self, namespace: KernFSNamespaceTag) -> Result<Vec<String>, SystemError> {
+        if self.inode_type != KernInodeType::Dir {
+            return Err(SystemError::ENOTDIR);
+        }
+        if !self.namespace_children.load(Ordering::Acquire) {
+            return self.list();
+        }
+        let children = self.children.lock();
+        let mut names = Vec::with_capacity(children.namespace_len(Some(namespace)) + 2);
+        names.push(".".to_string());
+        names.push("..".to_string());
+        children.extend_names(Some(namespace), &mut names);
+        Ok(names)
+    }
+
     /// Create a new KernFSInode with a parent.
     /// Uses Arc::new_cyclic to safely initialize self_ref without unsafe code.
     /// After construction, sets the fs reference from parent if available.
     pub fn new_with_parent(
         parent: Option<Arc<KernFSInode>>,
         name: String,
+        metadata: Metadata,
+        inode_type: KernInodeType,
+        private_data: Option<KernInodePrivateData>,
+        callback: Option<&'static dyn KernFSCallback>,
+    ) -> Arc<KernFSInode> {
+        Self::new_with_parent_ns(
+            parent,
+            name,
+            metadata,
+            inode_type,
+            private_data,
+            callback,
+            None,
+        )
+    }
+
+    fn new_with_parent_ns(
+        parent: Option<Arc<KernFSInode>>,
+        name: String,
         mut metadata: Metadata,
         inode_type: KernInodeType,
         private_data: Option<KernInodePrivateData>,
         callback: Option<&'static dyn KernFSCallback>,
+        namespace: Option<KernFSNamespaceTag>,
     ) -> Arc<KernFSInode> {
         metadata.file_type = inode_type.into();
 
@@ -474,7 +704,9 @@ impl KernFSInode {
             fs: RwSem::new(Weak::new()),
             private_data: Mutex::new(private_data),
             callback,
-            children: Mutex::new(HashMap::new()),
+            children: Mutex::new(KernFSChildren::default()),
+            namespace,
+            namespace_children: AtomicBool::new(false),
             child_mutation: Mutex::new(()),
             inode_type,
             lazy_list: Mutex::new(HashMap::new()),
@@ -535,6 +767,27 @@ impl KernFSInode {
         return self.inner_create(name, KernInodeType::Dir, mode, 0, private_data, callback);
     }
 
+    pub fn add_dir_ns(
+        &self,
+        name: String,
+        mode: InodeMode,
+        private_data: Option<KernInodePrivateData>,
+        callback: Option<&'static dyn KernFSCallback>,
+        namespace: KernFSNamespaceTag,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        self.inner_create_ns(
+            name,
+            KernFSInodeArgs {
+                mode,
+                inode_type: KernInodeType::Dir,
+                size: Some(0),
+                private_data,
+                callback,
+            },
+            Some(namespace),
+        )
+    }
+
     /// 在当前inode下增加文件
     ///
     /// ## 参数
@@ -583,11 +836,15 @@ impl KernFSInode {
         if unlikely(self.inode_type != KernInodeType::Dir) {
             return Err(SystemError::ENOTDIR);
         }
-
         let _mutation = self.child_mutation.lock();
+        if self.namespace_children.load(Ordering::Acquire) {
+            return Err(SystemError::EINVAL);
+        }
         let children = self.children.lock();
         let mut lazy_list = self.lazy_list.lock();
-        if children.contains_key(&name) || lazy_list.contains_key(&name) {
+        if children.contains_key(&KernFSChildKeyRef::new(&name, None))
+            || lazy_list.contains_key(&name)
+        {
             return Err(SystemError::EEXIST);
         }
 
@@ -598,7 +855,12 @@ impl KernFSInode {
     fn materialize_lazy_child(&self, name: &str) -> Result<Arc<KernFSInode>, SystemError> {
         let _build_guard = self.lazy_build_lock.lock();
 
-        if let Some(child) = self.children.lock().get(name).cloned() {
+        if let Some(child) = self
+            .children
+            .lock()
+            .get(&KernFSChildKeyRef::new(name, None))
+            .cloned()
+        {
             return Ok(child);
         }
 
@@ -610,27 +872,23 @@ impl KernFSInode {
             .ok_or(SystemError::ENOENT)?;
 
         let args = provider();
-        let inode = self.new_child_inode(
-            name.to_string(),
-            args.inode_type,
-            args.mode,
-            args.size.unwrap_or(4096),
-            args.private_data,
-            args.callback,
-        );
+        let inode = self.new_child_inode(name.to_string(), args, None);
 
         let _mutation = self.child_mutation.lock();
         let mut children = self.children.lock();
-        if let Some(child) = children.get(name).cloned() {
+        if let Some(child) = children.get(&KernFSChildKeyRef::new(name, None)).cloned() {
             return Ok(child);
         }
 
         let mut lazy_list = self.lazy_list.lock();
         if lazy_list.remove(name).is_none() {
-            return children.get(name).cloned().ok_or(SystemError::ENOENT);
+            return children
+                .get(&KernFSChildKeyRef::new(name, None))
+                .cloned()
+                .ok_or(SystemError::ENOENT);
         }
 
-        children.insert(name.to_string(), inode.clone());
+        children.insert(KernFSChildKey::new(name.to_string(), None), inode.clone());
         Ok(inode)
     }
 
@@ -643,17 +901,39 @@ impl KernFSInode {
         private_data: Option<KernInodePrivateData>,
         callback: Option<&'static dyn KernFSCallback>,
     ) -> Result<Arc<KernFSInode>, SystemError> {
+        self.inner_create_ns(
+            name,
+            KernFSInodeArgs {
+                mode,
+                inode_type: file_type,
+                size: Some(size),
+                private_data,
+                callback,
+            },
+            None,
+        )
+    }
+
+    fn inner_create_ns(
+        &self,
+        name: String,
+        args: KernFSInodeArgs,
+        namespace: Option<KernFSNamespaceTag>,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
         let _mutation = self.child_mutation.lock();
+        if self.namespace_children.load(Ordering::Acquire) != namespace.is_some() {
+            return Err(SystemError::EINVAL);
+        }
         let mut children = self.children.lock();
         let lazy_list = self.lazy_list.lock();
-        if children.contains_key(&name) || lazy_list.contains_key(&name) {
+        let borrowed_key = KernFSChildKeyRef::new(&name, namespace);
+        if children.contains_key(&borrowed_key) || lazy_list.contains_key(&name) {
             return Err(SystemError::EEXIST);
         }
 
-        let new_inode =
-            self.new_child_inode(name.clone(), file_type, mode, size, private_data, callback);
+        let new_inode = self.new_child_inode(name.clone(), args, namespace);
 
-        children.insert(name, new_inode.clone());
+        children.insert(KernFSChildKey::new(name, namespace), new_inode.clone());
 
         return Ok(new_inode);
     }
@@ -661,22 +941,17 @@ impl KernFSInode {
     fn new_child_inode(
         &self,
         name: String,
-        file_type: KernInodeType,
-        mode: InodeMode,
-        mut size: usize,
-        private_data: Option<KernInodePrivateData>,
-        callback: Option<&'static dyn KernFSCallback>,
+        args: KernFSInodeArgs,
+        namespace: Option<KernFSNamespaceTag>,
     ) -> Arc<KernFSInode> {
-        match file_type {
-            KernInodeType::Dir | KernInodeType::SymLink => {
-                size = 0;
-            }
-            _ => {}
-        }
+        let size = match args.inode_type {
+            KernInodeType::Dir | KernInodeType::SymLink => 0,
+            _ => args.size.unwrap_or(4096),
+        };
 
         let metadata = Metadata {
             size: size as i64,
-            mode,
+            mode: args.mode,
             uid: 0,
             gid: 0,
             blk_size: 0,
@@ -687,19 +962,20 @@ impl KernFSInode {
             btime: PosixTimeSpec::new(0, 0),
             dev_id: 0,
             inode_id: generate_inode_id(),
-            file_type: file_type.into(),
+            file_type: args.inode_type.into(),
             nlinks: 1,
             raw_dev: DeviceNumber::default(),
             flags: InodeFlags::empty(),
         };
 
-        Self::new_with_parent(
+        Self::new_with_parent_ns(
             Some(self.self_ref.upgrade().unwrap()),
             name,
             metadata,
-            file_type,
-            private_data,
-            callback,
+            args.inode_type,
+            args.private_data,
+            args.callback,
+            namespace,
         )
     }
 
@@ -717,15 +993,35 @@ impl KernFSInode {
     /// - 失败：错误码
     #[allow(dead_code)]
     pub fn remove(&self, name: &str) -> Result<(), SystemError> {
+        self.remove_ns(name, None)
+    }
+
+    pub fn remove_in_namespace(
+        &self,
+        name: &str,
+        namespace: KernFSNamespaceTag,
+    ) -> Result<(), SystemError> {
+        self.remove_ns(name, Some(namespace))
+    }
+
+    fn remove_ns(
+        &self,
+        name: &str,
+        namespace: Option<KernFSNamespaceTag>,
+    ) -> Result<(), SystemError> {
         if unlikely(self.inode_type != KernInodeType::Dir) {
             return Err(SystemError::ENOTDIR);
+        }
+        if self.namespace_children.load(Ordering::Acquire) != namespace.is_some() {
+            return Err(SystemError::EINVAL);
         }
 
         let _mutation = self.child_mutation.lock();
         let mut children = self.children.lock();
-        let inode = children.get(name).ok_or(SystemError::ENOENT)?;
+        let key = KernFSChildKeyRef::new(name, namespace);
+        let inode = children.get(&key).ok_or(SystemError::ENOENT)?;
         if inode.children.lock().is_empty() {
-            children.remove(name);
+            children.remove(&key);
             return Ok(());
         } else {
             return Err(SystemError::ENOTEMPTY);
@@ -750,13 +1046,31 @@ impl KernFSInode {
         target_absolute_path: String,
     ) -> Result<Arc<KernFSInode>, SystemError> {
         // debug!("kernfs add link: name:{name}, target path={target_absolute_path}");
-        let inode = self.inner_create(
+        let namespace = if self.namespace_children.load(Ordering::Acquire) {
+            Some(target.namespace().ok_or(SystemError::EINVAL)?)
+        } else {
+            None
+        };
+        self.add_link_ns(name, target, target_absolute_path, namespace)
+    }
+
+    fn add_link_ns(
+        &self,
+        name: String,
+        target: &Arc<KernFSInode>,
+        target_absolute_path: String,
+        namespace: Option<KernFSNamespaceTag>,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        let inode = self.inner_create_ns(
             name,
-            KernInodeType::SymLink,
-            InodeMode::S_IFLNK | InodeMode::S_IRWXUGO,
-            0,
-            None,
-            None,
+            KernFSInodeArgs {
+                mode: InodeMode::S_IFLNK | InodeMode::S_IRWXUGO,
+                inode_type: KernInodeType::SymLink,
+                size: Some(0),
+                private_data: None,
+                callback: None,
+            },
+            namespace,
         )?;
 
         inode.inner.write().symlink_target = Some(Arc::downgrade(target));
@@ -804,12 +1118,12 @@ impl KernFSInode {
     pub fn remove_recursive(&self) {
         let mut children = {
             let _mutation = self.child_mutation.lock();
-            self.children.lock().drain().collect::<Vec<_>>()
+            self.children.lock().drain_values()
         };
-        while let Some((_, child)) = children.pop() {
+        while let Some(child) = children.pop() {
             let mut descendants = {
                 let _mutation = child.child_mutation.lock();
-                child.children.lock().drain().collect::<Vec<_>>()
+                child.children.lock().drain_values()
             };
             children.append(&mut descendants);
         }
@@ -822,7 +1136,10 @@ impl KernFSInode {
         if let Some(parent) = parent {
             let name = self.name();
             let _mutation = parent.child_mutation.lock();
-            parent.children.lock().remove(&name);
+            parent
+                .children
+                .lock()
+                .remove(&KernFSChildKeyRef::new(&name, self.namespace));
         }
         self.remove_recursive();
     }

--- a/kernel/src/filesystem/kernfs/rename.rs
+++ b/kernel/src/filesystem/kernfs/rename.rs
@@ -3,7 +3,10 @@ use alloc::{string::String, sync::Arc};
 use hashbrown::HashMap;
 use system_error::SystemError;
 
-use super::{KernFS, KernFSInode, KernInodeType};
+use super::{
+    KernFS, KernFSChildKey, KernFSChildKeyRef, KernFSChildren, KernFSInode, KernFSInodeArgs,
+    KernInodeType,
+};
 
 /// One inode re-key requested as part of a two-node kernfs rename.
 ///
@@ -32,8 +35,8 @@ impl KernFSRenameSpec {
 struct PreparedRenameEntry {
     parent: Arc<KernFSInode>,
     inode: Arc<KernFSInode>,
-    old_name: String,
-    new_key: String,
+    old_key: KernFSChildKey,
+    new_key: KernFSChildKey,
     new_inode_name: String,
     symlink_target_absolute_path: Option<String>,
 }
@@ -50,11 +53,12 @@ impl PreparedRenameEntry {
         let parent = spec.inode.parent().ok_or(SystemError::ENOENT)?;
         let old_name = spec.inode.try_name()?;
         let new_inode_name = try_copy_string(&spec.new_name)?;
+        let namespace = spec.inode.namespace();
         Ok(Self {
             parent,
             inode: spec.inode,
-            old_name,
-            new_key: spec.new_name,
+            old_key: KernFSChildKey::new(old_name, namespace),
+            new_key: KernFSChildKey::new(spec.new_name, namespace),
             new_inode_name,
             symlink_target_absolute_path: spec.symlink_target_absolute_path,
         })
@@ -66,27 +70,38 @@ impl PreparedRenameEntry {
 
     fn validate(
         &self,
-        children: &HashMap<String, Arc<KernFSInode>>,
-        lazy: &HashMap<String, fn() -> super::KernFSInodeArgs>,
+        children: &KernFSChildren,
+        lazy: &HashMap<String, fn() -> KernFSInodeArgs>,
     ) -> Result<(), SystemError> {
-        let current = children.get(&self.old_name).ok_or(SystemError::ESTALE)?;
-        if !Arc::ptr_eq(current, &self.inode) || !self.inode.with_name(|name| name == self.old_name)
+        let current = children
+            .get(&KernFSChildKeyRef::new(
+                &self.old_key.name,
+                self.old_key.namespace,
+            ))
+            .ok_or(SystemError::ESTALE)?;
+        if !Arc::ptr_eq(current, &self.inode)
+            || !self.inode.with_name(|name| name == self.old_key.name)
         {
             return Err(SystemError::ESTALE);
         }
-        if self.new_key != self.old_name
-            && (children.contains_key(&self.new_key) || lazy.contains_key(&self.new_key))
+        if self.new_key != self.old_key
+            && (children.contains_key(&KernFSChildKeyRef::new(
+                &self.new_key.name,
+                self.new_key.namespace,
+            )) || lazy.contains_key(&self.new_key.name))
         {
             return Err(SystemError::EEXIST);
         }
         Ok(())
     }
 
-    fn publish(self, children: &mut HashMap<String, Arc<KernFSInode>>) {
-        let inode = children
-            .remove(&self.old_name)
+    fn publish(self, children: &mut KernFSChildren) {
+        children
+            .rekey(
+                &KernFSChildKeyRef::new(&self.old_key.name, self.old_key.namespace),
+                self.new_key,
+            )
             .expect("prepared kernfs rename source disappeared under mutation gate");
-        children.insert(self.new_key, inode);
 
         let mut inner = self.inode.inner.write();
         inner.name = self.new_inode_name;
@@ -117,7 +132,9 @@ impl PreparedKernFSRename {
         Ok(Self { entries })
     }
 
-    /// Revalidates and reserves both parent maps before changing either one.
+    /// Revalidates both parent maps before changing either one. Publication is
+    /// allocation-free because each re-key removes and inserts one entry in the
+    /// same existing namespace bucket.
     pub fn commit(self) -> Result<(), SystemError> {
         let [first, second] = self.entries;
         if Arc::ptr_eq(&first.parent, &second.parent) {
@@ -135,13 +152,6 @@ impl PreparedKernFSRename {
 
         first.validate(&first_children, &first_lazy)?;
         second.validate(&second_children, &second_lazy)?;
-        first_children
-            .try_reserve(1)
-            .map_err(|_| SystemError::ENOMEM)?;
-        second_children
-            .try_reserve(1)
-            .map_err(|_| SystemError::ENOMEM)?;
-
         drop(first_lazy);
         drop(second_lazy);
         first.publish(&mut first_children);
@@ -163,8 +173,6 @@ fn commit_same_parent(
     let lazy = parent.lazy_list.lock();
     first.validate(&children, &lazy)?;
     second.validate(&children, &lazy)?;
-    children.try_reserve(2).map_err(|_| SystemError::ENOMEM)?;
-
     drop(lazy);
     first.publish(&mut children);
     second.publish(&mut children);
@@ -230,14 +238,28 @@ mod tests {
 
         plan.commit().unwrap();
 
-        assert!(!devices.children.lock().contains_key("eth0"));
-        assert!(!class.children.lock().contains_key("eth0"));
+        assert!(!devices
+            .children
+            .lock()
+            .contains_key(&KernFSChildKeyRef::new("eth0", None)));
+        assert!(!class
+            .children
+            .lock()
+            .contains_key(&KernFSChildKeyRef::new("eth0", None)));
         assert!(Arc::ptr_eq(
-            devices.children.lock().get("eth1").unwrap(),
+            devices
+                .children
+                .lock()
+                .get(&KernFSChildKeyRef::new("eth1", None))
+                .unwrap(),
             &device
         ));
         assert!(Arc::ptr_eq(
-            class.children.lock().get("eth1").unwrap(),
+            class
+                .children
+                .lock()
+                .get(&KernFSChildKeyRef::new("eth1", None))
+                .unwrap(),
             &link
         ));
         assert_eq!(device.name(), "eth1");
@@ -269,19 +291,90 @@ mod tests {
         assert_eq!(plan.commit(), Err(SystemError::EEXIST));
 
         assert!(Arc::ptr_eq(
-            devices.children.lock().get("eth0").unwrap(),
+            devices
+                .children
+                .lock()
+                .get(&KernFSChildKeyRef::new("eth0", None))
+                .unwrap(),
             &device
         ));
         assert!(Arc::ptr_eq(
-            class.children.lock().get("eth0").unwrap(),
+            class
+                .children
+                .lock()
+                .get(&KernFSChildKeyRef::new("eth0", None))
+                .unwrap(),
             &link
         ));
-        assert!(!devices.children.lock().contains_key("eth1"));
+        assert!(!devices
+            .children
+            .lock()
+            .contains_key(&KernFSChildKeyRef::new("eth1", None)));
         assert_eq!(device.name(), "eth0");
         assert_eq!(link.name(), "eth0");
         assert_eq!(
             link.inner.read().symlink_target_absolute_path.as_deref(),
             Some("/sys/devices/eth0")
+        );
+    }
+
+    #[test]
+    fn namespace_keys_allow_same_name_and_rename_only_one_view() {
+        let root = KernFS::create_root_inode();
+        let mode = InodeMode::from_bits_truncate(0o755);
+        let devices = root
+            .add_dir("devices".to_string(), mode, None, None)
+            .unwrap();
+        let class = root.add_dir("class".to_string(), mode, None, None).unwrap();
+        devices.enable_namespace_children().unwrap();
+        class.enable_namespace_children().unwrap();
+        let tag_a = super::super::KernFSNamespaceTag::new(11);
+        let tag_b = super::super::KernFSNamespaceTag::new(12);
+        let device_a = devices
+            .add_dir_ns("lo".to_string(), mode, None, None, tag_a)
+            .unwrap();
+        let device_b = devices
+            .add_dir_ns("lo".to_string(), mode, None, None, tag_b)
+            .unwrap();
+        let link_a = class
+            .add_link("lo".to_string(), &device_a, "/sys/devices/lo".to_string())
+            .unwrap();
+        class
+            .add_link("lo".to_string(), &device_b, "/sys/devices/lo".to_string())
+            .unwrap();
+
+        let plan = PreparedKernFSRename::prepare(
+            KernFSRenameSpec::new(device_a.clone(), "lan0".to_string()),
+            KernFSRenameSpec::new(link_a, "lan0".to_string())
+                .with_symlink_target_absolute_path("/sys/devices/lan0".to_string()),
+        )
+        .unwrap();
+        plan.commit().unwrap();
+
+        assert!(devices.find_ns("lo", tag_a).is_err());
+        assert!(Arc::ptr_eq(
+            &devices
+                .find_ns("lan0", tag_a)
+                .unwrap()
+                .downcast_arc::<KernFSInode>()
+                .unwrap(),
+            &device_a
+        ));
+        assert!(Arc::ptr_eq(
+            &devices
+                .find_ns("lo", tag_b)
+                .unwrap()
+                .downcast_arc::<KernFSInode>()
+                .unwrap(),
+            &device_b
+        ));
+        assert_eq!(
+            class.list_ns(tag_a).unwrap(),
+            vec![".".to_string(), "..".to_string(), "lan0".to_string()]
+        );
+        assert_eq!(
+            class.list_ns(tag_b).unwrap(),
+            vec![".".to_string(), "..".to_string(), "lo".to_string()]
         );
     }
 }

--- a/kernel/src/filesystem/sysfs/dir.rs
+++ b/kernel/src/filesystem/sysfs/dir.rs
@@ -77,6 +77,28 @@ impl SysFS {
         return Ok(dir);
     }
 
+    pub fn create_dir_ns(
+        &self,
+        kobj: Arc<dyn KObject>,
+        namespace: crate::filesystem::kernfs::KernFSNamespaceTag,
+    ) -> Result<Arc<KernFSInode>, SystemError> {
+        let parent = kobj
+            .parent()
+            .and_then(|parent| parent.upgrade())
+            .and_then(|parent| parent.inode())
+            .ok_or(SystemError::ENOENT)?;
+        let private = SysFSKernPrivateData::Dir(SysKernDirPriv::new(kobj.clone()));
+        let dir = parent.add_dir_ns(
+            kobj.name(),
+            InodeMode::from_bits_truncate(0o755),
+            Some(KernInodePrivateData::SysFS(private)),
+            None,
+            namespace,
+        )?;
+        kobj.set_inode(Some(dir.clone()));
+        Ok(dir)
+    }
+
     pub fn ensure_mount_point_path(
         &self,
         components: &[&str],
@@ -185,6 +207,39 @@ impl SysFS {
             .map_err(|_| SystemError::ENOMEM)?;
         path.push_str("/sys");
         path.push_str(&parent_path);
+        path.push('/');
+        path.push_str(child_name);
+        Ok(path)
+    }
+
+    /// Build a mount-independent relative link from `from_dir` to a child of
+    /// `target_parent`. Namespace-aware class links must not embed the boot
+    /// mount's `/sys` path because they are also exposed by later sysfs mounts.
+    pub(crate) fn child_relative_path(
+        &self,
+        from_dir: &Arc<KernFSInode>,
+        target_parent: &Arc<KernFSInode>,
+        child_name: &str,
+    ) -> Result<String, SystemError> {
+        let from_path = self.try_kernfs_path(from_dir)?;
+        let target_path = self.try_kernfs_path(target_parent)?;
+        let parent_depth = from_path
+            .split('/')
+            .filter(|component| !component.is_empty())
+            .count();
+        let mut path = String::new();
+        let capacity = parent_depth
+            .checked_mul(3)
+            .and_then(|length| length.checked_add(target_path.len().saturating_sub(1)))
+            .and_then(|length| length.checked_add(1))
+            .and_then(|length| length.checked_add(child_name.len()))
+            .ok_or(SystemError::ENOMEM)?;
+        path.try_reserve_exact(capacity)
+            .map_err(|_| SystemError::ENOMEM)?;
+        for _ in 0..parent_depth {
+            path.push_str("../");
+        }
+        path.push_str(target_path.trim_start_matches('/'));
         path.push('/');
         path.push_str(child_name);
         Ok(path)

--- a/kernel/src/filesystem/sysfs/file.rs
+++ b/kernel/src/filesystem/sysfs/file.rs
@@ -60,7 +60,7 @@ impl SysKernFilePriv {
     pub fn callback_read(&self, buf: &mut [u8], offset: usize) -> Result<usize, SystemError> {
         if let Some(attribute) = self.attribute {
             // 当前文件所指向的kobject已经被释放
-            let kobj = self.kobj.upgrade().expect("kobj is None");
+            let kobj = self.kobj.upgrade().ok_or(SystemError::ENODEV)?;
             let len = attribute.show(kobj, buf)?;
             if offset > 0 {
                 if len <= offset {
@@ -73,7 +73,7 @@ impl SysKernFilePriv {
             return Ok(len);
         } else if let Some(bin_attribute) = self.bin_attribute.as_ref() {
             // 当前文件所指向的kobject已经被释放
-            let kobj = self.kobj.upgrade().expect("kobj is None");
+            let kobj = self.kobj.upgrade().ok_or(SystemError::ENODEV)?;
             return bin_attribute.read(kobj, buf, offset);
         } else {
             panic!("attribute and bin_attribute can't be both None");
@@ -83,11 +83,11 @@ impl SysKernFilePriv {
     pub fn callback_write(&self, buf: &[u8], offset: usize) -> Result<usize, SystemError> {
         if let Some(attribute) = self.attribute {
             // 当前文件所指向的kobject已经被释放
-            let kobj = self.kobj.upgrade().expect("kobj is None");
+            let kobj = self.kobj.upgrade().ok_or(SystemError::ENODEV)?;
             return attribute.store(kobj, buf);
         } else if let Some(bin_attribute) = self.bin_attribute.as_ref() {
             // 当前文件所指向的kobject已经被释放
-            let kobj = self.kobj.upgrade().expect("kobj is None");
+            let kobj = self.kobj.upgrade().ok_or(SystemError::ENODEV)?;
             return bin_attribute.write(kobj, buf, offset);
         } else {
             panic!("attribute and bin_attribute can't be both None");

--- a/kernel/src/filesystem/sysfs/mod.rs
+++ b/kernel/src/filesystem/sysfs/mod.rs
@@ -1,18 +1,27 @@
-use core::fmt::Debug;
+use core::{any::Any, fmt::Debug};
 
 use self::{dir::SysKernDirPriv, file::SysKernFilePriv};
 use super::{
-    kernfs::{KernFS, KernFSInode},
-    vfs::{FileSystem, FileSystemMakerData, InodeMode, MountableFileSystem, SuperBlock},
+    kernfs::{KernFS, KernFSInode, KernFSNamespaceTag},
+    vfs::{
+        DirectoryEntry, FileSystem, FileSystemMakerData, IndexNode, InodeMode, MountableFileSystem,
+        SuperBlock,
+    },
 };
 use crate::{
     driver::base::kobject::KObject,
     filesystem::vfs::{mount::MountFlags, FSMAKER},
     libs::{casting::DowncastArc, once::Once},
-    process::ProcessManager,
+    process::{
+        cred::{ns_capable, CAPFlags},
+        namespace::{
+            net_namespace::INIT_NET_NAMESPACE, user_namespace::UserNamespace, NamespaceOps,
+        },
+        ProcessManager,
+    },
     register_mountable_fs,
 };
-use alloc::sync::Arc;
+use alloc::{string::String, sync::Arc, vec::Vec};
 use log::{info, warn};
 use system_error::SystemError;
 
@@ -29,10 +38,6 @@ pub fn sysfs_instance() -> &'static SysFS {
     unsafe {
         return SYSFS_INSTANCE.as_deref().unwrap();
     }
-}
-
-pub fn sysfs_filesystem() -> Result<Arc<SysFS>, SystemError> {
-    unsafe { SYSFS_INSTANCE.as_ref().cloned().ok_or(SystemError::ENODEV) }
 }
 
 pub fn sysfs_init() -> Result<(), SystemError> {
@@ -209,6 +214,8 @@ bitflags! {
 pub struct SysFS {
     root_inode: Arc<KernFSInode>,
     kernfs: Arc<KernFS>,
+    netns_tag: KernFSNamespaceTag,
+    owner_user_ns: Arc<UserNamespace>,
 }
 
 impl SysFS {
@@ -217,13 +224,30 @@ impl SysFS {
 
         let root_inode: Arc<KernFSInode> = kernfs.root_inode().downcast_arc().unwrap();
 
-        let sysfs = SysFS { root_inode, kernfs };
+        // Sysfs is initialized before process management, so the boot mount
+        // binds explicitly to the initial network namespace.
+        let netns = INIT_NET_NAMESPACE.clone();
+        let sysfs = SysFS {
+            root_inode,
+            kernfs,
+            netns_tag: KernFSNamespaceTag::new(netns.ns_common().nsid.data()),
+            owner_user_ns: netns.user_ns().clone(),
+        };
 
         return sysfs;
     }
 
     pub fn root_inode(&self) -> &Arc<KernFSInode> {
         return &self.root_inode;
+    }
+
+    fn view_for(&self, netns_tag: KernFSNamespaceTag, owner_user_ns: Arc<UserNamespace>) -> Self {
+        Self {
+            root_inode: self.root_inode.clone(),
+            kernfs: self.kernfs.clone(),
+            netns_tag,
+            owner_user_ns,
+        }
     }
 
     /// 警告：重复的sysfs entry
@@ -244,6 +268,48 @@ impl FileSystem for SysFS {
 
     fn root_inode(&self) -> Arc<dyn super::vfs::IndexNode> {
         return self.root_inode.clone();
+    }
+
+    fn mount_owner_user_ns(&self) -> Option<Arc<UserNamespace>> {
+        Some(self.owner_user_ns.clone())
+    }
+
+    fn find_in_view(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+        name: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let inode = inode
+            .clone()
+            .downcast_arc::<KernFSInode>()
+            .ok_or(SystemError::EINVAL)?;
+        inode.find_ns(name, self.netns_tag)
+    }
+
+    fn find_bytes_in_view(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+        name: &[u8],
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        let name = core::str::from_utf8(name).map_err(|_| SystemError::EIO)?;
+        self.find_in_view(inode, name)
+    }
+
+    fn list_in_view(&self, inode: &Arc<dyn IndexNode>) -> Result<Vec<String>, SystemError> {
+        let inode = inode
+            .clone()
+            .downcast_arc::<KernFSInode>()
+            .ok_or(SystemError::EINVAL)?;
+        inode.list_ns(self.netns_tag)
+    }
+
+    fn list_entries_in_view(
+        &self,
+        _inode: &Arc<dyn IndexNode>,
+    ) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
+        // Kernfs supplies names lazily; MountFS resolves their metadata through
+        // this same view, so no raw list_entries path can bypass filtering.
+        Ok(None)
     }
 
     fn info(&self) -> super::vfs::FsInfo {
@@ -271,14 +337,36 @@ impl MountableFileSystem for SysFS {
         _raw_data: Option<&str>,
         _source: &str,
     ) -> Result<Option<Arc<dyn FileSystemMakerData + 'static>>, SystemError> {
-        // sysfs 不需要任何额外的挂载数据
-        Ok(None)
+        let netns = ProcessManager::current_netns();
+        if !ns_capable(netns.user_ns(), CAPFlags::CAP_SYS_ADMIN) {
+            return Err(SystemError::EPERM);
+        }
+        Ok(Some(Arc::new(SysFSMountData {
+            netns_tag: KernFSNamespaceTag::new(netns.ns_common().nsid.data()),
+            owner_user_ns: netns.user_ns().clone(),
+        })))
     }
 
     fn make_fs(
-        _data: Option<&dyn FileSystemMakerData>,
+        data: Option<&dyn FileSystemMakerData>,
     ) -> Result<Arc<dyn FileSystem + 'static>, SystemError> {
-        Ok(sysfs_filesystem()?)
+        let data = data
+            .and_then(|data| data.as_any().downcast_ref::<SysFSMountData>())
+            .ok_or(SystemError::EINVAL)?;
+        Ok(Arc::new(
+            sysfs_instance().view_for(data.netns_tag, data.owner_user_ns.clone()),
+        ))
+    }
+}
+
+struct SysFSMountData {
+    netns_tag: KernFSNamespaceTag,
+    owner_user_ns: Arc<UserNamespace>,
+}
+
+impl FileSystemMakerData for SysFSMountData {
+    fn as_any(&self) -> &dyn Any {
+        self
     }
 }
 

--- a/kernel/src/filesystem/sysfs/symlink.rs
+++ b/kernel/src/filesystem/sysfs/symlink.rs
@@ -57,6 +57,26 @@ impl SysFS {
         }
     }
 
+    /// Remove a class-style link using the target inode's namespace identity.
+    pub fn remove_link_to(&self, kobj: &Arc<dyn KObject>, target: &Arc<dyn KObject>, name: String) {
+        let Some(parent) = kobj.inode() else {
+            return;
+        };
+        let Some(namespace) = target.inode().and_then(|inode| inode.namespace()) else {
+            self.remove_link(kobj, name);
+            return;
+        };
+        match parent.remove_in_namespace(&name, namespace) {
+            Ok(()) | Err(SystemError::ENOENT) => {}
+            Err(err) => warn!(
+                "sysfs: failed to remove namespaced symlink '{}' under '{}': {:?}",
+                name,
+                kobj.name(),
+                err
+            ),
+        }
+    }
+
     fn do_create_link(
         &self,
         kobj: Option<&Arc<dyn KObject>>,
@@ -85,7 +105,12 @@ impl SysFS {
     ) -> Result<(), SystemError> {
         let target_inode = target.inode().ok_or(SystemError::ENOENT)?;
 
-        let target_abs_path = "/sys".to_string() + &self.kernfs_path(&target_inode).to_owned();
+        let target_abs_path = if inode.namespace_children_enabled() {
+            let target_parent = target_inode.parent().ok_or(SystemError::ENOENT)?;
+            self.child_relative_path(inode, &target_parent, &target_inode.name())?
+        } else {
+            "/sys".to_string() + &self.kernfs_path(&target_inode).to_owned()
+        };
         // let current_path = self.kernfs_path(inode);
         // debug!("sysfs: create link {} to {}", current_path, target_abs_path);
 

--- a/kernel/src/filesystem/sysfs/symlink.rs
+++ b/kernel/src/filesystem/sysfs/symlink.rs
@@ -105,7 +105,10 @@ impl SysFS {
     ) -> Result<(), SystemError> {
         let target_inode = target.inode().ok_or(SystemError::ENOENT)?;
 
-        let target_abs_path = if inode.namespace_children_enabled() {
+        // A link exposed through a namespace-filtered sysfs view must remain
+        // inside that mount. This covers both class links stored under a
+        // namespace-enabled parent and links inside a tagged device inode.
+        let target_abs_path = if inode.namespace_children_enabled() || inode.namespace().is_some() {
             let target_parent = target_inode.parent().ok_or(SystemError::ENOENT)?;
             self.child_relative_path(inode, &target_parent, &target_inode.name())?
         } else {

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -2306,6 +2306,43 @@ pub trait FileSystem: Any + Sync + Send + Debug {
     /// @brief 获取当前文件系统的root inode的指针
     fn root_inode(&self) -> Arc<dyn IndexNode>;
 
+    /// Optional owner for a newly created VFS superblock. Bind mounts and
+    /// mount-namespace copies reuse the existing superblock state.
+    fn mount_owner_user_ns(
+        &self,
+    ) -> Option<Arc<crate::process::namespace::user_namespace::UserNamespace>> {
+        None
+    }
+
+    /// Per-filesystem mount view hooks. Pseudo filesystems may override these
+    /// without teaching generic inodes about mount policy.
+    fn find_in_view(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+        name: &str,
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        inode.find(name)
+    }
+
+    fn find_bytes_in_view(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+        name: &[u8],
+    ) -> Result<Arc<dyn IndexNode>, SystemError> {
+        inode.find_bytes(name)
+    }
+
+    fn list_in_view(&self, inode: &Arc<dyn IndexNode>) -> Result<Vec<String>, SystemError> {
+        inode.list()
+    }
+
+    fn list_entries_in_view(
+        &self,
+        inode: &Arc<dyn IndexNode>,
+    ) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
+        inode.list_entries()
+    }
+
     /// @brief 获取当前文件系统的信息
     fn info(&self) -> FsInfo;
 

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -962,6 +962,10 @@ struct MountStateInit {
 
 impl SuperBlockState {
     pub fn new(flags: MountFlags) -> Self {
+        Self::new_with_owner(flags, ProcessManager::current_user_ns())
+    }
+
+    pub fn new_with_owner(flags: MountFlags, owner_user_ns: Arc<UserNamespace>) -> Self {
         let flags = flags & MountFlags::SB_SETTABLE_MASK;
         Self {
             fsnotify_id: NEXT_SUPERBLOCK_FSNOTIFY_ID.fetch_add(1, Ordering::Relaxed),
@@ -969,7 +973,7 @@ impl SuperBlockState {
             fsnotify_object_epoch: AtomicUsize::new(0),
             fsnotify_presence: Arc::new(MountedFsNotifyPresence::default()),
             fsnotify_link_epochs: core::array::from_fn(|_| AtomicUsize::new(0)),
-            owner_user_ns: ProcessManager::current_user_ns(),
+            owner_user_ns,
             flags: RwSem::new(flags),
             synchronous: AtomicBool::new(flags.contains(MountFlags::SYNCHRONOUS)),
             write_count: AtomicUsize::new(0),
@@ -1591,7 +1595,11 @@ impl MountFS {
         mount_flags: MountFlags,
         mount_source: Option<String>,
     ) -> Result<Arc<Self>, SystemError> {
-        let super_block_state = Arc::new(SuperBlockState::new(mount_flags));
+        let owner_user_ns = inner_filesystem
+            .mount_owner_user_ns()
+            .unwrap_or_else(ProcessManager::current_user_ns);
+        let super_block_state =
+            Arc::new(SuperBlockState::new_with_owner(mount_flags, owner_user_ns));
         if let Some(domain) = inner_filesystem.page_cache_writeback_domain() {
             domain.bind(&inner_filesystem, &super_block_state)?;
         }
@@ -4414,7 +4422,12 @@ impl MountFSInode {
 
         let super_block_state = match super_block_state {
             Some(super_block_state) => super_block_state,
-            None => Arc::new(SuperBlockState::new(mount_flags)),
+            None => {
+                let owner_user_ns = inner_fs
+                    .mount_owner_user_ns()
+                    .unwrap_or_else(ProcessManager::current_user_ns);
+                Arc::new(SuperBlockState::new_with_owner(mount_flags, owner_user_ns))
+            }
         };
         if let Some(domain) = inner_fs.page_cache_writeback_domain() {
             domain.bind(&inner_fs, &super_block_state)?;
@@ -4682,7 +4695,10 @@ impl MountFSInode {
             let _namespace_guard = base.mount_fs.super_block_state.dentry_namespace_lock.read();
             // Since downward lookups may cross filesystem boundaries, wrap the
             // exact alias before releasing rename serialization.
-            let inner_inode = base.dentry.inode.find(name)?;
+            let inner_inode = base
+                .mount_fs
+                .inner_filesystem
+                .find_in_view(&base.dentry.inode, name)?;
             let dname = DName::from(name);
             let mount_inode =
                 MountFSInode::new_child(inner_inode.clone(), base.mount_fs.clone(), &base, dname)?;
@@ -5496,7 +5512,9 @@ impl IndexNode for MountFSInode {
         // Mount dentries are currently keyed by UTF-8 DName. Raw-name lookup is
         // still required for metadata/whiteout checks during getdents, so pass
         // byte-only names to the backing filesystem without inventing a lossy key.
-        self.dentry.inode.find_bytes(name)
+        self.mount_fs
+            .inner_filesystem
+            .find_bytes_in_view(&self.dentry.inode, name)
     }
 
     #[inline]
@@ -5524,12 +5542,17 @@ impl IndexNode for MountFSInode {
 
     #[inline]
     fn list(&self) -> Result<alloc::vec::Vec<alloc::string::String>, SystemError> {
-        return self.dentry.inode.list();
+        return self
+            .mount_fs
+            .inner_filesystem
+            .list_in_view(&self.dentry.inode);
     }
 
     #[inline]
     fn list_entries(&self) -> Result<Option<Vec<DirectoryEntry>>, SystemError> {
-        self.dentry.inode.list_entries()
+        self.mount_fs
+            .inner_filesystem
+            .list_entries_in_view(&self.dentry.inode)
     }
 
     fn mount(

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -6,6 +6,7 @@ use crate::init::initcall::INITCALL_SUBSYS;
 use crate::libs::mutex::Mutex;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
 use crate::libs::rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard};
+use crate::libs::spinlock::SpinLock;
 use crate::libs::wait_queue::WaitQueue;
 use crate::net::neighbor::NeighborTable;
 use crate::net::routing::Router;
@@ -56,6 +57,58 @@ pub static mut NETNS_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
 const PACKET_SOCKET_CLEANUP_RETRY_MIN: Duration = Duration::from_millis(100);
 const PACKET_SOCKET_CLEANUP_RETRY_MAX: Duration = Duration::from_secs(5);
+
+type NetnsDeviceMap = BTreeMap<usize, Arc<dyn Iface>>;
+
+#[derive(Debug)]
+struct NetnsTeardownWork {
+    devices: Arc<SpinLock<Option<NetnsDeviceMap>>>,
+    work: Arc<Work>,
+}
+
+impl NetnsTeardownWork {
+    fn new() -> Self {
+        let devices = Arc::new(SpinLock::new(None));
+        let worker_devices = devices.clone();
+        let work = Work::new(move || {
+            let devices = worker_devices
+                .lock()
+                .take()
+                .expect("queued netns teardown work must own its device payload");
+            teardown_netns_devices(devices);
+        });
+        Self { devices, work }
+    }
+
+    fn enqueue(&self, devices: NetnsDeviceMap) {
+        let mut slot = self.devices.lock();
+        debug_assert!(slot.is_none());
+        *slot = Some(devices);
+        drop(slot);
+        NETNS_TEARDOWN_WQ.enqueue(self.work.clone());
+    }
+}
+
+fn teardown_netns_devices(devices: NetnsDeviceMap) {
+    for iface in devices.values() {
+        iface.common().close_tx_and_wait();
+        iface.begin_admin_down();
+    }
+    for iface in devices.values() {
+        if let Some(napi) = iface.napi_struct() {
+            crate::driver::net::napi::napi_pause_and_wait(&napi);
+            iface.quiesce_admin_down();
+            crate::driver::net::napi::napi_disable(&napi);
+        } else {
+            iface.quiesce_admin_down();
+        }
+    }
+    for iface in devices.values() {
+        iface.clear_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_PRESENT);
+        crate::driver::net::netdev_unregister_kobject(iface.clone());
+        iface.clear_net_namespace();
+    }
+}
 
 fn try_snapshot_devices(
     devices: &BTreeMap<usize, Arc<dyn Iface>>,
@@ -113,7 +166,9 @@ pub struct NetNamespace {
     ///
     /// 注意：该结构会在 bind/connect 等路径被访问，且这些路径可能会获取可睡眠的 Mutex，
     /// 因此这里使用可睡眠的 `RwSem`，避免自旋锁 + schedule 的组合导致崩溃。
-    device_list: RwSem<BTreeMap<usize, Arc<dyn Iface>>>,
+    device_list: RwSem<NetnsDeviceMap>,
+    /// Preallocated payload slot and work item for allocation-free final drop.
+    teardown_work: NetnsTeardownWork,
     /// Configured, non-aging neighbors owned by this network namespace.
     neighbor_table: NeighborTable,
     /// Per-netns UDP port reservation and local-delivery table.
@@ -505,6 +560,7 @@ impl NetNamespace {
             inner: RwLock::new(inner),
             poller: NetnsPoller::new(self_ref.clone()),
             device_list: RwSem::new(BTreeMap::new()),
+            teardown_work: NetnsTeardownWork::new(),
             neighbor_table: NeighborTable::new(),
             udp_bindings: UdpBindingTable::default(),
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
@@ -545,6 +601,7 @@ impl NetNamespace {
             inner: RwLock::new(inner),
             poller: NetnsPoller::new(self_ref.clone()),
             device_list: RwSem::new(BTreeMap::new()),
+            teardown_work: NetnsTeardownWork::new(),
             neighbor_table: NeighborTable::new(),
             udp_bindings: UdpBindingTable::default(),
             packet_sockets: RcuArcSlot::new(Arc::new(PacketSocketRegistrySnapshot::default())),
@@ -1195,33 +1252,14 @@ impl Drop for NetNamespace {
         }
 
         // The last netns Arc may be released by its own NAPI poll stack. Move
-        // the devices out without allocating and defer every blocking teardown
-        // step to process context, where waiting for the in-flight poll cannot
-        // self-deadlock. The namespace-owned FIB and neighbor state disappear
-        // with this object, so the worker only quiesces devices and removes
-        // their driver-core/sysfs projections.
+        // the devices into the preallocated work payload and enqueue it without
+        // allocating. Every blocking teardown step then runs in process context,
+        // where waiting for the in-flight poll cannot self-deadlock. The
+        // namespace-owned FIB and neighbor state disappear with this object, so
+        // the worker only quiesces devices and removes driver-core projections.
         let devices = core::mem::take(self.device_list.get_mut());
         if !devices.is_empty() {
-            NETNS_TEARDOWN_WQ.enqueue(Work::new(move || {
-                for iface in devices.values() {
-                    iface.common().close_tx_and_wait();
-                    iface.begin_admin_down();
-                }
-                for iface in devices.values() {
-                    if let Some(napi) = iface.napi_struct() {
-                        crate::driver::net::napi::napi_pause_and_wait(&napi);
-                        iface.quiesce_admin_down();
-                        crate::driver::net::napi::napi_disable(&napi);
-                    } else {
-                        iface.quiesce_admin_down();
-                    }
-                }
-                for iface in devices.values() {
-                    iface.clear_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_PRESENT);
-                    crate::driver::net::netdev_unregister_kobject(iface.clone());
-                    iface.clear_net_namespace();
-                }
-            }));
+            self.teardown_work.enqueue(devices);
         }
     }
 }

--- a/kernel/src/process/namespace/net_namespace.rs
+++ b/kernel/src/process/namespace/net_namespace.rs
@@ -1,6 +1,7 @@
 use crate::driver::net::bridge::BridgeDriver;
 use crate::driver::net::loopback::LoopbackInterface;
 use crate::driver::net::IfacePollScope;
+use crate::exception::workqueue::{Work, WorkQueue};
 use crate::init::initcall::INITCALL_SUBSYS;
 use crate::libs::mutex::Mutex;
 use crate::libs::rwlock::{RwLock, RwLockReadGuard, RwLockWriteGuard};
@@ -44,6 +45,8 @@ use unified_init::macros::unified_init;
 lazy_static! {
     /// # 所有网络设备，进程，socket的初始网络命名空间
     pub static ref INIT_NET_NAMESPACE: Arc<NetNamespace> = NetNamespace::new_root();
+    /// Netns teardown may wait for NAPI and must not block unrelated system work.
+    static ref NETNS_TEARDOWN_WQ: Arc<WorkQueue> = WorkQueue::new("netns_cleanup");
 }
 
 /// # 网络命名空间计数器
@@ -75,6 +78,7 @@ fn try_snapshot_devices(
 
 #[unified_init(INITCALL_SUBSYS)]
 pub fn root_net_namespace_init() -> Result<(), SystemError> {
+    lazy_static::initialize(&NETNS_TEARDOWN_WQ);
     // 创建root网络命名空间的轮询线程
     NetNamespace::create_polling_thread(INIT_NET_NAMESPACE.clone(), "root_netns".to_string());
 
@@ -567,7 +571,7 @@ impl NetNamespace {
         // registration lifecycle makes it PRESENT; as in Linux's
         // loopback_net_init(), it remains administratively down until
         // userspace opens the link.
-        crate::driver::net::register_netdevice_in_namespace(&netns, loopback)?;
+        crate::driver::net::register_netdevice(&netns, loopback)?;
 
         Ok(netns)
     }
@@ -1174,6 +1178,51 @@ impl NamespaceOps for NetNamespace {
 impl Drop for NetNamespace {
     fn drop(&mut self) {
         self.poller.stop();
+
+        if let Some(loopback) = self.loopback_iface() {
+            let loopback_iface = loopback as Arc<dyn Iface>;
+            if !self
+                .device_list
+                .get_mut()
+                .get(&crate::net::LOOPBACK_IFINDEX)
+                .is_some_and(|device| Arc::ptr_eq(device, &loopback_iface))
+            {
+                log::error!(
+                    "netns {} final release contains a non-canonical loopback",
+                    self.ns_common.nsid.data()
+                );
+            }
+        }
+
+        // The last netns Arc may be released by its own NAPI poll stack. Move
+        // the devices out without allocating and defer every blocking teardown
+        // step to process context, where waiting for the in-flight poll cannot
+        // self-deadlock. The namespace-owned FIB and neighbor state disappear
+        // with this object, so the worker only quiesces devices and removes
+        // their driver-core/sysfs projections.
+        let devices = core::mem::take(self.device_list.get_mut());
+        if !devices.is_empty() {
+            NETNS_TEARDOWN_WQ.enqueue(Work::new(move || {
+                for iface in devices.values() {
+                    iface.common().close_tx_and_wait();
+                    iface.begin_admin_down();
+                }
+                for iface in devices.values() {
+                    if let Some(napi) = iface.napi_struct() {
+                        crate::driver::net::napi::napi_pause_and_wait(&napi);
+                        iface.quiesce_admin_down();
+                        crate::driver::net::napi::napi_disable(&napi);
+                    } else {
+                        iface.quiesce_admin_down();
+                    }
+                }
+                for iface in devices.values() {
+                    iface.clear_net_state(crate::driver::net::NetDeivceState::__LINK_STATE_PRESENT);
+                    crate::driver::net::netdev_unregister_kobject(iface.clone());
+                    iface.clear_net_namespace();
+                }
+            }));
+        }
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -716,10 +716,15 @@ int RunFreshNetnsSysfsProjectionCase() {
     if (result == 0) {
         const std::string class_new = mountpoint + "/class/net/" + renamed;
         const std::string device_new = mountpoint + "/devices/virtual/net/" + renamed;
+        const std::string subsystem = device_new + "/subsystem";
         struct stat class_link_after {};
         struct stat class_target_after {};
         struct stat device_after {};
+        struct stat subsystem_device {};
         struct stat ignored {};
+        char subsystem_target[PATH_MAX] = {};
+        const ssize_t subsystem_target_len =
+            readlink(subsystem.c_str(), subsystem_target, sizeof(subsystem_target));
         if (lstat(class_old.c_str(), &ignored) == 0 || errno != ENOENT ||
             stat(device_old.c_str(), &ignored) == 0 || errno != ENOENT ||
             lstat(class_new.c_str(), &class_link_after) != 0 ||
@@ -729,7 +734,10 @@ int RunFreshNetnsSysfsProjectionCase() {
             class_target_after.st_ino != device_after.st_ino ||
             device_after.st_ino != device_before.st_ino ||
             !DirectoryContainsOnly(mountpoint + "/class/net", renamed) ||
-            !DirectoryContainsOnly(mountpoint + "/devices/virtual/net", renamed)) {
+            !DirectoryContainsOnly(mountpoint + "/devices/virtual/net", renamed) ||
+            subsystem_target_len <= 0 || subsystem_target[0] == '/' ||
+            stat((subsystem + "/" + renamed).c_str(), &subsystem_device) != 0 ||
+            subsystem_device.st_ino != device_after.st_ino) {
             result = 15;
         }
         // The inherited boot mount remains bound to the initial netns.

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -1,13 +1,16 @@
 #include <gtest/gtest.h>
 
 #include <arpa/inet.h>
+#include <fcntl.h>
 #include <linux/if_link.h>
 #include <linux/if.h>
 #include <linux/netlink.h>
 #include <linux/rtnetlink.h>
 #include <poll.h>
 #include <sched.h>
+#include <dirent.h>
 #include <sys/ioctl.h>
+#include <sys/mount.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/time.h>
@@ -392,6 +395,61 @@ std::optional<int> FindIfindex(const char* name) {
     return request.ifr_ifindex;
 }
 
+bool DirectoryContainsOnly(const std::string& path, std::string_view expected) {
+    DIR* directory = opendir(path.c_str());
+    if (directory == nullptr) return false;
+    bool found = false;
+    bool valid = true;
+    while (dirent* entry = readdir(directory)) {
+        const std::string_view name(entry->d_name);
+        if (name == "." || name == "..") continue;
+        if (name != expected || found) {
+            valid = false;
+            break;
+        }
+        found = true;
+    }
+    closedir(directory);
+    return valid && found;
+}
+
+bool SendFileDescriptor(int socket_fd, int file_fd) {
+    char byte = 'F';
+    iovec io {&byte, sizeof(byte)};
+    std::array<unsigned char, CMSG_SPACE(sizeof(int))> control {};
+    msghdr message {};
+    message.msg_iov = &io;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data();
+    message.msg_controllen = control.size();
+    cmsghdr* header = CMSG_FIRSTHDR(&message);
+    header->cmsg_level = SOL_SOCKET;
+    header->cmsg_type = SCM_RIGHTS;
+    header->cmsg_len = CMSG_LEN(sizeof(int));
+    std::memcpy(CMSG_DATA(header), &file_fd, sizeof(file_fd));
+    return sendmsg(socket_fd, &message, 0) == 1;
+}
+
+int ReceiveFileDescriptor(int socket_fd) {
+    char byte = 0;
+    iovec io {&byte, sizeof(byte)};
+    std::array<unsigned char, CMSG_SPACE(sizeof(int))> control {};
+    msghdr message {};
+    message.msg_iov = &io;
+    message.msg_iovlen = 1;
+    message.msg_control = control.data();
+    message.msg_controllen = control.size();
+    if (recvmsg(socket_fd, &message, 0) != 1) return -1;
+    cmsghdr* header = CMSG_FIRSTHDR(&message);
+    if (header == nullptr || header->cmsg_level != SOL_SOCKET ||
+        header->cmsg_type != SCM_RIGHTS || header->cmsg_len != CMSG_LEN(sizeof(int))) {
+        return -1;
+    }
+    int file_fd = -1;
+    std::memcpy(&file_fd, CMSG_DATA(header), sizeof(file_fd));
+    return file_fd;
+}
+
 int SetLinkUp(int fd, int ifindex, bool up, uint32_t seq) {
     struct {
         nlmsghdr header;
@@ -547,9 +605,8 @@ int RunRenameValidationCase() {
         const bool new_visible = stat(new_path.c_str(), &new_target) == 0;
         const bool old_visible = stat(old_path.c_str(), &old_after) == 0;
         if (IsDragonOS()) {
-            // DragonOS intentionally has no sysfs projection for the fresh
-            // namespace. Renaming its lo must not touch the initial-netns
-            // inode visible through this mount.
+            // This inherited sysfs mount remains bound to the initial netns;
+            // renaming fresh-netns lo must not change that projection.
             if (new_visible || !old_visible || old_after.st_ino != old_target.st_ino) {
                 projection_result = 17;
             }
@@ -618,6 +675,115 @@ int RunDragonOsSysfsRenameCase() {
         return 18;
     }
     return result;
+}
+
+int RunFreshNetnsSysfsProjectionCase() {
+    if (unshare(CLONE_NEWUSER | CLONE_NEWNET | CLONE_NEWNS) != 0) return 77;
+    if (mount(nullptr, "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0) return 77;
+
+    const std::string mountpoint = "/tmp/dunit-netns-sysfs";
+    if (mkdir(mountpoint.c_str(), 0755) != 0 && errno != EEXIST) return 10;
+    if (mount("sysfs", mountpoint.c_str(), "sysfs", MS_NOSUID | MS_NODEV | MS_NOEXEC,
+              nullptr) != 0) {
+        return errno == EPERM ? 77 : 11;
+    }
+
+    int result = 0;
+    const std::string class_old = mountpoint + "/class/net/lo";
+    const std::string device_old = mountpoint + "/devices/virtual/net/lo";
+    struct stat class_link_before {};
+    struct stat class_target_before {};
+    struct stat device_before {};
+    if (lstat(class_old.c_str(), &class_link_before) != 0 ||
+        stat(class_old.c_str(), &class_target_before) != 0 ||
+        stat(device_old.c_str(), &device_before) != 0 ||
+        class_target_before.st_ino != device_before.st_ino ||
+        !DirectoryContainsOnly(mountpoint + "/class/net", "lo") ||
+        !DirectoryContainsOnly(mountpoint + "/devices/virtual/net", "lo")) {
+        result = 12;
+    }
+
+    FdGuard route(OpenRouteSocket());
+    const auto ifindex = FindIfindex("lo");
+    uint32_t seq = 1;
+    const std::string renamed = "dunitns0";
+    if (result == 0 && (route.Get() < 0 || !ifindex.has_value())) result = 13;
+    if (result == 0 &&
+        SetLink(route.Get(), *ifindex, 0, 0, std::nullopt, renamed, seq++) != 0) {
+        result = 14;
+    }
+
+    if (result == 0) {
+        const std::string class_new = mountpoint + "/class/net/" + renamed;
+        const std::string device_new = mountpoint + "/devices/virtual/net/" + renamed;
+        struct stat class_link_after {};
+        struct stat class_target_after {};
+        struct stat device_after {};
+        struct stat ignored {};
+        if (lstat(class_old.c_str(), &ignored) == 0 || errno != ENOENT ||
+            stat(device_old.c_str(), &ignored) == 0 || errno != ENOENT ||
+            lstat(class_new.c_str(), &class_link_after) != 0 ||
+            stat(class_new.c_str(), &class_target_after) != 0 ||
+            stat(device_new.c_str(), &device_after) != 0 ||
+            class_link_after.st_ino != class_link_before.st_ino ||
+            class_target_after.st_ino != device_after.st_ino ||
+            device_after.st_ino != device_before.st_ino ||
+            !DirectoryContainsOnly(mountpoint + "/class/net", renamed) ||
+            !DirectoryContainsOnly(mountpoint + "/devices/virtual/net", renamed)) {
+            result = 15;
+        }
+        // The inherited boot mount remains bound to the initial netns.
+        if (stat("/sys/class/net/lo", &ignored) != 0 ||
+            stat((std::string("/sys/class/net/") + renamed).c_str(), &ignored) == 0) {
+            result = 16;
+        }
+    }
+
+    if (umount2(mountpoint.c_str(), MNT_DETACH) != 0 && result == 0) result = 17;
+    rmdir(mountpoint.c_str());
+    return result;
+}
+
+int RunStaleSysfsFdCase() {
+    int sockets[2] = {-1, -1};
+    if (socketpair(AF_UNIX, SOCK_STREAM, 0, sockets) != 0) return 10;
+    const pid_t child = fork();
+    if (child < 0) return 11;
+    if (child == 0) {
+        close(sockets[0]);
+        if (unshare(CLONE_NEWUSER | CLONE_NEWNET | CLONE_NEWNS) != 0 ||
+            mount(nullptr, "/", nullptr, MS_REC | MS_PRIVATE, nullptr) != 0) {
+            _exit(77);
+        }
+        const char* mountpoint = "/tmp/dunit-stale-sysfs";
+        if ((mkdir(mountpoint, 0755) != 0 && errno != EEXIST) ||
+            mount("sysfs", mountpoint, "sysfs", MS_NOSUID | MS_NODEV | MS_NOEXEC,
+                  nullptr) != 0) {
+            _exit(errno == EPERM ? 77 : 12);
+        }
+        const std::string type = std::string(mountpoint) + "/class/net/lo/type";
+        FdGuard attribute(open(type.c_str(), O_RDONLY));
+        if (attribute.Get() < 0 || !SendFileDescriptor(sockets[1], attribute.Get())) _exit(13);
+        umount2(mountpoint, MNT_DETACH);
+        close(sockets[1]);
+        _exit(0);
+    }
+
+    close(sockets[1]);
+    FdGuard attribute(ReceiveFileDescriptor(sockets[0]));
+    close(sockets[0]);
+    int status = 0;
+    if (waitpid(child, &status, 0) != child || !WIFEXITED(status)) return 14;
+    if (WEXITSTATUS(status) == 77) return 77;
+    if (WEXITSTATUS(status) != 0 || attribute.Get() < 0) return 15;
+
+    char buffer[64] = {};
+    errno = 0;
+    const ssize_t read_result = pread(attribute.Get(), buffer, sizeof(buffer), 0);
+    // Namespace and iface objects may remain alive behind RCU/NAPI references,
+    // so an opened fd can still complete. Once the kobject weak reference is
+    // gone, the callback must return ENODEV instead of panicking.
+    return read_result >= 0 || errno == ENODEV ? 0 : 16;
 }
 
 int RunOwnerNetnsMoveUeventCase() {
@@ -975,6 +1141,22 @@ TEST(RtnetlinkLinkSemantics, RenameValidatesNamesFormatsAndProjectedIdentity) {
 TEST(RtnetlinkLinkSemantics, DragonOsInitialNetnsRenamePreservesSysfsInodes) {
     if (!IsDragonOS()) GTEST_SKIP() << "initial-netns sysfs projection is DragonOS coverage";
     EXPECT_EQ(RunChild(RunDragonOsSysfsRenameCase), 0);
+}
+
+TEST(RtnetlinkLinkSemantics, FreshNetworkNamespaceHasMountedSysfsProjection) {
+    const int result = RunChild(RunFreshNetnsSysfsProjectionCase);
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host cannot create and mount a network-namespace sysfs view";
+    }
+    EXPECT_EQ(result, 0);
+}
+
+TEST(RtnetlinkLinkSemantics, StaleSysfsAttributeFdFailsWithoutKernelPanic) {
+    const int result = RunStaleSysfsFdCase();
+    if (result == 77 && !IsDragonOS()) {
+        GTEST_SKIP() << "host cannot create and mount a network-namespace sysfs view";
+    }
+    EXPECT_EQ(result, 0);
 }
 
 TEST(RtnetlinkLinkSemantics, MoveUeventIsDeliveredOnlyToOwningNetworkNamespace) {


### PR DESCRIPTION
## Summary

- give netdevices in every network namespace a real kobject and sysfs lifecycle
- isolate same-named devices with namespace-keyed kernfs children and mount-time sysfs views
- preserve inode identity across allocation-free rename commits and route uevents to the device owner
- defer final netns device teardown to a dedicated workqueue to avoid NAPI self-wait

## Design

The network namespace device table remains the ownership source of truth. Kernfs stores only a stable numeric namespace tag in a two-level `tag -> name -> inode` primary index. Sysfs mounts capture an immutable mount-time tag and owning user namespace, while narrow VFS filesystem-view hooks cover lookup and enumeration without exposing networking concepts to generic VFS code.

Rename preparation owns every fallible string allocation and commit only re-keys existing entries inside their current namespace buckets. Driver-core registration, class links, teardown, and uevents use the same tagged kobject identity.

Final namespace release moves devices to a dedicated cleanup workqueue before waiting for NAPI and removing driver-core projections, preventing teardown from waiting on its own poll stack or blocking unrelated system work.

## Validation

- `make fmt`
- `make kernel`
- host `rtnetlink_link_semantics_test`: 9 passed, 1 DragonOS-only test skipped
- DragonOS/QEMU `rtnetlink_link_semantics_test`: 10 passed
- adversarial reviews for correctness, concurrency/security, performance, maintainability, and overdesign: all GO after fixes

Closes #2254