### PR TITLE
refactor(net): remove noisy debug log in rtnetlink attr parsing

### DIFF
--- a/kernel/src/net/socket/netlink/route/message/attr/mod.rs
+++ b/kernel/src/net/socket/netlink/route/message/attr/mod.rs
@@ -10,7 +10,6 @@ pub mod route;
 pub(in crate::net::socket::netlink::route) const IFNAME_SIZE: usize = 16;
 
 pub(super) fn convert_one_from_raw_buf<T>(src: &[u8]) -> Result<&T, SystemError> {
-    log::info!("convert_one_from_raw_buf: src.len() = {}", src.len());
     if core::mem::size_of::<T>() > src.len() {
         return Err(SystemError::EINVAL);
     }


### PR DESCRIPTION
## Summary

Remove an accidentally committed `log::info!()` call inside `convert_one_from_raw_buf()`.

## Why

The debug statement printed an unrelated buffer-length message for every rtnetlink route attribute decode, adding noise to the kernel log at runtime. The value it reported is not specific to any call site and provides no actionable information.

## Test plan

- The change only removes a logging statement; no logic or behavior is modified.
- Netlink route attribute parsing continues to function unchanged.