### PR TITLE
fix(fs): correct ext4 initialization, FAT traversal and truncation

### DIFF
--- a/kernel/crates/another_ext4/ext4_test/src/bin/block_uninit_regression.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/block_uninit_regression.rs
@@ -1,0 +1,219 @@
+//! Cross-group BLOCK_UNINIT allocation against an unmodified mkfs.ext4 image.
+//! Run with `cargo run --bin block_uninit_regression` (requires e2fsprogs).
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+
+use another_ext4::{BlockDevice, Ext4, InodeMode, EXT4_ROOT_INO};
+use block_file::{BlockFile, CrashBlockFile};
+use std::fs::{self, File};
+use std::os::unix::fs::FileExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::Arc;
+
+const IMAGE_SIZE: u64 = 32 * 1024 * 1024;
+const CHUNK: usize = 64 * 1024;
+const PAYLOAD_SIZE: usize = 12 * 1024 * 1024;
+
+struct Image(PathBuf);
+impl Image {
+    fn new(name: &str) -> Self {
+        let path = std::env::current_dir()
+            .unwrap()
+            .join(format!("block-uninit-{}-{name}.img", std::process::id()));
+        File::options()
+            .write(true)
+            .create_new(true)
+            .open(&path)
+            .unwrap()
+            .set_len(IMAGE_SIZE)
+            .unwrap();
+        let mkfs = |features: &str| {
+            Command::new("mkfs.ext4")
+                .args([
+                    "-q", "-F", "-b", "4096", "-g", "1024", "-G", "2", "-I", "256", "-O", features,
+                ])
+                .arg(&path)
+                .output()
+                .expect("mkfs.ext4 is required")
+        };
+        let mut output = mkfs("metadata_csum,64bit,flex_bg,^orphan_file");
+        if !output.status.success()
+            && String::from_utf8_lossy(&output.stderr).contains("Invalid filesystem option set:")
+            && String::from_utf8_lossy(&output.stderr).contains("orphan_file")
+        {
+            output = mkfs("metadata_csum,64bit,flex_bg");
+        }
+        assert!(
+            output.status.success(),
+            "{}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let image = Self(path);
+        assert!(
+            image.group(1)[18] & 2 != 0,
+            "fixture must preserve BLOCK_UNINIT"
+        );
+        image
+    }
+    fn path(&self) -> &str {
+        self.0.to_str().unwrap()
+    }
+    fn group(&self, id: usize) -> [u8; 64] {
+        let mut bytes = [0; 64];
+        File::open(&self.0)
+            .unwrap()
+            .read_exact_at(&mut bytes, 4096 + id as u64 * 64)
+            .unwrap();
+        bytes
+    }
+    fn bitmap(&self, id: usize) -> u64 {
+        u32::from_le_bytes(self.group(id)[0..4].try_into().unwrap()) as u64
+    }
+}
+impl Drop for Image {
+    fn drop(&mut self) {
+        let _ = fs::remove_file(&self.0);
+    }
+}
+
+fn create(fs: &Ext4) -> u32 {
+    fs.generic_create(
+        EXT4_ROOT_INO,
+        "payload",
+        InodeMode::FILE | InodeMode::ALL_RWX,
+    )
+    .expect("create payload")
+}
+
+fn write_chunks(fs: &Ext4, ino: u32, end: usize, transactional: bool) {
+    for offset in (0..end).step_by(CHUNK) {
+        let data = vec![(offset / CHUNK % 251 + 1) as u8; CHUNK];
+        if transactional {
+            fs.prepare_buffered_write(ino, offset, CHUNK, (offset + CHUNK) as u64, None)
+                .unwrap_or_else(|e| panic!("transaction allocation at offset {offset}: {e:?}"));
+        }
+        assert_eq!(
+            fs.write(ino, offset, &data)
+                .unwrap_or_else(|e| panic!("write at offset {offset}: {e:?}")),
+            CHUNK
+        );
+    }
+}
+
+fn fsck(path: &Path) {
+    let out = Command::new("e2fsck")
+        .arg("-fn")
+        .arg(path)
+        .output()
+        .unwrap();
+    assert!(
+        out.status.success(),
+        "e2fsck:\n{}\n{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+}
+
+fn cross_group(transactional: bool) {
+    let mode = if transactional {
+        "transaction"
+    } else {
+        "direct"
+    };
+    let image = Image::new(mode);
+    let original_flags = image.group(1)[18];
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(image.path()))).unwrap();
+    let ino = create(&fs);
+    write_chunks(&fs, ino, PAYLOAD_SIZE, transactional);
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    assert_eq!(
+        image.group(1)[18],
+        original_flags & !2,
+        "only BLOCK_UNINIT may be cleared by data-block allocation"
+    );
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(image.path()))).unwrap();
+    let mut data = vec![0; CHUNK];
+    for offset in (0..PAYLOAD_SIZE).step_by(CHUNK) {
+        assert_eq!(fs.read(ino, offset, &mut data).unwrap(), CHUNK);
+        assert!(
+            data.iter().all(|b| *b == (offset / CHUNK % 251 + 1) as u8),
+            "remounted data mismatch at offset {offset}"
+        );
+    }
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    fsck(&image.0);
+    println!("PASS {mode}: 12 MiB crosses groups, flags preserved, remount and fsck clean");
+}
+
+fn corrupt_initialized_bitmap() {
+    let image = Image::new("bad-checksum");
+    let bitmap = image.bitmap(0);
+    let file = File::options()
+        .read(true)
+        .write(true)
+        .open(&image.0)
+        .unwrap();
+    let mut byte = [0];
+    file.read_exact_at(&mut byte, bitmap * 4096).unwrap();
+    byte[0] ^= 0x80;
+    file.write_all_at(&byte, bitmap * 4096).unwrap();
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(image.path()))).unwrap();
+    let ino = create(&fs);
+    let error = fs
+        .prepare_buffered_write(ino, 0, CHUNK, CHUNK as u64, None)
+        .unwrap_err();
+    assert_eq!(error.code(), another_ext4::ErrCode::EIO);
+    assert!(format!("{error:?}").contains("checksum"), "{error:?}");
+    fs.shutdown_writable().unwrap();
+    println!("PASS initialized bitmap checksum corruption is rejected");
+}
+
+fn aborted_first_initialization() {
+    let image = Image::new("abort");
+    let free = u16::from_le_bytes(image.group(0)[12..14].try_into().unwrap()) as usize;
+    let prefix = free * 4096 / CHUNK * CHUNK;
+    let device = Arc::new(CrashBlockFile::new(image.path()));
+    let fs = Ext4::load_writable(device.clone()).unwrap();
+    let ino = create(&fs);
+    write_chunks(&fs, ino, prefix, true);
+    assert_ne!(image.group(1)[18] & 2, 0);
+    let group_before = image.group(1);
+    let bitmap_before = device.read_block(image.bitmap(1)).unwrap();
+    device.reset_operation_log();
+    device.arm_io_error_at(0);
+    let error = fs
+        .prepare_buffered_write(ino, prefix, CHUNK, (prefix + CHUNK) as u64, None)
+        .unwrap_err();
+    assert_eq!(error.code(), another_ext4::ErrCode::EIO);
+    device.crash();
+    drop(fs);
+    assert_eq!(
+        image.group(1),
+        group_before,
+        "failed preparation published group initialization"
+    );
+    assert_eq!(
+        device.read_block(image.bitmap(1)).unwrap().data,
+        bitmap_before.data,
+        "failed preparation published the new bitmap"
+    );
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(image.path()))).unwrap();
+    fs.prepare_buffered_write(ino, prefix, CHUNK, (prefix + CHUNK) as u64, None)
+        .unwrap();
+    assert_eq!(fs.write(ino, prefix, &vec![0x73; CHUNK]).unwrap(), CHUNK);
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    fsck(&image.0);
+    println!("PASS first initialization preparation I/O failure leaves bitmap and descriptor unpublished; retry succeeds");
+}
+
+fn main() {
+    cross_group(true);
+    cross_group(false);
+    corrupt_initialized_bitmap();
+    aborted_first_initialization();
+}

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -993,6 +993,70 @@ impl Ext4 {
         core::cmp::min(sb.blocks_per_group() as u64, total - first) as usize
     }
 
+    /// Interpret BLOCK_UNINIT before using a bitmap as allocation state.
+    /// Only the first allocation constructs an owned image; ordinary and
+    /// transaction-staged bitmaps keep their existing storage. Publication of
+    /// the image and clearing the flag remain the caller's responsibility.
+    fn prepare_allocation_bitmap<'a>(
+        &self,
+        sb: &SuperBlock,
+        bg: &BlockGroupRef,
+        image: super::journal_transaction::BlockView<'a>,
+    ) -> Result<super::journal_transaction::BlockView<'a>> {
+        let metadata_csum =
+            sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM);
+        if metadata_csum && !bg.verify_checksum(sb.metadata_checksum_seed()) {
+            return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
+        }
+        if !bg.desc.block_bitmap_uninitialized() {
+            if metadata_csum
+                && !bg.desc.verify_block_bitmap_csum(
+                    sb.metadata_checksum_seed(),
+                    &*image,
+                    sb.clusters_per_group() as usize / 8,
+                )
+            {
+                return_error!(ErrCode::EIO, "Corrupt block bitmap checksum");
+            }
+            return Ok(image);
+        }
+        // Legacy GDT_CSUM is outside the mount's supported feature set. A
+        // flag without authenticated descriptor semantics is not permission
+        // to discard the on-disk allocation state.
+        if !metadata_csum || bg.id == 0 {
+            return_error!(ErrCode::EIO, "Invalid uninitialized block group");
+        }
+        let first = Self::block_group_first_block(sb, bg.id);
+        let count = Self::block_group_block_count(sb, bg.id);
+        let end = first + count as u64;
+        let mut bytes = Box::new([0xff; BLOCK_SIZE]);
+        let mut bitmap = Bitmap::new(bytes.as_mut(), BLOCK_SIZE * 8);
+        for bit in 0..count {
+            bitmap.clear_bit(bit);
+        }
+        // The mount already validates and merges all metadata ranges,
+        // including backups and metadata placed across groups by flex_bg.
+        let start = self
+            .system_metadata_ranges
+            .partition_point(|(_, range_end)| *range_end <= first);
+        for &(range_start, range_end) in &self.system_metadata_ranges[start..] {
+            if range_start >= end {
+                break;
+            }
+            for block in core::cmp::max(range_start, first)..core::cmp::min(range_end, end) {
+                bitmap.set_bit((block - first) as usize);
+            }
+        }
+        let free = (0..count).filter(|&bit| bitmap.is_bit_clear(bit)).count() as u64;
+        if free != bg.desc.get_free_blocks_count() {
+            return_error!(ErrCode::EIO, "Invalid uninitialized block-group free count");
+        }
+        Ok(super::journal_transaction::BlockView::Device(Block::new(
+            bg.desc.block_bitmap_block(),
+            bytes,
+        )))
+    }
+
     /// Stage one group-local contiguous data allocation without publishing
     /// any cache or disk metadata.  The caller owns the filesystem-wide
     /// transactional metadata gate, so no direct allocator can race the
@@ -1056,21 +1120,13 @@ impl Ext4 {
                 continue;
             }
             let bitmap_home = bg.desc.block_bitmap_block();
-            let bitmap_block = transaction.read(self.block_device.as_ref(), bitmap_home)?;
+            let bitmap_block = self.prepare_allocation_bitmap(
+                &sb,
+                &bg,
+                transaction.read(self.block_device.as_ref(), bitmap_home)?,
+            )?;
             self.prepare_stats.record_bitmap_io();
             let checksum_bytes = (sb.clusters_per_group() as usize) / 8;
