### PR TITLE
fix(net): implement Linux-compatible transmit queue length queries

### DIFF
--- a/kernel/src/driver/net/iface_common.rs
+++ b/kernel/src/driver/net/iface_common.rs
@@ -5,6 +5,9 @@ pub struct IfaceCommon {
     pub(super) name: RwLock<String>,
     pub(super) flags: AtomicU32,
     pub(super) mtu: AtomicUsize,
+    /// Linux-visible queue configuration, not a hardware descriptor count.
+    /// Immutable until transmit-queue reconfiguration is supported.
+    tx_queue_len: u32,
     pub(super) type_: InterfaceType,
     tx_admission: tx_admission::TxAdmission,
     pub(super) smol_iface: Mutex<smoltcp::iface::Interface>,
@@ -118,6 +121,7 @@ impl IfaceCommon {
             router_common_data,
             flags: AtomicU32::new(flags.bits()),
             mtu: AtomicUsize::new(mtu),
+            tx_queue_len: 1000,
             type_,
             tx_admission: tx_admission::TxAdmission::new(flags.contains(InterfaceFlags::UP)),
             napi_struct: RwLock::new(None),
@@ -1359,6 +1363,10 @@ impl IfaceCommon {
 
     pub fn type_(&self) -> InterfaceType {
         self.type_
+    }
+
+    pub fn tx_queue_len(&self) -> u32 {
+        self.tx_queue_len
     }
 
     pub fn mtu(&self) -> usize {

--- a/kernel/src/driver/net/sysfs.rs
+++ b/kernel/src/driver/net/sysfs.rs
@@ -716,12 +716,9 @@ impl Attribute for AttrTxQueueLen {
         SysFSOpsSupport::ATTR_SHOW
     }
 
-    fn show(&self, _kobj: Arc<dyn KObject>, _buf: &mut [u8]) -> Result<usize, SystemError> {
-        todo!("AttrTxQueueLen::show")
-    }
-
-    fn store(&self, _kobj: Arc<dyn KObject>, _buf: &[u8]) -> Result<usize, SystemError> {
-        todo!("AttrTxQueueLen::store")
+    fn show(&self, kobj: Arc<dyn KObject>, buf: &mut [u8]) -> Result<usize, SystemError> {
+        let net_device = kobj.cast::<dyn Iface>().map_err(|_| SystemError::EINVAL)?;
+        sysfs_emit_str(buf, &format!("{}\n", net_device.common().tx_queue_len()))
     }
 }
 

--- a/kernel/src/net/socket/inode.rs
+++ b/kernel/src/net/socket/inode.rs
@@ -13,7 +13,7 @@ use system_error::SystemError;
 use super::{
     ioctl::{
         handle_netdev_mutation, handle_netdev_query, handle_siocgifconf, SIOCGIFCONF, SIOCGIFFLAGS,
-        SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMTU, SIOCSIFFLAGS, SIOCSIFMTU,
+        SIOCGIFHWADDR, SIOCGIFINDEX, SIOCGIFMTU, SIOCGIFTXQLEN, SIOCSIFFLAGS, SIOCSIFMTU,
     },
     Socket,
 };
@@ -154,7 +154,7 @@ impl<T: Socket + 'static> IndexNode for T {
     ) -> Result<usize, SystemError> {
         match cmd {
             SIOCGIFCONF => handle_siocgifconf(self.netns(), data),
-            SIOCGIFINDEX | SIOCGIFFLAGS | SIOCGIFMTU | SIOCGIFHWADDR => {
+            SIOCGIFINDEX | SIOCGIFFLAGS | SIOCGIFMTU | SIOCGIFHWADDR | SIOCGIFTXQLEN => {
                 handle_netdev_query(self.netns(), cmd, data)
             }
             SIOCSIFFLAGS | SIOCSIFMTU => handle_netdev_mutation(self.netns(), cmd, data),

--- a/kernel/src/net/socket/ioctl.rs
+++ b/kernel/src/net/socket/ioctl.rs
@@ -31,6 +31,7 @@ pub(super) const SIOCGIFMTU: u32 = 0x8921;
 pub(super) const SIOCSIFMTU: u32 = 0x8922;
 pub(super) const SIOCGIFHWADDR: u32 = 0x8927;
 pub(super) const SIOCGIFINDEX: u32 = 0x8933;
+pub(super) const SIOCGIFTXQLEN: u32 = 0x8942;
 
 /// Native x86_64 Linux `struct ifreq` layout.
 #[repr(C)]
@@ -153,6 +154,7 @@ pub(super) fn handle_netdev_query(
         SIOCGIFINDEX => ifreq.set_i32(iface.nic_id() as i32),
         SIOCGIFFLAGS => ifreq.set_flags(iface.user_visible_flags().bits()),
         SIOCGIFMTU => ifreq.set_i32(iface.mtu() as i32),
+        SIOCGIFTXQLEN => ifreq.set_i32(iface.common().tx_queue_len() as i32),
         SIOCGIFHWADDR => ifreq.set_hwaddr(&iface),
         _ => return Err(SystemError::ENOTTY),
     }

--- a/kernel/src/net/socket/netlink/route/kern/link.rs
+++ b/kernel/src/net/socket/netlink/route/kern/link.rs
@@ -156,6 +156,7 @@ fn iface_to_link_message(
         LinkAttr::Address(iface.mac().as_bytes().to_vec()),
         LinkAttr::Name(CString::new(iface.name()).map_err(|_| SystemError::EINVAL)?),
         LinkAttr::Mtu(iface.mtu() as u32),
+        LinkAttr::TxqLen(iface.common().tx_queue_len()),
         LinkAttr::Promiscuity(flags.promiscuity),
         LinkAttr::Allmulti(flags.allmulti),
     ];

--- a/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
+++ b/user/apps/tests/dunitest/suites/normal/rtnetlink_link_semantics.cc
@@ -203,6 +203,7 @@ struct LinkSnapshot {
     uint32_t flags;
     uint32_t mtu;
     std::string name;
+    std::optional<uint32_t> tx_queue_len;
 };
 
 struct RouteProbe {
@@ -361,7 +362,7 @@ std::optional<LinkSnapshot> QueryLink(int fd, int ifindex, uint32_t seq) {
 
             const auto* link = reinterpret_cast<const ifinfomsg*>(NLMSG_DATA(header));
             if (link->ifi_index != ifindex) continue;
-            LinkSnapshot result {link->ifi_flags, 0, {}};
+            LinkSnapshot result {link->ifi_flags, 0, {}, std::nullopt};
             bool found_mtu = false;
             bool found_name = false;
             int attr_length = IFLA_PAYLOAD(header);
@@ -370,6 +371,10 @@ std::optional<LinkSnapshot> QueryLink(int fd, int ifindex, uint32_t seq) {
                 if (attr->rta_type == IFLA_MTU && RTA_PAYLOAD(attr) == sizeof(uint32_t)) {
                     std::memcpy(&result.mtu, RTA_DATA(attr), sizeof(result.mtu));
                     found_mtu = true;
+                } else if (attr->rta_type == IFLA_TXQLEN && RTA_PAYLOAD(attr) == sizeof(uint32_t)) {
+                    uint32_t value;
+                    std::memcpy(&value, RTA_DATA(attr), sizeof(value));
+                    result.tx_queue_len = value;
                 } else if (attr->rta_type == IFLA_IFNAME && RTA_PAYLOAD(attr) > 0) {
                     const auto* value = static_cast<const char*>(RTA_DATA(attr));
                     const size_t payload = RTA_PAYLOAD(attr);
@@ -964,6 +969,92 @@ std::optional<uint32_t> QueryLinkMtu(int ifindex) {
             }
             return std::nullopt;
         }
+    }
+}
+
+TEST(RtnetlinkLinkSemantics, TxQueueLengthMatchesIoctlSysfsAndLinkDump) {
+    FdGuard route(OpenRouteSocket());
+    FdGuard single(OpenRouteSocket());
+    FdGuard control(socket(AF_INET, SOCK_DGRAM, 0));
+    ASSERT_GE(route.Get(), 0);
+    ASSERT_GE(single.Get(), 0);
+    ASSERT_GE(control.Get(), 0);
+    struct {
+        nlmsghdr header;
+        ifinfomsg link;
+    } request {};
+    request.header.nlmsg_len = NLMSG_LENGTH(sizeof(ifinfomsg));
+    request.header.nlmsg_type = RTM_GETLINK;
+    request.header.nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
+    request.header.nlmsg_seq = 2258;
+    request.link.ifi_family = AF_UNSPEC;
+    ASSERT_EQ(send(route.Get(), &request, request.header.nlmsg_len, 0),
+              request.header.nlmsg_len);
+
+    bool done = false;
+    bool found_loopback = false;
+    bool found_ethernet = false;
+    // Dump enumerates devices without depending on configured IP addresses.
+    // Bound the receive loop in addition to the socket timeout.
+    for (int batch = 0; batch < 128 && !done; ++batch) {
+        alignas(nlmsghdr) std::array<unsigned char, 32768> buffer {};
+        const ssize_t received = recv(route.Get(), buffer.data(), buffer.size(), MSG_TRUNC);
+        ASSERT_GT(received, 0) << strerror(errno);
+        ASSERT_LE(static_cast<size_t>(received), buffer.size());
+        int remaining = static_cast<int>(received);
+        for (auto* header = reinterpret_cast<nlmsghdr*>(buffer.data());
+             NLMSG_OK(header, remaining); header = NLMSG_NEXT(header, remaining)) {
+            ASSERT_EQ(header->nlmsg_seq, 2258u);
+            ASSERT_EQ(header->nlmsg_flags & NLM_F_DUMP_INTR, 0);
+            if (header->nlmsg_type == NLMSG_DONE) {
+                done = true;
+                break;
+            }
+            ASSERT_EQ(header->nlmsg_type, RTM_NEWLINK);
+            ASSERT_GE(header->nlmsg_len, NLMSG_LENGTH(sizeof(ifinfomsg)));
+            const auto* link = static_cast<const ifinfomsg*>(NLMSG_DATA(header));
+            std::optional<uint32_t> dump_qlen;
+            int length = IFLA_PAYLOAD(header);
+            for (auto* attr = IFLA_RTA(link); RTA_OK(attr, length);
+                 attr = RTA_NEXT(attr, length)) {
+                if (attr->rta_type != IFLA_TXQLEN) continue;
+                ASSERT_FALSE(dump_qlen.has_value());
+                ASSERT_EQ(RTA_PAYLOAD(attr), sizeof(uint32_t));
+                uint32_t value;
+                std::memcpy(&value, RTA_DATA(attr), sizeof(value));
+                dump_qlen = value;
+            }
+            ASSERT_TRUE(dump_qlen.has_value()) << link->ifi_index;
+            const auto snapshot = QueryLink(single.Get(), link->ifi_index, 2259);
+            ASSERT_TRUE(snapshot.has_value());
+            ASSERT_TRUE(snapshot->tx_queue_len.has_value());
+            EXPECT_EQ(*snapshot->tx_queue_len, *dump_qlen);
+            ifreq ifr {};
+            std::strncpy(ifr.ifr_name, snapshot->name.c_str(), IFNAMSIZ - 1);
+            ASSERT_EQ(ioctl(control.Get(), SIOCGIFTXQLEN, &ifr), 0);
+            EXPECT_EQ(static_cast<uint32_t>(ifr.ifr_qlen), *dump_qlen);
+
+            const std::string path = "/sys/class/net/" + snapshot->name + "/tx_queue_len";
+            FdGuard attribute(open(path.c_str(), O_RDONLY));
+            ASSERT_GE(attribute.Get(), 0) << path << ": " << strerror(errno);
+            std::array<char, 32> text {};
+            const ssize_t count = read(attribute.Get(), text.data(), text.size());
+            ASSERT_GT(count, 0) << strerror(errno);
+            EXPECT_EQ(std::string(text.data(), count), std::to_string(*dump_qlen) + "\n");
+            if (IsDragonOS()) {
+                EXPECT_EQ(*dump_qlen, 1000u);
+                struct stat metadata {};
+                ASSERT_EQ(fstat(attribute.Get(), &metadata), 0);
+                EXPECT_EQ(metadata.st_mode & 0222, 0u);
+            }
+            found_loopback |= snapshot->name == "lo";
+            found_ethernet |= link->ifi_type == 1;  // ARPHRD_ETHER
+        }
+    }
+    EXPECT_TRUE(done);
+    EXPECT_TRUE(found_loopback);
+    if (IsDragonOS()) {
+        EXPECT_TRUE(found_ethernet);
     }
 }
 

--- a/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_query.cc
+++ b/user/apps/tests/dunitest/suites/normal/socket_ioctl_netdev_query.cc
@@ -23,8 +23,8 @@
 
 namespace {
 
-constexpr std::array<unsigned long, 4> kQueryCommands = {
-    SIOCGIFINDEX, SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFHWADDR};
+constexpr std::array<unsigned long, 5> kQueryCommands = {
+    SIOCGIFINDEX, SIOCGIFFLAGS, SIOCGIFMTU, SIOCGIFHWADDR, SIOCGIFTXQLEN};
 constexpr unsigned char kSentinel = 0xa5;
 
 class ScopedFd {
@@ -119,6 +119,13 @@ TEST(SocketIoctlNetdevQuery, LoopbackFieldsAndUnionWidths) {
         EXPECT_EQ(static_cast<unsigned char>(ifr.ifr_hwaddr.sa_data[i]), 0);
     }
     ExpectSentinelFrom(ifr, sizeof(sa_family_t) + 6);
+
+    InitIfreq(&ifr, "lo");
+    ASSERT_EQ(ioctl(fd.get(), SIOCGIFTXQLEN, &ifr), 0) << strerror(errno);
+    if (IsDragonOS()) {
+        EXPECT_EQ(ifr.ifr_qlen, 1000);
+    }
+    ExpectSentinelFrom(ifr, sizeof(int));
 }
 
 TEST(SocketIoctlNetdevQuery, NameNormalizationAndAliases) {
@@ -161,6 +168,41 @@ TEST(SocketIoctlNetdevQuery, NameNormalizationAndAliases) {
     EXPECT_EQ(errno, ENODEV);
 }
 
+TEST(SocketIoctlNetdevQuery, TxQueueLengthAcrossSocketFamiliesAndAliases) {
+    for (int family : {AF_INET, AF_UNIX}) {
+        ScopedFd fd(socket(family, SOCK_DGRAM, 0));
+        ASSERT_GE(fd.get(), 0);
+        struct ifreq plain {};
+        InitIfreq(&plain, "lo");
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFTXQLEN, &plain), 0);
+        struct ifreq alias {};
+        InitIfreq(&alias, "lo:1");
+        alias.ifr_name[IFNAMSIZ - 1] = 'x';
+        ASSERT_EQ(ioctl(fd.get(), SIOCGIFTXQLEN, &alias), 0);
+        EXPECT_EQ(alias.ifr_qlen, plain.ifr_qlen);
+        EXPECT_STREQ(alias.ifr_name, "lo:1");
+        EXPECT_EQ(alias.ifr_name[IFNAMSIZ - 1], '\0');
+        ExpectSentinelFrom(alias, sizeof(int));
+    }
+}
+
+TEST(SocketIoctlNetdevQuery, TxQueueLengthWithoutCapabilities) {
+    const pid_t child = fork();
+    ASSERT_GE(child, 0);
+    if (child == 0) {
+        if (DropAllCapabilities() != 0) _exit(10);
+        ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
+        if (fd.get() < 0) _exit(11);
+        struct ifreq ifr {};
+        InitIfreq(&ifr, "lo");
+        _exit(ioctl(fd.get(), SIOCGIFTXQLEN, &ifr) == 0 ? 0 : 12);
+    }
+    int status = 0;
+    ASSERT_EQ(waitpid(child, &status, 0), child);
+    ASSERT_TRUE(WIFEXITED(status));
+    EXPECT_EQ(WEXITSTATUS(status), 0);
+}
+
 TEST(SocketIoctlNetdevQuery, MissingDeviceAndUserCopyFaults) {
     ScopedFd fd(socket(AF_INET, SOCK_DGRAM, 0));
     ASSERT_GE(fd.get(), 0);
@@ -191,9 +233,11 @@ TEST(SocketIoctlNetdevQuery, MissingDeviceAndUserCopyFaults) {
         static_cast<char*>(mapping) + page_size - sizeof(struct ifreq) + 1);
     std::memset(partial, 0, sizeof(struct ifreq) - 1);
     std::memcpy(partial->ifr_name, "lo", 3);
-    errno = 0;
-    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, partial), -1);
-    EXPECT_EQ(errno, EFAULT);
+    for (unsigned long command : kQueryCommands) {
+        errno = 0;
+        EXPECT_EQ(ioctl(fd.get(), command, partial), -1) << command;
+        EXPECT_EQ(errno, EFAULT) << command;
+    }
     ASSERT_EQ(mprotect(static_cast<char*>(mapping) + page_size, page_size,
                        PROT_READ | PROT_WRITE),
               0);
@@ -205,9 +249,11 @@ TEST(SocketIoctlNetdevQuery, MissingDeviceAndUserCopyFaults) {
     auto* readonly_ifr = static_cast<struct ifreq*>(readonly);
     InitIfreq(readonly_ifr, "lo");
     ASSERT_EQ(mprotect(readonly, page_size, PROT_READ), 0);
-    errno = 0;
-    EXPECT_EQ(ioctl(fd.get(), SIOCGIFINDEX, readonly_ifr), -1);
-    EXPECT_EQ(errno, EFAULT);
+    for (unsigned long command : kQueryCommands) {
+        errno = 0;
+        EXPECT_EQ(ioctl(fd.get(), command, readonly_ifr), -1) << command;
+        EXPECT_EQ(errno, EFAULT) << command;
+    }
     ASSERT_EQ(mprotect(readonly, page_size, PROT_READ | PROT_WRITE), 0);
     ASSERT_EQ(munmap(readonly, page_size), 0);
 }
@@ -288,6 +334,7 @@ int RunSocketNetnsCase() {
     if (!old_unique.empty()) {
         InitIfreq(&ifr, old_unique.c_str());
         if (ioctl(old_fd.get(), SIOCGIFINDEX, &ifr) != 0) return 11;
+        if (ioctl(old_fd.get(), SIOCGIFTXQLEN, &ifr) != 0) return 22;
     }
 
     ScopedFd new_fd(socket(AF_INET, SOCK_DGRAM, 0));
@@ -301,6 +348,7 @@ int RunSocketNetnsCase() {
         if (ioctl(new_fd.get(), SIOCGIFINDEX, &ifr) != -1 || errno != ENODEV) {
             return 14;
         }
+        if (ioctl(new_fd.get(), SIOCGIFTXQLEN, &ifr) != -1 || errno != ENODEV) return 23;
         if (!Contains(ListInterfaces(old_fd.get()), old_unique)) return 15;
         if (Contains(ListInterfaces(new_fd.get()), old_unique)) return 16;
     } else if (IsDragonOS()) {
@@ -312,6 +360,8 @@ int RunSocketNetnsCase() {
     if (ioctl(new_fd.get(), SIOCGIFHWADDR, &ifr) != 0) return 19;
     if (ioctl(new_fd.get(), SIOCGIFFLAGS, &ifr) != 0) return 20;
     if (ioctl(new_fd.get(), SIOCGIFMTU, &ifr) != 0) return 21;
+    if (ioctl(new_fd.get(), SIOCGIFFLAGS, &ifr) != 0 || (ifr.ifr_flags & IFF_UP)) return 24;
+    if (ioctl(new_fd.get(), SIOCGIFTXQLEN, &ifr) != 0 || ifr.ifr_qlen != 1000) return 25;
     return 0;
 }
 


### PR DESCRIPTION
BusyBox `ip address` currently reports `SIOCGIFTXQLEN: Function not implemented` for each interface. This change implements the query and makes ioctl, rtnetlink, and sysfs report the same transmit queue length. Loopback and virtio-net now report `1000`, including when an interface has no IP address.

`IfaceCommon` owns one immutable `tx_queue_len` property. The generic netdevice ioctl path reuses existing protected user copies, interface-name normalization, and socket namespace lookup. The shared link-message builder emits `IFLA_TXQLEN`, and the read-only sysfs attribute reads the same property. Queries require no administrative capability and preserve the existing `ENODEV` and `EFAULT` error paths. This read-only change introduces no new locks or packet-path changes; queue resizing and write support remain outside its scope.

Validation:

- `make kernel`, Rust formatting checks, and diff whitespace checks passed.
- Linux host: ioctl query suite **8/8**, targeted ioctl/rtnetlink/sysfs consistency test **1/1**.
- DragonOS x86_64 QEMU: ioctl query suite **8/8**, rtnetlink link suite **11/11**, ioctl mutation regression suite **9/9**, with no skips.
- The complete link suite passed while virtio-net had no IPv4 address. Two existing ioctl fixtures initially failed because they enumerate IPv4-configured Ethernet interfaces through `SIOCGIFCONF`; after configuring the guest interface, the complete query suite passed without changing their expectations.
- BusyBox `ip address` displayed `qlen 1000` for loopback and virtio-net without the previous warning.

Coverage includes union width preservation, aliases, multiple socket families, unprivileged queries, socket namespace stability, DOWN loopback, missing devices, invalid input and output memory, and agreement between link dumps, individual queries, ioctl, and sysfs. Independent design and implementation reviews found no blocking issues. Validation was limited to x86_64 and focused suites; the complete gVisor suite and other architectures were not run.

Fixes #2258
