### PR TITLE
fix(process): release clear_child_tid in the correct address space

### DIFF
--- a/kernel/src/process/execve.rs
+++ b/kernel/src/process/execve.rs
@@ -6,7 +6,7 @@ use crate::{
         fcntl::AtFlags,
         open::{do_open_execat, do_open_execat_with_flags},
     },
-    libs::{futex::futex::RobustListHead, rand::rand_bytes},
+    libs::rand::rand_bytes,
     mm::ucontext::AddressSpace,
     process::{
         cred::{SUID_DUMPABLE, SUID_DUMP_DISABLE, SUID_DUMP_USER},
@@ -215,7 +215,7 @@ fn do_execve_internal(
 
             let pcb = ProcessManager::current_pcb();
 
-            commit_exec_robust_list(&pcb, old_vm.as_ref(), &address_space);
+            commit_exec_futex_state(&pcb, old_vm.as_ref(), &address_space);
 
             // close-on-exec 必须属于成功 exec 的 commit 过程，不能留在 syscall wrapper 尾部。
             let dropped_fds = {
@@ -423,14 +423,11 @@ fn do_execve_switch_user_vm(new_vm: Arc<AddressSpace>) -> Option<Arc<AddressSpac
     old_address_space
 }
 
-fn commit_exec_robust_list(
+fn commit_exec_futex_state(
     pcb: &Arc<ProcessControlBlock>,
     old_vm: Option<&Arc<AddressSpace>>,
     new_vm: &Arc<AddressSpace>,
 ) {
-    let Some(head) = pcb.take_robust_list() else {
-        return;
-    };
     let Some(old_vm) = old_vm else {
         return;
     };
@@ -439,9 +436,11 @@ fn commit_exec_robust_list(
         .expect("successful user exec must replace the new address space");
     assert!(Arc::ptr_eq(&replaced, new_vm));
 
-    RobustListHead::cleanup_robust_list_head(pcb, head);
+    // Both registrations belong to the old mm. A missing robust list does not
+    // imply that clear_child_tid is unset (for example after a libc-less exec).
+    ProcessManager::release_task_futex_state(pcb);
 
     let replaced = do_execve_switch_user_vm(new_vm.clone())
-        .expect("robust-list cleanup must leave the old address space installed");
+        .expect("futex cleanup must leave the old address space installed");
     assert!(Arc::ptr_eq(&replaced, old_vm));
 }

--- a/kernel/src/process/manager/exit.rs
+++ b/kernel/src/process/manager/exit.rs
@@ -420,46 +420,12 @@ impl ProcessManager {
             pcb.wait_queue.mark_dead();
 
             // Perform post-exit work for the process.
-            let thread = pcb.thread.write_irqsave();
-            let clear_child_tid = thread.clear_child_tid;
-            let vfork_done = thread.vfork_done.clone();
-            drop(thread);
-            if let Some(addr) = clear_child_tid {
-                // Per Linux semantics: first clear *clear_child_tid in userspace,
-                // then futex_wake(addr).
-                let cleared_ok = unsafe {
-                    match clear_user_protected(addr, core::mem::size_of::<i32>()) {
-                        Ok(_) => true,
-                        Err(e) => {
-                            // The clear_child_tid pointer may be invalid or
-                            // unmapped: do not panic because of this.
-                            warn!("clear tid failed: {e:?}");
-                            false
-                        }
-                    }
-                };
-                // If *clear_child_tid cannot be cleared, avoid futex_wake as well
-                // (avoid further invalid userspace accesses).
-                if cleared_ok
-                    && pcb
-                        .basic()
-                        .user_vm()
-                        .expect("User VM Not found")
-                        .user_count()
-                        > 1
-                {
-                    // Linux uses the FUTEX_SHARED flag to wake clear_child_tid.
-                    // This allows cross-process/thread synchronization (e.g.
-                    // pthread_join).
-                    let _ =
-                        Futex::futex_wake(addr, FutexFlag::FLAGS_SHARED, 1, FUTEX_BITSET_MATCH_ANY);
-                }
-            }
+            Self::release_task_futex_state(&pcb);
             compiler_fence(Ordering::SeqCst);
 
-            RobustListHead::cleanup_robust_list(&pcb);
             detach_sem_undo(&pcb);
             // If this process was created via vfork, complete the completion.
+            let vfork_done = pcb.thread.write_irqsave().vfork_done.take();
             if let Some(vd) = vfork_done {
                 vd.complete_all();
             }
@@ -741,6 +707,34 @@ impl ProcessManager {
                     .wakeup_all(Some(ProcessState::Blocked(true)));
             }
         }
+    }
+
+    /// Release the current task's user futex registrations on exit or exec.
+    ///
+    /// The caller must keep the old mm installed in both the PCB and the CPU,
+    /// and retain its user reference until this returns. Like Linux's
+    /// exit_mm_release/exec_mm_release, robust cleanup precedes clear_child_tid.
+    pub(crate) fn release_task_futex_state(pcb: &Arc<ProcessControlBlock>) {
+        RobustListHead::cleanup_robust_list(pcb);
+
+        // Consume the registration even when no user access is needed. In
+        // particular, an exec must not carry this address into the new mm.
+        let clear_child_tid = pcb.thread.write_irqsave().clear_child_tid.take();
+        let Some(addr) = clear_child_tid.filter(|addr| !addr.is_null()) else {
+            return;
+        };
+        let Some(vm) = pcb.basic().user_vm() else {
+            return;
+        };
+        if vm.user_count() <= 1 {
+            return;
+        }
+
+        // No PCB locks are held across faultable user access or futex wake.
+        // Linux ignores put_user failure and still attempts the shared wake:
+        // a read-only mapping can retain a valid futex key and waiting tasks.
+        let _ = unsafe { clear_user_protected(addr, core::mem::size_of::<i32>()) };
+        let _ = Futex::futex_wake(addr, FutexFlag::FLAGS_SHARED, 1, FUTEX_BITSET_MATCH_ANY);
     }
 
     /// Release the old user address space: if no task still uses it, tear down all mappings

--- a/user/apps/tests/dunitest/suites/normal/clear_child_tid.cc
+++ b/user/apps/tests/dunitest/suites/normal/clear_child_tid.cc
@@ -1,0 +1,273 @@
+#include <gtest/gtest.h>
+
+#include <elf.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/futex.h>
+#include <time.h>
+#include <sched.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/syscall.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace {
+
+constexpr int kSentinel = 0x12345678;
+constexpr size_t kStackSize = 64 * 1024;
+
+enum class Action { Exit, Cancel, FailedExec, Exec, ReadOnly, Unmapped, ReadOnlyWake };
+
+struct ChildArgs {
+    int* tid;
+    size_t page_size;
+    Action action;
+    const char* path;
+    int* wait_phase;
+    const char* parent_stat_path;
+};
+
+// Only the child changes its registration. In particular, never overwrite the
+// test runner's libc clear_child_tid, even when clone shares its address space.
+int child_main(void* opaque) {
+    auto* args = static_cast<ChildArgs*>(opaque);
+    if (syscall(SYS_set_tid_address, args->tid) != syscall(SYS_gettid)) {
+        return 90;
+    }
+    if (args->action == Action::Cancel) {
+        if (syscall(SYS_set_tid_address, nullptr) != syscall(SYS_gettid)) {
+            return 91;
+        }
+    } else if (args->action == Action::ReadOnly || args->action == Action::ReadOnlyWake) {
+        if (mprotect(args->tid, args->page_size, PROT_READ) != 0) {
+            return 92;
+        }
+        if (args->action == Action::ReadOnlyWake) {
+            timespec start = {}, now = {};
+            if (syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &start) != 0) return 96;
+            for (;;) {
+                int phase = __atomic_load_n(args->wait_phase, __ATOMIC_ACQUIRE);
+                if (phase == 2) return 97;
+                if (phase == 1) {
+                    // Between publishing phase 1 and phase 2 the parent's only
+                    // blocking operation is FUTEX_WAIT on tid. State S proves
+                    // that it has entered that wait, without probing with wake.
+                    int fd = open(args->parent_stat_path, O_RDONLY);
+                    if (fd < 0) return 100;
+                    char stat[512] = {};
+                    ssize_t size = read(fd, stat, sizeof(stat) - 1);
+                    close(fd);
+                    if (size <= 0) return 101;
+                    // comm is parenthesized and may itself contain ')'.
+                    char* comm_end = strrchr(stat, ')');
+                    if (!comm_end || comm_end[1] != ' ') return 102;
+                    if (comm_end[2] == 'S') break;
+                }
+                if (syscall(SYS_clock_gettime, CLOCK_MONOTONIC, &now) != 0) return 98;
+                if (now.tv_sec - start.tv_sec >= 3) return 99;
+                syscall(SYS_sched_yield);
+            }
+        }
+    } else if (args->action == Action::Unmapped) {
+        if (munmap(args->tid, args->page_size) != 0) {
+            return 93;
+        }
+    } else if (args->action == Action::Exec || args->action == Action::FailedExec) {
+        char* const argv[] = {const_cast<char*>(args->path), nullptr};
+        char* const envp[] = {nullptr};
+        execve(args->path, argv, envp);
+        if (args->action != Action::FailedExec || errno != ENOEXEC) {
+            return 94;
+        }
+        // An early failure must neither clear the word nor discard registration.
+        if (__atomic_load_n(args->tid, __ATOMIC_SEQ_CST) != kSentinel) {
+            return 95;
+        }
+    }
+    return 0;  // libc clone's trampoline performs SYS_exit, not exit_group.
+}
+
+class ClearChildTid : public ::testing::Test {
+protected:
+    void SetUp() override {
+        page_size_ = sysconf(_SC_PAGESIZE);
+        ASSERT_GT(page_size_, 0);
+        tid_ = static_cast<int*>(mmap(nullptr, page_size_, PROT_READ | PROT_WRITE,
+                                     MAP_SHARED | MAP_ANONYMOUS, -1, 0));
+        ASSERT_NE(MAP_FAILED, tid_);
+        *tid_ = kSentinel;
+        stack_ = mmap(nullptr, kStackSize, PROT_READ | PROT_WRITE,
+                      MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        ASSERT_NE(MAP_FAILED, stack_);
+    }
+
+    void TearDown() override {
+        if (child_ > 0) {
+            kill(child_, SIGKILL);
+            while (waitpid(child_, nullptr, 0) < 0 && errno == EINTR) {}
+        }
+        if (tid_ != MAP_FAILED) munmap(tid_, page_size_);
+        if (stack_ != MAP_FAILED) munmap(stack_, kStackSize);
+        if (path_[0]) unlink(path_);
+    }
+
+    void RunChild(Action action, bool share_vm = true) {
+        ASSERT_NO_FATAL_FAILURE(StartChild(action, share_vm));
+        WaitChild();
+    }
+
+    void StartChild(Action action, bool share_vm = true) {
+        snprintf(parent_stat_path_, sizeof(parent_stat_path_), "/proc/%d/stat", getpid());
+        args_ = {tid_, static_cast<size_t>(page_size_), action, path_,
+                 &wait_phase_, parent_stat_path_};
+        child_ = clone(child_main, static_cast<char*>(stack_) + kStackSize,
+                       SIGCHLD | (share_vm ? CLONE_VM : 0), &args_);
+        ASSERT_GT(child_, 0) << strerror(errno);
+    }
+
+    void WaitChild() {
+        int status = 0;
+        // Bounded polling also avoids coupling these tests to futex wake itself.
+        for (int i = 0; i < 1000; ++i) {
+            pid_t waited = waitpid(child_, &status, WNOHANG);
+            if (waited == child_) {
+                child_ = -1;
+                ASSERT_TRUE(WIFEXITED(status)) << status;
+                EXPECT_EQ(0, WEXITSTATUS(status));
+                return;
+            }
+            ASSERT_TRUE(waited == 0 || (waited < 0 && errno == EINTR));
+            usleep(10000);
+        }
+        FAIL() << "child did not exit within 10 seconds";
+    }
+
+    void WriteExecutable(const void* data, size_t size) {
+        ASSERT_TRUE(mkdir("/tmp", 0755) == 0 || errno == EEXIST);
+        snprintf(path_, sizeof(path_), "/tmp/clear_child_tid_%d_XXXXXX", getpid());
+        int fd = mkstemp(path_);
+        ASSERT_GE(fd, 0);
+        const char* bytes = static_cast<const char*>(data);
+        size_t done = 0;
+        while (done < size) {
+            ssize_t n = write(fd, bytes + done, size - done);
+            if (n < 0 && errno == EINTR) continue;
+            if (n <= 0) {
+                close(fd);
+                FAIL() << "write executable failed";
+            }
+            done += static_cast<size_t>(n);
+        }
+        int chmod_result = fchmod(fd, 0700);
+        int close_result = close(fd);
+        ASSERT_EQ(0, chmod_result);
+        ASSERT_EQ(0, close_result);
+    }
+
+    int* tid_ = static_cast<int*>(MAP_FAILED);
+    void* stack_ = MAP_FAILED;
+    long page_size_ = 0;
+    pid_t child_ = -1;
+    ChildArgs args_ = {};
+    int wait_phase_ = 0;
+    char parent_stat_path_[64] = {};
+    char path_[128] = {};
+};
+
+TEST_F(ClearChildTid, SingleMmUserDoesNotWriteSharedMapping) {
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::Exit, false));
+    EXPECT_EQ(kSentinel, *tid_);
+}
+
+TEST_F(ClearChildTid, SharedMmExitClearsTid) {
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::Exit));
+    EXPECT_EQ(0, *tid_);
+}
+
+TEST_F(ClearChildTid, NullAddressCancelsRegistration) {
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::Cancel));
+    EXPECT_EQ(kSentinel, *tid_);
+}
+
+TEST_F(ClearChildTid, FailedExecPreservesRegistration) {
+    static constexpr char invalid_elf[] = "not an ELF executable\n";
+    ASSERT_NO_FATAL_FAILURE(WriteExecutable(invalid_elf, sizeof(invalid_elf)));
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::FailedExec));
+    EXPECT_EQ(0, *tid_);
+}
+
+TEST_F(ClearChildTid, ReadOnlyAddressDoesNotPreventExit) {
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::ReadOnly));
+    EXPECT_EQ(kSentinel, *tid_);
+}
+
+TEST_F(ClearChildTid, ReadOnlyAddressStillWakesWaiter) {
+    ASSERT_NO_FATAL_FAILURE(StartChild(Action::ReadOnlyWake));
+    timespec timeout = {5, 0};
+    // Publish only immediately before the syscall; never sleep in this phase
+    // for any other reason. The child observes /proc state S before exiting.
+    __atomic_store_n(&wait_phase_, 1, __ATOMIC_RELEASE);
+    long waited = syscall(SYS_futex, tid_, FUTEX_WAIT, kSentinel, &timeout, nullptr, 0);
+    __atomic_store_n(&wait_phase_, 2, __ATOMIC_RELEASE);
+    int wait_error = errno;
+    ASSERT_NO_FATAL_FAILURE(WaitChild());
+    EXPECT_EQ(0, waited) << "futex wait errno=" << wait_error;
+    EXPECT_EQ(kSentinel, *tid_);
+}
+
+TEST_F(ClearChildTid, UnmappedAddressDoesNotPreventExit) {
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::Unmapped));
+    // CLONE_VM made the unmap visible here as well. Do not dereference tid_.
+    tid_ = static_cast<int*>(MAP_FAILED);
+}
+
+TEST_F(ClearChildTid, SuccessfulExecClearsTidInOldMm) {
+#if defined(__x86_64__)
+    // A tiny ET_EXEC runs exit(0) without libc registering another TID address.
+    // Build the standard ELF headers explicitly instead of opaque header bytes.
+    struct Image {
+        Elf64_Ehdr ehdr;
+        Elf64_Phdr phdr;
+        unsigned char code[9];
+    } image = {};
+    memcpy(image.ehdr.e_ident, ELFMAG, SELFMAG);
+    image.ehdr.e_ident[EI_CLASS] = ELFCLASS64;
+    image.ehdr.e_ident[EI_DATA] = ELFDATA2LSB;
+    image.ehdr.e_ident[EI_VERSION] = EV_CURRENT;
+    image.ehdr.e_type = ET_EXEC;
+    image.ehdr.e_machine = EM_X86_64;
+    image.ehdr.e_version = EV_CURRENT;
+    image.ehdr.e_entry = 0x400000 + offsetof(Image, code);
+    image.ehdr.e_phoff = offsetof(Image, phdr);
+    image.ehdr.e_ehsize = sizeof(Elf64_Ehdr);
+    image.ehdr.e_phentsize = sizeof(Elf64_Phdr);
+    image.ehdr.e_phnum = 1;
+    image.phdr.p_type = PT_LOAD;
+    image.phdr.p_flags = PF_R | PF_X;
+    image.phdr.p_vaddr = 0x400000;
+    image.phdr.p_filesz = sizeof(image);
+    image.phdr.p_memsz = sizeof(image);
+    image.phdr.p_align = 4096;
+    const unsigned char code[] = {0x31, 0xff, 0xb8, 0x3c, 0, 0, 0, 0x0f, 0x05};
+    memcpy(image.code, code, sizeof(code));
+    ASSERT_NO_FATAL_FAILURE(WriteExecutable(&image, sizeof(image)));
+    ASSERT_NO_FATAL_FAILURE(RunChild(Action::Exec));
+    EXPECT_EQ(0, *tid_) << "exec must notify users of the old mm before detaching";
+#else
+    GTEST_SKIP() << "raw exec helper currently targets x86_64";
+#endif
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Process exit could print `clear tid failed: EFAULT` during shell command execution because it wrote the registered TID even for a single-user address space. Successful exec also retained the old registration, allowing an obsolete pointer to clear unrelated memory in the new image. A failed clear additionally suppressed the futex wake required by Linux semantics.

This change shares task futex cleanup between exit and exec, clears robust state before consuming `clear_child_tid`, and gates user access on the mm user count. It attempts the shared wake even when clearing fails. Exec runs cleanup with the old address space installed using the existing switch helper; mm release and vfork completion retain their existing positions. No new lifecycle framework or state is introduced.

Validation:

- `make kernel`, Rustfmt checks, and `git diff --check` passed on x86_64.
- Eight new dunitests pass on Linux and DragonOS QEMU/KVM with 2 vCPUs. The unmodified kernel fails three: single-user-mm writes, read-only TID wake, and old-mm notification during exec.
- The read-only wake test passed 100 repetitions on Linux.
- Existing `ExecAbi` (9), `SpawnExecPipeRace` (3), and `ExecDumpableSemantics` (1) tests pass before and after the change.
- A separate libc-free exec probe keeps two users of the new mm and reuses the old TID address for a shared sentinel. The baseline corrupts it; the fixed kernel preserves it.
- The fixed regression run contains no `clear tid failed` warnings.

Runtime validation covered x86_64. The complete remote installer was not rerun; validation targets the reproduced process-lifecycle defects and related exec behavior.