-            if sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
-                if !bg.verify_checksum(sb.metadata_checksum_seed()) {
-                    return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
-                }
-                if !bg.desc.verify_block_bitmap_csum(
-                    sb.metadata_checksum_seed(),
-                    &*bitmap_block,
-                    checksum_bytes,
-                ) {
-                    return_error!(ErrCode::EIO, "Corrupt block bitmap checksum");
-                }
-            }
 
             let group_first = Self::block_group_first_block(&sb, bgid);
             let exact_hint = preferred_first
@@ -1111,9 +1167,23 @@ impl Ext4 {
                 .checked_sub(count as u64)
                 .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
 
+            // A staged view borrows the transaction. Only an uninitialized
+            // group needs to carry a replacement image across the mutation.
+            let initialized_image = if bg.desc.block_bitmap_uninitialized() {
+                match bitmap_block {
+                    super::journal_transaction::BlockView::Device(block) => Some(block.data),
+                    super::journal_transaction::BlockView::Staged(_) => unreachable!(),
+                }
+            } else {
+                None
+            };
             {
                 let image = self.transaction_block_for_update(transaction, bitmap_home)?;
                 self.prepare_stats.record_bitmap_io();
+                if let Some(initialized) = initialized_image {
+                    image.copy_from_slice(initialized.as_ref());
+                    bg.desc.clear_block_bitmap_uninitialized();
+                }
                 let mut bitmap = Bitmap::new(image, blocks_in_group);
                 if (bit..bit + count_usize).any(|index| !bitmap.is_bit_clear(index)) {
                     return_error!(ErrCode::EIO, "Range allocation changed during planning");
@@ -2082,6 +2152,14 @@ impl Ext4 {
             let old_bitmap_block = bitmap_block.clone();
             let old_bg = BlockGroupRef::new(bg.id, bg.desc);
             let old_sb = sb;
+            bitmap_block = match self.prepare_allocation_bitmap(
+                &sb,
+                &bg,
+                super::journal_transaction::BlockView::Device(bitmap_block),
+            )? {
+                super::journal_transaction::BlockView::Device(block) => block,
+                super::journal_transaction::BlockView::Staged(_) => unreachable!(),
+            };
             let bit = {
                 let mut bitmap = Bitmap::new(&mut *bitmap_block.data, blocks_in_group);
                 match bitmap.find_and_set_first_clear_bit(0, blocks_in_group) {
@@ -2090,6 +2168,17 @@ impl Ext4 {
                 }
             };
             let fblock = Self::block_group_first_block(&sb, bgid) + bit as PBlockId;
+            self.validate_data_blocks(fblock, 1)?;
+            let new_bg_free = bg
+                .desc
+                .get_free_blocks_count()
+                .checked_sub(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            let new_sb_free = sb
+                .free_blocks_count()
+                .checked_sub(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            bg.desc.clear_block_bitmap_uninitialized();
 
             // Set block group checksum
             if !bg.desc.update_block_bitmap_csum(
@@ -2103,8 +2192,7 @@ impl Ext4 {
             self.prepare_stats.record_bitmap_io();
 
             // Update block group counters
-            bg.desc
-                .set_free_blocks_count(bg.desc.get_free_blocks_count() - 1);
+            bg.desc.set_free_blocks_count(new_bg_free);
             if let Err(err) = self.write_block_group_with_csum(&mut bg) {
                 return match self.restore_block_allocation_state(
                     &old_bitmap_block,
@@ -2117,7 +2205,7 @@ impl Ext4 {
             }
 
             // Update superblock counters
-            sb.set_free_blocks_count(sb.free_blocks_count() - 1);
+            sb.set_free_blocks_count(new_sb_free);
             if let Err(err) = self.write_super_block(&sb) {
                 return match self.restore_block_allocation_state(
                     &old_bitmap_block,

--- a/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/block_group.rs
@@ -52,6 +52,16 @@ pub struct BlockGroupDesc {
 unsafe impl AsBytes for BlockGroupDesc {}
 
 impl BlockGroupDesc {
+    const BLOCK_UNINIT: u16 = 0x0002;
+
+    pub fn block_bitmap_uninitialized(&self) -> bool {
+        self.flags & Self::BLOCK_UNINIT != 0
+    }
+
+    pub fn clear_block_bitmap_uninitialized(&mut self) {
+        self.flags &= !Self::BLOCK_UNINIT;
+    }
+
     #[allow(unused)]
     const MIN_BLOCK_GROUP_DESC_SIZE: usize = 32;
     #[allow(unused)]

--- a/kernel/src/exception/workqueue.rs
+++ b/kernel/src/exception/workqueue.rs
@@ -9,6 +9,7 @@ use core::{
 };
 use lazy_static::lazy_static;
 use log;
+use system_error::SystemError;
 
 use crate::{
     libs::{spinlock::SpinLock, wait_queue::WaitQueue},
@@ -65,6 +66,12 @@ pub struct WorkQueue {
     worker: SpinLock<Option<Arc<ProcessControlBlock>>>,
 }
 
+impl fmt::Debug for WorkQueue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("WorkQueue").finish_non_exhaustive()
+    }
+}
+
 impl WorkQueue {
     /// Create a new workqueue with the given name.
     /// This will spawn a kernel thread with the given name.
@@ -86,6 +93,28 @@ impl WorkQueue {
         *wq.worker.lock() = Some(worker_pcb);
 
         wq
+    }
+
+    /// Create a serial queue whose worker exits when its last owner is dropped.
+    ///
+    /// Callers must retain the queue until their work finishes; a work item may
+    /// retain its owner for this purpose. Unlike `new`, the sleeping worker
+    /// does not keep the queue or its owner alive indefinitely.
+    pub fn try_new_owned(name: &str) -> Result<Arc<Self>, SystemError> {
+        let wq = Arc::new(Self {
+            queue: SpinLock::new(WorkList::default()),
+            wait_queue: Arc::new(WaitQueue::default()),
+            worker: SpinLock::new(None),
+        });
+        let queue = Arc::downgrade(&wq);
+        let wait_queue = wq.wait_queue.clone();
+        let closure = Box::new(move || owned_worker_loop(queue.clone(), wait_queue.clone()));
+        KernelThreadMechanism::create_and_run(
+            KernelThreadClosure::EmptyClosure((closure, ())),
+            name.to_string(),
+        )
+        .ok_or(SystemError::ENOMEM)?;
+        Ok(wq)
     }
 
     /// Enqueue a work item to the workqueue.
@@ -123,6 +152,29 @@ impl WorkQueue {
 
     fn is_empty(&self) -> bool {
         self.queue.lock().head.is_none()
+    }
+}
+
+impl Drop for WorkQueue {
+    fn drop(&mut self) {
+        // An owned worker waits without holding a strong queue reference.
+        self.wait_queue.wakeup(None);
+    }
+}
+
+fn owned_worker_loop(queue: Weak<WorkQueue>, wait_queue: Arc<WaitQueue>) -> i32 {
+    loop {
+        // Acquire the work in the predicate, then drop the temporary queue
+        // owner before sleeping or running it. Register-before-check in
+        // wait_until covers both enqueue and last-owner destruction wakeups.
+        let work = wait_queue.wait_until(|| match queue.upgrade() {
+            Some(queue) => queue.pop().map(Some),
+            None => Some(None),
+        });
+        match work {
+            Some(work) => work.run(),
+            None => return 0,
+        }
     }
 }
 

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -1,7 +1,6 @@
 #![allow(dead_code)]
 use crate::filesystem::fat::fs::LockedFATInode;
 use crate::filesystem::vfs::IndexNode;
-use crate::mm::truncate::truncate_inode_pages;
 use crate::{
     driver::base::block::{block_device::LBA_SIZE, SeekFrom},
     libs::vec_cursor::VecCursor,
@@ -65,9 +64,32 @@ pub struct FATFile {
     /// Last logical/physical read position, protected by the inode mutex.
     /// Forward cold-page reads resume here instead of rescanning the FAT chain.
     read_cursor: Option<(u64, Cluster)>,
+    /// The directory slot has been removed and may already belong to another file.
+    detached: bool,
 }
 
 impl FATFile {
+    pub(super) fn detach(&mut self) {
+        self.detached = true;
+    }
+
+    fn commit_directory_entry(
+        &self,
+        fs: &Arc<FATFileSystem>,
+        entry: &ShortDirEntry,
+        flush: bool,
+    ) -> Result<(), SystemError> {
+        if self.detached {
+            return Ok(());
+        }
+        let offset = fs.cluster_bytes_offset(self.loc.1 .0) + self.loc.1 .1;
+        if flush {
+            entry.flush(fs, offset)
+        } else {
+            entry.commit_without_barrier(fs, offset)
+        }
+    }
+
     /// @brief 获取文件大小
     #[inline]
     pub fn size(&self) -> u64 {
@@ -372,8 +394,7 @@ impl FATFile {
         let mut proposed = self.short_dir_entry;
         proposed.set_first_cluster(resulting_first);
         proposed.file_size = new_size as u32;
-        let short_entry_offset = fs.cluster_bytes_offset(self.loc.1 .0) + self.loc.1 .1;
-        if let Err(error) = proposed.commit_without_barrier(fs, short_entry_offset) {
+        if let Err(error) = self.commit_directory_entry(fs, &proposed, false) {
             // The chain may already be reachable on disk. Keep it as
             // preallocation at the old visible size so a retry reuses it.
             if !old_chain_exists {
@@ -437,23 +458,23 @@ impl FATFile {
             return Ok(());
         }
 
-        // A failed deallocation may already have freed part of the chain.
-        // Never retain a position into it across either success or failure.
+        // Publish the smaller reachable file before releasing clusters. If
+        // reclamation fails, the new size must remain authoritative.
+        let first = self.first_cluster;
+        let keep = new_size.div_ceil(fs.bytes_per_cluster());
+        let mut proposed = self.short_dir_entry;
+        proposed.file_size = new_size as u32;
+        if new_size == 0 {
+            proposed.set_first_cluster(Cluster::new(0));
+        }
+        self.commit_directory_entry(fs, &proposed, true)?;
         self.read_cursor = None;
         self.chain_extent = None;
-        let new_last_cluster = new_size.div_ceil(fs.bytes_per_cluster());
-        fs.truncate_cluster_chain(self.first_cluster, new_last_cluster as usize)?;
-
+        self.short_dir_entry = proposed;
         if new_size == 0 {
-            assert!(new_last_cluster == 0);
-            self.short_dir_entry.set_first_cluster(Cluster::new(0));
             self.first_cluster = Cluster::new(0);
         }
-
-        self.set_size(new_size as u32);
-        // 计算短目录项在分区内的字节偏移量
-        let short_entry_offset = fs.cluster_bytes_offset((self.loc.1).0) + (self.loc.1).1;
-        self.short_dir_entry.flush(fs, short_entry_offset)?;
+        fs.truncate_cluster_chain(first, keep as usize)?;
 
         return Ok(());
     }
@@ -970,14 +991,12 @@ impl FATDir {
             FATDirEntryOrShortName::DirEntry(e) => {
                 validate_rename_target(&old_dentry, &e, fs.clone())?;
 
-                if let Some(new_inode) = new_inode {
-                    if let Some(page_cache) = new_inode.page_cache().clone() {
-                        truncate_inode_pages(page_cache, 0);
-                    }
+                if e.is_dir() {
+                    self.remove(fs.clone(), new_name, true)?;
+                } else {
+                    let victim = new_inode.ok_or(SystemError::EIO)?;
+                    victim.remove_file_name(self, fs.clone(), new_name)?;
                 }
-
-                // 允许覆盖：若为非空目录，remove 会返回 ENOTEMPTY（这里只处理空目录或文件）
-                self.remove(fs.clone(), new_name, true)?;
                 e.short_name_raw()
             }
         };
@@ -1025,11 +1044,11 @@ impl FATDir {
             FATDirEntryOrShortName::DirEntry(e) => {
                 validate_rename_target(&old_dentry, &e, fs.clone())?;
 
-                if let Some(page_cache) = new_inode.unwrap().page_cache().clone() {
-                    truncate_inode_pages(page_cache, 0);
+                if e.is_dir() {
+                    target.remove(fs.clone(), new_name, true)?;
+                } else {
+                    new_inode?.remove_file_name(target, fs.clone(), new_name)?;
                 }
-                // 覆盖前删除目标目录项（空目录或文件），不截断源内容
-                target.remove(fs.clone(), new_name, true)?;
                 e.short_name_raw()
             }
         };
@@ -1388,6 +1407,7 @@ impl ShortDirEntry {
                 loc: (loc, loc),
                 chain_extent: None,
                 read_cursor: None,
+                detached: false,
             };
 
             // 根据当前短目录项的类型的不同，返回对应的枚举类型。
@@ -1433,6 +1453,7 @@ impl ShortDirEntry {
                 short_dir_entry: *self,
                 chain_extent: None,
                 read_cursor: None,
+                detached: false,
             };
 
             if self.is_file() {

--- a/kernel/src/filesystem/fat/entry.rs
+++ b/kernel/src/filesystem/fat/entry.rs
@@ -62,6 +62,9 @@ pub struct FATFile {
     /// on-disk chain has not been measured since this entry was loaded or
     /// truncated. The inode mutex serializes every update to this file.
     chain_extent: Option<(u64, Cluster)>,
+    /// Last logical/physical read position, protected by the inode mutex.
+    /// Forward cold-page reads resume here instead of rescanning the FAT chain.
+    read_cursor: Option<(u64, Cluster)>,
 }
 
 impl FATFile {
@@ -85,7 +88,7 @@ impl FATFile {
     /// @return Ok(usize) 成功读取到的字节数
     /// @return Err(SystemError) 读取时出现错误，返回错误码
     pub fn read(
-        &self,
+        &mut self,
         fs: &Arc<FATFileSystem>,
         buf: &mut [u8],
         offset: u64,
@@ -94,16 +97,21 @@ impl FATFile {
             return Ok(0);
         }
 
-        // 文件内的簇偏移量
         let start_cluster_number: u64 = offset / fs.bytes_per_cluster();
-        // 计算对应在分区内的簇号
-        let mut current_cluster = if let Some(c) =
-            fs.get_cluster_by_relative(self.first_cluster, start_cluster_number as usize)
-        {
+        let (cursor_index, cursor_cluster) = self
+            .read_cursor
+            .filter(|(index, _)| *index <= start_cluster_number)
+            .unwrap_or((0, self.first_cluster));
+        let mut current_cluster = if let Some(c) = fs.get_cluster_by_relative(
+            cursor_cluster,
+            (start_cluster_number - cursor_index) as usize,
+        ) {
             c
         } else {
             return Ok(0);
         };
+        let mut current_index = start_cluster_number;
+        self.read_cursor = Some((current_index, current_cluster));
 
         let bytes_remain: u64 = self.size() - offset;
 
@@ -119,6 +127,8 @@ impl FATFile {
             if in_cluster_offset >= fs.bytes_per_cluster() {
                 if let Ok(FATEntry::Next(c)) = fs.get_fat_entry(current_cluster) {
                     current_cluster = c;
+                    current_index += 1;
+                    self.read_cursor = Some((current_index, current_cluster));
                     in_cluster_offset %= fs.bytes_per_cluster();
                 } else {
                     break;
@@ -343,6 +353,7 @@ impl FATFile {
                     }
                     Err(AttachReservedError::Ambiguous(error)) => {
                         self.chain_extent = None;
+                        self.read_cursor = None;
                         return Err(error);
                     }
                 }
@@ -352,6 +363,7 @@ impl FATFile {
         let resulting_first = if old_chain_exists {
             self.first_cluster
         } else {
+            self.read_cursor = None;
             reserved_first.ok_or(SystemError::EIO)?
         };
         if let Some(tail) = reserved_last {
@@ -425,23 +437,18 @@ impl FATFile {
             return Ok(());
         }
 
+        // A failed deallocation may already have freed part of the chain.
+        // Never retain a position into it across either success or failure.
+        self.read_cursor = None;
+        self.chain_extent = None;
         let new_last_cluster = new_size.div_ceil(fs.bytes_per_cluster());
-        if let Some(begin_delete) =
-            fs.get_cluster_by_relative(self.first_cluster, new_last_cluster as usize)
-        {
-            fs.deallocate_cluster_chain(begin_delete)?;
-        };
+        fs.truncate_cluster_chain(self.first_cluster, new_last_cluster as usize)?;
 
         if new_size == 0 {
             assert!(new_last_cluster == 0);
             self.short_dir_entry.set_first_cluster(Cluster::new(0));
             self.first_cluster = Cluster::new(0);
         }
-
-        // Truncation changes the tail and can partially preallocate on some
-        // error paths. Re-measure once on the next growth instead of keeping a
-        // second, independently updated truncation state machine.
-        self.chain_extent = None;
 
         self.set_size(new_size as u32);
         // 计算短目录项在分区内的字节偏移量
@@ -1380,6 +1387,7 @@ impl ShortDirEntry {
                 short_dir_entry: *self,
                 loc: (loc, loc),
                 chain_extent: None,
+                read_cursor: None,
             };
 
             // 根据当前短目录项的类型的不同，返回对应的枚举类型。
@@ -1424,6 +1432,7 @@ impl ShortDirEntry {
                 loc,
                 short_dir_entry: *self,
                 chain_extent: None,
+                read_cursor: None,
             };
 
             if self.is_file() {

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1272,6 +1272,37 @@ impl FATFileSystem {
     /// @param start_cluster 簇链的第一个簇
     pub fn deallocate_cluster_chain(&self, start_cluster: Cluster) -> Result<(), SystemError> {
         let _fat_guard = self.fat_lock.lock();
+        self.deallocate_cluster_chain_locked(start_cluster)
+    }
+
+    /// Detach the discarded tail before any of its clusters can be reused.
+    pub(super) fn truncate_cluster_chain(
+        &self,
+        first: Cluster,
+        keep: usize,
+    ) -> Result<(), SystemError> {
+        let _fat_guard = self.fat_lock.lock();
+        let free_start = if keep == 0 {
+            first
+        } else {
+            let tail = self
+                .get_cluster_by_relative(first, keep - 1)
+                .ok_or(SystemError::EIO)?;
+            match self.get_fat_entry(tail)? {
+                FATEntry::Next(next) => {
+                    // On an ambiguous write error, retain the tail rather
+                    // than freeing clusters that may still be reachable.
+                    self.set_entry(tail, FATEntry::EndOfChain)?;
+                    next
+                }
+                FATEntry::EndOfChain => return Ok(()),
+                _ => return Err(SystemError::EIO),
+            }
+        };
+        self.deallocate_cluster_chain_locked(free_start)
+    }
+
+    fn deallocate_cluster_chain_locked(&self, start_cluster: Cluster) -> Result<(), SystemError> {
         let clusters: Vec<Cluster> = self.clusters(start_cluster);
         for c in clusters {
             self.deallocate_cluster_locked(c)?;
@@ -1752,7 +1783,7 @@ impl FATFileSystem {
                 let raw_val: u16 = match fat_entry {
                     FATEntry::Unused => 0,
                     FATEntry::Bad => 0xfff7,
-                    FATEntry::EndOfChain => 0xfdff,
+                    FATEntry::EndOfChain => 0xffff,
                     FATEntry::Next(c) => c.cluster_num as u16,
                 };
 
@@ -2126,10 +2157,11 @@ impl IndexNode for LockedFATInode {
     }
 
     fn read_sync(&self, offset: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
-        let guard: MutexGuard<FATInode> = self.0.lock();
-        match &guard.inode_type {
+        let mut guard: MutexGuard<FATInode> = self.0.lock();
+        let fs = guard.fs.upgrade().unwrap();
+        match &mut guard.inode_type {
             FATDirEntry::File(f) | FATDirEntry::VolId(f) => {
-                let r = f.read(&guard.fs.upgrade().unwrap(), buf, offset as u64);
+                let r = f.read(&fs, buf, offset as u64);
                 return r;
             }
 

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -15,10 +15,6 @@ use core::intrinsics::unlikely;
 use core::num::NonZeroUsize;
 use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
-lazy_static::lazy_static! {
-    static ref FAT_EVICTION_WQ: Arc<WorkQueue> = WorkQueue::new("fat_evict");
-}
-
 #[derive(Debug, Default)]
 struct FATReclaimQueue {
     next: u64,
@@ -130,6 +126,8 @@ impl Eq for Cluster {}
 pub struct FATFileSystem {
     writeback_domain: Arc<PageCacheWritebackDomain>,
     reclaim_queue: SpinLock<FATReclaimQueue>,
+    /// Serial within this filesystem, independent of other devices.
+    reclaim_worker: Arc<WorkQueue>,
     reclaim_wait: WaitQueue,
     /// 当前文件系统所在的分区
     pub gendisk: Arc<GenDisk>,
@@ -646,7 +644,7 @@ impl LockedFATInode {
         };
         queue.next = epoch;
         let worker_fs = fs.clone();
-        FAT_EVICTION_WQ.enqueue(Work::new(move || {
+        fs.reclaim_worker.enqueue(Work::new(move || {
             let result = inode.reclaim_detached(&worker_fs);
             let mut queue = worker_fs.reclaim_queue.lock();
             if let Err(error) = result {
@@ -990,6 +988,7 @@ impl FATFileSystem {
         let result: Arc<FATFileSystem> = Arc::new(FATFileSystem {
             writeback_domain: PageCacheWritebackDomain::new(),
             reclaim_queue: SpinLock::new(FATReclaimQueue::default()),
+            reclaim_worker: WorkQueue::try_new_owned("fat_evict")?,
             reclaim_wait: WaitQueue::default(),
             gendisk,
             _device_mount_holder: device_mount_holder,
@@ -1012,7 +1011,6 @@ impl FATFileSystem {
         root_guard.fs = Arc::downgrade(&result);
         *result.root_inode.3.owner.lock() =
             (Arc::downgrade(&result.root_inode), Arc::downgrade(&result));
-        lazy_static::initialize(&FAT_EVICTION_WQ);
         // 释放锁
         drop(root_guard);
 

--- a/kernel/src/filesystem/fat/fs.rs
+++ b/kernel/src/filesystem/fat/fs.rs
@@ -1,5 +1,8 @@
 use crate::arch::MMArch;
+use crate::exception::workqueue::{Work, WorkQueue};
+use crate::filesystem::vfs::inode_lifecycle::{EvictionEpoch, InodeRetentionState};
 use crate::filesystem::vfs::syscall::RenameFlags;
+use crate::libs::{spinlock::SpinLock, wait_queue::WaitQueue};
 use crate::mm::MemoryManagementArch;
 use alloc::string::ToString;
 use alloc::{
@@ -10,6 +13,28 @@ use alloc::{
 use core::cmp::Ordering;
 use core::intrinsics::unlikely;
 use core::num::NonZeroUsize;
+use core::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
+
+lazy_static::lazy_static! {
+    static ref FAT_EVICTION_WQ: Arc<WorkQueue> = WorkQueue::new("fat_evict");
+}
+
+#[derive(Debug, Default)]
+struct FATReclaimQueue {
+    next: u64,
+    completed: u64,
+    sealed: bool,
+    error: Option<SystemError>,
+}
+
+#[derive(Debug)]
+struct FATInodeLifetime {
+    retention: InodeRetentionState,
+    detached: AtomicBool,
+    // release() can run under arbitrary VFS locks: never take the inode mutex.
+    owner: SpinLock<(Weak<LockedFATInode>, Weak<FATFileSystem>)>,
+}
+
 use core::{any::Any, fmt::Debug};
 use hashbrown::HashMap;
 use log::error;
@@ -53,6 +78,16 @@ const FAT_MAX_NAMELEN: u64 = 255;
 const FAT_LRU_CACHE_SIZE: usize = 4096;
 const FAT_NEGATIVE_CHILDREN_CACHE_SIZE: usize = 256;
 
+impl Default for FATInodeLifetime {
+    fn default() -> Self {
+        Self {
+            retention: InodeRetentionState::new(),
+            detached: AtomicBool::new(false),
+            owner: SpinLock::new((Weak::new(), Weak::new())),
+        }
+    }
+}
+
 /// FAT32文件系统的最大的文件大小
 pub const MAX_FILE_SIZE: u64 = 0xffff_ffff;
 
@@ -94,6 +129,8 @@ impl Eq for Cluster {}
 #[derive(Debug)]
 pub struct FATFileSystem {
     writeback_domain: Arc<PageCacheWritebackDomain>,
+    reclaim_queue: SpinLock<FATReclaimQueue>,
+    reclaim_wait: WaitQueue,
     /// 当前文件系统所在的分区
     pub gendisk: Arc<GenDisk>,
     /// Prevents loop clear/remove for the complete filesystem lifetime.
@@ -137,7 +174,12 @@ pub struct FATFileSystem {
 
 /// FAT文件系统的Inode
 #[derive(Debug)]
-pub struct LockedFATInode(Mutex<FATInode>, RwSem<()>, LinkMutationCoordinator);
+pub struct LockedFATInode(
+    Mutex<FATInode>,
+    RwSem<()>,
+    LinkMutationCoordinator,
+    FATInodeLifetime,
+);
 
 #[derive(Debug)]
 pub struct LockedFATFsInfo(Mutex<FATFsInfo>);
@@ -338,6 +380,7 @@ impl LockedFATInode {
             }),
             RwSem::new(()),
             LinkMutationCoordinator::new(),
+            FATInodeLifetime::default(),
         ));
 
         if !inode.0.lock().inode_type.is_dir() {
@@ -353,6 +396,7 @@ impl LockedFATInode {
         }
 
         inode.0.lock().self_ref = Arc::downgrade(&inode);
+        *inode.3.owner.lock() = (Arc::downgrade(&inode), Arc::downgrade(&fs));
 
         inode.0.lock().synchronize_metadata();
 
@@ -418,7 +462,16 @@ impl LockedFATInode {
             }
         };
         // remove entries
-        old_inode_guard.inode_type = old_dir.rename(fs, old_name, new_name, new_inode)?;
+        let renamed = old_dir.rename(fs, old_name, new_name, new_inode.clone());
+        // Replacement may have detached the victim before a later directory
+        // update fails. Never leave that dead name in the positive cache.
+        if new_inode
+            .as_ref()
+            .is_some_and(|inode| inode.3.detached.load(AtomicOrdering::Acquire))
+        {
+            guard.mark_child_absent(new_name);
+        }
+        old_inode_guard.inode_type = renamed?;
         let old_inode = guard.children.remove(&old_key).unwrap();
         // the new_name should refer to old_inode
         guard.invalidate_negative_children();
@@ -491,13 +544,20 @@ impl LockedFATInode {
             }
         };
 
-        old_inode_guard.inode_type = old_dir.rename_across(
+        let renamed = old_dir.rename_across(
             fs,
             new_dir,
             old_name,
             new_name,
             new_inode.clone().ok_or(SystemError::ENOENT),
-        )?;
+        );
+        if new_inode
+            .as_ref()
+            .is_some_and(|inode| inode.3.detached.load(AtomicOrdering::Acquire))
+        {
+            new_guard.mark_child_absent(new_name);
+        }
+        old_inode_guard.inode_type = renamed?;
         // 将源节点从父目录中删除
         let old_key = to_search_name(old_name);
         let new_key = to_search_name(new_name);
@@ -532,7 +592,120 @@ pub struct FATFsInfo {
     offset: Option<u64>,
 }
 
+impl LockedFATInode {
+    /// The caller serializes directory mutation. Keep the victim inode locked
+    /// through slot removal and detachment so writeback cannot touch a reused slot.
+    pub(super) fn remove_file_name(
+        &self,
+        parent: &FATDir,
+        fs: Arc<FATFileSystem>,
+        name: &str,
+    ) -> Result<(), SystemError> {
+        {
+            let mut inode = self.0.lock();
+            let file = match &mut inode.inode_type {
+                FATDirEntry::File(file) | FATDirEntry::VolId(file) => file,
+                _ => return Err(SystemError::EINVAL),
+            };
+            parent.remove(fs, name, false)?;
+            file.detach();
+            inode.metadata.nlinks = 0;
+            self.3.detached.store(true, AtomicOrdering::Release);
+        }
+        self.schedule_reclaim();
+        Ok(())
+    }
+
+    fn schedule_reclaim(&self) {
+        if !self.3.detached.load(AtomicOrdering::Acquire)
+            || self.3.retention.try_begin_freeing().is_err()
+        {
+            return;
+        }
+        let (inode, fs) = {
+            let owner = self.3.owner.lock();
+            (owner.0.upgrade(), owner.1.upgrade())
+        };
+        let (Some(inode), Some(fs)) = (inode, fs) else {
+            return;
+        };
+        // FIFO publication and epoch assignment share the queue lock. Work
+        // owns both objects; neither release nor Drop performs filesystem I/O.
+        let mut queue = fs.reclaim_queue.lock();
+        if queue.sealed {
+            fs.writeback_domain
+                .record_writeback_error(SystemError::EBUSY);
+            queue.error.get_or_insert(SystemError::EBUSY);
+            return;
+        }
+        let Some(epoch) = queue.next.checked_add(1) else {
+            fs.writeback_domain
+                .record_writeback_error(SystemError::EOVERFLOW);
+            queue.error.get_or_insert(SystemError::EOVERFLOW);
+            return;
+        };
+        queue.next = epoch;
+        let worker_fs = fs.clone();
+        FAT_EVICTION_WQ.enqueue(Work::new(move || {
+            let result = inode.reclaim_detached(&worker_fs);
+            let mut queue = worker_fs.reclaim_queue.lock();
+            if let Err(error) = result {
+                // Replaying a partially completed free could double-free a
+                // reused cluster. Preserve the error, never retry the old head.
+                worker_fs
+                    .writeback_domain
+                    .record_writeback_error(error.clone());
+                queue.error.get_or_insert(error);
+            }
+            queue.completed = epoch;
+            drop(queue);
+            worker_fs.reclaim_wait.wake_all();
+        }));
+    }
+
+    fn reclaim_detached(&self, fs: &Arc<FATFileSystem>) -> Result<(), SystemError> {
+        let (cache, first) = {
+            let inode = self.0.lock();
+            (inode.page_cache.clone(), inode.inode_type.first_cluster())
+        };
+        if let Some(cache) = cache {
+            cache.manager().resize(0)?;
+        }
+        if first.cluster_num >= RESERVED_CLUSTERS as u64 {
+            fs.deallocate_cluster_chain(first)?;
+        }
+        Ok(())
+    }
+}
+
 impl FileSystem for FATFileSystem {
+    fn seal_eviction_queue(&self) -> EvictionEpoch {
+        let mut queue = self.reclaim_queue.lock();
+        queue.sealed = true;
+        EvictionEpoch::new(queue.next)
+    }
+
+    fn drain_evictions_through(&self, epoch: EvictionEpoch) -> Result<(), SystemError> {
+        self.reclaim_wait
+            .wait_until(|| {
+                let queue = self.reclaim_queue.lock();
+                (queue.completed >= epoch.value()).then(|| queue.error.clone())
+            })
+            .map_or(Ok(()), Err)
+    }
+
+    fn sync_fs(&self, wait: bool) -> Result<(), SystemError> {
+        if wait {
+            let epoch = EvictionEpoch::new(self.reclaim_queue.lock().next);
+            let reclaim_result = self.drain_evictions_through(epoch);
+            // A sticky reclamation error must not suppress durability for
+            // other files whose writeback has already completed.
+            let sync_result = self.gendisk.sync();
+            reclaim_result.and(sync_result)?;
+        }
+        Ok(())
+    }
+
     fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
         Some(&self.writeback_domain)
     }
@@ -811,10 +984,13 @@ impl FATFileSystem {
             }),
             RwSem::new(()),
             LinkMutationCoordinator::new(),
+            FATInodeLifetime::default(),
         ));
 
         let result: Arc<FATFileSystem> = Arc::new(FATFileSystem {
             writeback_domain: PageCacheWritebackDomain::new(),
+            reclaim_queue: SpinLock::new(FATReclaimQueue::default()),
+            reclaim_wait: WaitQueue::default(),
             gendisk,
             _device_mount_holder: device_mount_holder,
             bpb,
@@ -834,6 +1010,9 @@ impl FATFileSystem {
         root_guard.parent = Arc::downgrade(&result.root_inode);
         root_guard.self_ref = Arc::downgrade(&result.root_inode);
         root_guard.fs = Arc::downgrade(&result);
+        *result.root_inode.3.owner.lock() =
+            (Arc::downgrade(&result.root_inode), Arc::downgrade(&result));
+        lazy_static::initialize(&FAT_EVICTION_WQ);
         // 释放锁
         drop(root_guard);
 
@@ -2095,6 +2274,14 @@ impl LockedFATInode {
 }
 
 impl IndexNode for LockedFATInode {
+    fn retention_state(&self) -> Option<&InodeRetentionState> {
+        Some(&self.3.retention)
+    }
+
+    fn on_zero_retention(&self) {
+        self.schedule_reclaim();
+    }
+
     fn link_mutation_coordinator(&self) -> Option<&LinkMutationCoordinator> {
         Some(&self.2)
     }
@@ -2386,16 +2573,18 @@ impl IndexNode for LockedFATInode {
                         guard.metadata.size = len as i64;
                         drop(guard);
                         if let Some(page_cache) = page_cache {
-                            page_cache.manager().resize(len)?;
+                            if let Err(error) = page_cache.manager().resize(len) {
+                                self.0.lock().synchronize_metadata();
+                                return Err(error);
+                            }
                         }
                         let mut guard: MutexGuard<FATInode> = self.0.lock();
                         let fs: &Arc<FATFileSystem> = &guard.fs.upgrade().unwrap();
                         match &mut guard.inode_type {
                             FATDirEntry::File(file) | FATDirEntry::VolId(file) => {
-                                file.truncate(fs, len as u64)?;
+                                let result = file.truncate(fs, len as u64);
                                 guard.synchronize_metadata();
-                                guard.metadata.size = len as i64;
-                                return Ok(());
+                                return result;
                             }
                             FATDirEntry::Dir(_) => return Err(SystemError::ENOSYS),
                             FATDirEntry::UnInit => {
@@ -2554,43 +2743,22 @@ impl IndexNode for LockedFATInode {
     }
 
     fn unlink(&self, name: &str) -> Result<LinkRemovalOutcome, SystemError> {
-        let mut guard: MutexGuard<FATInode> = self.0.lock();
-        let target: Arc<LockedFATInode> = guard.find(name)?;
-        // 对目标inode上锁，以防更改
-        let target_guard: MutexGuard<FATInode> = target.0.lock();
-        // 先从缓存删除
-        let nod = guard.children.remove(&to_search_name(name));
-
-        // 若删除缓存中为管道的文件，则不需要再到磁盘删除
-        if nod.is_some() {
-            let file_type = target_guard.metadata.file_type;
-            if file_type == FileType::Pipe {
-                guard.invalidate_negative_children();
-                guard.mark_child_negative(to_search_name(name));
-                return Ok(LinkRemovalOutcome::LastLink);
-            }
-        }
-
-        let dir = match &guard.inode_type {
-            FATDirEntry::File(_) | FATDirEntry::VolId(_) => {
-                return Err(SystemError::ENOTDIR);
-            }
-            FATDirEntry::Dir(d) => d,
-            FATDirEntry::UnInit => {
-                error!("FATFS: param: Inode_type uninitialized.");
-                return Err(SystemError::EROFS);
-            }
-        };
-        // 检查文件是否存在
-        dir.check_existence(name, Some(false), guard.fs.upgrade().unwrap())?;
-
-        // 再从磁盘删除
-        let r = dir.remove(guard.fs.upgrade().unwrap().clone(), name, true);
-        drop(target_guard);
-        if r.is_ok() {
+        let mut guard = self.0.lock();
+        let target = guard.find(name)?;
+        let file_type = target.0.lock().metadata.file_type;
+        if file_type == FileType::Pipe {
             guard.mark_child_absent(name);
+            return Ok(LinkRemovalOutcome::LastLink);
         }
-        r.map(|_| LinkRemovalOutcome::LastLink)
+        let fs = guard.fs.upgrade().ok_or(SystemError::EIO)?;
+        let dir = match &guard.inode_type {
+            FATDirEntry::Dir(dir) => dir,
+            _ => return Err(SystemError::ENOTDIR),
+        };
+        dir.check_existence(name, Some(false), fs.clone())?;
+        target.remove_file_name(dir, fs, name)?;
+        guard.mark_child_absent(name);
+        Ok(LinkRemovalOutcome::LastLink)
     }
 
     fn rmdir(&self, name: &str) -> Result<(), SystemError> {

--- a/kernel/src/filesystem/vfs/file.rs
+++ b/kernel/src/filesystem/vfs/file.rs
@@ -695,15 +695,15 @@ pub struct File {
     /// via `eventpoll_release(file)`.  DragonOS keeps the same lifetime edge
     /// here so fd numbers can be safely reused after close.
     epitems: Arc<EPollItemList>,
+    /// Writer admission lasts through close and all shared descriptor/VMA owners.
+    /// Field destruction follows declaration order, after the explicit Drop body.
+    _write_access: Option<Arc<InodeWriteGuard>>,
     /// One semantic inode pin per open file description. Duplicated file
     /// descriptors and VMAs share this `File`, while `O_PATH` still owns it.
-    /// Declared last so the explicit `Drop` body runs `close()` before release.
     _inode_retention: InodeRetentionGuard,
-    /// Pins the mount used to resolve this pathname independently from the
-    /// operation inode (which device/FIFO resolution may replace).
+    /// Release every inode owner before the mount pin can start final shutdown
+    /// and seal the filesystem's eviction queue.
     _mount_guard: Option<MountExternalGuard>,
-    /// Writer admission lasts through close and all shared descriptor/VMA owners.
-    _write_access: Option<Arc<InodeWriteGuard>>,
 }
 
 #[derive(Debug, Clone)]
@@ -1134,6 +1134,7 @@ impl File {
             private_data_init,
             mount_guard,
             None,
+            None,
         )
     }
 
@@ -1145,15 +1146,14 @@ impl File {
         mount_guard: Option<MountExternalGuard>,
         operation_guard: InodeRetentionGuard,
     ) -> Result<Self, SystemError> {
-        let file = Self::new_with_private_data_and_mount_guard(
+        Self::new_with_private_data_and_mount_guard(
             inode,
             flags,
             FilePrivateData::default(),
             mount_guard,
+            Some(operation_guard),
             None,
-        );
-        drop(operation_guard);
-        file
+        )
     }
 
     /// Construct a pathname-backed file from an already-opened inode.
@@ -1164,15 +1164,14 @@ impl File {
         operation_guard: InodeRetentionGuard,
     ) -> Result<Self, SystemError> {
         let inode = preopened.inode();
-        let file = Self::new_with_private_data_and_mount_guard(
+        Self::new_with_private_data_and_mount_guard(
             inode,
             flags,
             FilePrivateData::default(),
             mount_guard,
+            Some(operation_guard),
             Some(preopened),
-        );
-        drop(operation_guard);
-        file
+        )
     }
 
     fn new_with_private_data_and_mount_guard(
@@ -1180,6 +1179,9 @@ impl File {
         mut flags: FileFlags,
         private_data_init: FilePrivateData,
         mount_guard: Option<MountExternalGuard>,
+        // Parameters drop in reverse order on failure: release the operation
+        // pin before the mount pin, just as the completed File does.
+        _operation_guard: Option<InodeRetentionGuard>,
         mut preopened: Option<PreopenedFile>,
     ) -> Result<Self, SystemError> {
         let mut inode = inode;
@@ -1321,9 +1323,9 @@ impl File {
             wb_error_seq: Mutex::new(wb_error_seq),
             sb_error_seq: Mutex::new(sb_error_seq),
             epitems: Arc::new(EPollItemList::default()),
+            _write_access: write_access,
             _inode_retention: inode_retention,
             _mount_guard: mount_guard,
-            _write_access: write_access,
         };
 
         return Ok(f);
@@ -2522,9 +2524,9 @@ impl File {
             wb_error_seq: Mutex::new(*self.wb_error_seq.lock()),
             sb_error_seq: Mutex::new(*self.sb_error_seq.lock()),
             epitems: Arc::new(EPollItemList::default()),
+            _write_access: self._write_access.clone(),
             _inode_retention: inode_retention,
             _mount_guard: mount_guard,
-            _write_access: self._write_access.clone(),
         };
         return Some(res);
     }

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -502,6 +502,9 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
         // An open hook may perform atomic O_TRUNC even for O_RDONLY. Hold
         // write access before invoking it and through the post-open truncate,
         // without retaining a writer for the returned read-only description.
+        // This owner outlives the temporary writer even when constructing the
+        // File or truncating it fails and releases the File's mount pin.
+        let _truncate_path = do_truncate.then(|| resolved.derive_existing_owner());
         let _truncate_write_access = if do_truncate {
             Some(super::write_access::InodeWriteGuard::writer(inode.clone())?)
         } else {

--- a/kernel/src/filesystem/vfs/open.rs
+++ b/kernel/src/filesystem/vfs/open.rs
@@ -499,6 +499,14 @@ fn do_sys_openat2(dirfd: i32, path: &str, how: OpenHow) -> Result<usize, SystemE
         // Linux clears O_TRUNC for this phase.
         let do_truncate =
             !created && file_type == FileType::File && how.o_flags.contains(FileFlags::O_TRUNC);
+        // An open hook may perform atomic O_TRUNC even for O_RDONLY. Hold
+        // write access before invoking it and through the post-open truncate,
+        // without retaining a writer for the returned read-only description.
+        let _truncate_write_access = if do_truncate {
+            Some(super::write_access::InodeWriteGuard::writer(inode.clone())?)
+        } else {
+            None
+        };
         let truncate_metadata = do_truncate.then(|| metadata.clone());
         let (inode, mount_guard, operation_guard) = resolved.into_parts();
         let file: File = match preopened {

--- a/kernel/src/filesystem/vfs/utils.rs
+++ b/kernel/src/filesystem/vfs/utils.rs
@@ -21,8 +21,9 @@ use crate::libs::casting::DowncastArc;
 #[derive(Debug)]
 pub struct ResolvedPath {
     inode: Arc<dyn IndexNode>,
-    mount_guard: Option<MountExternalGuard>,
+    // Publish final inode eviction before the mount pin can trigger shutdown.
     _operation_guard: InodeRetentionGuard,
+    mount_guard: Option<MountExternalGuard>,
 }
 
 /// Result of a pathname walk that may stop at a missing final component.

--- a/kernel/src/filesystem/vfs/vcore.rs
+++ b/kernel/src/filesystem/vfs/vcore.rs
@@ -859,13 +859,14 @@ pub(crate) fn prepare_open_truncate(metadata_before_open: Metadata) -> OpenTrunc
 }
 
 /// Complete Linux's post-open truncate stage for an existing regular file.
+/// The open caller holds temporary inode write access across the filesystem
+/// open hook and this stage, including for O_RDONLY | O_TRUNC.
 pub(crate) fn vfs_open_truncate(
     file: &File,
     context: &OpenTruncateContext,
 ) -> Result<(), SystemError> {
     let inode = file.inode();
     validate_truncate(&inode, &context.requested, 0)?;
-    let _write_access = super::write_access::InodeWriteGuard::writer(inode.clone())?;
     inode.resize_open_truncate(
         0,
         current_file_lock_owner_id(),

--- a/kernel/src/mm/ucontext/inner.rs
+++ b/kernel/src/mm/ucontext/inner.rs
@@ -12,10 +12,12 @@ pub struct InnerAddressSpace {
     pub mmap_min: VirtAddr,
     /// User stack information struct
     pub user_stack: Option<UserStack>,
-    /// Main image File and deny-write ownership, released at last mm user teardown.
+    /// Main image ownership, released at last mm user teardown. Tuple elements
+    /// drop in order: release deny-write before the File and its mount pin,
+    /// matching Linux's allow_write_access() before fput().
     pub(crate) exec_write_guard: Option<(
-        Arc<crate::filesystem::vfs::file::File>,
         Arc<crate::filesystem::vfs::write_access::InodeWriteGuard>,
+        Arc<crate::filesystem::vfs::file::File>,
     )>,
 
     pub elf_brk_start: VirtAddr,

--- a/kernel/src/process/exec.rs
+++ b/kernel/src/process/exec.rs
@@ -203,9 +203,10 @@ bitflags! {
 
 #[derive(Debug)]
 pub struct ExecParam {
-    file: Arc<File>,
-    // Loading protection is separate from File/VMA lifetime (notably PT_INTERP).
+    // Release loading protection before the File can drop its mount pin,
+    // including failed loads and interpreter parameters.
     exec_write_guard: Arc<crate::filesystem::vfs::write_access::InodeWriteGuard>,
+    file: Arc<File>,
     vm: Arc<AddressSpace>,
     /// Flags.
     flags: ExecParamFlags,
@@ -394,7 +395,7 @@ impl ExecParam {
         exec_task_namespaces().map_err(ExecError::SystemError)?;
         // The main image stays protected for the mm's user lifetime, including
         // fork. Interpreter ExecParams never call begin_new_exec().
-        self.vm.write().exec_write_guard = Some((self.file.clone(), self.exec_write_guard.clone()));
+        self.vm.write().exec_write_guard = Some((self.exec_write_guard.clone(), self.file.clone()));
         Ok(())
     }
 

--- a/user/apps/tests/dunitest/Makefile
+++ b/user/apps/tests/dunitest/Makefile
@@ -20,6 +20,7 @@ RESULTS_DIR = results
 BIN_DIR = bin
 BUILD_DIR = build
 EXT4_FIXTURE = $(BUILD_DIR)/fixtures/ext4_inode_identity.img
+EXT4_UNINIT_FIXTURE = $(BUILD_DIR)/fixtures/ext4_uninit_bitmap.img
 
 # 要编译的测试套件目录列表（suites/ 下的子目录名）
 SUITES = demo normal fuse
@@ -58,7 +59,7 @@ $(GTEST_SRC):
 	@mv "$(GTEST_TMP_ROOT)" "$(GTEST_ROOT)"
 	@test -f "$(GTEST_SRC)"
 
-build-suites: $(TEST_BINS) $(EXT4_FIXTURE)
+build-suites: $(TEST_BINS) $(EXT4_FIXTURE) $(EXT4_UNINIT_FIXTURE)
 
 $(EXT4_FIXTURE):
 	@mkdir -p "$(dir $@)"
@@ -69,6 +70,21 @@ $(EXT4_FIXTURE):
 				rm -f "$@"; \
 				truncate -s 8M "$@"; \
 				mke2fs -q -t ext4 -F "$@" ;; \
+			*) printf '%s\n' "$$output" >&2; exit 1 ;; \
+		esac; \
+	}
+
+# Small block groups force a modest payload into legal BLOCK_UNINIT groups.
+# Keep lazy bitmap initialization enabled; never pre-mount this source image.
+$(EXT4_UNINIT_FIXTURE):
+	@mkdir -p "$(dir $@)"
+	@truncate -s 32M "$@"
+	@output=$$(mke2fs -q -t ext4 -F -b 4096 -g 1024 -G 2 -I 256 -O metadata_csum,64bit,flex_bg,^orphan_file "$@" 2>&1) || { \
+		case "$$output" in \
+			*"Invalid filesystem option set:"*"orphan_file"*) \
+				rm -f "$@"; \
+				truncate -s 32M "$@"; \
+				mke2fs -q -t ext4 -F -b 4096 -g 1024 -G 2 -I 256 -O metadata_csum,64bit,flex_bg "$@" ;; \
 			*) printf '%s\n' "$$output" >&2; exit 1 ;; \
 		esac; \
 	}
@@ -99,7 +115,7 @@ install: build
 	@chmod +x $(INSTALL_DIR)/dunitest-runner
 	@cp -rf $(BIN_DIR) $(INSTALL_DIR)/
 	@mkdir -p $(INSTALL_DIR)/fixtures
-	@cp --sparse=always -f $(EXT4_FIXTURE) $(INSTALL_DIR)/fixtures/
+	@cp --sparse=always -f $(EXT4_FIXTURE) $(EXT4_UNINIT_FIXTURE) $(INSTALL_DIR)/fixtures/
 	@cp -f whitelist.txt $(INSTALL_DIR)/whitelist.txt
 	@cp -f no_skip.txt $(INSTALL_DIR)/no_skip.txt
 	@cp -f scripts/run_tests.sh $(INSTALL_DIR)/run_tests.sh

--- a/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
+++ b/user/apps/tests/dunitest/suites/fuse/fuse_extended.cc
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <atomic>
+#include <elf.h>
 #include <signal.h>
 #include <sched.h>
 #include <setjmp.h>
@@ -11350,6 +11351,144 @@ TEST(FuseExtended, FopenStreamDisablesRandomIo) {
 TEST(FuseExtended, FopenNonseekableDirectoryDisablesLseek) {
     ASSERT_EQ(0,
               ext_test_fopen_nonseekable_dir_mode(FOPEN_NONSEEKABLE, "/tmp/test_fuse_dir_nonseek"));
+}
+
+TEST(FuseExtended, ReadOnlyAtomicTruncateRejectsRunningExecutableBeforeOpen) {
+#if !defined(__x86_64__)
+    GTEST_SKIP() << "fixture contains x86_64 entry instructions";
+#else
+    char mount_point[] = "/tmp/fuse_exec_trunc_XXXXXX";
+    ASSERT_NE(nullptr, mkdtemp(mount_point));
+    int fuse_fd = open("/dev/fuse", O_RDWR | O_CLOEXEC);
+    if (fuse_fd < 0) {
+        rmdir(mount_point);
+        FAIL() << "open /dev/fuse: " << strerror(errno);
+    }
+    volatile int stop = 0;
+    volatile int init_done = 0;
+    volatile uint32_t open_count = 0;
+    struct fuse_daemon_args args = {};
+    args.fd = fuse_fd;
+    args.stop = &stop;
+    args.init_done = &init_done;
+    args.stop_on_destroy = 1;
+    args.enable_write_ops = 1;
+    args.open_count = &open_count;
+    args.hello_mode_override = S_IFREG | 0755;
+    args.init_out_flags_override = FUSE_INIT_EXT | FUSE_MAX_PAGES | FUSE_ATOMIC_O_TRUNC;
+    pthread_t daemon;
+    if (pthread_create(&daemon, NULL, fuse_daemon_thread, &args) != 0) {
+        close(fuse_fd);
+        rmdir(mount_point);
+        FAIL() << "pthread_create";
+    }
+    bool mounted = false;
+    int retained_reader = -1;
+    int writer = -1;
+    int ready[2] = {-1, -1};
+    pid_t child = -1;
+    // The lambda keeps assertion failures inside a scope whose resources are
+    // always released below, including the paused executable and FUSE daemon.
+    [&]() {
+        char options[256];
+        snprintf(options, sizeof(options), "fd=%d,rootmode=040755,user_id=0,group_id=0", fuse_fd);
+        ASSERT_EQ(0, mount("none", mount_point, "fuse", 0, options)) << strerror(errno);
+        mounted = true;
+        ASSERT_EQ(0, fuseg_wait_init(&init_done));
+        char path[256];
+        snprintf(path, sizeof(path), "%s/hello.txt", mount_point);
+        // Keep a successful read-only truncating fd open in the parent. Its
+        // temporary write authorization must not prevent a later exec.
+        retained_reader = open(path, O_RDONLY | O_TRUNC | O_CLOEXEC);
+        ASSERT_GE(retained_reader, 0) << strerror(errno);
+        unsigned char image[256] = {};
+        Elf64_Ehdr eh = {};
+        memcpy(eh.e_ident, ELFMAG, SELFMAG);
+        eh.e_ident[EI_CLASS] = ELFCLASS64;
+        eh.e_ident[EI_DATA] = ELFDATA2LSB;
+        eh.e_ident[EI_VERSION] = EV_CURRENT;
+        eh.e_type = ET_EXEC;
+        eh.e_machine = EM_X86_64;
+        eh.e_version = EV_CURRENT;
+        eh.e_entry = 0x400080;
+        eh.e_phoff = sizeof(eh);
+        eh.e_ehsize = sizeof(eh);
+        eh.e_phentsize = sizeof(Elf64_Phdr);
+        eh.e_phnum = 1;
+        Elf64_Phdr ph = {};
+        ph.p_type = PT_LOAD;
+        ph.p_flags = PF_R | PF_X;
+        ph.p_vaddr = 0x400000;
+        ph.p_filesz = ph.p_memsz = sizeof(image);
+        ph.p_align = 4096;
+        // write(3, stack byte 0x7b, 1), then pause forever. Readiness proves
+        // exec has completed; no timing assumption substitutes for that fact.
+        const unsigned char entry[] = {
+            0x6a, 0x7b, 0x48, 0x89, 0xe6, 0xba, 0x01, 0x00, 0x00, 0x00,
+            0xbf, 0x03, 0x00, 0x00, 0x00, 0xb8, 0x01, 0x00, 0x00, 0x00,
+            0x0f, 0x05, 0xb8, 0x22, 0x00, 0x00, 0x00, 0x0f, 0x05, 0xeb, 0xf7,
+        };
+        memcpy(image, &eh, sizeof(eh));
+        memcpy(image + eh.e_phoff, &ph, sizeof(ph));
+        memcpy(image + 0x80, entry, sizeof(entry));
+        writer = open(path, O_WRONLY | O_CLOEXEC);
+        ASSERT_GE(writer, 0) << strerror(errno);
+        ASSERT_EQ(static_cast<ssize_t>(sizeof(image)), write(writer, image, sizeof(image)));
+        ASSERT_EQ(0, fsync(writer));
+        int closed = close(writer);
+        writer = -1;
+        ASSERT_EQ(0, closed);
+        ASSERT_EQ(0, pipe(ready));
+        child = fork();
+        ASSERT_GE(child, 0);
+        if (child == 0) {
+            close(ready[0]);
+            if (dup2(ready[1], 3) < 0 || fcntl(3, F_SETFD, 0) < 0)
+                _exit(101);
+            execl(path, path, nullptr);
+            _exit(102);
+        }
+        close(ready[1]);
+        ready[1] = -1;
+        ASSERT_EQ(0, fuseg_wait_readable(ready[0], 3000))
+            << "exec failed or was blocked by retained read-only fd";
+        unsigned char byte = 0;
+        ASSERT_EQ(1, read(ready[0], &byte, 1));
+        ASSERT_EQ(0x7b, byte);
+        const uint32_t opens_before = open_count;
+        errno = 0;
+        int denied = open(path, O_RDONLY | O_TRUNC);
+        const int denied_errno = errno;
+        if (denied >= 0)
+            close(denied);
+        EXPECT_EQ(-1, denied);
+        EXPECT_EQ(ETXTBSY, denied_errno);
+        EXPECT_EQ(opens_before, open_count) << "rejected truncation reached FUSE_OPEN";
+        struct stat st = {};
+        EXPECT_EQ(0, fstat(retained_reader, &st));
+        EXPECT_EQ(static_cast<off_t>(sizeof(image)), st.st_size);
+        unsigned char observed[sizeof(image)] = {};
+        EXPECT_EQ(static_cast<ssize_t>(sizeof(observed)),
+                  pread(retained_reader, observed, sizeof(observed), 0));
+        EXPECT_EQ(0, memcmp(image, observed, sizeof(image))) << "executable was truncated";
+    }();
+    if (child > 0) {
+        kill(child, SIGKILL);
+        int status = 0;
+        EXPECT_EQ(child, waitpid(child, &status, 0));
+    }
+    if (ready[0] >= 0) close(ready[0]);
+    if (ready[1] >= 0) close(ready[1]);
+    if (writer >= 0) close(writer);
+    if (retained_reader >= 0) close(retained_reader);
+    if (mounted) {
+        EXPECT_EQ(0, umount(mount_point)) << strerror(errno);
+    }
+    stop = 1;
+    close(fuse_fd);
+    pthread_join(daemon, NULL);
+    EXPECT_EQ(0, rmdir(mount_point));
+#endif
 }
 
 TEST(FuseExtended, AtomicOTruncUsesOpenWithoutSetattr) {

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -59,7 +59,7 @@ constexpr unsigned long kLoopCtlGetFree = 0x4C82;
 constexpr unsigned long kLoopSetFd = 0x4C00;
 constexpr unsigned long kLoopClrFd = 0x4C01;
 
-std::string FixturePath() {
+std::string FixturePath(const char* name = "ext4_inode_identity.img") {
     char executable[512] = {};
     ssize_t size = readlink("/proc/self/exe", executable, sizeof(executable) - 1);
     if (size <= 0) {
@@ -73,7 +73,7 @@ std::string FixturePath() {
         }
         path.resize(slash);
     }
-    return path + "/fixtures/ext4_inode_identity.img";
+    return path + "/fixtures/" + name;
 }
 
 void CopySparseFile(const std::string& source, int destination) {
@@ -139,7 +139,7 @@ class LoopExt4 {
         }
     }
 
-    void SetUp() {
+    void SetUp(const char* fixture = "ext4_inode_identity.img") {
         image_ = "/tmp/ext4_inode_identity_" + std::to_string(getpid()) + ".img";
         mount_point_ = "/tmp/ext4_inode_identity_" + std::to_string(getpid()) + "_mnt";
 
@@ -147,7 +147,7 @@ class LoopExt4 {
 
         backing_fd_ = open(image_.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
         ASSERT_GE(backing_fd_, 0) << strerror(errno);
-        ASSERT_NO_FATAL_FAILURE(CopySparseFile(FixturePath(), backing_fd_));
+        ASSERT_NO_FATAL_FAILURE(CopySparseFile(FixturePath(fixture), backing_fd_));
         close(backing_fd_);
         backing_fd_ = -1;
 
@@ -2000,6 +2000,67 @@ TEST(Ext4InodeIdentity, BindAliasAndMapsShareDeletedDentryState) {
     ASSERT_EQ(0, rmdir(bind_dir.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(source_dir.c_str())) << strerror(errno);
     ASSERT_EQ(0, rmdir(base.c_str())) << strerror(errno);
+}
+
+TEST(Ext4InodeIdentity, BlockUninitCrossGroupWriteChmodFsyncAndRemount) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp("ext4_uninit_bitmap.img"));
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    const std::string path = fs.mount_point() + "/payload";
+    constexpr size_t kChunk = 64 * 1024;
+    constexpr size_t kSize = 12 * 1024 * 1024;
+    int fd = open(path.c_str(), O_CREAT | O_EXCL | O_RDWR, 0644);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    std::vector<unsigned char> data(kChunk);
+    bool written = true;
+    for (size_t offset = 0; offset < kSize; offset += kChunk) {
+        std::fill(data.begin(), data.end(), offset / kChunk % 251 + 1);
+        ssize_t count = pwrite(fd, data.data(), data.size(), offset);
+        if (count != static_cast<ssize_t>(data.size())) {
+            ADD_FAILURE() << "cross-group write offset=" << offset << " count="
+                          << count << " errno=" << errno;
+            written = false;
+            break;
+        }
+    }
+    // chmod must drain delayed data allocation successfully before publishing
+    // execute permission; fsync and remount prove this is persistent data.
+    int chmod_result = fchmod(fd, 0755);
+    int chmod_error = errno;
+    int sync_result = fsync(fd);
+    int sync_error = errno;
+    int closed = close(fd);
+    ASSERT_TRUE(written);
+    ASSERT_EQ(0, chmod_result) << strerror(chmod_error);
+    ASSERT_EQ(0, sync_result) << strerror(sync_error);
+    ASSERT_EQ(0, closed);
+    for (int pass = 0; pass < 2; ++pass) {
+        if (pass == 1) {
+            ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+            ASSERT_NO_FATAL_FAILURE(fs.Mount());
+        }
+        fd = open(path.c_str(), O_RDONLY);
+        ASSERT_GE(fd, 0) << strerror(errno);
+        struct stat st = {};
+        EXPECT_EQ(0, fstat(fd, &st));
+        EXPECT_EQ(static_cast<off_t>(kSize), st.st_size);
+        EXPECT_EQ(static_cast<mode_t>(0755), st.st_mode & 0777);
+        bool correct = true;
+        for (size_t offset = 0; offset < kSize; offset += kChunk) {
+            ssize_t count = pread(fd, data.data(), data.size(), offset);
+            unsigned char expected = offset / kChunk % 251 + 1;
+            if (count != static_cast<ssize_t>(data.size()) ||
+                !std::all_of(data.begin(), data.end(),
+                             [expected](unsigned char value) { return value == expected; })) {
+                ADD_FAILURE() << "payload mismatch pass=" << pass << " offset=" << offset;
+                correct = false;
+                break;
+            }
+        }
+        EXPECT_EQ(0, close(fd));
+        ASSERT_TRUE(correct);
+    }
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
+++ b/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
@@ -1,6 +1,7 @@
 #include <fcntl.h>
 #include <gtest/gtest.h>
 #include <sys/stat.h>
+#include <sys/mman.h>
 #include <sys/statfs.h>
 #include <sys/statvfs.h>
 #include <unistd.h>
@@ -263,6 +264,125 @@ TEST(FatConcurrentAllocation, FragmentedColdReadsSurviveTruncateRegrowthAndRenam
   files.fds[2] = open(TestPath(2).c_str(), O_RDONLY);
   ASSERT_GE(files.fds[2], 0) << strerror(errno);
   ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[2], false, kRetained));
+}
+
+void CheckRemovedOpenFile(bool replace_by_rename) {
+  struct statfs fs_type {};
+  ASSERT_EQ(0, statfs("/", &fs_type)) << strerror(errno);
+  if (fs_type.f_type != kMsdosSuperMagic) {
+    GTEST_SKIP() << "root filesystem is not FAT";
+  }
+  constexpr size_t kSize = 256 * 1024;
+  struct statvfs space {};
+  ASSERT_EQ(0, statvfs("/", &space));
+  if (space.f_bavail * space.f_frsize < 4 * kSize + 1024 * 1024) {
+    GTEST_SKIP() << "insufficient free FAT space";
+  }
+  TestFiles files;
+  std::vector<uint8_t> old_data(kSize, 0x31);
+  const std::vector<uint8_t> new_data(kSize, 0x62);
+  files.fds[0] = open(TestPath(0).c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+  ASSERT_GE(files.fds[0], 0) << strerror(errno);
+  ASSERT_TRUE(WriteAll(files.fds[0], old_data.data(), old_data.size()));
+  ASSERT_EQ(0, fsync(files.fds[0]));
+  ASSERT_EQ(0, posix_fadvise(files.fds[0], 0, 0, POSIX_FADV_DONTNEED));
+  std::array<uint8_t, kBlockSize> tail;
+  ASSERT_TRUE(ReadAllAt(files.fds[0], tail.data(), tail.size(), kSize - kBlockSize));
+  // The old inode's physical read cursor now points into its last cluster.
+  if (!replace_by_rename) {
+    ASSERT_EQ(0, unlink(TestPath(0).c_str())) << strerror(errno);
+  }
+  files.fds[1] = open(TestPath(replace_by_rename ? 1 : 0).c_str(),
+                      O_CREAT | O_EXCL | O_RDWR, 0600);
+  ASSERT_GE(files.fds[1], 0) << strerror(errno);
+  ASSERT_TRUE(WriteAll(files.fds[1], new_data.data(), new_data.size()));
+  ASSERT_EQ(0, fsync(files.fds[1]));
+  if (replace_by_rename) {
+    ASSERT_EQ(0, rename(TestPath(1).c_str(), TestPath(0).c_str())) << strerror(errno);
+  }
+  files.fds[2] = open(TestPath(2).c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+  ASSERT_GE(files.fds[2], 0);
+  std::vector<uint8_t> pressure(2 * kSize, 0xa7);
+  ASSERT_TRUE(WriteAll(files.fds[2], pressure.data(), pressure.size()));
+  ASSERT_EQ(0, fsync(files.fds[2]));
+  auto check_cold = [&](int fd, const std::vector<uint8_t>& expected) {
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
+    std::vector<uint8_t> observed(expected.size());
+    ASSERT_TRUE(ReadAllAt(fd, observed.data(), observed.size(), 0)) << strerror(errno);
+    ASSERT_TRUE(observed == expected) << "cold content mismatch after namespace removal";
+    struct stat st {};
+    ASSERT_EQ(0, fstat(fd, &st));
+    ASSERT_EQ(static_cast<off_t>(expected.size()), st.st_size);
+  };
+  // Check the cursor hit directly before a full cold scan could reset it.
+  ASSERT_EQ(0, posix_fadvise(files.fds[0], 0, 0, POSIX_FADV_DONTNEED));
+  ASSERT_TRUE(ReadAllAt(files.fds[0], tail.data(), tail.size(), kSize - kBlockSize));
+  ASSERT_TRUE(std::all_of(tail.begin(), tail.end(), [](uint8_t b) { return b == 0x31; }));
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], old_data));
+  old_data[0] = 0x45;
+  ASSERT_EQ(1, pwrite(files.fds[0], old_data.data(), 1, 0));
+  std::array<uint8_t, kBlockSize> appended;
+  appended.fill(0x56);
+  ASSERT_EQ(static_cast<ssize_t>(appended.size()),
+            pwrite(files.fds[0], appended.data(), appended.size(), old_data.size()));
+  old_data.insert(old_data.end(), appended.begin(), appended.end());
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], old_data));
+  const size_t grown_size = old_data.size();
+  constexpr size_t kShrunk = kSize / 2 + 123;
+  ASSERT_EQ(0, ftruncate(files.fds[0], kShrunk)) << strerror(errno);
+  old_data.resize(kShrunk);
+  ASSERT_EQ(0, ftruncate(files.fds[0], grown_size)) << strerror(errno);
+  old_data.resize(grown_size, 0);
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], old_data));
+  // Reopen by pathname: stale directory-entry writeback must not overwrite
+  // the replacement file's size or cluster pointer.
+  files.fds[3] = open(TestPath(0).c_str(), O_RDONLY);
+  ASSERT_GE(files.fds[3], 0) << strerror(errno);
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[3], new_data));
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[2], pressure));
+  // A mapping is another live reference to the removed inode. Release the
+  // final fd first, then verify shared writes and delayed inode reclamation.
+  struct MappedPage {
+    void* address = MAP_FAILED;
+    ~MappedPage() {
+      if (address != MAP_FAILED) munmap(address, kBlockSize);
+    }
+  } mapping;
+  mapping.address = mmap(nullptr, kBlockSize, PROT_READ | PROT_WRITE,
+                         MAP_SHARED, files.fds[0], 0);
+  ASSERT_NE(MAP_FAILED, mapping.address) << strerror(errno);
+  struct statvfs before {}, after {};
+  // Drain unrelated dirty allocations (including a freshly downloaded test
+  // binary) before measuring reclamation. The mapping still pins this inode.
+  ASSERT_EQ(0, syncfs(files.fds[3])) << strerror(errno);
+  ASSERT_EQ(0, statvfs("/", &before));
+  int closed = close(files.fds[0]);
+  files.fds[0] = -1;
+  ASSERT_EQ(0, closed);
+  ASSERT_EQ(0, syncfs(files.fds[3])) << strerror(errno);
+  auto* mapped = static_cast<volatile uint8_t*>(mapping.address);
+  EXPECT_EQ(old_data[0], mapped[0]);
+  mapped[3] = 0x7c;
+  EXPECT_EQ(0x7c, mapped[3]);
+  ASSERT_EQ(0, msync(mapping.address, kBlockSize, MS_SYNC)) << strerror(errno);
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[3], new_data));
+  ASSERT_EQ(0, munmap(mapping.address, kBlockSize));
+  mapping.address = MAP_FAILED;
+  ASSERT_EQ(0, syncfs(files.fds[3])) << strerror(errno);
+  ASSERT_EQ(0, statvfs("/", &after));
+  ASSERT_GE(after.f_bfree, before.f_bfree);
+  EXPECT_GE((after.f_bfree - before.f_bfree) * after.f_frsize, old_data.size())
+      << "final munmap plus syncfs must release the removed file's data clusters";
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[3], new_data));
+}
+
+TEST(FatConcurrentAllocation, UnlinkedOpenFileRetainsPrivateChainUntilLastClose) {
+  CheckRemovedOpenFile(false);
+}
+
+TEST(FatConcurrentAllocation, ReplacedOpenFileRetainsPrivateChainUntilLastClose) {
+  CheckRemovedOpenFile(true);
 }
 
 }  // namespace

--- a/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
+++ b/user/apps/tests/dunitest/suites/normal/fat_concurrent_allocation.cc
@@ -195,6 +195,76 @@ TEST(FatConcurrentAllocation, FallocateAcrossExactClusterBoundaries) {
   ASSERT_EQ(0, unlink(path.c_str())) << strerror(errno);
 }
 
+TEST(FatConcurrentAllocation, FragmentedColdReadsSurviveTruncateRegrowthAndRename) {
+  struct statfs fs_type {};
+  ASSERT_EQ(0, statfs("/", &fs_type)) << strerror(errno);
+  if (fs_type.f_type != kMsdosSuperMagic) {
+    GTEST_SKIP() << "root filesystem is not FAT";
+  }
+  constexpr size_t kChunk = 64 * 1024;
+  constexpr size_t kSize = 2 * 1024 * 1024;
+  struct statvfs space {};
+  ASSERT_EQ(0, statvfs("/", &space));
+  if (space.f_bavail * space.f_frsize < 3 * kSize) {
+    GTEST_SKIP() << "insufficient free FAT space";
+  }
+  TestFiles files;
+  for (size_t i = 0; i < 2; ++i) {
+    files.fds[i] = open(TestPath(i).c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(files.fds[i], 0) << strerror(errno);
+  }
+  std::vector<uint8_t> chunk(kChunk);
+  // Alternate actual allocation between two files, rather than assuming that
+  // writing a single file produces a fragmented chain. Sync each growth step.
+  for (size_t offset = 0; offset < kSize; offset += kChunk) {
+    for (size_t i = 0; i < chunk.size(); ++i) {
+      chunk[i] = static_cast<uint8_t>(((offset + i) / kBlockSize) % 251 + 1);
+    }
+    ASSERT_TRUE(WriteAll(files.fds[0], chunk.data(), chunk.size()));
+    ASSERT_EQ(0, fsync(files.fds[0])) << strerror(errno);
+    std::fill(chunk.begin(), chunk.end(), 0xde);
+    ASSERT_TRUE(WriteAll(files.fds[1], chunk.data(), chunk.size()));
+    ASSERT_EQ(0, fsync(files.fds[1])) << strerror(errno);
+  }
+  auto check_cold = [&](int fd, bool reverse, size_t preserved) {
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, posix_fadvise(fd, 0, 0, POSIX_FADV_RANDOM));
+    ASSERT_EQ(0, posix_fadvise(fd, 0, 0, POSIX_FADV_DONTNEED));
+    std::array<uint8_t, kBlockSize> block;
+    for (size_t n = 0; n < kSize / kBlockSize; ++n) {
+      size_t index = reverse ? kSize / kBlockSize - 1 - n : n;
+      const size_t offset = index * kBlockSize;
+      ASSERT_TRUE(ReadAllAt(fd, block.data(), block.size(), offset))
+          << "offset=" << offset << ": " << strerror(errno);
+      for (size_t i = 0; i < block.size(); ++i) {
+        uint8_t expected = offset + i < preserved
+                               ? static_cast<uint8_t>(index % 251 + 1) : 0;
+        ASSERT_EQ(expected, block[i]) << "offset=" << offset + i;
+      }
+    }
+  };
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], false, kSize));
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], true, kSize));
+  // Leave the physical lookup cursor at the old tail before freeing it.
+  ASSERT_EQ(0, posix_fadvise(files.fds[0], 0, 0, POSIX_FADV_DONTNEED));
+  std::array<uint8_t, kBlockSize> tail;
+  ASSERT_TRUE(ReadAllAt(files.fds[0], tail.data(), tail.size(), kSize - kBlockSize));
+  constexpr size_t kRetained = 3 * kChunk + 123;
+  ASSERT_EQ(0, ftruncate(files.fds[0], kRetained));
+  ASSERT_EQ(0, fsync(files.fds[0]));
+  // Reuse released space in another chain before growing the original again.
+  std::fill(chunk.begin(), chunk.end(), 0xa7);
+  ASSERT_TRUE(WriteAll(files.fds[1], chunk.data(), chunk.size()));
+  ASSERT_EQ(0, fsync(files.fds[1]));
+  ASSERT_EQ(0, ftruncate(files.fds[0], kSize)) << strerror(errno) << " errno=" << errno;
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], false, kRetained));
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[0], true, kRetained));
+  ASSERT_EQ(0, rename(TestPath(0).c_str(), TestPath(2).c_str())) << strerror(errno);
+  files.fds[2] = open(TestPath(2).c_str(), O_RDONLY);
+  ASSERT_GE(files.fds[2], 0) << strerror(errno);
+  ASSERT_NO_FATAL_FAILURE(check_cold(files.fds[2], false, kRetained));
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Fix filesystem correctness and performance problems exposed by large-file installation and regression testing.

## Changes

### Initialize ext4 BLOCK_UNINIT bitmaps before allocation

The allocator previously checked the raw bitmap checksum of a legitimately uninitialized block group. Crossing into that group could fail delayed writeback with EIO, including when chmod flushed CodeBuddy installation data.

Share bitmap preparation between transactional and direct allocation. Reuse existing system metadata ranges to protect flex_bg metadata, backup metadata and out-of-group bits. Authenticate descriptors and validate free counts; retain checksum validation for initialized bitmaps. Publish the complete bitmap, BLOCK_UNINIT transition, counts and checksums through the existing transaction path, retaining original images for direct rollback. Other group flags remain intact.

### Protect executable images before atomic open truncation

Address the [review finding in #2264](https://github.com/DragonOS-Community/DragonOS/pull/2264#discussion_r3953607919). Acquire the temporary O_TRUNC writer guard before filesystem open hooks and retain it through post-open truncation. An O_RDONLY | O_TRUNC open now returns ETXTBSY before an atomic FUSE open can destroy the executable. The returned read-only descriptor does not retain a writer guard.

### Avoid repeated FAT chain scans during cold sequential reads

The initial Dunitest run timed out while reading the new 32 MiB fixture from its FAT32 source, before ext4 allocation began. Every cold page restarted cluster lookup at the first cluster. Prefixes exceeding the 4096-entry FAT LRU caused repeated traversal and cache thrashing. GDB samples from a separate cold FAT read confirmed this path.

Retain one logical/physical read cursor per FATFile under its existing inode mutex. Forward reads resume from the cursor; backward reads restart at the first cluster. Invalidate before cluster release, first-cluster replacement and ambiguous chain attachment. No additional lock, unbounded index, test timeout increase or fixture reduction is introduced.

The cursor validation also exposed an existing nonzero-truncation defect: the retained FAT chain still pointed to freed tail clusters. Terminate the retained tail with EOC before freeing the discarded chain under the existing FAT lock, and invalidate both cached positions before mutation. Correct the shared FAT16 EOC encoding from 0xfdff to 0xffff.

### Preserve unlinked FAT inode lifetimes and failed-truncate state

Unlink and replacement rename previously freed clusters still reachable through open files, mappings and writeback. Keep detached files alive through the existing semantic inode-retention mechanism, then reclaim their page cache and cluster chain on a deferred worker. The existing sync/unmount eviction contract drains this work and reports errors. Directory-entry submission is centralized so detached files can grow or truncate without overwriting a reused directory slot. Do not retry a partially freed chain.

Publish the smaller short directory entry before cutting and reclaiming a truncated tail. Reclamation errors preserve the new length, and the outer inode metadata is synchronized on both success and failure. A reclamation error does not suppress the device flush for other files.

### Release inode owners before final mount shutdown

Keep File writer/inode retention ahead of its mount pin in destruction order. Apply the same ownership rule to resolved paths, failed File construction, temporary O_TRUNC admission, exec loading and the MM executable-image pair. These local ordering changes ensure the last semantic inode release can publish reclamation before final mount shutdown seals the queue. The eviction seal protocol remains unchanged.

### Isolate FAT reclamation by filesystem

Each FAT filesystem now owns an independent serial reclamation queue, so a slow device cannot hold up another filesystem's eviction completion. Add an owner-lifetime WorkQueue constructor whose worker holds only a weak queue reference while waiting. Pending FAT work retains the filesystem, and the worker exits when the last owner disappears. Existing global WorkQueue behavior and FAT FIFO/epoch/seal semantics are unchanged; worker creation failure is returned to the mount caller.

## Validation

- Kernel build, formatting and diff checks passed.
- another_ext4: 168 library tests passed; real-image transactional/direct cross-group allocation, remount/content/fsck checks, checksum corruption rejection and initialization-preparation I/O failure/retry passed.
- DragonOS exec write-access tests: 8 passed.
- The atomic FUSE truncation regression fails before the fix and passes afterward. Related FUSE tests improved from 14/17 to 15/17; the two existing flag-mask failures have identical baseline results.
- Final DragonOS FAT32: all 5 tests passed in 989 ms, including open-unlink/replacement, cold reads, writes, truncate/regrow, mmap after close and reclamation after final munmap plus syncfs. Both new lifetime tests fail on the pre-fix kernel and pass on Linux FAT32.
- All 37 ext4 inode-identity tests passed in 2.983 s, including the previously timing-out case in 450 ms.
- Injecting EIO at discarded-tail release after EOC reproduces the old inconsistent size: immediate stat 4096, remount stat 32768. The fixed kernel returns EIO and reports 4096 both before and after remount.
- The same independent 32 MiB cold FAT32 read improved from 59.448 s before the fix to 0.311 s with the cursor.
- FAT16 compiled and its EOC encoding was checked against FAT semantics. Guest runtime coverage was blocked by the existing fixed-root-directory ENOSYS limitation; it is not counted as a passing test.
- FAT regression exercises fragmented chains, backward cold reads, shrink/regrow and rename using fsync and FADV_DONTNEED. Linux FAT32 loop/chroot reference passed.

Independent agents reviewed the complete PR and the FAT follow-up before submission. The two existing FUSE flag-mask failures are OpenFlagsMatchLinuxMask (0107002 versus 07002) and CreateReusesFuseHandleWithoutOpen (0107102 versus 07102). Linux 6.8 also reproduces the destructive FUSE open side effect; this change preserves ETXTBSY while preventing that side effect. Fault injection covers preparation failure, not an exhaustive power-loss matrix.

Cross-directory replacement lifetime handling was reviewed statically; the new runtime cases use same-directory replacement. Existing multi-step rename source-removal/create failure atomicity is outside this victim-lifetime fix. FAT fault injection checks a reclamation error boundary, not an exhaustive storage-failure or crash-consistency matrix.

Latest ownership-order follow-up: kernel build and formatting passed; DragonOS exec write-access 8/8, FAT32 5/5 and ext4 inode identity 37/37 passed. A manual lazy-unmount/last-writer-close/remount test passed 64 rounds with full space reclamation. The baseline also passed 64 stress rounds; the timing window is established by the ownership/destruction audit, not claimed as a reliably reproduced failure. Independent agents reviewed the complete PR again before this commit.

Latest queue-isolation follow-up: the same two-volume workload reclaimed a 16 MiB slow-file chain and a 4 KiB fast-file chain. Before the fix, fast-volume syncfs took 367.392 ms of 376.239 ms total reclamation. Afterward it took 15.812 ms while the slow volume still needed 360.468 ms. These are measured samples, not latency guarantees. Both mounted filesystems had one worker each; worker count returned to zero after unmount and after 64 lazy-unmount/remount rounds. Final FAT32 5/5 and ext4 inode identity 37/37 tests, kernel build and formatting passed.
