### PR TITLE
fix(ext4): batch metadata writeback while preserving sync semantics

### DIFF
--- a/kernel/crates/another_ext4/ext4_test/src/bin/batched_delalloc.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/batched_delalloc.rs
@@ -1,0 +1,225 @@
+//! Real ext4 delayed-allocation acceptance and durability ownership regression.
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+use another_ext4::{
+    DelallocAppendBlockPublication, DelallocAppendBlockSubmitOutcome as Outcome, ErrCode, Ext4,
+    InodeMode, EXT4_ROOT_INO,
+};
+use block_file::{BlockFile, CrashBlockFile, CrashDeviceOperation};
+use std::{fs::File, process::Command, sync::Arc};
+
+fn submit(
+    fs: &Ext4,
+    authority: &another_ext4::DelallocAppendMapperAuthority,
+    reservation: &mut another_ext4::DelallocAppendBlockReservation,
+    publication: DelallocAppendBlockPublication<'_>,
+    pool: &mut another_ext4::DelallocExtentNodePool,
+    single: bool,
+) -> Outcome {
+    if single {
+        fs.submit_delalloc_append_block_authorized_with_pool(
+            authority,
+            reservation,
+            publication,
+            Some(pool),
+        )
+    } else {
+        fs.submit_delalloc_append_batch_authorized_with_pool(
+            authority,
+            &mut [reservation],
+            &[publication],
+            pool,
+        )
+    }
+}
+
+fn run(background_error: bool, single: bool, partial: bool) {
+    let path = if background_error {
+        "delalloc-batch-failed.img"
+    } else {
+        "delalloc-batch-ok.img"
+    };
+    File::create(path)
+        .unwrap()
+        .set_len(32 * 1024 * 1024)
+        .unwrap();
+    assert!(Command::new("mkfs.ext4")
+        .args([
+            "-q",
+            "-F",
+            "-b",
+            "4096",
+            "-I",
+            "256",
+            "-O",
+            "^orphan_file",
+            path
+        ])
+        .status()
+        .unwrap()
+        .success());
+    let device = Arc::new(CrashBlockFile::new(path));
+    let mut fs = Ext4::load_writable(device.clone()).unwrap();
+    let inode = fs
+        .create(EXT4_ROOT_INO, "file", InodeMode::FILE | InodeMode::ALL_RW)
+        .unwrap();
+    let old_eof = if partial { 17 } else { 0 };
+    let offset = if partial { 4096 } else { 0 };
+    let length = if partial { 17 } else { 4096 };
+    let new_eof = (offset + length) as u64;
+    if partial {
+        // Dirty bytes beyond the shortened EOF must never be exposed by the
+        // next sparse append, even though its metadata is only accepted.
+        fs.write(inode, 0, &[0x66; 4096]).unwrap();
+        fs.setattr(
+            inode,
+            another_ext4::SetAttr {
+                size: Some(old_eof),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    fs.enable_batching(256).unwrap();
+    let authority = fs.delalloc_append_mapper_authority().unwrap();
+    let mut pool = fs
+        .create_delalloc_extent_node_pool_authorized(&authority, inode)
+        .unwrap();
+    let mut reservation = fs
+        .reserve_delalloc_append_block_projected_authorized(
+            &authority, inode, offset, old_eof, &mut pool,
+        )
+        .unwrap();
+    let bytes = vec![0xa7; length];
+    let publication = DelallocAppendBlockPublication {
+        payload: &bytes,
+        durable_eof: new_eof,
+        mtime: Some(111),
+        ctime: Some(112),
+    };
+    device.reset_operation_log();
+    device.arm_io_error_at(0);
+    let first = submit(
+        &fs,
+        &authority,
+        &mut reservation,
+        publication,
+        &mut pool,
+        single,
+    );
+    assert_eq!(
+        first,
+        Outcome::RetryableNotPublished(ErrCode::EIO),
+        "partial={partial} single={single} attrs={:?} progress={:?}",
+        fs.getattr(inode),
+        fs.batch_progress()
+    );
+    assert_eq!(fs.batch_progress().unwrap().accepted, 0);
+    assert_eq!(fs.getattr(inode).unwrap().size, old_eof);
+    device.reset_operation_log();
+    let publication = DelallocAppendBlockPublication {
+        payload: &bytes,
+        durable_eof: new_eof,
+        mtime: Some(111),
+        ctime: Some(112),
+    };
+    let sequence = match submit(
+        &fs,
+        &authority,
+        &mut reservation,
+        publication,
+        &mut pool,
+        single,
+    ) {
+        Outcome::Published(sequence) => sequence,
+        other => panic!("unexpected submission outcome: {other:?}"),
+    };
+    assert_eq!(
+        fs.getattr(inode).unwrap().size,
+        new_eof,
+        "accepted mapping is immediately visible"
+    );
+    assert_eq!(fs.batch_progress().unwrap().durable, 0);
+    assert!(
+        !device.operations().contains(&CrashDeviceOperation::Flush),
+        "accepted descriptor must not force durability"
+    );
+    fs.release_delalloc_extent_node_pool_authorized(&authority, &mut pool)
+        .unwrap();
+    device.reset_operation_log();
+    if background_error {
+        device.arm_io_error_at(0);
+    }
+    fs.request_batch_commit();
+    let commit = fs.commit_pending_batch();
+    if background_error {
+        assert_eq!(commit.unwrap_err().code(), ErrCode::EIO);
+        assert_eq!(fs.batch_progress().unwrap().accepted, sequence);
+        assert_eq!(fs.batch_progress().unwrap().durable, 0);
+        // The old lease remains terminal even when the *disk* failure happened
+        // before a commit record. It must never be restored and retried.
+        let publication = DelallocAppendBlockPublication {
+            payload: &bytes,
+            durable_eof: new_eof,
+            mtime: None,
+            ctime: None,
+        };
+        assert!(matches!(
+            submit(
+                &fs,
+                &authority,
+                &mut reservation,
+                publication,
+                &mut pool,
+                single
+            ),
+            Outcome::Terminal(_)
+        ));
+        device.crash();
+    } else {
+        assert_eq!(commit.unwrap(), Some(sequence));
+        assert_eq!(fs.batch_progress().unwrap().durable, sequence);
+        fs.shutdown_writable().unwrap();
+    }
+    drop(reservation);
+    drop(pool);
+    drop(fs);
+    drop(device);
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(path))).unwrap();
+    assert_eq!(
+        fs.getattr(inode).unwrap().size,
+        if background_error { old_eof } else { new_eof }
+    );
+    if !background_error {
+        let mut read = vec![0; length];
+        assert_eq!(fs.read(inode, offset, &mut read).unwrap(), length);
+        assert_eq!(read, bytes);
+        if partial {
+            let mut gap = vec![0x88; offset - old_eof as usize];
+            assert_eq!(
+                fs.read(inode, old_eof as usize, &mut gap).unwrap(),
+                gap.len()
+            );
+            assert!(gap.iter().all(|byte| *byte == 0));
+        }
+    }
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    let check = Command::new("e2fsck").args(["-fn", path]).output().unwrap();
+    assert!(
+        check.status.success(),
+        "{}",
+        String::from_utf8_lossy(&check.stdout)
+    );
+    std::fs::remove_file(path).unwrap();
+    println!("batched delalloc background_error={background_error} single={single} partial={partial} passed");
+}
+fn main() {
+    for single in [false, true] {
+        for partial in [false, true] {
+            run(false, single, partial);
+            run(true, single, partial);
+        }
+    }
+}

--- a/kernel/crates/another_ext4/ext4_test/src/bin/batched_filesystem.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/batched_filesystem.rs
@@ -1,0 +1,184 @@
+//! End-to-end real-image coverage for the bounded live metadata view.
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+use another_ext4::{ErrCode, Ext4, Ext4Error, InodeMode, InodeReclaimHandle, EXT4_ROOT_INO};
+use block_file::{BlockFile, CrashBlockFile, CrashDeviceOperation};
+use std::{fs::File, process::Command, sync::Arc};
+
+fn progress(fs: &Ext4) {
+    fs.request_batch_commit();
+    assert!(
+        fs.commit_pending_batch().unwrap().is_some(),
+        "EAGAIN must have an independently committable batch"
+    );
+}
+fn retry<T>(fs: &Ext4, mut operation: impl FnMut() -> Result<T, Ext4Error>) -> T {
+    for _ in 0..1024 {
+        match operation() {
+            Ok(value) => return value,
+            Err(error) if error.code() == ErrCode::EAGAIN => progress(fs),
+            Err(error) => panic!("operation failed: {error:?}"),
+        }
+    }
+    panic!("operation cannot make bounded progress");
+}
+fn reclaim(fs: &Ext4, mut handle: InodeReclaimHandle) {
+    for _ in 0..1024 {
+        match fs.reclaim_inode(handle) {
+            Ok(()) => return,
+            Err(failure) => {
+                let (error, returned) = failure.into_parts();
+                handle = returned;
+                assert_eq!(error.code(), ErrCode::EAGAIN);
+                progress(fs);
+            }
+        }
+    }
+    panic!("reclaim cannot make bounded progress");
+}
+fn main() {
+    const PATH: &str = "batched-filesystem.img";
+    File::create(PATH)
+        .unwrap()
+        .set_len(64 * 1024 * 1024)
+        .unwrap();
+    assert!(Command::new("mkfs.ext4")
+        .args([
+            "-q",
+            "-F",
+            "-b",
+            "4096",
+            "-I",
+            "256",
+            "-O",
+            "^orphan_file",
+            PATH
+        ])
+        .status()
+        .unwrap()
+        .success());
+    let device = Arc::new(CrashBlockFile::new(PATH));
+    let mut fs = Ext4::load_writable(device.clone()).unwrap();
+    fs.enable_batching(256).unwrap();
+    device.reset_operation_log();
+    let directory = retry(&fs, || {
+        fs.mkdir(EXT4_ROOT_INO, "working", InodeMode::ALL_RWX)
+    });
+    let other = retry(&fs, || {
+        fs.mkdir(EXT4_ROOT_INO, "destination", InodeMode::ALL_RWX)
+    });
+    // Reclaim must detach the xattr reference and its i_blocks charge in the
+    // same transaction, including inode formats without an extent tree.
+    for kind in 0..3 {
+        let name = format!("xattr-reclaim-{kind}");
+        let inode = match kind {
+            0 => retry(&fs, || {
+                fs.create(directory, &name, InodeMode::FILE | InodeMode::ALL_RW)
+            }),
+            1 => {
+                retry(&fs, || {
+                    fs.symlink_with_owner_and_attr(
+                        directory,
+                        &name,
+                        "abc",
+                        another_ext4::InodeOwner { uid: 0, gid: 0 },
+                    )
+                })
+                .ino
+            }
+            _ => {
+                retry(&fs, || {
+                    fs.mknod_with_owner_and_attr(
+                        directory,
+                        &name,
+                        InodeMode::CHARDEV | InodeMode::ALL_RW,
+                        1,
+                        3,
+                        another_ext4::InodeOwner { uid: 0, gid: 0 },
+                    )
+                })
+                .ino
+            }
+        };
+        retry(&fs, || fs.setxattr(inode, "user.retained", b"value"));
+        assert_eq!(retry(&fs, || fs.getattr(inode)).blocks, 8);
+        let handle = retry(&fs, || fs.unlink(directory, &name)).unwrap();
+        reclaim(&fs, handle);
+        println!("xattr reclaim kind {kind} passed");
+    }
+    let mut files = Vec::new();
+    for index in 0..400 {
+        let name = format!("{index:04}-{}", "name".repeat(32));
+        let file = retry(&fs, || {
+            fs.create(directory, &name, InodeMode::FILE | InodeMode::ALL_RW)
+        });
+        let payload = format!("file {index}").into_bytes();
+        assert_eq!(retry(&fs, || fs.write(file, 0, &payload)), payload.len());
+        if index % 32 == 0 {
+            assert_eq!(retry(&fs, || fs.write(file, 3 * 4096, b"tail")), 4);
+            retry(&fs, || fs.setxattr(file, "user.tag", b"stored"));
+            assert_eq!(retry(&fs, || fs.getxattr(file, "user.tag")), b"stored");
+            retry(&fs, || fs.removexattr(file, "user.tag"));
+        }
+        assert_eq!(
+            retry(&fs, || fs.lookup(directory, &name)),
+            file,
+            "read-your-writes before checkpoint"
+        );
+        files.push((name, file, payload));
+    }
+    retry(&fs, || fs.rename(directory, &files[0].0, other, "moved"));
+    retry(&fs, || {
+        fs.rename_exchange(directory, &files[1].0, other, "moved")
+    });
+    for index in (2..400).step_by(2) {
+        let handle = retry(&fs, || fs.unlink(directory, &files[index].0)).unwrap();
+        reclaim(&fs, handle);
+    }
+    // Reuse retired capacity in later operations. No explicit fsync is issued;
+    // bounded admission and retirement must request the necessary checkpoint.
+    for index in 0..220 {
+        let name = format!("reused-{index}");
+        let file = retry(&fs, || {
+            fs.create(other, &name, InodeMode::FILE | InodeMode::ALL_RW)
+        });
+        retry(&fs, || fs.write(file, 0, &[0x71; 4096]));
+    }
+    while fs.batch_progress().unwrap().durable < fs.batch_progress().unwrap().accepted {
+        progress(&fs);
+    }
+    let count = device
+        .operations()
+        .iter()
+        .filter(|operation| **operation == CrashDeviceOperation::Flush)
+        .count();
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    drop(device);
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(PATH))).unwrap();
+    assert_eq!(fs.lookup(other, "moved").unwrap(), files[1].1);
+    assert_eq!(fs.lookup(directory, &files[1].0).unwrap(), files[0].1);
+    for index in (3..400).step_by(2) {
+        let mut bytes = vec![0; files[index].2.len()];
+        assert_eq!(fs.read(files[index].1, 0, &mut bytes).unwrap(), bytes.len());
+        assert_eq!(bytes, files[index].2);
+    }
+    let mut gap = vec![0xff; 3 * 4096 - files[0].2.len()];
+    assert_eq!(
+        fs.read(files[0].1, files[0].2.len(), &mut gap).unwrap(),
+        gap.len()
+    );
+    assert!(gap.iter().all(|byte| *byte == 0));
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    let output = Command::new("e2fsck").args(["-fn", PATH]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::remove_file(PATH).unwrap();
+    println!("real batched namespace/eager/xattr/reclaim passed; observed {count} flushes");
+}

--- a/kernel/crates/another_ext4/ext4_test/src/bin/batched_fragmented_reclaim.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/batched_fragmented_reclaim.rs
@@ -1,0 +1,106 @@
+//! Real-image regression: many nonadjacent extents share a few bitmap homes,
+//! so retirement capacity, not metadata image capacity, bounds each reclaim.
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+use another_ext4::{ErrCode, Ext4, Ext4Error, InodeMode, EXT4_ROOT_INO};
+use block_file::BlockFile;
+use std::{fs::File, process::Command, sync::Arc};
+
+fn advance(fs: &Ext4) {
+    fs.request_batch_commit();
+    assert!(fs.commit_pending_batch().unwrap().is_some());
+}
+
+fn retry<T>(fs: &Ext4, mut operation: impl FnMut() -> Result<T, Ext4Error>) -> T {
+    for _ in 0..1024 {
+        match operation() {
+            Ok(value) => return value,
+            Err(error) if error.code() == ErrCode::EAGAIN => advance(fs),
+            Err(error) => panic!("unexpected error: {error:?}"),
+        }
+    }
+    panic!("operation failed to make bounded progress");
+}
+
+fn main() {
+    const PATH: &str = "batched-fragmented-reclaim.img";
+    File::create(PATH)
+        .unwrap()
+        .set_len(64 * 1024 * 1024)
+        .unwrap();
+    assert!(Command::new("mkfs.ext4")
+        .args([
+            "-q",
+            "-F",
+            "-b",
+            "4096",
+            "-I",
+            "256",
+            "-O",
+            "^orphan_file",
+            PATH
+        ])
+        .status()
+        .unwrap()
+        .success());
+    let mut fs = Ext4::load_writable(Arc::new(BlockFile::new(PATH))).unwrap();
+    fs.enable_batching(256).unwrap();
+    let victim = retry(&fs, || {
+        fs.create(EXT4_ROOT_INO, "victim", InodeMode::FILE | InodeMode::ALL_RW)
+    });
+    let survivor = retry(&fs, || {
+        fs.create(
+            EXT4_ROOT_INO,
+            "survivor",
+            InodeMode::FILE | InodeMode::ALL_RW,
+        )
+    });
+    for index in 0..64 {
+        // Alternating allocation prevents the victim's retired ranges from
+        // merging even though their bitmap/GDT/SB images are shared.
+        retry(&fs, || fs.write(victim, index * 4096, &[0x31; 4096]));
+        retry(&fs, || fs.write(survivor, index * 4096, &[0x72; 4096]));
+    }
+    while fs.batch_progress().unwrap().accepted != fs.batch_progress().unwrap().durable {
+        advance(&fs);
+    }
+    let mut handle = retry(&fs, || fs.unlink(EXT4_ROOT_INO, "victim")).unwrap();
+    let mut completed = false;
+    for _ in 0..1024 {
+        match fs.reclaim_inode(handle) {
+            Ok(()) => {
+                completed = true;
+                break;
+            }
+            Err(failure) => {
+                let (error, returned) = failure.into_parts();
+                assert_eq!(
+                    error.code(),
+                    ErrCode::EAGAIN,
+                    "fragmented reclaim must restart before E2BIG"
+                );
+                handle = returned;
+                advance(&fs);
+            }
+        }
+    }
+    assert!(completed, "reclaim did not make bounded progress");
+    while fs.batch_progress().unwrap().accepted != fs.batch_progress().unwrap().durable {
+        advance(&fs);
+    }
+    let mut bytes = vec![0; 64 * 4096];
+    assert_eq!(fs.read(survivor, 0, &mut bytes).unwrap(), bytes.len());
+    assert!(bytes.iter().all(|byte| *byte == 0x72));
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    let output = Command::new("e2fsck").args(["-fn", PATH]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    std::fs::remove_file(PATH).unwrap();
+    println!("64 fragmented extents reclaimed without E2BIG; adjacent file and e2fsck clean");
+}

--- a/kernel/crates/another_ext4/ext4_test/src/bin/batched_inode_cache.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/batched_inode_cache.rs
@@ -1,0 +1,129 @@
+//! Cold inode reads retain their metadata view through cache insertion.
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+use another_ext4::{Block, BlockDevice, ErrCode, Ext4, Ext4Error, SetAttr, EXT4_ROOT_INO};
+use block_file::BlockFile;
+use std::{
+    fs::File,
+    process::Command,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        mpsc, Arc, Mutex,
+    },
+    time::Duration,
+};
+
+type Pause = (mpsc::SyncSender<()>, mpsc::Receiver<()>);
+struct PausingDevice {
+    file: Mutex<BlockFile>,
+    reads: AtomicUsize,
+    pause: Mutex<Option<Pause>>,
+}
+impl BlockDevice for PausingDevice {
+    fn read_block(&self, id: u64) -> Result<Block, Ext4Error> {
+        let block = self.file.lock().unwrap().read_block(id)?;
+        self.reads.fetch_add(1, Ordering::Relaxed);
+        let pause = self.pause.lock().unwrap().take();
+        if let Some((entered, resume)) = pause {
+            entered.send(()).unwrap();
+            resume.recv_timeout(Duration::from_secs(10)).unwrap();
+        }
+        Ok(block)
+    }
+    fn write_block(&self, block: &Block) -> Result<(), Ext4Error> {
+        self.file.lock().unwrap().write_block(block)
+    }
+    fn flush(&self) -> Result<(), Ext4Error> {
+        self.file.lock().unwrap().flush()
+    }
+    fn supports_reliable_flush(&self) -> bool {
+        true
+    }
+}
+
+fn main() {
+    let path = format!("/tmp/batched-inode-cache-{}.img", std::process::id());
+    File::create(&path)
+        .unwrap()
+        .set_len(64 * 1024 * 1024)
+        .unwrap();
+    assert!(Command::new("mkfs.ext4")
+        .args([
+            "-q",
+            "-F",
+            "-b",
+            "4096",
+            "-I",
+            "256",
+            "-O",
+            "^orphan_file",
+            &path
+        ])
+        .status()
+        .unwrap()
+        .success());
+    let device = Arc::new(PausingDevice {
+        file: Mutex::new(BlockFile::new(&path)),
+        reads: AtomicUsize::new(0),
+        pause: Mutex::new(None),
+    });
+    let mut fs = Ext4::load_writable(device.clone()).unwrap();
+    fs.enable_batching(256).unwrap();
+    let fs = Arc::new(fs);
+    let (entered_tx, entered_rx) = mpsc::sync_channel(1);
+    let (resume_tx, resume_rx) = mpsc::sync_channel(1);
+    *device.pause.lock().unwrap() = Some((entered_tx, resume_rx));
+    let reader_fs = fs.clone();
+    let reader = std::thread::spawn(move || reader_fs.getattr(EXT4_ROOT_INO).unwrap());
+    entered_rx.recv_timeout(Duration::from_secs(10)).unwrap();
+    let attr = SetAttr {
+        uid: Some(1234),
+        ..SetAttr::default()
+    };
+    // The cold value has been fetched but not inserted. Publication must not
+    // pass it and then be overwritten by that old insertion.
+    assert_eq!(
+        fs.setattr(EXT4_ROOT_INO, attr).unwrap_err().code(),
+        ErrCode::EAGAIN
+    );
+    resume_tx.send(()).unwrap();
+    assert_eq!(reader.join().unwrap().uid, 0);
+    fs.setattr(
+        EXT4_ROOT_INO,
+        SetAttr {
+            uid: Some(1234),
+            ..SetAttr::default()
+        },
+    )
+    .unwrap();
+    assert_eq!(fs.getattr(EXT4_ROOT_INO).unwrap().uid, 1234);
+    let before = device.reads.load(Ordering::Relaxed);
+    for _ in 0..100 {
+        assert_eq!(fs.getattr(EXT4_ROOT_INO).unwrap().uid, 1234);
+    }
+    assert_eq!(device.reads.load(Ordering::Relaxed), before);
+    fs.request_batch_commit();
+    fs.commit_pending_batch().unwrap();
+    let before = device.reads.load(Ordering::Relaxed);
+    assert_eq!(fs.getattr(EXT4_ROOT_INO).unwrap().uid, 1234);
+    assert_eq!(
+        device.reads.load(Ordering::Relaxed),
+        before,
+        "Frozen checkpoint must not republish or invalidate live cache"
+    );
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    drop(device);
+    let check = Command::new("e2fsck")
+        .args(["-fn", &path])
+        .output()
+        .unwrap();
+    assert!(
+        check.status.success(),
+        "{}",
+        String::from_utf8_lossy(&check.stdout)
+    );
+    std::fs::remove_file(path).unwrap();
+    println!("cold read excludes publication; live inode cache survives checkpoint; e2fsck clean");
+}

--- a/kernel/crates/another_ext4/ext4_test/src/bin/namespace_transactions.rs
+++ b/kernel/crates/another_ext4/ext4_test/src/bin/namespace_transactions.rs
@@ -1,0 +1,271 @@
+//! Focused namespace transaction regression coverage, including durable
+//! validation with e2fsck. Run in a disposable working directory.
+#[path = "../block_file.rs"]
+#[allow(dead_code)]
+mod block_file;
+
+use another_ext4::{ErrCode, Ext4, InodeMode, InodeOwner, EXT4_ROOT_INO};
+use block_file::BlockFile;
+use std::{fs::File, process::Command, sync::Arc};
+
+fn fsck(path: &str) {
+    let output = Command::new("e2fsck").args(["-fn", path]).output().unwrap();
+    assert!(
+        output.status.success(),
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn run(journal: bool) {
+    let path = if journal {
+        "namespace-journal.img"
+    } else {
+        "namespace-direct.img"
+    };
+    File::create(path)
+        .unwrap()
+        .set_len(64 * 1024 * 1024)
+        .unwrap();
+    let features = if journal {
+        "^orphan_file"
+    } else {
+        "^orphan_file,^has_journal"
+    };
+    assert!(Command::new("mkfs.ext4")
+        .args(["-q", "-F", "-b", "4096", "-I", "256", "-O", features, path])
+        .status()
+        .unwrap()
+        .success());
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(path))).unwrap();
+    let directory = fs
+        .mkdir(EXT4_ROOT_INO, "namespace", InodeMode::ALL_RWX)
+        .unwrap();
+    // Long names force repeated directory block allocation, exercising the
+    // append helper's single ownership of i_blocks accounting.
+    for index in 0..96 {
+        let name = format!("{index:03}-{}", "x".repeat(180));
+        fs.create(directory, &name, InodeMode::FILE | InodeMode::ALL_RW)
+            .unwrap();
+    }
+    let owner = InodeOwner { uid: 123, gid: 456 };
+    let target = "a/".repeat(700);
+    let symlink = fs
+        .symlink_with_owner_and_attr(directory, "long-link", &target, owner)
+        .unwrap();
+    assert_eq!((symlink.uid, symlink.gid), (123, 456));
+    assert_eq!(
+        symlink.blocks, 8,
+        "one 4 KiB target must count once in 512-byte units"
+    );
+    let short = fs
+        .symlink_with_owner_and_attr(directory, "short-link", "abc", owner)
+        .unwrap();
+    assert_eq!(short.blocks, 0);
+    let device = fs
+        .mknod_with_owner_and_attr(
+            directory,
+            "device",
+            InodeMode::CHARDEV | InodeMode::ALL_RW,
+            259,
+            1234,
+            owner,
+        )
+        .unwrap();
+    assert_eq!(device.rdev, (259, 1234));
+    assert_eq!(device.blocks, 0);
+
+    // Failure happens after inode staging; abort must not leak an allocated
+    // zero-link inode or any directory/bitmap image to disk.
+    let error = fs
+        .create(
+            directory,
+            &"z".repeat(256),
+            InodeMode::FILE | InodeMode::ALL_RW,
+        )
+        .unwrap_err();
+    assert_eq!(error.code(), ErrCode::ENAMETOOLONG);
+    assert!(fs.lookup(directory, &"z".repeat(256)).is_err());
+
+    let file = fs
+        .create(directory, "xattrs", InodeMode::FILE | InodeMode::ALL_RW)
+        .unwrap();
+    fs.setxattr(file, "user.payload", &vec![0x31; 1000])
+        .unwrap();
+    fs.setxattr(file, "user.payload", &vec![0x32; 1700])
+        .unwrap();
+    assert_eq!(fs.getxattr(file, "user.payload").unwrap(), vec![0x32; 1700]);
+    fs.setxattr(file, "user.other", b"retained").unwrap();
+    fs.removexattr(file, "user.payload").unwrap();
+    assert_eq!(fs.getxattr(file, "user.other").unwrap(), b"retained");
+    // Allocation after xattr creation must retain the external xattr block
+    // in i_blocks, including the direct backend's extent-count recomputation.
+    assert_eq!(fs.write(file, 0, b"payload").unwrap(), 7);
+    assert_eq!(fs.getattr(file).unwrap().blocks, 16);
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    fsck(path);
+
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(path))).unwrap();
+    let mut bytes = vec![0; target.len()];
+    assert_eq!(
+        fs.readlink(symlink.ino, 0, &mut bytes).unwrap(),
+        target.len()
+    );
+    assert_eq!(bytes, target.as_bytes());
+    assert_eq!(fs.getattr(device.ino).unwrap().rdev, (259, 1234));
+    assert_eq!(fs.getxattr(file, "user.other").unwrap(), b"retained");
+    fs.removexattr(file, "user.other").unwrap();
+    assert_eq!(fs.getattr(file).unwrap().blocks, 8);
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    fsck(path);
+    std::fs::remove_file(path).unwrap();
+    println!(
+        "namespace transactions {} passed",
+        if journal { "journal" } else { "nojournal" }
+    );
+}
+
+fn crash_matrix() {
+    use block_file::{CrashBlockFile, SimulatedPowerLoss};
+    use std::panic::{catch_unwind, AssertUnwindSafe};
+    const SEED: &str = "namespace-crash-seed.img";
+    const WORK: &str = "namespace-crash-work.img";
+    File::create(SEED)
+        .unwrap()
+        .set_len(32 * 1024 * 1024)
+        .unwrap();
+    assert!(Command::new("mkfs.ext4")
+        .args([
+            "-q",
+            "-F",
+            "-b",
+            "4096",
+            "-I",
+            "256",
+            "-O",
+            "^orphan_file",
+            SEED
+        ])
+        .status()
+        .unwrap()
+        .success());
+    let fs = Ext4::load_writable(Arc::new(BlockFile::new(SEED))).unwrap();
+    let a = fs.mkdir(EXT4_ROOT_INO, "a", InodeMode::ALL_RWX).unwrap();
+    let b = fs.mkdir(EXT4_ROOT_INO, "b", InodeMode::ALL_RWX).unwrap();
+    let left = fs.mkdir(a, "entry", InodeMode::ALL_RWX).unwrap();
+    let right = fs
+        .create(b, "entry", InodeMode::FILE | InodeMode::ALL_RW)
+        .unwrap();
+    fs.shutdown_writable().unwrap();
+    drop(fs);
+    let perform = |fs: &Ext4, case| match case {
+        0 => {
+            fs.mkdir(a, "new", InodeMode::ALL_RWX).unwrap();
+        }
+        1 => {
+            fs.symlink_with_owner_and_attr(
+                a,
+                "new",
+                &"target/".repeat(100),
+                InodeOwner { uid: 0, gid: 0 },
+            )
+            .unwrap();
+        }
+        2 => {
+            fs.rename_exchange(a, "entry", b, "entry").unwrap();
+        }
+        _ => unreachable!(),
+    };
+    for write_through in [false, true] {
+        for case in 0..3 {
+            std::fs::copy(SEED, WORK).unwrap();
+            let device = Arc::new(CrashBlockFile::new(WORK));
+            let fs = Ext4::load_writable(device.clone()).unwrap();
+            device.set_write_through(write_through);
+            device.reset_operation_log();
+            perform(&fs, case);
+            let points = device.operations().len();
+            drop(fs);
+            drop(device);
+            for point in 0..points {
+                std::fs::copy(SEED, WORK).unwrap();
+                let device = Arc::new(CrashBlockFile::new(WORK));
+                let fs = Ext4::load_writable(device.clone()).unwrap();
+                device.set_write_through(write_through);
+                device.reset_operation_log();
+                device.arm_power_loss_at(point);
+                // Namespace operations own no delayed-allocation linear lease;
+                // unwinding only discards private images and releases guards.
+                let hook = std::panic::take_hook();
+                std::panic::set_hook(Box::new(|_| {}));
+                let result = catch_unwind(AssertUnwindSafe(|| perform(&fs, case)));
+                std::panic::set_hook(hook);
+                let payload = result.expect_err("did not reach armed persistence point");
+                assert!(payload.downcast_ref::<SimulatedPowerLoss>().is_some());
+                device.crash();
+                drop(fs);
+                drop(device);
+                let recovered = Ext4::load_writable(Arc::new(BlockFile::new(WORK))).unwrap();
+                if case == 2 {
+                    let x = recovered.lookup(a, "entry").unwrap();
+                    let y = recovered.lookup(b, "entry").unwrap();
+                    assert!(
+                        (x == left && y == right) || (x == right && y == left),
+                        "partial exchange at {point}"
+                    );
+                    let moved = x == right;
+                    assert_eq!(
+                        recovered.lookup(left, "..").unwrap(),
+                        if moved { b } else { a }
+                    );
+                    assert_eq!(
+                        recovered.getattr(a).unwrap().links,
+                        if moved { 2 } else { 3 }
+                    );
+                    assert_eq!(
+                        recovered.getattr(b).unwrap().links,
+                        if moved { 3 } else { 2 }
+                    );
+                } else {
+                    match recovered.lookup(a, "new") {
+                        Err(error) => assert_eq!(error.code(), ErrCode::ENOENT),
+                        Ok(inode) if case == 0 => {
+                            assert_eq!(recovered.lookup(inode, ".").unwrap(), inode);
+                            assert_eq!(recovered.lookup(inode, "..").unwrap(), a);
+                        }
+                        Ok(inode) => {
+                            let expected = "target/".repeat(100);
+                            let mut bytes = vec![0; expected.len()];
+                            assert_eq!(
+                                recovered.readlink(inode, 0, &mut bytes).unwrap(),
+                                bytes.len()
+                            );
+                            assert_eq!(bytes, expected.as_bytes());
+                        }
+                    }
+                }
+                recovered.shutdown_writable().unwrap();
+                drop(recovered);
+                fsck(WORK);
+            }
+            println!(
+                "namespace crash case {case} write_through={write_through}: {points} points passed"
+            );
+        }
+    }
+    std::fs::remove_file(SEED).unwrap();
+    std::fs::remove_file(WORK).unwrap();
+}
+
+fn main() {
+    if std::env::args().any(|arg| arg == "--crash-only") {
+        crash_matrix();
+        return;
+    }
+    run(true);
+    run(false);
+    crash_matrix();
+}

--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -1,3 +1,4 @@
+use super::rw::MetadataIo;
 use super::{
     AllocationClass, AllocationState, DelallocClaim, DelallocConsumptionRecord, DelallocLease,
     DelallocReservation, DelallocReservationId, DelallocReservationUse, Ext4,
@@ -1099,6 +1100,7 @@ impl Ext4 {
             .filter(|group| *group < bg_count)
             .unwrap_or(preferred_inode_group);
         let count_usize = count as usize;
+        let mut saw_retired = false;
 
         // This is a speculative fast path.  Bound its metadata I/O under the
         // transaction writer gate; on a miss the caller aborts the
@@ -1139,19 +1141,44 @@ impl Ext4 {
                         && (*bit..*bit + count_usize)
                             .all(|index| bitmap_block[index / 8] & (1 << (index % 8)) == 0)
                 });
-            let bit = exact_hint.or_else(|| {
-                (!require_preferred)
-                    .then(|| {
-                        Bitmap::first_clear_run_in(
-                            &*bitmap_block,
-                            blocks_in_group,
-                            0,
-                            blocks_in_group,
-                            count_usize,
-                        )
-                    })
-                    .flatten()
-            });
+            let mut bit = exact_hint;
+            if let Some(candidate) = bit {
+                if !transaction
+                    .block_range_reusable(group_first + candidate as u64, count as u64)?
+                {
+                    saw_retired = true;
+                    bit = None;
+                }
+            }
+            if bit.is_none() && !require_preferred {
+                let mut cursor = 0;
+                while let Some(candidate) = Bitmap::first_clear_run_in(
+                    &*bitmap_block,
+                    blocks_in_group,
+                    cursor,
+                    blocks_in_group,
+                    count_usize,
+                ) {
+                    match transaction
+                        .block_reuse_restart(group_first + candidate as u64, count as u64)?
+                    {
+                        None => {
+                            bit = Some(candidate);
+                            break;
+                        }
+                        Some(end) => {
+                            saw_retired = true;
+                            // A freed extent may span thousands of blocks;
+                            // jump over its retirement in one bounded probe.
+                            cursor =
+                                core::cmp::min(end - group_first, blocks_in_group as u64) as usize;
+                            if cursor >= blocks_in_group {
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
             let Some(bit) = bit else { continue };
             let first = group_first
                 .checked_add(bit as PBlockId)
@@ -1215,6 +1242,9 @@ impl Ext4 {
                 consumption,
             ));
         }
+        if saw_retired && transaction.request_retirement_progress() {
+            return_error!(ErrCode::EAGAIN, "Free blocks await journal checkpoint");
+        }
         return_error!(ErrCode::ENOSPC, "No contiguous direct range available");
     }
 
@@ -1247,6 +1277,35 @@ impl Ext4 {
         )?;
         debug_assert!(consumption.is_none());
         Ok(allocation)
+    }
+
+    /// Allocate one metadata block, searching every group before ENOSPC.
+    /// Directory growth has no legacy fallback and must not inherit the eager
+    /// data fast path's speculative probe limit. The caller initializes the
+    /// private block image before publishing any reference to it.
+    pub(super) fn transaction_alloc_metadata_block(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_id: InodeId,
+        preferred_first: Option<PBlockId>,
+    ) -> Result<PBlockId> {
+        let groups = self
+            .transaction_read_super_block(transaction)?
+            .block_group_count();
+        let (allocation, consumption) = self.transaction_alloc_range_with_class(
+            transaction,
+            TransactionRangeAllocationRequest {
+                inode_id,
+                preferred_first,
+                require_preferred: false,
+                count: 1,
+                class: AllocationClass::Unreserved,
+                reservation_use: DelallocReservationUse::Metadata,
+                probe_limit: groups,
+            },
+        )?;
+        debug_assert!(consumption.is_none());
+        Ok(allocation.first)
     }
 
     /// Materialise an already reserved delayed-allocation data range.
@@ -1332,6 +1391,108 @@ impl Ext4 {
     ) -> Result<()> {
         let mut allocation = self.alloc_lock.lock();
         allocation.rollback_delalloc_consumption(consumption)
+    }
+
+    /// Validate an entire delayed operation before publishing any live image.
+    /// The allocator guard spans the memory-only publication, so finalisation
+    /// cannot fail or race another owner after readers can observe the mapping.
+    /// On error all leases/debits are untouched and the caller rolls them back.
+    pub(super) fn publish_delalloc_operation(
+        &self,
+        transaction: super::journal_transaction::Transaction<'_>,
+        leases: &mut [&mut DelallocLease],
+        consumptions: &mut [&mut DelallocConsumption],
+    ) -> Result<u64> {
+        if !transaction.is_batch() || leases.is_empty() || consumptions.is_empty() {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        let mut allocation = self.alloc_lock.lock();
+        let mut released_metadata = 0u64;
+        for (index, lease) in leases.iter().enumerate() {
+            if !lease.active
+                || lease.id.mount_generation != allocation.mount_generation
+                || leases[..index].iter().any(|prior| prior.id == lease.id)
+            {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+            let claim = allocation
+                .delalloc_claims
+                .get(&lease.id)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            let mut count = 0u64;
+            let mut data = 0u64;
+            let mut metadata = 0u64;
+            for debit in consumptions.iter() {
+                let record = allocation
+                    .delalloc_consumptions
+                    .get(&debit.serial)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EINVAL))?;
+                if record.reservation == lease.id {
+                    count = count
+                        .checked_add(1)
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                    let blocks = match record.use_kind {
+                        DelallocReservationUse::Data => &mut data,
+                        DelallocReservationUse::Metadata => &mut metadata,
+                    };
+                    *blocks = blocks
+                        .checked_add(record.blocks)
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                }
+            }
+            if count == 0
+                || count != claim.inflight_consumptions
+                || claim.data_blocks != 0
+                || data != lease.data_blocks
+                || metadata.checked_add(claim.metadata_blocks) != Some(lease.metadata_blocks)
+            {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            released_metadata = released_metadata
+                .checked_add(claim.metadata_blocks)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        }
+        for (index, debit) in consumptions.iter().enumerate() {
+            let record = allocation
+                .delalloc_consumptions
+                .get(&debit.serial)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EINVAL))?;
+            if !debit.unresolved
+                || debit.mount_generation != allocation.mount_generation
+                || consumptions[..index]
+                    .iter()
+                    .any(|prior| prior.serial == debit.serial)
+                || !leases.iter().any(|lease| lease.id == record.reservation)
+            {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+        }
+        let reserved_metadata = allocation
+            .reserved_metadata_blocks
+            .checked_sub(released_metadata)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+        // Batch publication performs no device I/O. Its fallible scratch
+        // reservations precede cache publication; after acceptance only
+        // infallible ownership transfer remains.
+        let sequence = match self
+            .commit_metadata_operation(transaction)
+            .map_err(|error| error.error)?
+        {
+            super::journal::MetadataPublication::Accepted(sequence) => sequence,
+            super::journal::MetadataPublication::Durable => {
+                unreachable!("batch publication cannot be synchronous")
+            }
+        };
+        for debit in consumptions.iter_mut() {
+            allocation.delalloc_consumptions.remove(&debit.serial);
+            debit.resolve();
+        }
+        for lease in leases.iter_mut() {
+            allocation.delalloc_claims.remove(&lease.id);
+            lease.deactivate();
+        }
+        allocation.reserved_metadata_blocks = reserved_metadata;
+        Ok(sequence)
     }
 
     /// Commit a delayed data debit after the mapping transaction has either
@@ -1474,6 +1635,10 @@ impl Ext4 {
             .checked_add(count as u64)
             .filter(|value| *value <= sb.block_count())
             .ok_or_else(|| format_error!(ErrCode::EINVAL, "Invalid filesystem free count"))?;
+        // Reserve quarantine ownership before any bitmap bit is cleared.
+        // A full retirement budget aborts this private operation, never a
+        // previously published free or a partially durable transaction.
+        transaction.retire_blocks(first, count as u64)?;
         {
             let image = self.transaction_block_for_update(transaction, bitmap_block_id)?;
             let mut bitmap = Bitmap::new(image, blocks_in_group);
@@ -1559,6 +1724,7 @@ impl Ext4 {
             } else {
                 None
             };
+        transaction.retire_inode(inode_id)?;
         {
             let image = self.transaction_block_for_update(transaction, bitmap_block_id)?;
             let mut bitmap = Bitmap::new(image, inode_count);
@@ -1586,7 +1752,7 @@ impl Ext4 {
         self.transaction_stage_super_block(transaction, &sb)
     }
 
-    /// Create a new inode with its final owner, returning the inode and its number.
+    /// Create a new inode with its final owner.
     #[inline(never)]
     pub(super) fn create_inode_with_owner(
         &self,
@@ -1594,84 +1760,84 @@ impl Ext4 {
         uid: u32,
         gid: u32,
     ) -> Result<InodeRef> {
-        self.ensure_mutable()?;
-        // Allocate an inode
-        let is_dir = mode.file_type() == FileType::Directory;
-        let id = self.alloc_inode(is_dir)?;
-
-        let initialized = (|| {
-            let generation = self.next_inode_generation(id)?;
-            let mut inode = Box::new(Inode::default());
-            inode.set_generation(generation);
-            inode.set_mode(mode);
-            inode.set_uid(uid);
-            inode.set_gid(gid);
-            inode.extent_init();
-            let mut inode_ref = InodeRef::new(id, inode);
-            self.write_inode_with_csum(&mut inode_ref)?;
-            Ok(inode_ref)
-        })();
-        let inode_ref = match initialized {
-            Ok(inode_ref) => inode_ref,
-            Err(error) => {
-                if self.rollback_new_inode(id, is_dir).is_err() {
-                    self.poison(ErrCode::EIO);
-                }
-                return Err(error);
-            }
-        };
-
-        trace!("Alloc inode {} ok", inode_ref.id);
-        Ok(inode_ref)
+        self.create_inode_with_metadata(&mut MetadataIo::direct(self), mode, uid, gid, None)
     }
 
-    /// Create a device inode (character or block device).
-    ///
-    /// Unlike `create_inode()`, this function:
-    /// - Does NOT initialize the extent tree
-    /// - Stores the device number in i_block[0..1] (Linux ext4 standard)
-    #[inline(never)]
-    pub(super) fn create_device_inode(
+    /// Stage inode allocation and initialization in the caller's operation.
+    /// On error the caller must abort the entire transaction.
+    pub(super) fn transaction_create_inode_with_owner(
         &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        mode: InodeMode,
+        uid: u32,
+        gid: u32,
+    ) -> Result<InodeRef> {
+        self.create_inode_with_metadata(
+            &mut MetadataIo::transaction(self, transaction),
+            mode,
+            uid,
+            gid,
+            None,
+        )
+    }
+
+    /// Stage a device inode using the same allocation algorithm as direct mode.
+    /// On error the caller must abort the entire transaction.
+    pub(super) fn transaction_create_device_inode(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
         mode: InodeMode,
         major: u32,
         minor: u32,
         uid: u32,
         gid: u32,
     ) -> Result<InodeRef> {
-        self.ensure_mutable()?;
-        // Device nodes are never directories
-        let id = self.alloc_inode(false)?;
+        self.create_inode_with_metadata(
+            &mut MetadataIo::transaction(self, transaction),
+            mode,
+            uid,
+            gid,
+            Some((major, minor)),
+        )
+    }
 
+    fn create_inode_with_metadata(
+        &self,
+        metadata: &mut MetadataIo<'_, '_, '_>,
+        mode: InodeMode,
+        uid: u32,
+        gid: u32,
+        device: Option<(u32, u32)>,
+    ) -> Result<InodeRef> {
+        self.ensure_mutable()?;
+        let is_dir = device.is_none() && mode.file_type() == FileType::Directory;
+        let id = self.alloc_inode(metadata, is_dir)?;
         let initialized = (|| {
-            let generation = self.next_inode_generation(id)?;
+            // Read through the operation so a reused table slot never obtains
+            // its generation from an older durable image or value cache.
+            let previous = metadata.read_inode(id)?.inode.generation();
+            let next = previous.wrapping_add(1);
             let mut inode = Box::new(Inode::default());
-            inode.set_generation(generation);
+            inode.set_generation(if next == 0 { 1 } else { next });
             inode.set_mode(mode);
             inode.set_uid(uid);
             inode.set_gid(gid);
-            inode.set_device(major, minor);
+            match device {
+                Some((major, minor)) => inode.set_device(major, minor),
+                None => inode.extent_init(),
+            }
             let mut inode_ref = InodeRef::new(id, inode);
-            self.write_inode_with_csum(&mut inode_ref)?;
+            metadata.write_inode_with_csum(&mut inode_ref)?;
             Ok(inode_ref)
         })();
-        let inode_ref = match initialized {
-            Ok(inode_ref) => inode_ref,
-            Err(error) => {
-                if self.rollback_new_inode(id, false).is_err() {
-                    self.poison(ErrCode::EIO);
-                }
-                return Err(error);
+        if initialized.is_err() && !metadata.is_transactional() {
+            // Direct mode may already have allocated on disk. Private mode
+            // must discard the operation instead of writing a rollback home.
+            if self.rollback_new_inode(id, is_dir).is_err() {
+                self.poison(ErrCode::EIO);
             }
-        };
-
-        trace!(
-            "Alloc device inode {} ({}:{}) ok",
-            inode_ref.id,
-            major,
-            minor
-        );
-        Ok(inode_ref)
+        }
+        initialized
     }
 
     /// Create(initialize) the root inode of the file system
@@ -1729,12 +1895,6 @@ impl Ext4 {
         // Invalidate inode cache entry
         self.inode_cache.lock().invalidate(inode_id);
         Ok(())
-    }
-
-    fn next_inode_generation(&self, inode_id: InodeId) -> Result<u32> {
-        let previous = self.read_inode_uncached(inode_id)?.inode.generation();
-        let next = previous.wrapping_add(1);
-        Ok(if next == 0 { 1 } else { next })
     }
 
     fn rollback_new_inode(&self, inode_id: InodeId, is_dir: bool) -> Result<()> {
@@ -1896,7 +2056,10 @@ impl Ext4 {
         loop {
             let mut inode = self.validate_reclaim_inode(inode_id, generation)?;
             if !inode.inode.uses_extents() {
-                if inode.inode.fs_block_count() != 0 {
+                // Inline symlinks and device inodes may own an external
+                // xattr block, which the common detach phase releases below.
+                let xattr_blocks = u64::from(inode.inode.xattr_block() != 0);
+                if inode.inode.fs_block_count() != xattr_blocks {
                     return_error!(ErrCode::EIO, "Non-extent orphan owns blocks");
                 }
                 break;
@@ -2062,8 +2225,10 @@ impl Ext4 {
         &self,
         transaction: super::journal_transaction::Transaction<'_>,
     ) -> Result<()> {
-        if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
-            self.poison(ErrCode::EIO);
+        if let Err(error) = self.commit_metadata_operation(transaction) {
+            if error.poisoned {
+                self.poison(ErrCode::EIO);
+            }
             return Err(error.error);
         }
         Ok(())
@@ -2322,15 +2487,16 @@ impl Ext4 {
     }
 
     /// Allocate a new inode, returning the inode number.
-    fn alloc_inode(&self, is_dir: bool) -> Result<InodeId> {
+    fn alloc_inode(&self, metadata: &mut MetadataIo<'_, '_, '_>, is_dir: bool) -> Result<InodeId> {
         let _alloc_guard = self.alloc_lock.lock();
-        let mut sb = self.read_super_block_cached();
+        let mut sb = metadata.read_super_block()?;
         let bg_count = sb.block_group_count();
+        let mut saw_retired = false;
 
         let mut bgid = 0;
         while bgid < bg_count {
             // Load block group descriptor
-            let mut bg = self.read_block_group(bgid)?;
+            let mut bg = metadata.read_block_group(bgid)?;
             // If there are no free inodes in this block group, try the next one
             if bg.desc.free_inodes_count() == 0 {
                 bgid += 1;
@@ -2338,7 +2504,7 @@ impl Ext4 {
             }
             // Load inode bitmap
             let bitmap_block_id = bg.desc.inode_bitmap_block();
-            let mut bitmap_block = self.read_block(bitmap_block_id)?;
+            let mut bitmap_block = metadata.read_block(bitmap_block_id)?;
             let old_bitmap_block = bitmap_block.clone();
             let old_bg = BlockGroupRef::new(bg.id, bg.desc);
             let old_sb = sb;
@@ -2347,13 +2513,26 @@ impl Ext4 {
             // the checksum covers the fixed inodes_per_group bitmap length.
             let idx_in_bg = {
                 let mut bitmap = Bitmap::new(&mut *bitmap_block.data, inode_count);
-                bitmap
-                    .find_and_set_first_clear_bit(0, inode_count)
-                    .ok_or(format_error!(
-                        ErrCode::ENOSPC,
-                        "No free inodes in block group {}",
-                        bgid
-                    ))? as u32
+                let mut next = 0;
+                let mut found = None;
+                while let Some(index) = bitmap.find_and_set_first_clear_bit(next, inode_count) {
+                    let inode_id = bgid * sb.inodes_per_group() + index as u32 + 1;
+                    if metadata.inode_reusable(inode_id) {
+                        found = Some(index as u32);
+                        break;
+                    }
+                    // This image is still private; rejected retired slots
+                    // remain free in the logical bitmap but unavailable to
+                    // allocation until the owning batch cleans its tail.
+                    bitmap.clear_bit(index);
+                    saw_retired = true;
+                    next = index + 1;
+                }
+                let Some(index) = found else {
+                    bgid += 1;
+                    continue;
+                };
+                index
             };
             // Update bitmap in disk
             if !bg.desc.update_inode_bitmap_csum(
@@ -2363,7 +2542,7 @@ impl Ext4 {
             ) {
                 return_error!(ErrCode::EIO, "Invalid inode bitmap checksum length");
             }
-            self.write_block(&bitmap_block)?;
+            metadata.write_block(&bitmap_block)?;
 
             // Modify block group counters
             bg.desc
@@ -2377,10 +2556,11 @@ impl Ext4 {
                 unused = inode_count as u32 - (idx_in_bg + 1);
                 bg.desc.set_itable_unused(unused);
             }
-            if let Err(error) = self.write_block_group_with_csum(&mut bg) {
-                if self
-                    .restore_inode_allocation_state(&old_bitmap_block, &old_bg, &old_sb)
-                    .is_err()
+            if let Err(error) = metadata.write_block_group_with_csum(&mut bg) {
+                if !metadata.is_transactional()
+                    && self
+                        .restore_inode_allocation_state(&old_bitmap_block, &old_bg, &old_sb)
+                        .is_err()
                 {
                     self.poison(ErrCode::EIO);
                 }
@@ -2389,10 +2569,11 @@ impl Ext4 {
 
             // Update superblock counters
             sb.set_free_inodes_count(sb.free_inodes_count() - 1);
-            if let Err(error) = self.write_super_block(&sb) {
-                if self
-                    .restore_inode_allocation_state(&old_bitmap_block, &old_bg, &old_sb)
-                    .is_err()
+            if let Err(error) = metadata.write_super_block(&sb) {
+                if !metadata.is_transactional()
+                    && self
+                        .restore_inode_allocation_state(&old_bitmap_block, &old_bg, &old_sb)
+                        .is_err()
                 {
                     self.poison(ErrCode::EIO);
                 }
@@ -2405,6 +2586,9 @@ impl Ext4 {
             return Ok(inode_id);
         }
         trace!("no free inode");
+        if saw_retired && metadata.request_retirement_progress() {
+            return_error!(ErrCode::EAGAIN, "Free inodes await journal checkpoint");
+        }
         return_error!(ErrCode::ENOSPC, "No free inodes in block group {}", bgid);
     }
 

--- a/kernel/crates/another_ext4/src/ext4/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4/dir.rs
@@ -78,85 +78,6 @@ impl Ext4 {
         u32::try_from(size / BLOCK_SIZE as u64).map_err(|_| Ext4Error::new(ErrCode::EIO))
     }
 
-    pub(super) fn dir_has_insert_space(
-        &self,
-        dir: &InodeRef,
-        child: &InodeRef,
-        name: &str,
-    ) -> Result<bool> {
-        Self::validate_dir_name(name)?;
-        for iblock in 0..Self::dir_data_block_count(dir)? {
-            let fblock = self.extent_query(dir, iblock)?;
-            let mut candidate = DirBlock::new(self.read_block(fblock)?);
-            if self.validate_dir_block(dir, iblock, &candidate)? == DirBlockLayout::Htree {
-                continue;
-            }
-            if candidate.insert(
-                name,
-                child.id,
-                child.inode.file_type(),
-                self.metadata_csum_enabled(),
-            ) {
-                return Ok(true);
-            }
-        }
-        Ok(false)
-    }
-
-    /// Prepare one checksum-valid empty directory block without publishing a
-    /// name.  If initialization fails, the allocation is rolled back before
-    /// any extent references it.  Once extent publication starts, failures are
-    /// indeterminate and the caller must poison the mount.
-    pub(super) fn prepare_empty_dir_slot(&self, dir: &mut InodeRef) -> Result<()> {
-        let mut empty = DirBlock::new(Block::new(0, Box::new([0; BLOCK_SIZE])));
-        let metadata_csum = self.metadata_csum_enabled();
-        empty.init(metadata_csum);
-        self.set_dir_block_checksum(dir, &mut empty, DirBlockLayout::Leaf)?;
-        let iblock = self.extent_next_data_lblock(dir)?;
-        let old_size = dir.inode.size();
-        let old_blocks = dir.inode.fs_block_count();
-        let new_size = old_size
-            .checked_add(BLOCK_SIZE as u64)
-            .ok_or_else(|| crate::format_error!(ErrCode::EFBIG, "Directory size overflow"))?;
-        let new_blocks = old_blocks.checked_add(1).ok_or_else(|| {
-            crate::format_error!(ErrCode::EFBIG, "Directory block count overflow")
-        })?;
-        dir.inode.set_size(new_size);
-        dir.inode.set_fs_block_count(new_blocks);
-        if let Err(error) = self.extent_query_or_create_initialized(
-            dir,
-            iblock,
-            1,
-            Some(empty.block().data.clone()),
-        ) {
-            dir.inode.set_size(old_size);
-            dir.inode.set_fs_block_count(old_blocks);
-            // Extent publication may have reached disk before reporting an
-            // error; freeing pblock could create a dangling mapping.
-            self.poison(ErrCode::EIO);
-            return Err(error);
-        }
-        let total_blocks = match self.extent_all_data_blocks(dir).and_then(|data| {
-            self.extent_all_tree_blocks(dir).and_then(|tree| {
-                data.len().checked_add(tree.len()).ok_or_else(|| {
-                    crate::format_error!(ErrCode::EFBIG, "Directory blocks overflow")
-                })
-            })
-        }) {
-            Ok(total) => total,
-            Err(error) => {
-                self.poison(ErrCode::EIO);
-                return Err(error);
-            }
-        };
-        dir.inode.set_fs_block_count(total_blocks as u64);
-        if let Err(error) = self.write_inode_with_csum(dir) {
-            self.poison(ErrCode::EIO);
-            return Err(error);
-        }
-        Ok(())
-    }
-
     /// Stage insertion into an existing directory data block.  The read-only
     /// scan consumes no journal credit; only the matching free-space block is
     /// copied into the transaction image.  Directory growth requires extent
@@ -171,7 +92,7 @@ impl Ext4 {
     ) -> Result<()> {
         Self::validate_dir_name(name)?;
         for iblock in 0..Self::dir_data_block_count(dir)? {
-            let fblock = self.extent_query(dir, iblock)?;
+            let fblock = self.transaction_extent_query(transaction, dir, iblock)?;
             let view = transaction.read(self.block_device.as_ref(), fblock)?;
             let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
             let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
@@ -194,6 +115,59 @@ impl Ext4 {
             "Atomic relink requires free space in directory {}",
             dir.id
         );
+    }
+
+    /// Insert a name, including any directory/extent growth, in one private
+    /// operation. Reuse the existing insertion and right-spine algorithms;
+    /// none of the allocation or new directory contents reaches home early.
+    pub(super) fn transaction_dir_add(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        dir: &mut InodeRef,
+        child: &InodeRef,
+        name: &str,
+    ) -> Result<()> {
+        match self.transaction_dir_add_existing(transaction, dir, child, name) {
+            Ok(()) => return Ok(()),
+            Err(error) if error.code() == ErrCode::ENOSPC => {}
+            Err(error) => return Err(error),
+        }
+        let iblock = Self::dir_data_block_count(dir)?;
+        let plan = self.transaction_right_spine_append_plan(transaction, dir, iblock)?;
+        let home =
+            self.transaction_alloc_metadata_block(transaction, dir.id, plan.preferred_first)?;
+        let node_count = if plan.can_merge(home, 1) {
+            0
+        } else {
+            plan.new_nodes()
+        };
+        let mut nodes = Vec::new();
+        nodes
+            .try_reserve_exact(node_count)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        for _ in 0..node_count {
+            nodes.push(self.transaction_alloc_metadata_block(transaction, dir.id, Some(home))?);
+        }
+        let mut block = DirBlock::new(Block::new(home, Box::new([0; BLOCK_SIZE])));
+        block.init(self.metadata_csum_enabled());
+        if !block.insert(
+            name,
+            child.id,
+            child.inode.file_type(),
+            self.metadata_csum_enabled(),
+        ) {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        self.set_dir_block_checksum(dir, &mut block, DirBlockLayout::Leaf)?;
+        transaction.stage(home, block.block().data.clone())?;
+        self.stage_journaled_right_spine_append(transaction, dir, &plan, &nodes, home, 1)?;
+        let size = dir
+            .inode
+            .size()
+            .checked_add(BLOCK_SIZE as u64)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        dir.inode.set_size(size);
+        self.transaction_stage_inode_with_csum(transaction, dir)
     }
 
     /// Find a directory entry that matches a given name under a parent directory
@@ -331,43 +305,6 @@ impl Ext4 {
         Ok(())
     }
 
-    /// Remove a entry from a directory
-    pub(super) fn dir_remove_entry(&self, dir: &InodeRef, name: &str) -> Result<()> {
-        Self::validate_dir_name(name)?;
-        trace!("Dir remove entry: dir {}, name {}", dir.id, name);
-        let total_blocks = Self::dir_data_block_count(dir)?;
-        // Check each block
-        let mut iblock: LBlockId = 0;
-        while iblock < total_blocks {
-            // Get the parent physical block id
-            let fblock = self.extent_query(dir, iblock)?;
-            // Load the block from disk
-            let mut dir_block = DirBlock::new(self.read_block(fblock)?);
-            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
-            if layout == DirBlockLayout::Htree {
-                iblock += 1;
-                continue;
-            }
-            // Try removing the entry
-            if dir_block.remove(name, self.metadata_csum_enabled()) {
-                // Update checksum
-                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
-                // Write the block back to disk
-                self.write_block(dir_block.block())?;
-                return Ok(());
-            }
-            // Current block has no enough space
-            iblock += 1;
-        }
-        // Not found the target entry
-        return_error!(
-            ErrCode::ENOENT,
-            "Directory entry not found: dir {}, name {}",
-            dir.id,
-            name
-        );
-    }
-
     /// Stage removal of a directory entry in a transaction-private image.
     /// No namespace change becomes visible on disk or through caches until the
     /// caller commits the same transaction as its link-count updates.
@@ -385,7 +322,7 @@ impl Ext4 {
         );
         let total_blocks = Self::dir_data_block_count(dir)?;
         for iblock in 0..total_blocks {
-            let fblock = self.extent_query(dir, iblock)?;
+            let fblock = self.transaction_extent_query(transaction, dir, iblock)?;
             // Scanning must not consume a credit for every non-matching block
             // in a large directory. `read` still observes an already-staged
             // image if this helper is composed with another directory update.
@@ -427,43 +364,6 @@ impl Ext4 {
         Ok(entries)
     }
 
-    /// Replace a directory entry's inode in place.
-    /// Used for atomic rename when target exists (equivalent to Linux ext4_setent).
-    pub(super) fn dir_replace_entry(
-        &self,
-        dir: &InodeRef,
-        name: &str,
-        new_inode: InodeId,
-        new_type: FileType,
-    ) -> Result<()> {
-        Self::validate_dir_name(name)?;
-        trace!(
-            "Dir replace entry: dir {}, name {}, new_inode {}",
-            dir.id,
-            name,
-            new_inode
-        );
-        let total_blocks = Self::dir_data_block_count(dir)?;
-        let mut iblock: LBlockId = 0;
-        while iblock < total_blocks {
-            let fblock = self.extent_query(dir, iblock)?;
-            let mut dir_block = DirBlock::new(self.read_block(fblock)?);
-            let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
-            if dir_block.replace(name, new_inode, new_type, self.metadata_csum_enabled()) {
-                self.set_dir_block_checksum(dir, &mut dir_block, layout)?;
-                self.write_block(dir_block.block())?;
-                return Ok(());
-            }
-            iblock += 1;
-        }
-        return_error!(
-            ErrCode::ENOENT,
-            "Directory entry not found for replace: dir {}, name {}",
-            dir.id,
-            name
-        );
-    }
-
     /// Stage an in-place directory-entry replacement in the caller's
     /// transaction (the JBD2 equivalent of Linux `ext4_setent()`).
     ///
@@ -489,7 +389,7 @@ impl Ext4 {
         );
         let total_blocks = Self::dir_data_block_count(dir)?;
         for iblock in 0..total_blocks {
-            let fblock = self.extent_query(dir, iblock)?;
+            let fblock = self.transaction_extent_query(transaction, dir, iblock)?;
             let view = transaction.read(self.block_device.as_ref(), fblock)?;
             let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
             let layout = self.validate_dir_block(dir, iblock, &dir_block)?;

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -996,9 +996,24 @@ impl Ext4 {
     /// header or entry.  Linux performs the equivalent check in
     /// `ext4_extent_block_csum_verify()`.
     fn read_extent_block(&self, inode_ref: &InodeRef, pblock: PBlockId) -> Result<Block> {
+        self.read_extent_block_from_view(inode_ref, pblock, None)
+    }
+
+    fn read_extent_block_from_view(
+        &self,
+        inode_ref: &InodeRef,
+        pblock: PBlockId,
+        transaction: Option<&super::journal_transaction::Transaction<'_>>,
+    ) -> Result<Block> {
         self.ensure_valid_pblock(inode_ref.id, pblock, "extent tree node")?;
         self.validate_data_blocks(pblock, 1)?;
-        let block = self.read_block(pblock)?;
+        let block = match transaction {
+            Some(tx) => Block::new(
+                pblock,
+                Box::new(*tx.read(self.block_device.as_ref(), pblock)?),
+            ),
+            None => self.read_block(pblock)?,
+        };
         self.prepare_stats.record_extent_io();
         self.verify_extent_block_checksum(inode_ref, &block.data[..])?;
         Ok(block)
@@ -1259,8 +1274,12 @@ impl Ext4 {
         image[tail_offset..tail_offset + 4].copy_from_slice(&checksum.to_le_bytes());
     }
 
-    /// Write an extent block to disk with checksum in the extent tail.
-    fn write_extent_block(&self, block: &mut Block, inode_ref: &InodeRef) -> Result<()> {
+    fn write_extent_block_with_metadata(
+        &self,
+        metadata: &mut super::rw::MetadataIo<'_, '_, '_>,
+        block: &mut Block,
+        inode_ref: &InodeRef,
+    ) -> Result<()> {
         let tail_offset = BLOCK_SIZE - core::mem::size_of::<crate::ext4_defs::ExtentTail>();
         let csum = extent_block_checksum(
             self.read_super_block_cached().metadata_checksum_seed(),
@@ -1270,7 +1289,8 @@ impl Ext4 {
         );
         // Write checksum into the tail
         block.data[tail_offset..tail_offset + 4].copy_from_slice(&csum.to_le_bytes());
-        self.write_block(block)
+        metadata
+            .write_block(block)
             .inspect(|_| self.prepare_stats.record_extent_io())
     }
 }
@@ -1295,7 +1315,25 @@ impl ExtentSearchStep {
 impl Ext4 {
     /// Given a logic block id, find the corresponding fs block id.
     pub(super) fn extent_query(&self, inode_ref: &InodeRef, iblock: LBlockId) -> Result<PBlockId> {
-        let path = self.find_extent(inode_ref, iblock)?;
+        self.extent_query_from_view(inode_ref, iblock, None)
+    }
+
+    pub(super) fn transaction_extent_query(
+        &self,
+        transaction: &super::journal_transaction::Transaction<'_>,
+        inode_ref: &InodeRef,
+        iblock: LBlockId,
+    ) -> Result<PBlockId> {
+        self.extent_query_from_view(inode_ref, iblock, Some(transaction))
+    }
+
+    fn extent_query_from_view(
+        &self,
+        inode_ref: &InodeRef,
+        iblock: LBlockId,
+        transaction: Option<&super::journal_transaction::Transaction<'_>>,
+    ) -> Result<PBlockId> {
+        let path = self.find_extent_from_view(inode_ref, iblock, transaction)?;
         // Leaf is the last element of the path
         let leaf = path.last().ok_or(format_error!(
             ErrCode::EIO,
@@ -1308,7 +1346,8 @@ impl Ext4 {
             let ex_node = if leaf.pblock != 0 {
                 // Load the extent node
                 self.ensure_valid_pblock(inode_ref.id, leaf.pblock, "extent leaf node")?;
-                block_data = self.read_extent_block(inode_ref, leaf.pblock)?;
+                block_data =
+                    self.read_extent_block_from_view(inode_ref, leaf.pblock, transaction)?;
                 // Load the next extent header
                 ExtentNode::from_bytes(&*block_data.data)
             } else {
@@ -1348,7 +1387,38 @@ impl Ext4 {
         block_count: u32,
         initial_image: Option<Box<[u8; BLOCK_SIZE]>>,
     ) -> Result<PBlockId> {
-        let path = self.find_extent(inode_ref, iblock)?;
+        let mut metadata = super::rw::MetadataIo::direct(self);
+        self.extent_query_or_create_with_metadata(
+            &mut metadata,
+            inode_ref,
+            iblock,
+            block_count,
+            initial_image,
+        )
+    }
+
+    pub(super) fn transaction_extent_query_or_create(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
+        inode_ref: &mut InodeRef,
+        iblock: LBlockId,
+    ) -> Result<PBlockId> {
+        let mut metadata = super::rw::MetadataIo::transaction(self, transaction);
+        let home =
+            self.extent_query_or_create_with_metadata(&mut metadata, inode_ref, iblock, 1, None)?;
+        metadata.write_inode_with_csum(inode_ref)?;
+        Ok(home)
+    }
+
+    fn extent_query_or_create_with_metadata(
+        &self,
+        metadata: &mut super::rw::MetadataIo<'_, '_, '_>,
+        inode_ref: &mut InodeRef,
+        iblock: LBlockId,
+        block_count: u32,
+        initial_image: Option<Box<[u8; BLOCK_SIZE]>>,
+    ) -> Result<PBlockId> {
+        let path = self.find_extent_from_view(inode_ref, iblock, metadata.transaction_ref())?;
         // Leaf is the last element of the path
         let leaf = path.last().ok_or(format_error!(
             ErrCode::EIO,
@@ -1358,7 +1428,11 @@ impl Ext4 {
         // Note: block data must be defined here to keep it alive
         let mut block_data: Block;
         let ex_node = if leaf.pblock != 0 {
-            block_data = self.read_extent_block(inode_ref, leaf.pblock)?;
+            block_data = self.read_extent_block_from_view(
+                inode_ref,
+                leaf.pblock,
+                metadata.transaction_ref(),
+            )?;
             ExtentNodeMut::from_bytes(&mut *block_data.data)
         } else {
             // Root node
@@ -1391,9 +1465,9 @@ impl Ext4 {
                 // extent node.  Metadata-node allocations below continue to
                 // use alloc_block directly.
                 let fblock = if let Some(image) = initial_image {
-                    self.alloc_initialized_data_block(inode_ref, image)?
+                    metadata.allocate_initialized_data(inode_ref, image)?
                 } else {
-                    self.alloc_zeroed_data_block(inode_ref)?
+                    metadata.allocate_initialized_data(inode_ref, Box::new([0; BLOCK_SIZE]))?
                 };
                 let new_ext = Extent::new(iblock, fblock, block_count as u16);
 
@@ -1407,22 +1481,30 @@ impl Ext4 {
                         let prev_idx = insert_pos - 1;
                         if leaf_pblock != 0 {
                             // Re-read the leaf block and update
-                            let mut leaf_block = self.read_extent_block(inode_ref, leaf_pblock)?;
+                            let mut leaf_block = self.read_extent_block_from_view(
+                                inode_ref,
+                                leaf_pblock,
+                                metadata.transaction_ref(),
+                            )?;
                             let mut leaf_node = ExtentNodeMut::from_bytes(&mut *leaf_block.data);
                             *leaf_node.extent_mut_at(prev_idx) = merged;
-                            self.write_extent_block(&mut leaf_block, inode_ref)?;
+                            self.write_extent_block_with_metadata(
+                                metadata,
+                                &mut leaf_block,
+                                inode_ref,
+                            )?;
                         } else {
                             // Root node
                             let mut root = inode_ref.inode.extent_root_mut();
                             *root.extent_mut_at(prev_idx) = merged;
-                            self.write_inode_with_csum(inode_ref)?;
+                            metadata.write_inode_with_csum(inode_ref)?;
                         }
                         return Ok(fblock);
                     }
                 }
 
                 // Cannot merge, insert as a new extent entry
-                self.insert_extent(inode_ref, &path, &new_ext)?;
+                self.insert_extent(metadata, inode_ref, &path, &new_ext)?;
                 Ok(fblock)
             }
         }
@@ -1562,8 +1644,13 @@ impl Ext4 {
         Ok(())
     }
 
-    /// Find the given logic block id in the extent tree, return the search path
-    fn find_extent(&self, inode_ref: &InodeRef, iblock: LBlockId) -> Result<Vec<ExtentSearchStep>> {
+    /// Find a logical block in the selected live or operation-private view.
+    fn find_extent_from_view(
+        &self,
+        inode_ref: &InodeRef,
+        iblock: LBlockId,
+        transaction: Option<&super::journal_transaction::Transaction<'_>>,
+    ) -> Result<Vec<ExtentSearchStep>> {
         let mut path: Vec<ExtentSearchStep> = Vec::new();
         let mut ex_node = inode_ref.inode.extent_root();
         let mut pblock = 0;
@@ -1587,7 +1674,7 @@ impl Ext4 {
             let next = ex_idx.leaf();
             self.ensure_valid_pblock(inode_ref.id, next, "extent index target")?;
             // Note: block data cannot be released until the next assigment
-            block_data = self.read_extent_block(inode_ref, next)?;
+            block_data = self.read_extent_block_from_view(inode_ref, next, transaction)?;
             // Load the next extent header
             ex_node = ExtentNode::from_bytes(&*block_data.data);
             self.validate_extent_node(inode_ref.id, &ex_node)?;
@@ -1603,6 +1690,7 @@ impl Ext4 {
     /// Insert a new extent into the extent tree.
     fn insert_extent(
         &self,
+        metadata: &mut super::rw::MetadataIo<'_, '_, '_>,
         inode_ref: &mut InodeRef,
         path: &[ExtentSearchStep],
         new_ext: &Extent,
@@ -1617,20 +1705,21 @@ impl Ext4 {
             let mut leaf_node = inode_ref.inode.extent_root_mut();
             // Insert the extent
             let res = leaf_node.insert_extent(new_ext, leaf.index.unwrap_err());
-            self.write_inode_with_csum(inode_ref)?;
+            metadata.write_inode_with_csum(inode_ref)?;
             // Handle split
             return if let Err(split) = res {
-                self.split_root(inode_ref, &split)
+                self.split_root(metadata, inode_ref, &split)
             } else {
                 Ok(())
             };
         }
         // 2. Leaf is not root, load the leaf node
-        let mut leaf_block = self.read_extent_block(inode_ref, leaf.pblock)?;
+        let mut leaf_block =
+            self.read_extent_block_from_view(inode_ref, leaf.pblock, metadata.transaction_ref())?;
         let mut leaf_node = ExtentNodeMut::from_bytes(&mut *leaf_block.data);
         // Insert the extent
         let res = leaf_node.insert_extent(new_ext, leaf.index.unwrap_err());
-        self.write_extent_block(&mut leaf_block, inode_ref)?;
+        self.write_extent_block_with_metadata(metadata, &mut leaf_block, inode_ref)?;
         // Handle split
         if let Err(mut split) = res {
             // Handle split until root
@@ -1644,7 +1733,7 @@ impl Ext4 {
                         inode_ref.id
                     )
                 })?;
-                let res = self.split(inode_ref, parent.pblock, parent_index, &split)?;
+                let res = self.split(metadata, inode_ref, parent.pblock, parent_index, &split)?;
                 // Handle split again
                 if let Err(split_again) = res {
                     // Insertion to parent also causes split, continue to solve
@@ -1654,7 +1743,7 @@ impl Ext4 {
                 }
             }
             // Root node needs to be split
-            self.split_root(inode_ref, &split)
+            self.split_root(metadata, inode_ref, &split)
         } else {
             Ok(())
         }
@@ -1669,13 +1758,14 @@ impl Ext4 {
     /// This function will create a new leaf node to store the split part.
     fn split(
         &self,
+        metadata: &mut super::rw::MetadataIo<'_, '_, '_>,
         inode_ref: &mut InodeRef,
         parent_pblock: PBlockId,
         child_pos: usize,
         split: &[FakeExtent],
     ) -> Result<core::result::Result<(), Vec<FakeExtent>>> {
-        let right_bid = self.alloc_block(inode_ref)?;
-        let mut right_block = self.read_block(right_bid)?;
+        let right_bid = metadata.allocate_block(inode_ref)?;
+        let mut right_block = metadata.read_block(right_bid)?;
         let mut right_node = ExtentNodeMut::from_bytes(&mut *right_block.data);
 
         // Insert the split half to right node
@@ -1697,19 +1787,23 @@ impl Ext4 {
             let mut parent_node = inode_ref.inode.extent_root_mut();
             parent_depth = parent_node.header().depth();
             res = parent_node.insert_extent_index(&extent_index, child_pos + 1);
-            self.write_inode_with_csum(inode_ref)?;
+            metadata.write_inode_with_csum(inode_ref)?;
         } else {
             // Parent is not root
-            let mut parent_block = self.read_extent_block(inode_ref, parent_pblock)?;
+            let mut parent_block = self.read_extent_block_from_view(
+                inode_ref,
+                parent_pblock,
+                metadata.transaction_ref(),
+            )?;
             let mut parent_node = ExtentNodeMut::from_bytes(&mut *parent_block.data);
             parent_depth = parent_node.header().depth();
             res = parent_node.insert_extent_index(&extent_index, child_pos + 1);
-            self.write_extent_block(&mut parent_block, inode_ref)?;
+            self.write_extent_block_with_metadata(metadata, &mut parent_block, inode_ref)?;
         }
 
         // Right node is the child of parent, so its depth is 1 less than parent
         right_node.header_mut().set_depth(parent_depth - 1);
-        self.write_extent_block(&mut right_block, inode_ref)?;
+        self.write_extent_block_with_metadata(metadata, &mut right_block, inode_ref)?;
 
         Ok(res)
     }
@@ -1720,12 +1814,17 @@ impl Ext4 {
     /// The root node has already been split by calling `insert_extent` or
     /// `insert_extent_index`, and the split part is stored in `split`.
     /// This function will create a new leaf node to store the split part.
-    fn split_root(&self, inode_ref: &mut InodeRef, split: &[FakeExtent]) -> Result<()> {
+    fn split_root(
+        &self,
+        metadata: &mut super::rw::MetadataIo<'_, '_, '_>,
+        inode_ref: &mut InodeRef,
+        split: &[FakeExtent],
+    ) -> Result<()> {
         // Create left and right blocks
-        let l_bid = self.alloc_block(inode_ref)?;
-        let r_bid = self.alloc_block(inode_ref)?;
-        let mut l_block = self.read_block(l_bid)?;
-        let mut r_block = self.read_block(r_bid)?;
+        let l_bid = metadata.allocate_block(inode_ref)?;
+        let r_bid = metadata.allocate_block(inode_ref)?;
+        let mut l_block = metadata.read_block(l_bid)?;
+        let mut r_block = metadata.read_block(r_bid)?;
 
         // Load root, left, right nodes
         let mut root = inode_ref.inode.extent_root_mut();
@@ -1755,9 +1854,9 @@ impl Ext4 {
         *root.extent_index_mut_at(1) = ExtentIndex::new(right.extent_at(0).start_lblock(), r_bid);
 
         // Sync to disk
-        self.write_extent_block(&mut l_block, inode_ref)?;
-        self.write_extent_block(&mut r_block, inode_ref)?;
-        self.write_inode_with_csum(inode_ref)?;
+        self.write_extent_block_with_metadata(metadata, &mut l_block, inode_ref)?;
+        self.write_extent_block_with_metadata(metadata, &mut r_block, inode_ref)?;
+        metadata.write_inode_with_csum(inode_ref)?;
 
         Ok(())
     }

--- a/kernel/crates/another_ext4/src/ext4/high_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/high_level.rs
@@ -115,13 +115,18 @@ impl Ext4 {
         let parent_id = self.generic_lookup(root, &parent_path)?;
         // Get the child inode
         let child_id = self.lookup(parent_id, file_name)?;
-        let child = self.read_inode(child_id)?;
-        // Check if child is a non-empty directory
-        if child.inode.is_dir() && self.dir_list_entries(&child)?.len() > 2 {
-            return_error!(ErrCode::ENOTEMPTY, "Directory {} not empty", path);
-        }
+        let is_dir = {
+            // Keep the cold inode-cache insertion and directory inspection
+            // in one view; release it before entering the mutating operation.
+            let _view = self.lock_metadata_read_view()?;
+            let child = self.read_inode(child_id)?;
+            if child.inode.is_dir() && self.dir_list_entries(&child)?.len() > 2 {
+                return_error!(ErrCode::ENOTEMPTY, "Directory {} not empty", path);
+            }
+            child.inode.is_dir()
+        };
         // Unlink the file
-        let reclaim = if child.inode.is_dir() {
+        let reclaim = if is_dir {
             self.rmdir(parent_id, file_name)
         } else {
             self.unlink(parent_id, file_name)

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -4,6 +4,15 @@ use crate::ext4_defs::{AsBytes, Block, BlockDevice, InodeRef, SuperBlock};
 use crate::jbd2::Superblock as JournalSuperblock;
 use crate::prelude::*;
 
+/// Publication is deliberately separate from disk commit failures. Accepted
+/// operations may never be rolled back, even if the worker later fails before
+/// writing a commit record.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum MetadataPublication {
+    Durable,
+    Accepted(u64),
+}
+
 fn validate_journal_inode(sb: &SuperBlock, inode: &InodeRef) -> Result<()> {
     if !inode.inode.is_file()
         || !inode.inode.uses_extents()
@@ -156,7 +165,10 @@ impl Ext4 {
     }
 
     pub fn uses_journal(&self) -> bool {
-        matches!(self.metadata_mode, MetadataMutationMode::Journal(_))
+        matches!(
+            self.metadata_mode,
+            MetadataMutationMode::Journal(_) | MetadataMutationMode::Batched(_)
+        )
     }
 
     pub(super) fn supports_direct_range_stage(&self) -> bool {
@@ -168,7 +180,7 @@ impl Ext4 {
         // Clearing RECOVER is a metadata state transition and must not race a
         // direct writer even if the VFS normally excludes writers at umount.
         let _metadata_guard = self.lock_transactional_metadata_mutation()?;
-        let journal = match &self.metadata_mode {
+        let can_shutdown = match &self.metadata_mode {
             MetadataMutationMode::ReadOnly => return Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Direct(core) => {
                 if !core.can_shutdown() || self.poisoned.lock().is_some() {
@@ -187,9 +199,10 @@ impl Ext4 {
                 }
                 return Ok(());
             }
-            MetadataMutationMode::Journal(core) => core,
+            MetadataMutationMode::Journal(core) => core.can_shutdown(),
+            MetadataMutationMode::Batched(core) => core.can_shutdown(),
         };
-        if !journal.can_shutdown() {
+        if !can_shutdown {
             return Err(Ext4Error::new(ErrCode::EIO));
         }
         // Every synchronous transaction checkpoints and clears s_start before
@@ -197,8 +210,75 @@ impl Ext4 {
         // to clear RECOVER as Linux does at clean shutdown.
         let mut sb = self.read_super_block_cached();
         sb.set_incompatible_feature(SuperBlock::FEATURE_INCOMPAT_RECOVER, false);
-        self.write_super_block(&sb)?;
+        let mut block = self.block_device.read_block(0)?;
+        sb.set_checksum();
+        block.write_offset_as(crate::constants::BASE_OFFSET, &sb);
+        self.block_device.write_block(&block)?;
         self.block_device.flush()
+    }
+
+    /// Consume the recovered synchronous journal before the mount is exposed.
+    /// All runtime metadata writers must already use private operations.
+    pub fn enable_batching(&mut self, block_budget: usize) -> Result<()> {
+        if matches!(self.metadata_mode, MetadataMutationMode::Journal(_)) {
+            let old = core::mem::replace(&mut self.metadata_mode, MetadataMutationMode::ReadOnly);
+            let MetadataMutationMode::Journal(journal) = old else {
+                unreachable!()
+            };
+            self.metadata_mode = MetadataMutationMode::Batched(journal.into_batch(block_budget)?);
+        }
+        Ok(())
+    }
+
+    pub fn batch_progress(&self) -> Option<super::BatchProgress> {
+        match &self.metadata_mode {
+            MetadataMutationMode::Batched(core) => Some(core.progress()),
+            _ => None,
+        }
+    }
+
+    pub fn request_batch_commit(&self) {
+        if let MetadataMutationMode::Batched(core) = &self.metadata_mode {
+            core.request_seal();
+        }
+    }
+
+    pub fn commit_pending_batch(&self) -> Result<Option<u64>> {
+        match &self.metadata_mode {
+            MetadataMutationMode::Batched(core) => core
+                .commit_pending(self.block_device.as_ref())
+                .map_err(|failure| {
+                    self.poison(ErrCode::EIO);
+                    failure.error
+                }),
+            _ => Ok(None),
+        }
+    }
+
+    pub fn close_batch_admission(&self) {
+        if let MetadataMutationMode::Batched(core) = &self.metadata_mode {
+            core.close();
+        }
+    }
+
+    pub(super) fn commit_metadata_operation(
+        &self,
+        transaction: journal_transaction::Transaction<'_>,
+    ) -> core::result::Result<MetadataPublication, journal_transaction::CommitError> {
+        if transaction.is_batch() {
+            transaction
+                .publish(self)
+                .map(MetadataPublication::Accepted)
+                .map_err(|error| journal_transaction::CommitError {
+                    error,
+                    failure: journal_transaction::CommitFailure::BeforeCommit,
+                    poisoned: self.metadata_mutations_terminal(),
+                })
+        } else {
+            transaction
+                .commit(self.block_device.as_ref(), self)
+                .map(|()| MetadataPublication::Durable)
+        }
     }
 
     #[allow(dead_code)]
@@ -209,6 +289,7 @@ impl Ext4 {
         let result = match &self.metadata_mode {
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Journal(core) => core.start(credits),
+            MetadataMutationMode::Batched(core) => return core.start(credits),
             MetadataMutationMode::Direct(core) => core.start(credits),
         };
         self.normalize_transaction_start(result)
@@ -217,6 +298,7 @@ impl Ext4 {
     pub(super) fn transaction_credits_fit(&self, credits: usize) -> Result<bool> {
         match &self.metadata_mode {
             MetadataMutationMode::Journal(core) => core.credits_fit(credits),
+            MetadataMutationMode::Batched(core) => core.credits_fit(credits),
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
             MetadataMutationMode::Direct(_) => Ok(true),
         }
@@ -229,7 +311,9 @@ impl Ext4 {
         let result = match &self.metadata_mode {
             MetadataMutationMode::Direct(core) => core.start_direct_range(credits),
             MetadataMutationMode::ReadOnly => Err(Ext4Error::new(ErrCode::EROFS)),
-            MetadataMutationMode::Journal(_) => Err(Ext4Error::new(ErrCode::ENOTSUP)),
+            MetadataMutationMode::Journal(_) | MetadataMutationMode::Batched(_) => {
+                Err(Ext4Error::new(ErrCode::ENOTSUP))
+            }
         };
         self.normalize_transaction_start(result)
     }
@@ -394,6 +478,7 @@ impl Ext4 {
     pub(super) fn journal_owns_block_range(&self, start: PBlockId, end: PBlockId) -> bool {
         match &self.metadata_mode {
             MetadataMutationMode::Journal(journal) => journal.owns_block_range(start, end),
+            MetadataMutationMode::Batched(journal) => journal.owns_block_range(start, end),
             MetadataMutationMode::ReadOnly | MetadataMutationMode::Direct(_) => false,
         }
     }
@@ -405,8 +490,9 @@ impl journal_transaction::CachePublisher for Ext4 {
         // validated bitmap/table addresses. Therefore system_metadata_ranges
         // remains immutable here; journal replay is the only path which can
         // replace the complete SB/BGD snapshot and rebuilds it explicitly.
-        // Home blocks are durable at this point.  Decode cacheable value
-        // snapshots directly from the transaction-owned images; all updates
+        // This is the logical publication boundary (also durable for the
+        // synchronous backend). Decode value snapshots from private images;
+        // a batched checkpoint never calls this publisher. All updates
         // below are infallible and allocation-free.
         if let Some(block0) = blocks.get(&0) {
             let sb = SuperBlock::from_bytes(&block0.bytes()[crate::constants::BASE_OFFSET..]);

--- a/kernel/crates/another_ext4/src/ext4/journal_batch.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_batch.rs
@@ -1,0 +1,603 @@
+//! Bounded logical metadata publication, separate from journal durability.
+//!
+//! There is one operation writer, one Running image set and at most one
+//! immutable Frozen set. The mount owns scheduling and waiting; this module
+//! never sleeps and never invokes callbacks while holding its state lock.
+//! It must only be selected after *all* runtime metadata access uses this view.
+
+use super::journal_transaction::{
+    CachePublisher, CommitError, JournalContext, JournalTransactionCore, StagedBlock, Transaction,
+    TransactionCoreRef,
+};
+use super::MetadataMutationWaker;
+use crate::constants::BLOCK_SIZE;
+use crate::ext4_defs::{Block, BlockDevice};
+use crate::prelude::*;
+
+/// Logical sequence numbers are checked, not wrapping JBD2 transaction IDs.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub struct BatchProgress {
+    pub accepted: u64,
+    pub durable: u64,
+    /// Equality token for wait/recheck and multi-block optimistic readers.
+    pub generation: u64,
+    pub running_blocks: usize,
+    pub frozen_blocks: usize,
+    pub seal_requested: bool,
+    pub active_operation: bool,
+    pub publishing: bool,
+    pub failed: bool,
+    pub closed: bool,
+    pub running_retirements: usize,
+    pub frozen_retirements: usize,
+    pub running_operations: usize,
+    pub frozen_operations: usize,
+}
+
+/// Half-open ranges keep large extent releases bounded by metadata work,
+/// rather than allocating one retirement node for every freed data block.
+#[derive(Clone, Copy)]
+pub(super) struct RetiredRange {
+    inode: bool,
+    start: u64,
+    end: u64,
+}
+
+impl RetiredRange {
+    pub(super) fn blocks(start: PBlockId, count: u64) -> Result<Self> {
+        let end = start
+            .checked_add(count)
+            .filter(|end| *end > start)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EINVAL))?;
+        Ok(Self {
+            inode: false,
+            start,
+            end,
+        })
+    }
+
+    pub(super) fn inode(id: InodeId) -> Self {
+        Self {
+            inode: true,
+            start: id as u64,
+            end: id as u64 + 1,
+        }
+    }
+
+    fn overlaps(self, other: Self) -> bool {
+        self.inode == other.inode && self.start < other.end && other.start < self.end
+    }
+}
+
+/// Called before any allocator mutation. Capacity allocation is only needed
+/// in the private operation; batch vectors were fully reserved at mount.
+pub(super) fn retire(
+    ranges: &mut Vec<RetiredRange>,
+    limit: usize,
+    mut new: RetiredRange,
+) -> Result<()> {
+    // Find the transitive union before modifying the list, so every error
+    // still leaves the operation's existing retirement ownership intact.
+    loop {
+        let previous = (new.start, new.end);
+        for old in ranges.iter() {
+            if old.inode == new.inode && old.start <= new.end && new.start <= old.end {
+                new.start = new.start.min(old.start);
+                new.end = new.end.max(old.end);
+            }
+        }
+        if previous == (new.start, new.end) {
+            break;
+        }
+    }
+    let merged = ranges
+        .iter()
+        .filter(|old| old.inode == new.inode && old.start <= new.end && new.start <= old.end)
+        .count();
+    if ranges.len() - merged >= limit {
+        return Err(Ext4Error::new(ErrCode::E2BIG));
+    }
+    if merged == 0 {
+        ranges
+            .try_reserve(1)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+    }
+    ranges.retain(|old| !(old.inode == new.inode && old.start <= new.end && new.start <= old.end));
+    ranges.push(new);
+    Ok(())
+}
+
+pub(super) fn reusable(ranges: &[RetiredRange], query: RetiredRange) -> bool {
+    !ranges.iter().any(|retired| retired.overlaps(query))
+}
+
+pub(super) fn reuse_restart(ranges: &[RetiredRange], query: RetiredRange) -> Option<u64> {
+    ranges
+        .iter()
+        .filter(|retired| retired.overlaps(query))
+        .map(|retired| retired.end)
+        .max()
+}
+
+struct Frozen {
+    blocks: Vec<StagedBlock>,
+    retired: Vec<RetiredRange>,
+    operations: usize,
+}
+
+struct State {
+    running: Vec<StagedBlock>,
+    retired: Vec<RetiredRange>,
+    spare: Option<Arc<Frozen>>,
+    frozen: Option<Arc<Frozen>>,
+    accepted: u64,
+    durable: u64,
+    generation: u64,
+    reserved: usize,
+    operations: usize,
+    active: bool,
+    publishing: bool,
+    committing: bool,
+    seal_requested: bool,
+    failed: bool,
+    closed: bool,
+}
+
+pub struct JournalBatchCore {
+    journal: JournalTransactionCore,
+    capacity: usize,
+    state: spin::Mutex<State>,
+    waker: spin::Once<Arc<dyn MetadataMutationWaker>>,
+}
+
+impl JournalBatchCore {
+    /// `block_budget` bounds each live image set and each private operation.
+    /// The effective limit is additionally constrained by descriptor/tag space
+    /// and the journal ring, using the same calculation as the disk encoder.
+    pub fn new(context: JournalContext, block_budget: usize) -> Result<Self> {
+        JournalTransactionCore::new(context)?.into_batch(block_budget)
+    }
+
+    pub(super) fn from_journal(
+        journal: JournalTransactionCore,
+        block_budget: usize,
+    ) -> Result<Self> {
+        if block_budget == 0 {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        let mut low = 0;
+        let mut high = block_budget;
+        while low < high {
+            let mid = low + (high - low) / 2 + 1;
+            if journal.credits_fit(mid)? {
+                low = mid;
+            } else {
+                high = mid - 1;
+            }
+        }
+        if low == 0 {
+            return Err(Ext4Error::new(ErrCode::E2BIG));
+        }
+        let mut running = Vec::new();
+        let mut spare = Vec::new();
+        let mut retired = Vec::new();
+        let mut spare_retired = Vec::new();
+        running
+            .try_reserve_exact(low)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        spare
+            .try_reserve_exact(low)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        retired
+            .try_reserve_exact(low)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        spare_retired
+            .try_reserve_exact(low)
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        Ok(Self {
+            journal,
+            capacity: low,
+            state: spin::Mutex::new(State {
+                running,
+                retired,
+                spare: Some(Arc::new(Frozen {
+                    blocks: spare,
+                    retired: spare_retired,
+                    operations: 0,
+                })),
+                frozen: None,
+                accepted: 0,
+                durable: 0,
+                generation: 0,
+                reserved: 0,
+                operations: 0,
+                active: false,
+                publishing: false,
+                committing: false,
+                seal_requested: false,
+                failed: false,
+                closed: false,
+            }),
+            waker: spin::Once::new(),
+        })
+    }
+
+    pub fn install_waker(&self, waker: Arc<dyn MetadataMutationWaker>) {
+        self.waker.call_once(|| waker);
+    }
+
+    fn wake(&self) {
+        if let Some(waker) = self.waker.get() {
+            waker.wake_all();
+        }
+    }
+
+    pub fn is_poisoned(&self) -> bool {
+        self.state.lock().failed
+    }
+
+    pub fn credits_fit(&self, credits: usize) -> Result<bool> {
+        if credits == 0 {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        if self.is_poisoned() {
+            return Err(Ext4Error::new(ErrCode::EROFS));
+        }
+        Ok(credits <= self.capacity)
+    }
+
+    pub fn can_shutdown(&self) -> bool {
+        let state = self.state.lock();
+        !state.active
+            && !state.committing
+            && state.running.is_empty()
+            && state.frozen.is_none()
+            && !state.failed
+    }
+
+    pub fn progress(&self) -> BatchProgress {
+        let state = self.state.lock();
+        BatchProgress {
+            accepted: state.accepted,
+            durable: state.durable,
+            generation: state.generation,
+            running_blocks: state.running.len(),
+            frozen_blocks: state.frozen.as_ref().map_or(0, |batch| batch.blocks.len()),
+            seal_requested: state.seal_requested,
+            active_operation: state.active,
+            publishing: state.publishing,
+            failed: state.failed,
+            closed: state.closed,
+            running_retirements: state.retired.len(),
+            frozen_retirements: state.frozen.as_ref().map_or(0, |batch| batch.retired.len()),
+            running_operations: state.operations,
+            frozen_operations: state.frozen.as_ref().map_or(0, |batch| batch.operations),
+        }
+    }
+
+    pub fn owns_block_range(&self, start: PBlockId, end: PBlockId) -> bool {
+        self.journal.owns_block_range(start, end)
+    }
+
+    pub(super) fn validate_home(&self, home: PBlockId) -> Result<()> {
+        self.journal.validate_home(home)
+    }
+
+    /// Reserve worst-case unique images before entering an operation. EAGAIN
+    /// means release upper locks and wait/revalidate, never retry in a spin.
+    pub fn start(&self, credits: usize) -> Result<Transaction<'_>> {
+        if credits == 0 || credits > self.capacity {
+            return Err(Ext4Error::new(if credits == 0 {
+                ErrCode::EINVAL
+            } else {
+                ErrCode::E2BIG
+            }));
+        }
+        let mut state = self.state.lock();
+        if state.failed || state.closed {
+            return Err(Ext4Error::new(ErrCode::EROFS));
+        }
+        if state.active || state.seal_requested {
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        if credits > self.capacity - state.running.len()
+            || credits > self.capacity - state.retired.len()
+            || state.operations == self.capacity
+        {
+            state.seal_requested = true;
+            state.generation = state.generation.wrapping_add(1);
+            drop(state);
+            self.wake();
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        state.active = true;
+        state.reserved = credits;
+        drop(state);
+        Ok(Transaction::new(
+            TransactionCoreRef::Batch(self),
+            credits,
+            false,
+        ))
+    }
+
+    pub(super) fn release_operation(&self) {
+        let mut state = self.state.lock();
+        state.active = false;
+        state.reserved = 0;
+        state.generation = state.generation.wrapping_add(1);
+        drop(state);
+        self.wake();
+    }
+
+    /// The caller owns the operation token and its existing inode/namespace
+    /// locks. Its publisher is infallible. The publishing flag and generation
+    /// bracket cache updates performed outside the engine spinlock; readers
+    /// of upper caches must participate in the same view validation protocol.
+    pub(super) fn publish(
+        &self,
+        staged: &mut BTreeMap<PBlockId, StagedBlock>,
+        retired: &mut Vec<RetiredRange>,
+        publisher: &dyn CachePublisher,
+    ) -> Result<u64> {
+        // Deallocate map nodes and replaced images outside the engine lock.
+        // Reserve both owner arrays before any cache becomes visible.
+        let mut incoming = Vec::new();
+        let mut replaced = Vec::new();
+        incoming
+            .try_reserve_exact(staged.len())
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        replaced
+            .try_reserve_exact(staged.len())
+            .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+        let sequence = {
+            let mut state = self.state.lock();
+            if state.failed || state.closed {
+                return Err(Ext4Error::new(ErrCode::EROFS));
+            }
+            if !state.active || staged.len() > state.reserved || retired.len() > state.reserved {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+            if staged.is_empty() {
+                if !retired.is_empty() {
+                    return Err(Ext4Error::new(ErrCode::EINVAL));
+                }
+                return Ok(state.accepted);
+            }
+            let next = state
+                .accepted
+                .checked_add(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::ERANGE))?;
+            state.publishing = true;
+            state.generation = state.generation.wrapping_add(1);
+            next
+        };
+        publisher.publish(staged);
+        incoming.extend(core::mem::take(staged).into_values());
+        // Capacity and all validation were settled before the first visible
+        // cache change. Sorted Vec insertion moves only small block owners,
+        // never allocates nodes, and binary search serves metadata reads.
+        let mut state = self.state.lock();
+        for block in incoming.drain(..) {
+            let home = block.home();
+            match state.running.binary_search_by_key(&home, StagedBlock::home) {
+                Ok(index) => replaced.push(core::mem::replace(&mut state.running[index], block)),
+                Err(index) => state.running.insert(index, block),
+            }
+        }
+        for range in retired.drain(..) {
+            // Admission reserved worst-case independent records, so this
+            // merge cannot allocate or fail after logical publication.
+            retire(&mut state.retired, self.capacity, range).expect("reserved retirement capacity");
+        }
+        state.accepted = sequence;
+        state.operations += 1;
+        state.publishing = false;
+        state.generation = state.generation.wrapping_add(1);
+        if state.running.len() == self.capacity
+            || state.retired.len() == self.capacity
+            || state.operations == self.capacity
+        {
+            state.seal_requested = true;
+        }
+        drop(state);
+        self.wake();
+        Ok(sequence)
+    }
+
+    /// Read from the latest accepted view. Allocate the destination before
+    /// locking; a cold read is revalidated after I/O even when an intervening
+    /// checkpoint removed the last overlay version of this home.
+    pub fn read_metadata(&self, device: &dyn BlockDevice, home: PBlockId) -> Result<Block> {
+        self.validate_home(home)?;
+        let mut image = Box::new([0; BLOCK_SIZE]);
+        loop {
+            let generation = {
+                let state = self.state.lock();
+                if state.publishing {
+                    return Err(Ext4Error::new(ErrCode::EAGAIN));
+                }
+                if let Some(block) = lookup(&state, home) {
+                    image.copy_from_slice(block.bytes());
+                    return Ok(Block::new(home, image));
+                }
+                state.generation
+            };
+            let disk = device.read_block(home)?;
+            let state = self.state.lock();
+            if state.publishing {
+                return Err(Ext4Error::new(ErrCode::EAGAIN));
+            }
+            if let Some(block) = lookup(&state, home) {
+                image.copy_from_slice(block.bytes());
+                return Ok(Block::new(home, image));
+            }
+            if state.generation == generation {
+                return Ok(disk);
+            }
+        }
+    }
+
+    pub(super) fn resource_reusable(&self, range: RetiredRange) -> bool {
+        let state = self.state.lock();
+        reusable(&state.retired, range)
+            && state
+                .frozen
+                .as_ref()
+                .is_none_or(|batch| reusable(&batch.retired, range))
+    }
+
+    pub(super) fn resource_reuse_restart(&self, range: RetiredRange) -> Option<u64> {
+        let state = self.state.lock();
+        reuse_restart(&state.retired, range).max(
+            state
+                .frozen
+                .as_ref()
+                .and_then(|batch| reuse_restart(&batch.retired, range)),
+        )
+    }
+
+    pub(super) fn request_retirement_progress(&self) -> bool {
+        let mut state = self.state.lock();
+        let pending = !state.retired.is_empty()
+            || state
+                .frozen
+                .as_ref()
+                .is_some_and(|batch| !batch.retired.is_empty());
+        if pending && !state.running.is_empty() {
+            state.seal_requested = true;
+            state.generation = state.generation.wrapping_add(1);
+        }
+        drop(state);
+        if pending {
+            self.wake();
+        }
+        pending
+    }
+
+    pub fn block_range_reusable(&self, start: PBlockId, count: u64) -> Result<bool> {
+        Ok(self.resource_reusable(RetiredRange::blocks(start, count)?))
+    }
+
+    pub fn inode_reusable(&self, id: InodeId) -> bool {
+        self.resource_reusable(RetiredRange::inode(id))
+    }
+
+    /// Sealing is fair: no new operation starts until the current operation
+    /// exits and the worker has frozen its final images.
+    pub fn request_seal(&self) {
+        let mut state = self.state.lock();
+        if !state.running.is_empty() || state.active {
+            state.seal_requested = true;
+            state.generation = state.generation.wrapping_add(1);
+        }
+        drop(state);
+        self.wake();
+    }
+
+    /// Stop admitting new operations; an already active operation may abort.
+    /// Mount teardown must drain its upper-level work before closing admission.
+    pub fn close(&self) {
+        let mut state = self.state.lock();
+        state.closed = true;
+        state.seal_requested = !state.running.is_empty();
+        state.generation = state.generation.wrapping_add(1);
+        drop(state);
+        self.wake();
+    }
+
+    pub fn fail_stop(&self) {
+        let mut state = self.state.lock();
+        state.failed = true;
+        state.generation = state.generation.wrapping_add(1);
+        drop(state);
+        self.wake();
+    }
+
+    /// Execute at most one requested batch. None means no work is ready; the
+    /// mount waits for generation/deadline changes rather than busy polling.
+    /// A returned disk error is always post-publication, regardless of its
+    /// CommitFailure phase, so every such failure stops further publication.
+    pub fn commit_pending(
+        &self,
+        device: &dyn BlockDevice,
+    ) -> core::result::Result<Option<u64>, CommitError> {
+        let (mut frozen, sequence) = {
+            let mut state = self.state.lock();
+            if state.failed || state.committing || state.active || !state.seal_requested {
+                return Ok(None);
+            }
+            if state.running.is_empty() {
+                state.seal_requested = false;
+                state.generation = state.generation.wrapping_add(1);
+                drop(state);
+                self.wake();
+                return Ok(None);
+            }
+            debug_assert!(state.frozen.is_none());
+            // Reuse the control block and both fixed-capacity owner vectors
+            // reserved at mount; sealing itself performs no allocation.
+            let mut owner = state.spare.take().expect("idle frozen owner");
+            let frozen = Arc::get_mut(&mut owner).expect("unpublished frozen owner");
+            core::mem::swap(&mut frozen.blocks, &mut state.running);
+            core::mem::swap(&mut frozen.retired, &mut state.retired);
+            frozen.operations = core::mem::take(&mut state.operations);
+            state.frozen = Some(Arc::clone(&owner));
+            let sequence = state.accepted;
+            state.committing = true;
+            state.seal_requested = false;
+            state.generation = state.generation.wrapping_add(1);
+            (owner, sequence)
+        };
+        self.wake();
+        let mut images = Vec::new();
+        if images.try_reserve_exact(frozen.blocks.len()).is_err() {
+            self.fail_stop();
+            return Err(CommitError {
+                error: Ext4Error::new(ErrCode::ENOMEM),
+                failure: super::journal_transaction::CommitFailure::BeforeCommit,
+                poisoned: true,
+            });
+        }
+        images.extend(frozen.blocks.iter());
+        let result = self.journal.commit_batch_images(device, &images);
+        drop(images);
+        if let Err(mut error) = result {
+            // Even a pre-I/O allocation/format failure happened after live
+            // acceptance. Retain both overlays, wake everyone, never retry
+            // leases or report the accepted sequence as durable.
+            self.fail_stop();
+            error.poisoned = true;
+            return Err(error);
+        }
+        let old_owner = {
+            let mut state = self.state.lock();
+            state.durable = sequence;
+            state.generation = state.generation.wrapping_add(1);
+            state.frozen.take()
+        };
+        drop(old_owner);
+        let recycled = Arc::get_mut(&mut frozen).expect("only worker owns retired frozen images");
+        recycled.blocks.clear();
+        recycled.retired.clear();
+        recycled.operations = 0;
+        let mut state = self.state.lock();
+        state.spare = Some(frozen);
+        state.committing = false;
+        state.generation = state.generation.wrapping_add(1);
+        drop(state);
+        self.wake();
+        Ok(Some(sequence))
+    }
+}
+
+fn lookup(state: &State, home: PBlockId) -> Option<&StagedBlock> {
+    if let Ok(index) = state.running.binary_search_by_key(&home, StagedBlock::home) {
+        return Some(&state.running[index]);
+    }
+    let frozen = state.frozen.as_ref()?;
+    frozen
+        .blocks
+        .binary_search_by_key(&home, StagedBlock::home)
+        .ok()
+        .map(|index| &frozen.blocks[index])
+}

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -6,6 +6,7 @@
 //! that no filesystem spin lock is held while block I/O is in flight.
 #![allow(dead_code)] // Activated only after every production metadata writer uses handles.
 
+use super::journal_batch::{retire, reusable, reuse_restart, JournalBatchCore, RetiredRange};
 use crate::constants::BLOCK_SIZE;
 use crate::ext4_defs::{Block, BlockDevice};
 use crate::jbd2::{
@@ -76,13 +77,14 @@ impl StagedBlock {
     }
 }
 
-/// Publishes metadata images after the selected backend has completed its
-/// commit point. Journal commits publish after a durable checkpoint; direct
-/// commits publish after every synchronous home-block write has succeeded.
+/// Publishes metadata images at the selected backend's logical commit point.
+/// Synchronous journal commits publish after a durable checkpoint; batch
+/// operations publish at acceptance. Old batch checkpoints never republish.
+/// Direct commits publish after every synchronous home write has succeeded.
 pub trait CachePublisher: Send + Sync {
-    /// Publish already-checkpointed images to in-memory caches.
+    /// Publish the operation's final images to in-memory caches.
     ///
-    /// This callback runs after the home-block flush, so it must not allocate,
+    /// This is an irrevocable logical publication, so it must not allocate,
     /// perform I/O, or otherwise fail.  Borrowing the transaction's map also
     /// lets publishers inspect the final image for a particular home block
     /// without building a temporary collection.
@@ -204,6 +206,22 @@ impl JournalTransactionCore {
         self.poison.load(Ordering::Acquire) != CLEAN
     }
 
+    /// Transfer the single recovered journal owner into batching. Recovery
+    /// and host callers may continue using the original synchronous backend;
+    /// a mounted filesystem cannot retain another owner of the same context.
+    pub(super) fn into_batch(self, block_budget: usize) -> Result<JournalBatchCore> {
+        if self.is_poisoned() {
+            return Err(Ext4Error::new(ErrCode::EROFS));
+        }
+        if !self.can_shutdown() {
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        if self.context.lock().superblock.start != 0 {
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
+        JournalBatchCore::from_journal(self, block_budget)
+    }
+
     pub fn can_shutdown(&self) -> bool {
         !self.writer.load(Ordering::Acquire) && !self.is_poisoned()
     }
@@ -279,21 +297,23 @@ impl JournalTransactionCore {
 }
 
 #[derive(Clone, Copy)]
-enum TransactionCoreRef<'a> {
+pub(super) enum TransactionCoreRef<'a> {
     Journal(&'a JournalTransactionCore),
     Direct(&'a DirectTransactionCore),
+    Batch(&'a JournalBatchCore),
 }
 
 pub struct Transaction<'a> {
     core: TransactionCoreRef<'a>,
     credits: usize,
     staged: BTreeMap<PBlockId, StagedBlock>,
+    retired: Vec<RetiredRange>,
     preserve_originals: bool,
     owns_writer: bool,
 }
 
 impl Transaction<'_> {
-    fn new(
+    pub(super) fn new(
         core: TransactionCoreRef<'_>,
         credits: usize,
         preserve_originals: bool,
@@ -302,6 +322,7 @@ impl Transaction<'_> {
             core,
             credits,
             staged: BTreeMap::new(),
+            retired: Vec::new(),
             preserve_originals,
             owns_writer: true,
         }
@@ -309,6 +330,9 @@ impl Transaction<'_> {
     /// Replace the final image for `home`.  Re-staging the same home block does
     /// not consume another credit and subsequent reads observe the replacement.
     pub fn stage(&mut self, home: PBlockId, image: Box<[u8; BLOCK_SIZE]>) -> Result<()> {
+        if let TransactionCoreRef::Batch(core) = self.core {
+            core.validate_home(home)?;
+        }
         if !self.staged.contains_key(&home) && self.staged.len() == self.credits {
             return Err(Ext4Error::new(ErrCode::E2BIG));
         }
@@ -323,13 +347,14 @@ impl Transaction<'_> {
         Ok(())
     }
 
-    /// Credits which are still available for previously untouched home blocks.
+    /// Remaining operation budget for new metadata homes or retired ranges.
     ///
     /// Batched operations use this only to stop at a restartable boundary
     /// before beginning their next logical mutation. Re-staging an existing
     /// home remains free and the transaction is still the final authority.
     pub(super) fn remaining_credits(&self) -> usize {
-        self.credits.saturating_sub(self.staged.len())
+        self.credits
+            .saturating_sub(self.staged.len().max(self.retired.len()))
     }
 
     /// Return the transaction-private final image of `home` for mutation.
@@ -346,7 +371,7 @@ impl Transaction<'_> {
             if self.staged.len() == self.credits {
                 return Err(Ext4Error::new(ErrCode::E2BIG));
             }
-            let block = device.read_block(home)?;
+            let block = self.read_base(device, home)?;
             let original = self.preserve_originals.then(|| block.data.clone());
             self.staged.insert(
                 home,
@@ -369,8 +394,87 @@ impl Transaction<'_> {
         if let Some(block) = self.staged.get(&home) {
             Ok(BlockView::Staged(block.bytes()))
         } else {
-            Ok(BlockView::Device(device.read_block(home)?))
+            Ok(BlockView::Device(self.read_base(device, home)?))
         }
+    }
+
+    fn read_base(&self, device: &dyn BlockDevice, home: PBlockId) -> Result<Block> {
+        match self.core {
+            TransactionCoreRef::Batch(core) => core.read_metadata(device, home),
+            _ => device.read_block(home),
+        }
+    }
+
+    pub fn is_batch(&self) -> bool {
+        matches!(self.core, TransactionCoreRef::Batch(_))
+    }
+
+    /// Record retirement before clearing allocation metadata. Synchronous
+    /// backends already exclude reuse until their checkpoint completes.
+    pub fn retire_blocks(&mut self, start: PBlockId, count: u64) -> Result<()> {
+        let range = RetiredRange::blocks(start, count)?;
+        if self.is_batch() {
+            retire(&mut self.retired, self.credits, range)?;
+        }
+        Ok(())
+    }
+
+    pub fn retire_inode(&mut self, id: InodeId) -> Result<()> {
+        if self.is_batch() {
+            retire(&mut self.retired, self.credits, RetiredRange::inode(id))?;
+        }
+        Ok(())
+    }
+
+    pub fn block_range_reusable(&self, start: PBlockId, count: u64) -> Result<bool> {
+        let range = RetiredRange::blocks(start, count)?;
+        Ok(reusable(&self.retired, range)
+            && match self.core {
+                TransactionCoreRef::Batch(core) => core.resource_reusable(range),
+                _ => true,
+            })
+    }
+
+    pub fn inode_reusable(&self, id: InodeId) -> bool {
+        let range = RetiredRange::inode(id);
+        reusable(&self.retired, range)
+            && match self.core {
+                TransactionCoreRef::Batch(core) => core.resource_reusable(range),
+                _ => true,
+            }
+    }
+
+    /// On a quarantined candidate return the first possible restart address.
+    /// Allocators skip whole freed extents instead of probing each block while
+    /// holding their accounting lock. None means the candidate is reusable.
+    pub fn block_reuse_restart(&self, start: PBlockId, count: u64) -> Result<Option<PBlockId>> {
+        let range = RetiredRange::blocks(start, count)?;
+        Ok(reuse_restart(&self.retired, range).max(match self.core {
+            TransactionCoreRef::Batch(core) => core.resource_reuse_restart(range),
+            _ => None,
+        }))
+    }
+
+    /// True means a published retirement can progress after this operation
+    /// drops its token. Private-only frees cannot be checkpointed separately
+    /// from an atomic operation and must not create an endless EAGAIN retry.
+    pub fn request_retirement_progress(&self) -> bool {
+        match self.core {
+            TransactionCoreRef::Batch(core) => core.request_retirement_progress(),
+            _ => false,
+        }
+    }
+
+    /// Accept an operation into the live metadata view. This is deliberately
+    /// distinct from `commit`: successful publication is not durability, and
+    /// subsequent disk failures must never trigger reservation rollback.
+    pub fn publish(mut self, publisher: &dyn CachePublisher) -> Result<u64> {
+        let TransactionCoreRef::Batch(core) = self.core else {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        };
+        let result = core.publish(&mut self.staged, &mut self.retired, publisher);
+        self.release_writer();
+        result
     }
 
     pub fn abort(mut self) {
@@ -389,6 +493,11 @@ impl Transaction<'_> {
         match self.core {
             TransactionCoreRef::Journal(_) => self.commit_journal(device, publisher),
             TransactionCoreRef::Direct(_) => self.commit_direct(device, publisher),
+            TransactionCoreRef::Batch(_) => self.fail(
+                Ext4Error::new(ErrCode::EINVAL),
+                CommitFailure::BeforeCommit,
+                false,
+            ),
         }
     }
 
@@ -531,8 +640,111 @@ impl Transaction<'_> {
         let TransactionCoreRef::Journal(core) = self.core else {
             unreachable!()
         };
+        let images = self.staged.values().collect::<Vec<_>>();
+        let result = core.commit_images(device, &images, || publisher.publish(&self.staged));
+        self.release_writer();
+        result
+    }
+
+    fn fail<T>(
+        &mut self,
+        error: Ext4Error,
+        failure: CommitFailure,
+        poison: bool,
+    ) -> core::result::Result<T, CommitError> {
+        if poison {
+            match self.core {
+                TransactionCoreRef::Journal(core) => core.poison(),
+                TransactionCoreRef::Direct(core) => core.poison(),
+                TransactionCoreRef::Batch(core) => core.fail_stop(),
+            }
+        }
+        self.release_writer();
+        Err(CommitError {
+            error,
+            failure,
+            poisoned: poison,
+        })
+    }
+
+    fn release_writer(&mut self) {
+        if self.owns_writer {
+            self.owns_writer = false;
+            match self.core {
+                TransactionCoreRef::Journal(core) => core.writer.store(false, Ordering::Release),
+                TransactionCoreRef::Direct(core) => core.writer.store(false, Ordering::Release),
+                TransactionCoreRef::Batch(core) => core.release_operation(),
+            }
+        }
+    }
+}
+
+impl JournalTransactionCore {
+    pub(super) fn validate_home(&self, home: PBlockId) -> Result<()> {
+        let context = self.context.lock();
+        if home >= context.target_blocks || context.journal_blocks.contains(&home) {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        Ok(())
+    }
+
+    /// Borrow immutable frozen images without copying their 4 KiB payloads.
+    /// The batch owner is the only caller and owns the disk writer until return.
+    pub(super) fn commit_batch_images(
+        &self,
+        device: &dyn BlockDevice,
+        images: &[&StagedBlock],
+    ) -> core::result::Result<(), CommitError> {
+        if self.is_poisoned() {
+            return self.commit_error(
+                Ext4Error::new(ErrCode::EROFS),
+                CommitFailure::BeforeCommit,
+                true,
+            );
+        }
+        if self
+            .writer
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return self.commit_error(
+                Ext4Error::new(ErrCode::EAGAIN),
+                CommitFailure::BeforeCommit,
+                false,
+            );
+        }
+        // Live caches were published at acceptance. Checkpoint must never
+        // republish these older images over the next Running batch.
+        let result = self.commit_images(device, images, || {});
+        self.writer.store(false, Ordering::Release);
+        result
+    }
+
+    fn commit_error<T>(
+        &self,
+        error: Ext4Error,
+        failure: CommitFailure,
+        poison: bool,
+    ) -> core::result::Result<T, CommitError> {
+        if poison {
+            self.poison();
+        }
+        Err(CommitError {
+            error,
+            failure,
+            poisoned: poison,
+        })
+    }
+
+    fn commit_images(
+        &self,
+        device: &dyn BlockDevice,
+        images: &[&StagedBlock],
+        publish: impl FnOnce(),
+    ) -> core::result::Result<(), CommitError> {
+        let core = self;
         if !device.supports_reliable_flush() {
-            return self.fail(
+            return core.commit_error(
                 Ext4Error::new(ErrCode::ENOTSUP),
                 CommitFailure::BeforeCommit,
                 false,
@@ -548,11 +760,12 @@ impl Transaction<'_> {
                 Arc::clone(&context.journal_blocks),
                 context.target_blocks,
                 context.head,
-                context.superblock_image.clone(),
+                *context.superblock_image,
             )
         };
+        let sb_image = Box::new(sb_image);
         let needed =
-            required_log_blocks(self.staged.len(), sb.features).map_err(|error| CommitError {
+            required_log_blocks(images.len(), sb.features).map_err(|error| CommitError {
                 error,
                 failure: CommitFailure::BeforeCommit,
                 poisoned: false,
@@ -564,7 +777,7 @@ impl Transaction<'_> {
                 poisoned: false,
             })?
         {
-            return self.fail(
+            return core.commit_error(
                 Ext4Error::new(ErrCode::E2BIG),
                 CommitFailure::BeforeCommit,
                 false,
@@ -577,12 +790,12 @@ impl Transaction<'_> {
             failure: CommitFailure::BeforeCommit,
             poisoned: false,
         })?;
-        if self
-            .staged
-            .values()
+        if images
+            .iter()
+            .copied()
             .any(|block| block.home >= target_blocks || journal_blocks.contains(&block.home))
         {
-            return self.fail(
+            return core.commit_error(
                 Ext4Error::new(ErrCode::EINVAL),
                 CommitFailure::BeforeCommit,
                 false,
@@ -591,7 +804,7 @@ impl Transaction<'_> {
         // Finish every fallible format operation before the first write.  Once
         // the active tail reaches disk, all remaining failures are I/O failures
         // which must poison the mount.
-        let encoded = encode_log(&sb, sequence, &self.staged).map_err(|error| CommitError {
+        let encoded = encode_log_images(&sb, sequence, images).map_err(|error| CommitError {
             error,
             failure: CommitFailure::BeforeCommit,
             poisoned: false,
@@ -620,7 +833,7 @@ impl Transaction<'_> {
         })?;
         let scratch_blocks = encoded
             .len()
-            .max(self.staged.len())
+            .max(images.len())
             .min(MAX_COALESCED_WRITE_BLOCKS);
         let scratch_capacity =
             scratch_blocks
@@ -644,7 +857,7 @@ impl Transaction<'_> {
         if let Err(error) = write_journal_superblock(device, &mapping, &active_sb_image)
             .and_then(|_| device.flush())
         {
-            return self.fail(error, CommitFailure::BeforeCommit, true);
+            return core.commit_error(error, CommitFailure::BeforeCommit, true);
         }
 
         debug_assert_eq!(encoded.len() + 1, positions.len());
@@ -670,40 +883,40 @@ impl Transaction<'_> {
             if let Err(error) =
                 write_contiguous_blocks(device, blocks, &mut write_scratch, scratch_blocks)
             {
-                return self.fail(error, CommitFailure::BeforeCommit, true);
+                return core.commit_error(error, CommitFailure::BeforeCommit, true);
             }
             segment_start = segment_end;
         }
         if let Err(error) = device.flush() {
-            return self.fail(error, CommitFailure::BeforeCommit, true);
+            return core.commit_error(error, CommitFailure::BeforeCommit, true);
         }
 
         let commit_logical = *positions.last().unwrap();
         if let Err(error) = write_bytes(device, mapping[commit_logical as usize], &commit) {
-            return self.fail(error, CommitFailure::CommitUncertain, true);
+            return core.commit_error(error, CommitFailure::CommitUncertain, true);
         }
         if let Err(error) = device.flush() {
-            return self.fail(error, CommitFailure::CommitUncertain, true);
+            return core.commit_error(error, CommitFailure::CommitUncertain, true);
         }
 
-        let home_blocks = self
-            .staged
-            .values()
+        let home_blocks = images
+            .iter()
+            .copied()
             .map(|staged| (staged.home, staged.bytes()));
         if let Err(error) =
             write_contiguous_blocks(device, home_blocks, &mut write_scratch, scratch_blocks)
         {
-            return self.fail(error, CommitFailure::CheckpointFailed, true);
+            return core.commit_error(error, CommitFailure::CheckpointFailed, true);
         }
         if let Err(error) = device.flush() {
-            return self.fail(error, CommitFailure::CheckpointFailed, true);
+            return core.commit_error(error, CommitFailure::CheckpointFailed, true);
         }
-        publisher.publish(&self.staged);
+        publish();
 
         if let Err(error) =
             write_journal_superblock(device, &mapping, &clean_sb_image).and_then(|_| device.flush())
         {
-            return self.fail(error, CommitFailure::TailUpdateFailed, true);
+            return core.commit_error(error, CommitFailure::TailUpdateFailed, true);
         }
         {
             let mut context = core.context.lock();
@@ -712,38 +925,7 @@ impl Transaction<'_> {
             context.head = ring_next(&sb, commit_logical);
             context.superblock_image = clean_sb_image;
         }
-        self.release_writer();
         Ok(())
-    }
-
-    fn fail<T>(
-        &mut self,
-        error: Ext4Error,
-        failure: CommitFailure,
-        poison: bool,
-    ) -> core::result::Result<T, CommitError> {
-        if poison {
-            match self.core {
-                TransactionCoreRef::Journal(core) => core.poison(),
-                TransactionCoreRef::Direct(core) => core.poison(),
-            }
-        }
-        self.release_writer();
-        Err(CommitError {
-            error,
-            failure,
-            poisoned: poison,
-        })
-    }
-
-    fn release_writer(&mut self) {
-        if self.owns_writer {
-            self.owns_writer = false;
-            match self.core {
-                TransactionCoreRef::Journal(core) => core.writer.store(false, Ordering::Release),
-                TransactionCoreRef::Direct(core) => core.writer.store(false, Ordering::Release),
-            }
-        }
     }
 }
 
@@ -830,9 +1012,17 @@ fn encode_log(
     sequence: u32,
     staged: &BTreeMap<PBlockId, StagedBlock>,
 ) -> Result<Vec<Box<[u8; BLOCK_SIZE]>>> {
+    let all = staged.values().collect::<Vec<_>>();
+    encode_log_images(sb, sequence, &all)
+}
+
+fn encode_log_images(
+    sb: &Superblock,
+    sequence: u32,
+    all: &[&StagedBlock],
+) -> Result<Vec<Box<[u8; BLOCK_SIZE]>>> {
     let seed = checksum_seed(&sb.uuid);
     let per_descriptor = tags_per_descriptor(sb.features)?;
-    let all = staged.values().collect::<Vec<_>>();
     let mut output = Vec::new();
     for group in all.chunks(per_descriptor) {
         let mut descriptor = Box::new([0; BLOCK_SIZE]);
@@ -1411,6 +1601,282 @@ mod tests {
 
     fn context() -> JournalContext {
         context_with_ring(8, 7)
+    }
+
+    #[test]
+    fn batch_coalesces_operations_without_claiming_durability() {
+        let core = JournalBatchCore::new(context_with_ring(64, 1), 32).unwrap();
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        for value in 1..=20 {
+            let mut operation = core.start(1).unwrap();
+            assert_eq!(operation.read_for_update(&device, 2).unwrap()[0], value - 1);
+            operation.read_for_update(&device, 2).unwrap()[0] = value;
+            assert_eq!(operation.publish(&publisher).unwrap(), value as u64);
+        }
+        assert_eq!(core.progress().running_blocks, 1);
+        assert_eq!(core.progress().durable, 0);
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 0);
+        core.request_seal();
+        assert_eq!(core.commit_pending(&device).unwrap(), Some(20));
+        assert_eq!(device.flushes.load(Ordering::SeqCst), 5);
+        assert_eq!(device.stable_block(2).unwrap()[0], 20);
+        assert_eq!(core.progress().durable, 20);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 20);
+    }
+
+    /// Runs an operation exactly inside a device read/flush. This deterministic
+    /// interleaving exercises unlocked I/O without timing-dependent threads.
+    struct InterleavedDevice {
+        inner: MemoryDevice,
+        read_hook: spin::Mutex<Option<Box<dyn FnOnce() + Send>>>,
+        flush_hook: spin::Mutex<Option<Box<dyn FnOnce() + Send>>>,
+        flush_hook_at: AtomicUsize,
+    }
+
+    impl InterleavedDevice {
+        fn new() -> Self {
+            Self {
+                inner: MemoryDevice::new(),
+                read_hook: spin::Mutex::new(None),
+                flush_hook: spin::Mutex::new(None),
+                flush_hook_at: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl BlockDevice for InterleavedDevice {
+        fn read_block(&self, home: PBlockId) -> Result<Block> {
+            let snapshot = self.inner.read_block(home)?;
+            let hook = if home == 2 {
+                self.read_hook.lock().take()
+            } else {
+                None
+            };
+            if let Some(hook) = hook {
+                hook();
+            }
+            Ok(snapshot)
+        }
+        fn write_block(&self, block: &Block) -> Result<()> {
+            self.inner.write_block(block)
+        }
+        fn flush(&self) -> Result<()> {
+            let hook = if self.inner.flushes.load(Ordering::SeqCst)
+                == self.flush_hook_at.load(Ordering::SeqCst)
+            {
+                self.flush_hook.lock().take()
+            } else {
+                None
+            };
+            if let Some(hook) = hook {
+                hook();
+            }
+            self.inner.flush()
+        }
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn batch_old_checkpoint_preserves_new_running_image_and_live_cache() {
+        let core = Arc::new(JournalBatchCore::new(context(), 4).unwrap());
+        let device = Arc::new(InterleavedDevice::new());
+        let publisher = Arc::new(Publisher(AtomicUsize::new(0)));
+        let mut operation = core.start(1).unwrap();
+        operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+        operation.publish(publisher.as_ref()).unwrap();
+        let next_core = Arc::clone(&core);
+        let next_device = Arc::clone(&device);
+        let next_publisher = Arc::clone(&publisher);
+        *device.flush_hook.lock() = Some(Box::new(move || {
+            assert_eq!(next_core.progress().frozen_blocks, 1);
+            let mut operation = next_core.start(1).unwrap();
+            assert_eq!(
+                operation.read_for_update(next_device.as_ref(), 2).unwrap()[0],
+                1
+            );
+            operation.read_for_update(next_device.as_ref(), 2).unwrap()[0] = 2;
+            operation.publish(next_publisher.as_ref()).unwrap();
+            assert_eq!(
+                next_core.commit_pending(next_device.as_ref()).unwrap(),
+                None
+            );
+        }));
+        core.request_seal();
+        assert_eq!(core.commit_pending(device.as_ref()).unwrap(), Some(1));
+        assert_eq!(device.inner.stable_block(2).unwrap()[0], 1);
+        assert_eq!(core.read_metadata(device.as_ref(), 2).unwrap().data[0], 2);
+        assert_eq!(core.progress().accepted, 2);
+        assert_eq!(core.progress().durable, 1);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 2);
+        core.request_seal();
+        assert_eq!(core.commit_pending(device.as_ref()).unwrap(), Some(2));
+        assert_eq!(device.inner.stable_block(2).unwrap()[0], 2);
+        assert_eq!(publisher.0.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn batch_cold_read_retries_when_publication_was_already_checkpointed() {
+        let core = Arc::new(JournalBatchCore::new(context(), 4).unwrap());
+        let device = Arc::new(InterleavedDevice::new());
+        let next_core = Arc::clone(&core);
+        let next_device = Arc::clone(&device);
+        *device.read_hook.lock() = Some(Box::new(move || {
+            let mut operation = next_core.start(1).unwrap();
+            operation.stage(2, Box::new([7; BLOCK_SIZE])).unwrap();
+            operation.publish(&Publisher(AtomicUsize::new(0))).unwrap();
+            next_core.request_seal();
+            next_core.commit_pending(next_device.as_ref()).unwrap();
+        }));
+        assert_eq!(core.read_metadata(device.as_ref(), 2).unwrap().data[0], 7);
+        assert_eq!(core.progress().running_blocks, 0);
+        assert_eq!(core.progress().frozen_blocks, 0);
+    }
+
+    #[test]
+    fn batch_capacity_and_seal_respect_private_operation_boundary() {
+        let core = JournalBatchCore::new(context(), 2).unwrap();
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        assert_eq!(core.start(3).err().unwrap().code(), ErrCode::E2BIG);
+        let mut operation = core.start(1).unwrap();
+        operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+        core.request_seal();
+        assert_eq!(core.commit_pending(&device).unwrap(), None);
+        operation.publish(&publisher).unwrap();
+        assert_eq!(core.start(1).err().unwrap().code(), ErrCode::EAGAIN);
+        assert_eq!(core.commit_pending(&device).unwrap(), Some(1));
+        let operation = core.start(1).unwrap();
+        core.request_seal();
+        operation.abort();
+        assert_eq!(core.commit_pending(&device).unwrap(), None);
+        assert!(core.start(1).is_ok());
+    }
+
+    #[test]
+    fn batch_same_home_operations_have_bounded_completion_admission() {
+        let core = JournalBatchCore::new(context(), 2).unwrap();
+        let device = MemoryDevice::new();
+        let publisher = Publisher(AtomicUsize::new(0));
+        core.start(1).unwrap().publish(&publisher).unwrap();
+        assert_eq!(core.progress().running_operations, 0);
+        for value in 1..=2 {
+            let mut operation = core.start(1).unwrap();
+            operation.stage(2, Box::new([value; BLOCK_SIZE])).unwrap();
+            operation.publish(&publisher).unwrap();
+        }
+        assert_eq!(core.progress().running_blocks, 1);
+        assert_eq!(core.progress().running_operations, 2);
+        assert!(core.progress().seal_requested);
+        assert_eq!(core.start(1).err().unwrap().code(), ErrCode::EAGAIN);
+        assert_eq!(core.commit_pending(&device).unwrap(), Some(2));
+        assert_eq!(core.progress().running_operations, 0);
+        assert!(core.start(1).is_ok());
+    }
+
+    #[test]
+    fn batch_retirements_survive_frozen_checkpoint_until_clean_tail() {
+        let core = Arc::new(JournalBatchCore::new(context(), 4).unwrap());
+        let device = Arc::new(InterleavedDevice::new());
+        let publisher = Arc::new(Publisher(AtomicUsize::new(0)));
+        // The last barrier is after homes were checkpointed. Reuse must still
+        // be blocked until this clean-tail flush has completed successfully.
+        device.flush_hook_at.store(4, Ordering::SeqCst);
+        let mut operation = core.start(2).unwrap();
+        operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+        operation.retire_blocks(20, 10).unwrap();
+        operation.retire_inode(7).unwrap();
+        assert!(!operation.block_range_reusable(29, 1).unwrap());
+        assert!(!operation.inode_reusable(7));
+        operation.publish(publisher.as_ref()).unwrap();
+        assert!(!core.block_range_reusable(20, 1).unwrap());
+        let next_core = Arc::clone(&core);
+        let next_publisher = Arc::clone(&publisher);
+        *device.flush_hook.lock() = Some(Box::new(move || {
+            assert!(!next_core.block_range_reusable(20, 10).unwrap());
+            assert!(!next_core.inode_reusable(7));
+            let mut operation = next_core.start(2).unwrap();
+            assert!(!operation.block_range_reusable(20, 1).unwrap());
+            operation.stage(3, Box::new([2; BLOCK_SIZE])).unwrap();
+            operation.retire_blocks(30, 10).unwrap();
+            operation.retire_inode(8).unwrap();
+            operation.publish(next_publisher.as_ref()).unwrap();
+        }));
+        core.request_seal();
+        core.commit_pending(device.as_ref()).unwrap();
+        assert!(core.block_range_reusable(20, 10).unwrap());
+        assert!(core.inode_reusable(7));
+        assert!(!core.block_range_reusable(30, 10).unwrap());
+        assert!(!core.inode_reusable(8));
+        core.request_seal();
+        core.commit_pending(device.as_ref()).unwrap();
+        assert!(core.block_range_reusable(20, 20).unwrap());
+        assert!(core.inode_reusable(8));
+    }
+
+    #[test]
+    fn batch_retirement_capacity_failure_stays_private_and_ranges_coalesce() {
+        let core = JournalBatchCore::new(context(), 2).unwrap();
+        let mut operation = core.start(1).unwrap();
+        operation.retire_blocks(20, 10).unwrap();
+        operation.retire_blocks(30, 10).unwrap();
+        assert!(!operation.block_range_reusable(39, 1).unwrap());
+        assert!(operation.block_range_reusable(40, 1).unwrap());
+        assert_eq!(
+            operation.retire_inode(7).unwrap_err().code(),
+            ErrCode::E2BIG
+        );
+        assert_eq!(core.progress().accepted, 0);
+        assert!(core.block_range_reusable(20, 20).unwrap());
+        operation.abort();
+        assert!(core.block_range_reusable(20, 20).unwrap());
+    }
+
+    #[test]
+    fn batch_reclaim_budget_stops_before_fragmented_retirements_exhaust_it() {
+        let core = JournalBatchCore::new(context_with_ring(64, 1), 32).unwrap();
+        let mut operation = core.start(32).unwrap();
+        operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+        for index in 0..18 {
+            assert!(operation.remaining_credits() >= 15);
+            operation.retire_blocks(200 + index * 2, 1).unwrap();
+        }
+        // All releases share one bitmap home. Counting only metadata images
+        // would still report 31 credits and overrun retirement capacity.
+        assert_eq!(operation.staged.len(), 1);
+        assert_eq!(operation.remaining_credits(), 14);
+    }
+
+    #[test]
+    fn batch_every_disk_failure_is_post_publication_fail_stop() {
+        let baseline = MemoryDevice::new();
+        let core = JournalBatchCore::new(context(), 4).unwrap();
+        let publisher = Publisher(AtomicUsize::new(0));
+        let mut operation = core.start(1).unwrap();
+        operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+        operation.publish(&publisher).unwrap();
+        core.request_seal();
+        core.commit_pending(&baseline).unwrap();
+        for fail_at in 0..baseline.operation.load(Ordering::SeqCst) {
+            let device = MemoryDevice::new();
+            device.fail_at.store(fail_at, Ordering::SeqCst);
+            let core = JournalBatchCore::new(context(), 4).unwrap();
+            let mut operation = core.start(1).unwrap();
+            operation.stage(2, Box::new([1; BLOCK_SIZE])).unwrap();
+            operation.retire_blocks(20, 10).unwrap();
+            operation.publish(&publisher).unwrap();
+            core.request_seal();
+            let error = core.commit_pending(&device).unwrap_err();
+            assert!(error.poisoned);
+            assert!(core.progress().failed);
+            assert_eq!(core.progress().accepted, 1);
+            assert_eq!(core.progress().durable, 0);
+            assert!(!core.block_range_reusable(20, 10).unwrap());
+            assert_eq!(core.read_metadata(&device, 2).unwrap().data[0], 1);
+            assert_eq!(core.start(1).err().unwrap().code(), ErrCode::EROFS);
+        }
     }
 
     fn context_with_ring(max_len: u32, head: u32) -> JournalContext {

--- a/kernel/crates/another_ext4/src/ext4/link.rs
+++ b/kernel/crates/another_ext4/src/ext4/link.rs
@@ -3,19 +3,6 @@ use super::Ext4;
 use crate::ext4_defs::*;
 use crate::prelude::*;
 
-pub(super) enum LinkFailure {
-    Unmodified(Ext4Error),
-    Indeterminate(Ext4Error),
-}
-
-impl LinkFailure {
-    pub(super) fn into_error(self) -> Ext4Error {
-        match self {
-            Self::Unmodified(error) | Self::Indeterminate(error) => error,
-        }
-    }
-}
-
 /// Whether removing one published namespace entry makes the inode an orphan.
 /// Directories cannot have hard-link aliases: once rmdir/rename has verified
 /// that the directory is empty, Linux clears even an unexpectedly high nlink.
@@ -24,114 +11,88 @@ pub(super) fn namespace_removal_is_final(is_dir: bool, link_count: u16) -> bool 
 }
 
 impl Ext4 {
-    /// Link a child inode to a parent directory.
-    pub(super) fn link_inode(
+    /// Conservative distinct-home budget for namespace directory growth.
+    /// At depth d, one append touches at most d old nodes and allocates at
+    /// most d+2 new nodes plus a directory block. Each allocation can touch
+    /// a separate bitmap/GDT pair; SB and the directory inode add two homes.
+    /// 5*d+16 therefore bounds this set even without physical-block sharing.
+    /// `other_homes` covers inode creation, orphan changes and fixed dirents.
+    pub(super) fn namespace_transaction_credits(
         &self,
+        growing_dirs: &[&InodeRef],
+        other_homes: usize,
+    ) -> Result<usize> {
+        growing_dirs.iter().try_fold(other_homes, |credits, dir| {
+            let depth = dir.inode.extent_root().header().depth() as usize;
+            if depth > 5 {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            credits
+                .checked_add(5 * depth + 16)
+                .ok_or_else(|| Ext4Error::new(ErrCode::E2BIG))
+        })
+    }
+
+    pub(super) fn commit_namespace_transaction(
+        &self,
+        transaction: super::journal_transaction::Transaction<'_>,
+    ) -> Result<()> {
+        self.commit_metadata_operation(transaction)
+            .map(|_| ())
+            .map_err(|failure| {
+                if failure.poisoned {
+                    self.poison(ErrCode::EIO);
+                }
+                failure.error
+            })
+    }
+
+    /// Compose the new name, link counts and optional orphan removal in the
+    /// caller's private operation. Errors require aborting that operation.
+    pub(super) fn transaction_link_inode(
+        &self,
+        transaction: &mut super::journal_transaction::Transaction<'_>,
         parent: &mut InodeRef,
         child: &mut InodeRef,
         name: &str,
         allow_orphan_relink: bool,
     ) -> Result<()> {
-        self.link_inode_classified(parent, child, name, allow_orphan_relink)
-            .map_err(LinkFailure::into_error)
-    }
-
-    pub(super) fn link_inode_classified(
-        &self,
-        parent: &mut InodeRef,
-        child: &mut InodeRef,
-        name: &str,
-        allow_orphan_relink: bool,
-    ) -> core::result::Result<(), LinkFailure> {
-        self.ensure_mutable().map_err(LinkFailure::Unmodified)?;
-        let child_link_count = child.inode.link_count();
-        let parent_link_count = parent.inode.link_count();
-        if child_link_count == 0 && allow_orphan_relink {
-            if self
-                .legacy_orphan_membership(child)
-                .map_err(LinkFailure::Unmodified)?
+        let child_links = child.inode.link_count();
+        if child_links == 0 && allow_orphan_relink {
+            if self.legacy_orphan_membership(child)?
                 != super::orphan::LegacyOrphanMembership::ZeroLink
             {
-                return Err(LinkFailure::Unmodified(Ext4Error::new(ErrCode::EINVAL)));
+                return Err(Ext4Error::new(ErrCode::EINVAL));
             }
             if child.inode.is_dir() {
-                return Err(LinkFailure::Unmodified(Ext4Error::new(ErrCode::EPERM)));
+                return Err(Ext4Error::new(ErrCode::EPERM));
             }
-            if !self
-                .dir_has_insert_space(parent, child, name)
-                .map_err(LinkFailure::Unmodified)?
-            {
-                self.prepare_empty_dir_slot(parent)
-                    .map_err(LinkFailure::Indeterminate)?;
-            }
-            // A zero-link inode is discoverable through the durable orphan
-            // chain.  Linux removes it from that chain in the same handle that
-            // publishes the new name and link count; otherwise a crash could
-            // reclaim a newly reachable inode.
-            let mut transaction = self.transaction_start(3).map_err(LinkFailure::Unmodified)?;
-            let mut sb = self.read_super_block_cached();
-            self.transaction_orphan_del(&mut transaction, child, &mut sb)
-                .map_err(LinkFailure::Unmodified)?;
-            self.transaction_dir_add_existing(&mut transaction, parent, child, name)
-                .map_err(LinkFailure::Unmodified)?;
-            child.inode.set_link_count(1);
+            let mut sb = self.transaction_read_super_block(transaction)?;
+            self.transaction_orphan_del(transaction, child, &mut sb)?;
             child.inode.set_next_orphan(0);
-            self.transaction_stage_inode_with_csum(&mut transaction, child)
-                .map_err(LinkFailure::Unmodified)?;
-            if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
-                self.poison(ErrCode::EIO);
-                return Err(LinkFailure::Indeterminate(error.error));
-            }
-            return Ok(());
         }
         if child.inode.is_dir() {
-            // Prepare all inode metadata before publishing parent/name.  A
-            // failure before the final dir_add_entry cannot leave a namespace
-            // entry pointing at an inode that cleanup may release.
-            match self.dir_add_entry_classified(child, parent, "..") {
-                Ok(()) => {}
-                Err(super::dir::DirAddFailure::Unmodified(error)) => {
-                    return Err(LinkFailure::Unmodified(error));
-                }
-                Err(super::dir::DirAddFailure::Indeterminate(error)) => {
-                    self.poison(ErrCode::EIO);
-                    return Err(LinkFailure::Indeterminate(error));
-                }
-            }
-            parent.inode.set_link_count(parent_link_count + 1);
-            if let Err(error) = self.write_inode_with_csum(parent) {
-                self.poison(ErrCode::EIO);
-                return Err(LinkFailure::Indeterminate(error));
-            }
+            let links = parent
+                .inode
+                .link_count()
+                .checked_add(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EMLINK))?;
+            self.transaction_dir_add(transaction, child, parent, "..")?;
+            parent.inode.set_link_count(links);
         }
-        child.inode.set_link_count(child_link_count + 1);
-        if let Err(error) = self.write_inode_with_csum(child) {
-            if child.inode.is_dir() {
-                self.poison(ErrCode::EIO);
-                return Err(LinkFailure::Indeterminate(error));
-            }
-            return Err(LinkFailure::Unmodified(error));
+        child.inode.set_link_count(
+            child_links
+                .checked_add(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EMLINK))?,
+        );
+        self.transaction_stage_inode_with_csum(transaction, child)?;
+        self.transaction_dir_add(transaction, parent, child, name)?;
+        // Directory growth already stages its inode. Otherwise only a new
+        // subdirectory changes the parent link count in this operation.
+        if child.inode.is_dir() {
+            self.transaction_stage_inode_with_csum(transaction, parent)?;
         }
-        match self.dir_add_entry_classified(parent, child, name) {
-            Ok(()) => Ok(()),
-            Err(super::dir::DirAddFailure::Indeterminate(error)) => {
-                self.poison(ErrCode::EIO);
-                Err(LinkFailure::Indeterminate(error))
-            }
-            Err(super::dir::DirAddFailure::Unmodified(error)) => {
-                child.inode.set_link_count(child_link_count);
-                let mut rollback_ok = self.write_inode_with_csum(child).is_ok();
-                if child.inode.is_dir() {
-                    parent.inode.set_link_count(parent_link_count);
-                    rollback_ok &= self.write_inode_with_csum(parent).is_ok();
-                }
-                if !rollback_ok {
-                    self.poison(ErrCode::EIO);
-                    return Err(LinkFailure::Indeterminate(error));
-                }
-                Err(LinkFailure::Unmodified(error))
-            }
-        }
+        Ok(())
     }
 
     /// Unlink a child inode from a parent directory.
@@ -190,33 +151,18 @@ impl Ext4 {
                 self.transaction_stage_inode_with_csum(&mut transaction, child)?;
             }
 
-            if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
-                // A commit-path failure may make journal state uncertain.  Do
-                // not let legacy direct writers continue after this boundary.
-                self.poison(ErrCode::EIO);
-                return Err(error.error);
-            }
+            self.commit_namespace_transaction(transaction)?;
             return Ok(Some(InodeReclaimHandle::new(
                 child.id,
                 child.inode.generation(),
             )));
         }
 
-        // Non-final hard-link removal does not create an orphan.  Preserve the
-        // established path until all namespace writers move under JBD2.
-        self.dir_remove_entry(parent, name)?;
-        if child.inode.is_dir() {
-            parent.inode.set_link_count(parent.inode.link_count() - 1);
-            if let Err(error) = self.write_inode_with_csum(parent) {
-                self.poison(ErrCode::EIO);
-                return Err(error);
-            }
-        }
+        let mut transaction = self.transaction_start(2)?;
+        self.transaction_dir_remove_entry(&mut transaction, parent, name)?;
         child.inode.set_link_count(child_link_cnt - 1);
-        if let Err(error) = self.write_inode_with_csum(child) {
-            self.poison(ErrCode::EIO);
-            return Err(error);
-        }
+        self.transaction_stage_inode_with_csum(&mut transaction, child)?;
+        self.commit_namespace_transaction(transaction)?;
         Ok(None)
     }
 }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -233,6 +233,8 @@ impl core::fmt::Debug for DelallocAppendMapperAuthority {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DelallocAppendBlockSubmitOutcome {
     Completed,
+    /// Mapping is live and leases are consumed; completion awaits this batch.
+    Published(u64),
     RetryableNotPublished(ErrCode),
     Terminal(ErrCode),
 }
@@ -429,9 +431,9 @@ impl Ext4 {
         if target_lblock == eof_lblock {
             return Err(Ext4Error::new(ErrCode::EINVAL));
         }
-        let mut block = self.read_block(pblock)?;
+        let mut block = self.block_device.read_block(pblock)?;
         block.data[tail_offset..].fill(0);
-        self.write_block(&block)?;
+        self.block_device.write_block(&block)?;
         Ok(true)
     }
 
@@ -732,12 +734,12 @@ impl Ext4 {
         failure.map_or(Ok(()), Err)
     }
 
-    fn finish_unpublished_delalloc_error(
+    fn finish_unpublished_delalloc_error<T>(
         &self,
         cleanup: Result<()>,
         lease: &mut DelallocLease,
         original: Ext4Error,
-    ) -> Result<()> {
+    ) -> Result<T> {
         if cleanup.is_ok() {
             return Err(original);
         }
@@ -824,7 +826,7 @@ impl Ext4 {
         pool: Option<&mut DelallocExtentNodePool>,
         strict_aligned: bool,
         journal_credits_bound: Option<usize>,
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
         let mut pool = pool;
         self.ensure_mutable()?;
         if !self.uses_journal()
@@ -908,7 +910,7 @@ impl Ext4 {
         let credits =
             validate_delalloc_journal_credit_bound(actual_credits, journal_credits_bound)?;
         let mut transaction = self.transaction_start(credits)?;
-        let (allocation, data_consumption) = match self.transaction_alloc_delalloc_range(
+        let (allocation, mut data_consumption) = match self.transaction_alloc_delalloc_range(
             &mut transaction,
             id,
             extent_plan.preferred_first,
@@ -999,9 +1001,13 @@ impl Ext4 {
         let mut initialized = [0u8; BLOCK_SIZE];
         initialized[..visible_len].copy_from_slice(request.payload);
         if !strict_aligned {
-            if let Err(error) =
+            let tail_result = if transaction.is_batch() {
+                self.write_delalloc_append_eof_tail(&inode, on_disk_eof, request.offset)
+                    .map(|_| ())
+            } else {
                 self.zero_delalloc_append_eof_tail(&inode, on_disk_eof, request.offset)
-            {
+            };
+            if let Err(error) = tail_result {
                 let cleanup = self.abort_delalloc_append_block_transaction_many(
                     transaction,
                     data_consumption,
@@ -1024,7 +1030,11 @@ impl Ext4 {
             );
             return self.finish_unpublished_delalloc_error(cleanup, lease, error);
         }
-        if let Err(error) = self.block_device.flush() {
+        if let Err(error) = if transaction.is_batch() {
+            Ok(())
+        } else {
+            self.block_device.flush()
+        } {
             let cleanup = self.abort_delalloc_append_block_transaction_many(
                 transaction,
                 data_consumption,
@@ -1064,6 +1074,47 @@ impl Ext4 {
             return self.finish_unpublished_delalloc_error(cleanup, lease, error);
         }
 
+        if transaction.is_batch() {
+            let result = (|| {
+                let mut leases = Vec::new();
+                let mut debits = Vec::new();
+                leases
+                    .try_reserve_exact(1 + metadata_pool_indices.len())
+                    .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+                debits
+                    .try_reserve_exact(1 + metadata_consumptions.len())
+                    .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+                leases.push(&mut *lease);
+                if let Some(pool) = pool.as_deref_mut() {
+                    for (index, lease) in pool.leases.iter_mut().enumerate() {
+                        if metadata_pool_indices.contains(&index) {
+                            leases.push(lease);
+                        }
+                    }
+                }
+                debits.push(&mut data_consumption);
+                debits.extend(metadata_consumptions.iter_mut());
+                self.publish_delalloc_operation(transaction, &mut leases, &mut debits)
+            })();
+            return match result {
+                Ok(sequence) => {
+                    if let Some(pool) = pool.as_deref_mut() {
+                        for index in metadata_pool_indices.into_iter().rev() {
+                            drop(pool.leases.swap_remove(index));
+                        }
+                    }
+                    Ok(Some(sequence))
+                }
+                Err(error) => {
+                    let cleanup = self.rollback_delalloc_consumptions_many(
+                        data_consumption,
+                        metadata_consumptions,
+                    );
+                    self.finish_unpublished_delalloc_error(cleanup, lease, error)
+                }
+            };
+        }
+
         match transaction.commit(self.block_device.as_ref(), self) {
             Ok(()) => {
                 let mut data_consumption = data_consumption;
@@ -1080,7 +1131,7 @@ impl Ext4 {
                     self.poison(ErrCode::EIO);
                     return Err(Ext4Error::new(ErrCode::EIO));
                 }
-                Ok(())
+                Ok(None)
             }
             Err(error) => {
                 if error.failure == super::journal_transaction::CommitFailure::BeforeCommit {
@@ -1218,7 +1269,7 @@ impl Ext4 {
         reservations: &mut [&mut DelallocAppendBlockReservation],
         publications: &[DelallocAppendBlockPublication<'_>],
         pool: &mut DelallocExtentNodePool,
-    ) -> Result<()> {
+    ) -> Result<Option<u64>> {
         self.ensure_mutable()?;
         if !self.uses_journal()
             || reservations.is_empty()
@@ -1403,7 +1454,9 @@ impl Ext4 {
                 )?;
                 run_start = run_end;
             }
-            self.block_device.flush()?;
+            if !transaction.is_batch() {
+                self.block_device.flush()?;
+            }
 
             let last_publication = publications
                 .last()
@@ -1430,6 +1483,56 @@ impl Ext4 {
                 return Err(Ext4Error::new(ErrCode::EIO));
             }
             return Err(error);
+        }
+
+        if transaction.is_batch() {
+            let result = (|| {
+                let mut leases = Vec::new();
+                let mut debits = Vec::new();
+                leases
+                    .try_reserve_exact(reservations.len() + metadata_pool_indices.len())
+                    .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+                debits
+                    .try_reserve_exact(data_consumptions.len() + metadata_consumptions.len())
+                    .map_err(|_| Ext4Error::new(ErrCode::ENOMEM))?;
+                leases.extend(
+                    reservations
+                        .iter_mut()
+                        .map(|reservation| &mut reservation.lease),
+                );
+                for (index, lease) in pool.leases.iter_mut().enumerate() {
+                    if metadata_pool_indices.contains(&index) {
+                        leases.push(lease);
+                    }
+                }
+                debits.extend(data_consumptions.iter_mut());
+                debits.extend(metadata_consumptions.iter_mut());
+                self.publish_delalloc_operation(transaction, &mut leases, &mut debits)
+            })();
+            return match result {
+                Ok(sequence) => {
+                    for index in metadata_pool_indices.into_iter().rev() {
+                        drop(pool.leases.swap_remove(index));
+                    }
+                    Ok(Some(sequence))
+                }
+                Err(error) => {
+                    if self
+                        .rollback_delalloc_consumption_vectors(
+                            data_consumptions,
+                            metadata_consumptions,
+                        )
+                        .is_err()
+                    {
+                        self.poison(ErrCode::EIO);
+                        for reservation in reservations.iter_mut() {
+                            reservation.lease.deactivate();
+                        }
+                        return Err(Ext4Error::new(ErrCode::EIO));
+                    }
+                    Err(error)
+                }
+            };
         }
 
         match transaction.commit(self.block_device.as_ref(), self) {
@@ -1466,7 +1569,7 @@ impl Ext4 {
                     self.poison(ErrCode::EIO);
                     return Err(error);
                 }
-                Ok(())
+                Ok(None)
             }
             Err(error)
                 if !error.poisoned
@@ -1532,7 +1635,8 @@ impl Ext4 {
         }
         let outcome = self.submit_delalloc_append_batch_inner(reservations, publications, pool);
         let result = match outcome {
-            Ok(()) => DelallocAppendBlockSubmitOutcome::Completed,
+            Ok(None) => DelallocAppendBlockSubmitOutcome::Completed,
+            Ok(Some(sequence)) => DelallocAppendBlockSubmitOutcome::Published(sequence),
             Err(error)
                 if reservations
                     .iter()
@@ -1616,6 +1720,12 @@ impl Ext4 {
         publication: DelallocAppendBlockPublication<'_>,
         pool: Option<&mut DelallocExtentNodePool>,
     ) -> DelallocAppendBlockSubmitOutcome {
+        // Accepted publication consumed this capability even if its later
+        // disk commit failed. Authority rejection must not relabel that
+        // terminal ownership as a retryable, unpublished operation.
+        if !reservation.lease.active {
+            return DelallocAppendBlockSubmitOutcome::Terminal(ErrCode::EINVAL);
+        }
         if let Err(error) = self.validate_delalloc_append_mapper_authority(authority) {
             // A capability issued by this exact mount must not remain live
             // when validation fails only because another writer has already
@@ -1893,7 +2003,8 @@ impl Ext4 {
             strict_aligned,
             journal_credits_bound,
         ) {
-            Ok(()) => DelallocAppendBlockSubmitOutcome::Completed,
+            Ok(None) => DelallocAppendBlockSubmitOutcome::Completed,
+            Ok(Some(sequence)) => DelallocAppendBlockSubmitOutcome::Published(sequence),
             // The mapper can terminalise a lease itself after a commit
             // failure. Re-check after the call as well as before it so that
             // path never falls through to the pre-existing-fail-stop
@@ -1978,8 +2089,16 @@ impl Ext4 {
         request: DelallocAppendBlockWriteback<'_>,
         lease: &mut DelallocLease,
     ) -> Result<()> {
+        if self.batch_progress().is_some() {
+            // This legacy host-only Result API cannot convey accepted but
+            // incomplete ownership. Batched tests use the typed outcome API.
+            return Err(Ext4Error::new(ErrCode::ENOTSUP));
+        }
         match self.submit_delalloc_append_block(id, request, lease) {
             DelallocAppendBlockSubmitOutcome::Completed => Ok(()),
+            DelallocAppendBlockSubmitOutcome::Published(_) => {
+                unreachable!("synchronous host facade")
+            }
             DelallocAppendBlockSubmitOutcome::RetryableNotPublished(error)
             | DelallocAppendBlockSubmitOutcome::Terminal(error) => Err(Ext4Error::new(error)),
         }
@@ -2608,7 +2727,7 @@ impl Ext4 {
         }
         self.prepare_stats.record_inode_io();
         let commit_result = if journaled {
-            transaction.commit(self.block_device.as_ref(), self)
+            self.commit_metadata_operation(transaction).map(|_| ())
         } else {
             transaction.commit_direct_range(
                 self.block_device.as_ref(),
@@ -2635,36 +2754,6 @@ impl Ext4 {
         Ok(TransactionalRangePrepare::Handled)
     }
 
-    fn xattr_checksum_seed(&self) -> Result<Option<MetadataChecksumSeed>> {
-        let sb = self.read_super_block_cached();
-        if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
-            return Ok(None);
-        }
-        Ok(Some(sb.metadata_checksum_seed()))
-    }
-
-    fn verify_xattr_block_checksum(&self, block_id: PBlockId, block: &XattrBlock) -> Result<()> {
-        if let Some(seed) = self.xattr_checksum_seed()? {
-            if !block.verify_checksum(seed, block_id) {
-                return Err(Ext4Error::new(ErrCode::EIO));
-            }
-        }
-        Ok(())
-    }
-
-    fn update_xattr_block_checksum(
-        &self,
-        block_id: PBlockId,
-        block: &mut XattrBlock,
-    ) -> Result<()> {
-        if let Some(seed) = self.xattr_checksum_seed()? {
-            if !block.update_checksum(seed, block_id) {
-                return Err(Ext4Error::new(ErrCode::EIO));
-            }
-        }
-        Ok(())
-    }
-
     fn read_extent_or_hole(
         &self,
         file: &InodeRef,
@@ -2674,7 +2763,7 @@ impl Ext4 {
     ) -> Result<()> {
         match self.extent_query(file, iblock) {
             Ok(fblock) => {
-                let block = self.read_block(fblock)?;
+                let block = self.block_device.read_block(fblock)?;
                 buf.copy_from_slice(block.read_offset(block_offset, buf.len()));
             }
             Err(err) if err.code() == ErrCode::ENOENT => {
@@ -2699,6 +2788,7 @@ impl Ext4 {
     ///
     /// `EINVAL` if the inode-table entry is physically free.
     pub fn getattr(&self, id: InodeId) -> Result<FileAttr> {
+        let _view = self.lock_metadata_read_view()?;
         let inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
             return_error!(ErrCode::EINVAL, "Invalid inode {}", id);
@@ -2744,7 +2834,7 @@ impl Ext4 {
     /// `EINVAL` if the inode is invalid (mode == 0).
     pub fn setattr(&self, id: InodeId, attr: SetAttr) -> Result<()> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -2777,17 +2867,22 @@ impl Ext4 {
         if let Some(crtime) = attr.crtime {
             inode.inode.set_crtime(crtime);
         }
-        self.write_inode_with_csum(&mut inode)?;
+        let mut transaction = self.transaction_start(1)?;
+        self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+        self.commit_metadata_operation(transaction)
+            .map(|_| ())
+            .map_err(|error| error.error)?;
         Ok(())
     }
 
     fn recompute_inode_block_count(&self, inode: &mut InodeRef) -> Result<()> {
         let data_blocks = self.extent_all_data_blocks(inode)?.len() as u64;
         let tree_blocks = self.extent_all_tree_blocks(inode)?.len() as u64;
+        let xattr_blocks = u64::from(inode.inode.xattr_block() != 0);
         let sectors_per_block = (BLOCK_SIZE / INODE_BLOCK_SIZE) as u64;
         inode
             .inode
-            .set_block_count((data_blocks + tree_blocks) * sectors_per_block);
+            .set_block_count((data_blocks + tree_blocks + xattr_blocks) * sectors_per_block);
         Ok(())
     }
 
@@ -2824,7 +2919,24 @@ impl Ext4 {
                     }
                     Err(err) if err.code() == ErrCode::ENOENT => {
                         self.prepare_stats.record_missing();
-                        self.extent_query_or_create(inode, iblock, 1)?;
+                        if self.uses_journal() {
+                            // One missing mapping is a restartable allocation
+                            // boundary; do not accumulate an unbounded range
+                            // under one finite journal reservation.
+                            let credits =
+                                5 * usize::from(inode.inode.extent_root().header().depth()) + 16;
+                            let mut transaction = self.transaction_start(credits)?;
+                            self.transaction_extent_query_or_create(
+                                &mut transaction,
+                                inode,
+                                iblock,
+                            )?;
+                            self.commit_metadata_operation(transaction)
+                                .map(|_| ())
+                                .map_err(|error| error.error)?;
+                        } else {
+                            self.extent_query_or_create(inode, iblock, 1)?;
+                        }
                         self.extent_query(inode, iblock).map_err(|err| {
                             format_error!(
                                 ErrCode::EIO,
@@ -2839,7 +2951,7 @@ impl Ext4 {
                     Err(err) => return Err(err),
                 }
             }
-            if changed {
+            if changed && !self.uses_journal() {
                 self.recompute_inode_block_count(inode)?;
                 self.write_inode_with_csum(inode)?;
             }
@@ -2859,7 +2971,7 @@ impl Ext4 {
         len: usize,
     ) -> Result<()> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -2883,7 +2995,24 @@ impl Ext4 {
         _mtime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
-        if self.uses_journal() || self.supports_direct_range_stage() {
+        if self.uses_journal() {
+            let _metadata_guard = self.lock_transactional_metadata_mutation()?;
+            let _mutation_guard =
+                self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
+            let mut inode = self.read_inode(id)?;
+            if inode.inode.mode().bits() == 0 {
+                return Err(Ext4Error::new(ErrCode::EINVAL));
+            }
+            self.reject_external_linked_tail_mutation(&inode)?;
+            if matches!(
+                self.try_prepare_transactional_range(&mut inode, offset, len)?,
+                TransactionalRangePrepare::Handled
+            ) {
+                return Ok(());
+            }
+            return self.ensure_blocks_for_write_range_locked(&mut inode, offset, len);
+        }
+        if self.supports_direct_range_stage() {
             // Classify the request under a compatible direct guard first.
             // Unsupported small, overwrite, sparse, and oversized writes can
             // continue through the legacy allocator without ever contending
@@ -2944,7 +3073,7 @@ impl Ext4 {
         ctime: Option<u32>,
     ) -> Result<()> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _mutation_guard = self.inode_mutation_locks[self.inode_mutation_lock_index(id)].lock();
         let mut inode = self.read_inode(id)?;
         if inode.inode.mode().bits() == 0 {
@@ -2967,7 +3096,11 @@ impl Ext4 {
         if let Some(ctime) = ctime {
             inode.inode.set_ctime(ctime);
         }
-        self.write_inode_with_csum(&mut inode)?;
+        let mut transaction = self.transaction_start(1)?;
+        self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+        self.commit_metadata_operation(transaction)
+            .map(|_| ())
+            .map_err(|error| error.error)?;
         Ok(())
     }
 
@@ -2977,38 +3110,6 @@ impl Ext4 {
     /// Call this after successful page-cache write to finalise the new file size.
     pub fn commit_inode_size(&self, id: InodeId, size: u64, mtime: Option<u32>) -> Result<()> {
         self.commit_inode_metadata(id, Some(size), None, mtime, None)
-    }
-
-    /// Link a newly created inode into `parent`.
-    ///
-    /// If linking fails, this function frees the newly allocated inode to avoid leaks.
-    fn link_new_inode_or_free(
-        &self,
-        parent: &mut InodeRef,
-        child: &mut InodeRef,
-        name: &str,
-    ) -> Result<()> {
-        match self.link_inode_classified(parent, child, name, false) {
-            Ok(()) => Ok(()),
-            Err(super::link::LinkFailure::Indeterminate(link_err)) => {
-                self.poison(ErrCode::EIO);
-                Err(link_err)
-            }
-            Err(super::link::LinkFailure::Unmodified(link_err)) => {
-                if let Err(cleanup_err) = self.free_inode(child) {
-                    trace!(
-                        "link failed for new inode {} (name {}), cleanup failed: {:?}; original link error: {:?}",
-                        child.id,
-                        name,
-                        cleanup_err,
-                        link_err
-                    );
-                    self.poison(ErrCode::EIO);
-                    return Err(cleanup_err);
-                }
-                Err(link_err)
-            }
-        }
     }
 
     /// Create a file. This function will not check the existence of
@@ -3055,7 +3156,7 @@ impl Ext4 {
         owner: InodeOwner,
     ) -> Result<FileAttr> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent = self.read_inode(parent)?;
@@ -3064,8 +3165,19 @@ impl Ext4 {
             return_error!(ErrCode::ENOTDIR, "Inode {} is not a directory", parent.id);
         }
         // Create child inode and link it to parent directory
-        let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
-        self.link_new_inode_or_free(&mut parent, &mut child, name)?;
+        let credits = self.namespace_transaction_credits(
+            &[&parent],
+            if mode.file_type() == FileType::Directory {
+                20
+            } else {
+                4
+            },
+        )?;
+        let mut transaction = self.transaction_start(credits)?;
+        let mut child =
+            self.transaction_create_inode_with_owner(&mut transaction, mode, owner.uid, owner.gid)?;
+        self.transaction_link_inode(&mut transaction, &mut parent, &mut child, name, false)?;
+        self.commit_namespace_transaction(transaction)?;
         Ok(Self::file_attr(&child))
     }
 
@@ -3086,7 +3198,7 @@ impl Ext4 {
             return_error!(ErrCode::ENAMETOOLONG, "Symbolic link target is too long");
         }
 
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent = self.read_inode(parent)?;
@@ -3095,31 +3207,29 @@ impl Ext4 {
         }
 
         let mode = InodeMode::SOFTLINK | InodeMode::ALL_RWX;
-        let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
-        let initialized = if target.len() < child.inode.inline_block().len() {
-            child
-                .inode
-                .set_fast_symlink(target.as_bytes())
-                .and_then(|_| self.write_inode_with_csum(&mut child))
+        // Four allocation/initialization homes plus a one-block long target
+        // allocation (bitmap, GDT, SB). The new inode has an inline extent root.
+        let credits = self.namespace_transaction_credits(&[&parent], 7)?;
+        let mut transaction = self.transaction_start(credits)?;
+        let mut child =
+            self.transaction_create_inode_with_owner(&mut transaction, mode, owner.uid, owner.gid)?;
+        if target.len() < child.inode.inline_block().len() {
+            child.inode.set_fast_symlink(target.as_bytes())?;
         } else {
             let mut image = Box::new([0; BLOCK_SIZE]);
             image[..target.len()].copy_from_slice(target.as_bytes());
-            self.extent_query_or_create_initialized(&mut child, 0, 1, Some(image))
-                .and_then(|_| self.recompute_inode_block_count(&mut child))
-                .and_then(|_| {
-                    child.inode.set_size(target.len() as u64);
-                    self.write_inode_with_csum(&mut child)
-                })
-        };
-        if let Err(init_error) = initialized {
-            if let Err(cleanup_error) = self.free_inode(&mut child) {
-                self.poison(ErrCode::EIO);
-                return Err(cleanup_error);
-            }
-            return Err(init_error);
+            let allocation =
+                self.transaction_alloc_metadata_block(&mut transaction, child.id, None)?;
+            // Payload bypasses metadata staging. It is initialized before any
+            // reader can reach it; journal's first flush orders it on this device.
+            self.block_device
+                .write_block(&Block::new(allocation, image))?;
+            self.stage_direct_append_extent(&mut child, 0, allocation, 1)?;
+            child.inode.set_size(target.len() as u64);
         }
-
-        self.link_new_inode_or_free(&mut parent, &mut child, name)?;
+        self.transaction_stage_inode_with_csum(&mut transaction, &mut child)?;
+        self.transaction_link_inode(&mut transaction, &mut parent, &mut child, name, false)?;
+        self.commit_namespace_transaction(transaction)?;
         Ok(Self::file_attr(&child))
     }
 
@@ -3189,7 +3299,7 @@ impl Ext4 {
         owner: InodeOwner,
     ) -> Result<FileAttr> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent_ref = self.read_inode(parent)?;
@@ -3204,10 +3314,18 @@ impl Ext4 {
         }
 
         // Create device inode (uses create_device_inode which sets device number)
-        let mut child = self.create_device_inode(mode, major, minor, owner.uid, owner.gid)?;
-
-        // Link to parent directory
-        self.link_new_inode_or_free(&mut parent_ref, &mut child, name)?;
+        let credits = self.namespace_transaction_credits(&[&parent_ref], 4)?;
+        let mut transaction = self.transaction_start(credits)?;
+        let mut child = self.transaction_create_device_inode(
+            &mut transaction,
+            mode,
+            major,
+            minor,
+            owner.uid,
+            owner.gid,
+        )?;
+        self.transaction_link_inode(&mut transaction, &mut parent_ref, &mut child, name, false)?;
+        self.commit_namespace_transaction(transaction)?;
 
         trace!("mknod {} ({}:{}) -> inode {}", name, major, minor, child.id);
         Ok(Self::file_attr(&child))
@@ -3230,6 +3348,7 @@ impl Ext4 {
     ///
     /// * `EISDIR` - `file` is not a regular file
     pub fn read(&self, file: InodeId, offset: usize, buf: &mut [u8]) -> Result<usize> {
+        let _view = self.lock_metadata_read_view()?;
         // Get the inode of the file
         let file = self.read_inode(file)?;
         if !file.inode.is_file() {
@@ -3282,6 +3401,7 @@ impl Ext4 {
     /// - For fast symlink (length <= 60), content is stored in inode.i_block (here inode.block[60])
     /// - For non-fast symlink, content is stored in data blocks, reusing extent read path
     pub fn readlink(&self, inode_id: InodeId, offset: usize, buf: &mut [u8]) -> Result<usize> {
+        let _view = self.lock_metadata_read_view()?;
         let inode_ref = self.read_inode(inode_id)?;
         if !inode_ref.inode.is_softlink() {
             return_error!(ErrCode::EINVAL, "Inode {} is not a symlink", inode_id);
@@ -3349,7 +3469,7 @@ impl Ext4 {
     /// * `ENOSPC` - no space left on device
     pub fn write(&self, file: InodeId, offset: usize, data: &[u8]) -> Result<usize> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let write_size = data.len();
         if write_size == 0 {
             return Ok(0);
@@ -3372,9 +3492,9 @@ impl Ext4 {
             let block_offset = (offset + cursor) % BLOCK_SIZE;
             let write_len = min(BLOCK_SIZE - block_offset, write_size - cursor);
             let fblock = self.extent_query(&file, iblock)?;
-            let mut block = self.read_block(fblock)?;
+            let mut block = self.block_device.read_block(fblock)?;
             block.write_offset(block_offset, &data[cursor..cursor + write_len]);
-            self.write_block(&block)?;
+            self.block_device.write_block(&block)?;
             cursor += write_len;
             iblock += 1;
         }
@@ -3387,7 +3507,15 @@ impl Ext4 {
         if new_end > file.inode.size() as usize {
             file.inode.set_size(new_end as u64);
         }
-        self.write_inode_with_csum(&mut file)?;
+        if self.uses_journal() {
+            let mut transaction = self.transaction_start(1)?;
+            self.transaction_stage_inode_with_csum(&mut transaction, &mut file)?;
+            self.commit_metadata_operation(transaction)
+                .map(|_| ())
+                .map_err(|error| error.error)?;
+        } else {
+            self.write_inode_with_csum(&mut file)?;
+        }
 
         Ok(cursor)
     }
@@ -3450,9 +3578,9 @@ impl Ext4 {
                 self.block_device
                     .write_blocks(fblock, &data[cursor..cursor + write_len])?;
             } else {
-                let mut block = self.read_block(fblock)?;
+                let mut block = self.block_device.read_block(fblock)?;
                 block.write_offset(block_offset, &data[cursor..cursor + write_len]);
-                self.write_block(&block)?;
+                self.block_device.write_block(&block)?;
             }
         }
 
@@ -3542,7 +3670,10 @@ impl Ext4 {
         if child.inode.is_dir() {
             return_error!(ErrCode::EISDIR, "Cannot link a directory");
         }
-        self.link_inode(&mut parent, &mut child, name, true)?;
+        let credits = self.namespace_transaction_credits(&[&parent], 3)?;
+        let mut transaction = self.transaction_start(credits)?;
+        self.transaction_link_inode(&mut transaction, &mut parent, &mut child, name, true)?;
+        self.commit_namespace_transaction(transaction)?;
         Ok(())
     }
 
@@ -3695,7 +3826,11 @@ impl Ext4 {
 
         // 4. 检查目标是否存在
         let target_dir_ref = new_parent_ref.as_ref().unwrap_or(&parent_ref);
-        let existing = self.dir_find_entry(target_dir_ref, new_name).ok();
+        let existing = match self.dir_find_entry(target_dir_ref, new_name) {
+            Ok(inode) => Some(inode),
+            Err(error) if error.code() == ErrCode::ENOENT => None,
+            Err(error) => return Err(error),
+        };
         let mut mutation_ids = vec![parent, new_parent, child_id];
         if let Some(existing_id) = existing {
             mutation_ids.push(existing_id);
@@ -3860,13 +3995,7 @@ impl Ext4 {
                     self.transaction_stage_inode_with_csum(&mut transaction, &mut existing_inode)?;
                 }
 
-                if let Err(error) = transaction.commit(self.block_device.as_ref(), self) {
-                    // Once commit processing starts, failures can leave an
-                    // uncertain committed/checkpointed state.  Fail-stop every
-                    // subsequent metadata writer on this mount.
-                    self.poison(ErrCode::EIO);
-                    return Err(error.error);
-                }
+                self.commit_namespace_transaction(transaction)?;
                 if final_target {
                     reclaim = Some(InodeReclaimHandle::new(
                         existing_inode.id,
@@ -3876,51 +4005,43 @@ impl Ext4 {
                 // 文件的 link count 不变（只是换了名字/位置）
             }
             None => {
-                // 情况 C：目标不存在 → 简单重命名
-                // Without a journal, any failure after the first namespace
-                // write fail-stops this mount so a partial rename cannot be
-                // followed by further allocation or metadata mutation.
-
-                // C-1. 在目标父目录添加新条目（先 add）
+                // Publish destination insertion, source removal and parent
+                // changes as one operation, including destination growth.
+                let target_dir = new_parent_ref.as_ref().unwrap_or(&parent_ref);
+                let credits = self.namespace_transaction_credits(&[target_dir], 4)?;
+                let mut transaction = self.transaction_start(credits)?;
                 let target_dir = new_parent_ref.as_mut().unwrap_or(&mut parent_ref);
-                match self.dir_add_entry_classified(target_dir, &child, new_name) {
-                    Ok(()) => {}
-                    Err(super::dir::DirAddFailure::Unmodified(error)) => return Err(error),
-                    Err(super::dir::DirAddFailure::Indeterminate(error)) => {
-                        self.poison(ErrCode::EIO);
-                        return Err(error);
-                    }
-                }
-
-                // C-2. 从源父目录删除旧条目（后 delete）
-                self.poison_on_error(self.dir_remove_entry(&parent_ref, name))?;
-
-                // C-3. 目录跨目录移动时，原子更新 ".." 并调整 link count
+                self.transaction_dir_add(&mut transaction, target_dir, &child, new_name)?;
+                self.transaction_dir_remove_entry(&mut transaction, &parent_ref, name)?;
                 if child_is_dir && parent != new_parent {
-                    // ".." 原地替换：旧父 → 新父，单次 I/O，无中间态
-                    self.poison_on_error(self.dir_replace_entry(
+                    self.transaction_dir_replace_entry(
+                        &mut transaction,
                         &child,
                         "..",
                         new_parent,
                         FileType::Directory,
-                    ))?;
-
-                    // 源父目录失去 ".." 引用
-                    parent_ref
-                        .inode
-                        .set_link_count(parent_ref.inode.link_count() - 1);
-                    self.poison_on_error(self.write_inode_with_csum(&mut parent_ref))?;
-
-                    // 目标父目录获得 ".." 引用
-                    let new_parent_dir = new_parent_ref.as_mut().ok_or(format_error!(
-                        ErrCode::EINVAL,
-                        "rename: missing new parent reference for directory move"
-                    ))?;
-                    new_parent_dir
-                        .inode
-                        .set_link_count(new_parent_dir.inode.link_count() + 1);
-                    self.poison_on_error(self.write_inode_with_csum(new_parent_dir))?;
+                    )?;
+                    parent_ref.inode.set_link_count(
+                        parent_ref
+                            .inode
+                            .link_count()
+                            .checked_sub(1)
+                            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+                    );
+                    self.transaction_stage_inode_with_csum(&mut transaction, &mut parent_ref)?;
+                    let new_parent_dir = new_parent_ref
+                        .as_mut()
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                    new_parent_dir.inode.set_link_count(
+                        new_parent_dir
+                            .inode
+                            .link_count()
+                            .checked_add(1)
+                            .ok_or_else(|| Ext4Error::new(ErrCode::EMLINK))?,
+                    );
+                    self.transaction_stage_inode_with_csum(&mut transaction, new_parent_dir)?;
                 }
+                self.commit_namespace_transaction(transaction)?;
                 // 文件：无 ".."，nlink 不变（只换了名字/位置）
                 // 目录同目录：".." 已指向正确的父，link count 不变
             }
@@ -3954,7 +4075,7 @@ impl Ext4 {
         new_name: &str,
     ) -> Result<()> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         // 1. 验证父目录
         let (mut parent_ref, mut new_parent_ref) = self.read_rename_dirs(parent, new_parent)?;
@@ -3992,64 +4113,95 @@ impl Ext4 {
             }
         }
 
+        // Two dirents, two possible ".." blocks and two parent inode homes.
+        let mut transaction = self.transaction_start(6)?;
         // 5. 原子交换：原地替换目录项的 inode 引用
         if parent == new_parent {
-            self.poison_on_error(self.dir_replace_entry(&parent_ref, name, new_id, new_type))?;
-            self.poison_on_error(self.dir_replace_entry(&parent_ref, new_name, old_id, old_type))?;
+            self.transaction_dir_replace_entry(
+                &mut transaction,
+                &parent_ref,
+                name,
+                new_id,
+                new_type,
+            )?;
+            self.transaction_dir_replace_entry(
+                &mut transaction,
+                &parent_ref,
+                new_name,
+                old_id,
+                old_type,
+            )?;
         } else {
-            self.poison_on_error(self.dir_replace_entry(&parent_ref, name, new_id, new_type))?;
+            self.transaction_dir_replace_entry(
+                &mut transaction,
+                &parent_ref,
+                name,
+                new_id,
+                new_type,
+            )?;
             let new_parent_dir = new_parent_ref.as_ref().ok_or(format_error!(
                 ErrCode::EINVAL,
                 "rename_exchange: missing new parent reference for cross-dir exchange"
             ))?;
-            self.poison_on_error(self.dir_replace_entry(
+            self.transaction_dir_replace_entry(
+                &mut transaction,
                 new_parent_dir,
                 new_name,
                 old_id,
                 old_type,
-            ))?;
+            )?;
         }
 
-        // 6. 跨目录时更新目录的 ".." 指向和父目录 link_count
+        // Update each moved directory's parent. Equal-type exchange has no
+        // net nlink change, so do not transiently overflow either parent.
         if parent != new_parent {
             if old_is_dir {
-                self.poison_on_error(self.dir_replace_entry(
+                self.transaction_dir_replace_entry(
+                    &mut transaction,
                     &old_inode,
                     "..",
                     new_parent,
                     FileType::Directory,
-                ))?;
-                parent_ref
-                    .inode
-                    .set_link_count(parent_ref.inode.link_count() - 1);
-                self.poison_on_error(self.write_inode_with_csum(&mut parent_ref))?;
-                let np = new_parent_ref.as_mut().ok_or(format_error!(
-                    ErrCode::EINVAL,
-                    "rename_exchange: missing new parent reference for old_dir update"
-                ))?;
-                np.inode.set_link_count(np.inode.link_count() + 1);
-                self.poison_on_error(self.write_inode_with_csum(np))?;
+                )?;
             }
             if new_is_dir {
-                self.poison_on_error(self.dir_replace_entry(
+                self.transaction_dir_replace_entry(
+                    &mut transaction,
                     &new_inode,
                     "..",
                     parent,
                     FileType::Directory,
-                ))?;
-                let np = new_parent_ref.as_mut().ok_or(format_error!(
-                    ErrCode::EINVAL,
-                    "rename_exchange: missing new parent reference for new_dir update"
-                ))?;
-                np.inode.set_link_count(np.inode.link_count() - 1);
-                self.poison_on_error(self.write_inode_with_csum(np))?;
-                parent_ref
-                    .inode
-                    .set_link_count(parent_ref.inode.link_count() + 1);
-                self.poison_on_error(self.write_inode_with_csum(&mut parent_ref))?;
+                )?;
+            }
+            if old_is_dir != new_is_dir {
+                let np = new_parent_ref
+                    .as_mut()
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                let (losing, gaining) = if old_is_dir {
+                    (&mut parent_ref, np)
+                } else {
+                    (np, &mut parent_ref)
+                };
+                losing.inode.set_link_count(
+                    losing
+                        .inode
+                        .link_count()
+                        .checked_sub(1)
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+                );
+                gaining.inode.set_link_count(
+                    gaining
+                        .inode
+                        .link_count()
+                        .checked_add(1)
+                        .ok_or_else(|| Ext4Error::new(ErrCode::EMLINK))?,
+                );
+                self.transaction_stage_inode_with_csum(&mut transaction, losing)?;
+                self.transaction_stage_inode_with_csum(&mut transaction, gaining)?;
             }
         }
 
+        self.commit_namespace_transaction(transaction)?;
         Ok(())
     }
 
@@ -4096,7 +4248,7 @@ impl Ext4 {
         owner: InodeOwner,
     ) -> Result<FileAttr> {
         self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _metadata_guard = self.lock_transactional_metadata_mutation()?;
         let _namespace_guard = self.namespace_lock.lock();
         let _mutation_guards = self.lock_inode_mutations(&[parent]);
         let mut parent = self.read_inode(parent)?;
@@ -4106,18 +4258,15 @@ impl Ext4 {
         }
         // Create file/directory
         let mode = mode & InodeMode::PERM_MASK | InodeMode::DIRECTORY;
-        let mut child = self.create_inode_with_owner(mode, owner.uid, owner.gid)?;
-        // Add "." entry
+        let credits = self.namespace_transaction_credits(&[&parent], 20)?;
+        let mut transaction = self.transaction_start(credits)?;
+        let mut child =
+            self.transaction_create_inode_with_owner(&mut transaction, mode, owner.uid, owner.gid)?;
         let child_self = child.clone();
-        if let Err(error) = self.dir_add_entry(&mut child, &child_self, ".") {
-            if self.free_inode(&mut child).is_err() {
-                self.poison(ErrCode::EIO);
-            }
-            return Err(error);
-        }
+        self.transaction_dir_add(&mut transaction, &mut child, &child_self, ".")?;
         child.inode.set_link_count(1);
-        // Link the new inode
-        self.link_new_inode_or_free(&mut parent, &mut child, name)?;
+        self.transaction_link_inode(&mut transaction, &mut parent, &mut child, name, false)?;
+        self.commit_namespace_transaction(transaction)?;
         Ok(Self::file_attr(&child))
     }
 
@@ -4137,6 +4286,7 @@ impl Ext4 {
     /// * `ENOTDIR` - `parent` is not a directory
     /// * `ENOENT` - `name` does not exist in `parent`
     pub fn lookup(&self, parent: InodeId, name: &str) -> Result<InodeId> {
+        let _view = self.lock_metadata_read_view()?;
         let parent = self.read_inode(parent)?;
         // Can only lookup in a directory
         if !parent.inode.is_dir() {
@@ -4159,6 +4309,7 @@ impl Ext4 {
     ///
     /// `ENOTDIR` - `inode` is not a directory
     pub fn listdir(&self, inode: InodeId) -> Result<Vec<DirEntry>> {
+        let _view = self.lock_metadata_read_view()?;
         let inode_ref = self.read_inode(inode)?;
         // Can only list a directory
         if inode_ref.inode.file_type() != FileType::Directory {
@@ -4209,184 +4360,6 @@ impl Ext4 {
         }
         // Remove directory entry
         self.unlink_inode(&mut parent_ref, &mut child, name)
-    }
-
-    /// Get extended attribute of a file.
-    ///
-    /// # Params
-    ///
-    /// * `inode` - the inode of the file
-    /// * `name` - the name of the attribute
-    ///
-    /// # Return
-    ///
-    /// `Ok(value)` - the value of the attribute
-    ///
-    /// # Error
-    ///
-    /// `ENODATA` - the attribute does not exist
-    pub fn getxattr(&self, inode: InodeId, name: &str) -> Result<Vec<u8>> {
-        let inode_ref = self.read_inode(inode)?;
-        let xattr_block_id = inode_ref.inode.xattr_block();
-        if xattr_block_id == 0 {
-            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
-        }
-        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
-        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
-        match xattr_block.get(name) {
-            Some(value) => Ok(value.to_owned()),
-            None => Err(format_error!(
-                ErrCode::ENODATA,
-                "Xattr {} does not exist",
-                name
-            )),
-        }
-    }
-
-    /// Set extended attribute of a file.
-    ///
-    /// # Params
-    ///
-    /// * `inode` - the inode of the file
-    /// * `name` - the name of the attribute
-    /// * `value` - the value of the attribute
-    ///
-    /// # Error
-    ///
-    /// `ENOSPC` - xattr block does not have enough space
-    pub fn setxattr(&self, inode: InodeId, name: &str, value: &[u8]) -> Result<()> {
-        self.ensure_mutable()?;
-        self.setxattr_with_flags(inode, name, value, false, false)
-    }
-
-    /// Set extended attribute of a file with Linux create/replace semantics.
-    ///
-    /// Existing xattr blocks are modified on a cloned candidate block first and
-    /// written back only after the whole operation succeeds. This preserves the
-    /// old value when replacing with a value that does not fit.
-    pub fn setxattr_with_flags(
-        &self,
-        inode: InodeId,
-        name: &str,
-        value: &[u8],
-        create: bool,
-        replace: bool,
-    ) -> Result<()> {
-        self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
-        let _mutation_guard =
-            self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
-        let mut inode_ref = self.read_inode(inode)?;
-        let xattr_block_id = inode_ref.inode.xattr_block();
-        if xattr_block_id == 0 {
-            if replace {
-                return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
-            }
-            // lazy allocate xattr block
-            let pblock = self.alloc_block(&mut inode_ref)?;
-            let old_xattr_block = xattr_block_id;
-            let result = (|| {
-                let mut xattr_block = XattrBlock::new(self.read_block(pblock)?);
-                xattr_block.init();
-                if !xattr_block.insert(name, value) {
-                    return_error!(
-                        ErrCode::ENOSPC,
-                        "Xattr block of Inode {} does not have enough space",
-                        inode
-                    );
-                }
-                self.update_xattr_block_checksum(pblock, &mut xattr_block)?;
-                self.write_block(&xattr_block.block())?;
-                inode_ref.inode.set_xattr_block(pblock);
-                self.write_inode_with_csum(&mut inode_ref)?;
-                Ok(())
-            })();
-            if let Err(err) = result {
-                inode_ref.inode.set_xattr_block(old_xattr_block);
-                return match self.dealloc_block(&mut inode_ref, pblock) {
-                    Ok(()) => Err(err),
-                    Err(rollback_err) => Err(rollback_err),
-                };
-            }
-            return Ok(());
-        }
-
-        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
-        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
-        let exists = xattr_block.get(name).is_some();
-        if exists && create {
-            return_error!(ErrCode::EEXIST, "Xattr {} already exists", name);
-        }
-        if !exists && replace {
-            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
-        }
-
-        let mut new_xattr_block = xattr_block;
-        if exists {
-            let _ = new_xattr_block.remove(name);
-        }
-        if new_xattr_block.insert(name, value) {
-            self.update_xattr_block_checksum(xattr_block_id, &mut new_xattr_block)?;
-            self.write_block(&new_xattr_block.block())?;
-            Ok(())
-        } else {
-            return_error!(
-                ErrCode::ENOSPC,
-                "Xattr block of Inode {} does not have enough space",
-                inode
-            );
-        }
-    }
-
-    /// Remove extended attribute of a file.
-    ///
-    /// # Params
-    ///
-    /// * `inode` - the inode of the file
-    /// * `name` - the name of the attribute
-    ///
-    /// # Error
-    ///
-    /// `ENODATA` - the attribute does not exist
-    pub fn removexattr(&self, inode: InodeId, name: &str) -> Result<()> {
-        self.ensure_mutable()?;
-        let _metadata_guard = self.lock_direct_metadata_mutation()?;
-        let _mutation_guard =
-            self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
-        let inode_ref = self.read_inode(inode)?;
-        let xattr_block_id = inode_ref.inode.xattr_block();
-        if xattr_block_id == 0 {
-            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
-        }
-        let mut xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
-        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
-        if xattr_block.remove(name) {
-            self.update_xattr_block_checksum(xattr_block_id, &mut xattr_block)?;
-            self.write_block(&xattr_block.block())?;
-            Ok(())
-        } else {
-            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
-        }
-    }
-
-    /// List extended attributes of a file.
-    ///
-    /// # Params
-    ///
-    /// * `inode` - the inode of the file
-    ///
-    /// # Returns
-    ///
-    /// A list of extended attributes of the file.
-    pub fn listxattr(&self, inode: InodeId) -> Result<Vec<String>> {
-        let inode_ref = self.read_inode(inode)?;
-        let xattr_block_id = inode_ref.inode.xattr_block();
-        if xattr_block_id == 0 {
-            return Ok(Vec::new());
-        }
-        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
-        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
-        Ok(xattr_block.list())
     }
 }
 

--- a/kernel/crates/another_ext4/src/ext4/metadata_gate.rs
+++ b/kernel/crates/another_ext4/src/ext4/metadata_gate.rs
@@ -1,0 +1,291 @@
+//! Metadata view exclusion and cancellation-safe writer preference.
+use crate::prelude::*;
+use core::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+
+/// Non-blocking gate separating legacy direct writers from journal snapshots.
+///
+/// The top bit denotes an exclusive transactional owner; the remaining bits
+/// count direct writers. Acquisition is lock-free rather than per-caller
+/// wait-free: it never sleeps or waits for an incompatible owner, which is
+/// essential because guards intentionally span block-device I/O.
+pub trait MetadataMutationWaker: Send + Sync {
+    /// Wake every upper-layer waiter which may have observed the previous
+    /// metadata-mutation generation.
+    ///
+    /// This callback runs after a guard releases the atomic gate state or when
+    /// the filesystem first enters fail-stop. It must not block or call back
+    /// into this filesystem.
+    fn wake_all(&self);
+}
+
+pub(super) struct MetadataMutationGate {
+    pub(super) state: AtomicUsize,
+    pub(super) generation: AtomicU64,
+    waker_installed: AtomicBool,
+    waker: spin::Once<Arc<dyn MetadataMutationWaker>>,
+    waiting_writers: AtomicUsize,
+}
+
+const METADATA_GATE_EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
+pub(super) const METADATA_GATE_DIRECT_MAX: usize = METADATA_GATE_EXCLUSIVE - 1;
+
+impl MetadataMutationGate {
+    pub(super) const fn new() -> Self {
+        Self {
+            state: AtomicUsize::new(0),
+            generation: AtomicU64::new(0),
+            waker_installed: AtomicBool::new(false),
+            waker: spin::Once::new(),
+            waiting_writers: AtomicUsize::new(0),
+        }
+    }
+
+    pub(super) fn install_waker(&self, waker: Arc<dyn MetadataMutationWaker>) -> Result<()> {
+        if self
+            .waker_installed
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        self.waker.call_once(|| waker);
+        Ok(())
+    }
+
+    #[inline]
+    pub(super) fn generation(&self) -> u64 {
+        self.generation.load(Ordering::Acquire)
+    }
+
+    pub(super) fn notify_progress(&self) {
+        self.generation.fetch_add(1, Ordering::Release);
+        if let Some(waker) = self.waker.get() {
+            waker.wake_all();
+        }
+    }
+
+    pub(super) fn try_direct(&self) -> Result<MetadataMutationGuard<'_>> {
+        let mut state = self.state.load(Ordering::Relaxed);
+        loop {
+            if state & METADATA_GATE_EXCLUSIVE != 0 {
+                return Err(Ext4Error::new(ErrCode::EAGAIN));
+            }
+            if state == METADATA_GATE_DIRECT_MAX {
+                // This is a corrupted/impossible owner count, not contention:
+                // no finite gate-release event can make a fabricated maximum
+                // count a safe acquisition.
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            match self.state.compare_exchange_weak(
+                state,
+                state + 1,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => {
+                    return Ok(MetadataMutationGuard {
+                        gate: self,
+                        exclusive: false,
+                    });
+                }
+                // Retry only a compatible direct-count collision. Observing an
+                // exclusive owner is rejected at the top of the next iteration;
+                // no acquisition waits for an I/O-spanning owner to depart.
+                //
+                // Do not turn a retry limit into EAGAIN: generation advances
+                // only when the last direct owner exits, so compatible count
+                // churn has no matching progress event for an upper-layer
+                // waiter. Such a rejection could strand an otherwise
+                // compatible caller until the whole direct cohort drains.
+                Err(observed) => state = observed,
+            }
+        }
+    }
+
+    pub(super) fn try_transactional(&self) -> Result<MetadataMutationGuard<'_>> {
+        self.state
+            .compare_exchange(
+                0,
+                METADATA_GATE_EXCLUSIVE,
+                Ordering::Acquire,
+                Ordering::Relaxed,
+            )
+            .map_err(|_| Ext4Error::new(ErrCode::EAGAIN))?;
+        Ok(MetadataMutationGuard {
+            gate: self,
+            exclusive: true,
+        })
+    }
+
+    /// Register only an actual gate wait, never a journal-capacity wait at an
+    /// idle gate. The retry owner keeps this capability through its next
+    /// operation attempt and drops it on success, cancellation or any error.
+    pub(super) fn writer_wait(&self) -> Result<Option<MetadataWriterWait<'_>>> {
+        if self.state.load(Ordering::Acquire) == 0 {
+            return Ok(None);
+        }
+        self.waiting_writers
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+                count.checked_add(1)
+            })
+            .map_err(|_| Ext4Error::new(ErrCode::EIO))?;
+        let intent = MetadataWriterWait { gate: self };
+        // If the cohort drained during registration, the retry can use its
+        // generation wakeup without leaving admission closed while idle.
+        if self.state.load(Ordering::Acquire) == 0 {
+            drop(intent);
+            return Ok(None);
+        }
+        Ok(Some(intent))
+    }
+
+    /// Public read views may not extend a cohort in front of an already
+    /// waiting writer. Direct mutation guards retain their existing class:
+    /// these short reservation/data operations may be the wait owner's retry
+    /// and must not reject themselves because their intent is still alive.
+    pub(super) fn try_read_view(&self) -> Result<MetadataMutationGuard<'_>> {
+        if self.waiting_writers.load(Ordering::Acquire) != 0 {
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        let guard = self.try_direct()?;
+        if self.waiting_writers.load(Ordering::Acquire) != 0 {
+            drop(guard);
+            return Err(Ext4Error::new(ErrCode::EAGAIN));
+        }
+        Ok(guard)
+    }
+}
+
+/// A scoped preference for an operation retry, not ownership of the gate.
+/// There is no persistent pending bit: abandoning the retry always reopens
+/// reader admission once the final writer waiter has gone away.
+#[must_use = "keep the preference alive through the wait and next operation attempt"]
+pub struct MetadataWriterWait<'a> {
+    gate: &'a MetadataMutationGate,
+}
+
+impl Drop for MetadataWriterWait<'_> {
+    fn drop(&mut self) {
+        let previous = self.gate.waiting_writers.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous != 0);
+        if previous == 1 {
+            self.gate.notify_progress();
+        }
+    }
+}
+
+pub(crate) struct MetadataMutationGuard<'a> {
+    gate: &'a MetadataMutationGate,
+    exclusive: bool,
+}
+
+impl core::fmt::Debug for MetadataMutationGuard<'_> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MetadataMutationGuard")
+            .field("exclusive", &self.exclusive)
+            .finish_non_exhaustive()
+    }
+}
+
+impl Drop for MetadataMutationGuard<'_> {
+    fn drop(&mut self) {
+        if self.exclusive {
+            debug_assert_eq!(
+                self.gate.state.load(Ordering::Relaxed),
+                METADATA_GATE_EXCLUSIVE
+            );
+            self.gate.state.store(0, Ordering::Release);
+            self.gate.notify_progress();
+        } else {
+            let previous = self.gate.state.fetch_sub(1, Ordering::Release);
+            debug_assert!(previous > 0 && previous < METADATA_GATE_EXCLUSIVE);
+            if previous == 1 {
+                self.gate.notify_progress();
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn waiting_writer_stops_a_continuously_overlapping_read_cohort() {
+        let gate = MetadataMutationGate::new();
+        let first = gate.try_read_view().unwrap();
+        let second = gate.try_read_view().unwrap();
+        assert_eq!(
+            gate.try_transactional().unwrap_err().code(),
+            ErrCode::EAGAIN
+        );
+        let observed = gate.generation();
+        let preference = gate.writer_wait().unwrap().unwrap();
+        drop(first);
+        // Without writer preference a replacement first reader could enter
+        // here and keep the cohort alive forever across second's release.
+        assert_eq!(gate.try_read_view().unwrap_err().code(), ErrCode::EAGAIN);
+        assert_eq!(gate.generation(), observed);
+        drop(second);
+        assert_ne!(gate.generation(), observed);
+        let writer = gate.try_transactional().unwrap();
+        assert_eq!(gate.try_read_view().unwrap_err().code(), ErrCode::EAGAIN);
+        drop(writer);
+        drop(preference);
+        assert!(gate.try_read_view().is_ok());
+    }
+
+    #[test]
+    fn cancelled_writer_reopens_read_admission_while_other_readers_continue() {
+        let gate = MetadataMutationGate::new();
+        let reader = gate.try_read_view().unwrap();
+        let first = gate.writer_wait().unwrap().unwrap();
+        let second = gate.writer_wait().unwrap().unwrap();
+        let observed = gate.generation();
+        drop(first);
+        assert_eq!(gate.generation(), observed);
+        assert!(gate.try_read_view().is_err());
+        drop(second);
+        assert_ne!(gate.generation(), observed);
+        assert!(gate.try_read_view().is_ok());
+        drop(reader);
+        assert!(gate.try_transactional().is_ok());
+    }
+
+    #[test]
+    fn capacity_wait_does_not_close_read_admission_at_an_idle_gate() {
+        let gate = MetadataMutationGate::new();
+        assert!(gate.writer_wait().unwrap().is_none());
+        assert_eq!(gate.generation(), 0);
+        assert!(gate.try_read_view().is_ok());
+    }
+
+    #[test]
+    fn compatible_mutation_retry_does_not_reject_its_own_preference() {
+        let gate = MetadataMutationGate::new();
+        let writer = gate.try_transactional().unwrap();
+        let preference = gate.writer_wait().unwrap().unwrap();
+        drop(writer);
+        let direct = gate.try_direct().unwrap();
+        drop(preference);
+        drop(direct);
+        assert!(gate.try_read_view().is_ok());
+    }
+
+    #[test]
+    fn retry_rearms_after_its_own_cancellation_notification() {
+        let gate = MetadataMutationGate::new();
+        let reader = gate.try_read_view().unwrap();
+        let previous = gate.writer_wait().unwrap().unwrap();
+        assert!(gate.try_transactional().is_err());
+        drop(previous);
+        let after_release = gate.generation();
+        let next = gate.writer_wait().unwrap().unwrap();
+        // Registration itself is not progress. A scheduler waiter using this
+        // token sleeps until the live owner releases, rather than self-waking.
+        assert_eq!(gate.generation(), after_release);
+        drop(reader);
+        assert_ne!(gate.generation(), after_release);
+        drop(next);
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -12,13 +12,21 @@ mod alloc;
 mod dir;
 mod extent;
 mod high_level;
+mod metadata_gate;
+#[cfg(test)]
+use metadata_gate::METADATA_GATE_DIRECT_MAX;
+use metadata_gate::{MetadataMutationGate, MetadataMutationGuard};
+pub use metadata_gate::{MetadataMutationWaker, MetadataWriterWait};
 mod journal;
+mod journal_batch;
+pub use journal_batch::BatchProgress;
 mod journal_recovery;
 mod journal_transaction;
 mod link;
 mod low_level;
 mod orphan;
 mod rw;
+mod xattr;
 mod xattr_reclaim;
 
 #[cfg(any(test, feature = "test-api"))]
@@ -540,156 +548,12 @@ impl PrepareStats {
 pub(super) enum MetadataMutationMode {
     ReadOnly,
     Journal(journal_transaction::JournalTransactionCore),
+    Batched(journal_batch::JournalBatchCore),
     Direct(journal_transaction::DirectTransactionCore),
 }
 
-/// Non-blocking gate separating legacy direct writers from journal snapshots.
-///
-/// The top bit denotes an exclusive transactional owner; the remaining bits
-/// count direct writers. Acquisition is lock-free rather than per-caller
-/// wait-free: it never sleeps or waits for an incompatible owner, which is
-/// essential because guards intentionally span block-device I/O.
-pub trait MetadataMutationWaker: Send + Sync {
-    /// Wake every upper-layer waiter which may have observed the previous
-    /// metadata-mutation generation.
-    ///
-    /// This callback runs after a guard releases the atomic gate state or when
-    /// the filesystem first enters fail-stop. It must not block or call back
-    /// into this filesystem.
-    fn wake_all(&self);
-}
-
-struct MetadataMutationGate {
-    state: AtomicUsize,
-    generation: AtomicU64,
-    waker_installed: AtomicBool,
-    waker: spin::Once<Arc<dyn MetadataMutationWaker>>,
-}
-
-const METADATA_GATE_EXCLUSIVE: usize = 1usize << (usize::BITS - 1);
-const METADATA_GATE_DIRECT_MAX: usize = METADATA_GATE_EXCLUSIVE - 1;
 const P6_2_STATS_ENABLED: bool = option_env!("DRAGONOS_P6_2_STATS").is_some();
 static NEXT_PREPARE_STATS_GENERATION: AtomicUsize = AtomicUsize::new(1);
-
-impl MetadataMutationGate {
-    const fn new() -> Self {
-        Self {
-            state: AtomicUsize::new(0),
-            generation: AtomicU64::new(0),
-            waker_installed: AtomicBool::new(false),
-            waker: spin::Once::new(),
-        }
-    }
-
-    fn install_waker(&self, waker: Arc<dyn MetadataMutationWaker>) -> Result<()> {
-        if self
-            .waker_installed
-            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
-            .is_err()
-        {
-            return Err(Ext4Error::new(ErrCode::EINVAL));
-        }
-        self.waker.call_once(|| waker);
-        Ok(())
-    }
-
-    #[inline]
-    fn generation(&self) -> u64 {
-        self.generation.load(Ordering::Acquire)
-    }
-
-    fn notify_progress(&self) {
-        self.generation.fetch_add(1, Ordering::Release);
-        if let Some(waker) = self.waker.get() {
-            waker.wake_all();
-        }
-    }
-
-    fn try_direct(&self) -> Result<MetadataMutationGuard<'_>> {
-        let mut state = self.state.load(Ordering::Relaxed);
-        loop {
-            if state & METADATA_GATE_EXCLUSIVE != 0 {
-                return Err(Ext4Error::new(ErrCode::EAGAIN));
-            }
-            if state == METADATA_GATE_DIRECT_MAX {
-                // This is a corrupted/impossible owner count, not contention:
-                // no finite gate-release event can make a fabricated maximum
-                // count a safe acquisition.
-                return Err(Ext4Error::new(ErrCode::EIO));
-            }
-            match self.state.compare_exchange_weak(
-                state,
-                state + 1,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            ) {
-                Ok(_) => {
-                    return Ok(MetadataMutationGuard {
-                        gate: self,
-                        exclusive: false,
-                    });
-                }
-                // Retry only a compatible direct-count collision. Observing an
-                // exclusive owner is rejected at the top of the next iteration;
-                // no acquisition waits for an I/O-spanning owner to depart.
-                //
-                // Do not turn a retry limit into EAGAIN: generation advances
-                // only when the last direct owner exits, so compatible count
-                // churn has no matching progress event for an upper-layer
-                // waiter. Such a rejection could strand an otherwise
-                // compatible caller until the whole direct cohort drains.
-                Err(observed) => state = observed,
-            }
-        }
-    }
-
-    fn try_transactional(&self) -> Result<MetadataMutationGuard<'_>> {
-        self.state
-            .compare_exchange(
-                0,
-                METADATA_GATE_EXCLUSIVE,
-                Ordering::Acquire,
-                Ordering::Relaxed,
-            )
-            .map_err(|_| Ext4Error::new(ErrCode::EAGAIN))?;
-        Ok(MetadataMutationGuard {
-            gate: self,
-            exclusive: true,
-        })
-    }
-}
-
-pub(super) struct MetadataMutationGuard<'a> {
-    gate: &'a MetadataMutationGate,
-    exclusive: bool,
-}
-
-impl core::fmt::Debug for MetadataMutationGuard<'_> {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.debug_struct("MetadataMutationGuard")
-            .field("exclusive", &self.exclusive)
-            .finish_non_exhaustive()
-    }
-}
-
-impl Drop for MetadataMutationGuard<'_> {
-    fn drop(&mut self) {
-        if self.exclusive {
-            debug_assert_eq!(
-                self.gate.state.load(Ordering::Relaxed),
-                METADATA_GATE_EXCLUSIVE
-            );
-            self.gate.state.store(0, Ordering::Release);
-            self.gate.notify_progress();
-        } else {
-            let previous = self.gate.state.fetch_sub(1, Ordering::Release);
-            debug_assert!(previous > 0 && previous < METADATA_GATE_EXCLUSIVE);
-            if previous == 1 {
-                self.gate.notify_progress();
-            }
-        }
-    }
-}
 
 /// Maximum number of inodes to cache in memory.
 const INODE_CACHE_SIZE: usize = 512;
@@ -1050,16 +914,37 @@ impl Ext4 {
         self.metadata_mutation_barrier.install_waker(waker)
     }
 
+    /// Install batch progress separately: a read-view release changes gate
+    /// progress but supplies no journal work. Install before publication.
+    pub fn install_batch_progress_waker(&self, waker: Arc<dyn MetadataMutationWaker>) {
+        if let MetadataMutationMode::Batched(core) = &self.metadata_mode {
+            core.install_waker(waker);
+        }
+    }
+
     /// Snapshot the metadata gate progress generation before attempting an
     /// operation which may return gate-contention `EAGAIN`.
     #[inline]
     pub fn metadata_mutation_generation(&self) -> u64 {
-        self.metadata_mutation_barrier.generation()
+        let gate = self.metadata_mutation_barrier.generation();
+        // Both monotone progress domains participate in the equality token:
+        // a completed checkpoint can unblock capacity without releasing a gate.
+        match &self.metadata_mode {
+            MetadataMutationMode::Batched(core) => gate.wrapping_add(core.progress().generation),
+            _ => gate,
+        }
+    }
+
+    /// Hold across an exclusive operation's contention wait and next retry.
+    /// Read-only retries must not register a writer preference of their own.
+    pub fn begin_metadata_writer_wait(&self) -> Result<Option<MetadataWriterWait<'_>>> {
+        self.metadata_mutation_barrier.writer_wait()
     }
 
     /// Whether all future metadata mutations are terminally rejected.
     pub fn metadata_mutations_terminal(&self) -> bool {
         self.poisoned.lock().is_some()
+            || matches!(&self.metadata_mode, MetadataMutationMode::Batched(core) if core.is_poisoned())
     }
 
     /// Host-only synchronization point immediately before fail-stop tries to
@@ -1118,17 +1003,13 @@ impl Ext4 {
         }
         drop(poisoned);
         if first {
+            if let MetadataMutationMode::Batched(core) = &self.metadata_mode {
+                core.fail_stop();
+            }
             // A fail-stop can occur without a live gate owner. Publish it as
             // progress so upper waiters do not sleep forever awaiting Drop.
             self.metadata_mutation_barrier.notify_progress();
         }
-    }
-
-    pub(super) fn poison_on_error<T>(&self, result: Result<T>) -> Result<T> {
-        if result.is_err() {
-            self.poison(ErrCode::EIO);
-        }
-        result
     }
 
     pub(super) fn lock_inode_mutations(
@@ -1145,6 +1026,16 @@ impl Ext4 {
             .into_iter()
             .map(|index| self.inode_mutation_locks[index].lock())
             .collect()
+    }
+
+    /// Keep a multi-block public read in one logical metadata view. Compatible
+    /// readers can overlap; publication is excluded, checkpoint I/O is not.
+    pub(super) fn lock_metadata_read_view(&self) -> Result<Option<MetadataMutationGuard<'_>>> {
+        if matches!(self.metadata_mode, MetadataMutationMode::Batched(_)) {
+            self.metadata_mutation_barrier.try_read_view().map(Some)
+        } else {
+            Ok(None)
+        }
     }
 
     /// Enter a complete legacy/direct metadata mutation operation.

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -3,6 +3,156 @@ use crate::constants::*;
 use crate::ext4_defs::*;
 use crate::prelude::*;
 
+/// Explicit metadata image access for algorithms shared by direct and journal
+/// operations. File payload I/O never goes through this context. A journal
+/// context owns no global cache side effects: publication belongs to its caller.
+/// Keeping the transaction borrow here prevents private images escaping an
+/// operation or being mistaken for the mounted filesystem's live view.
+pub(super) struct MetadataIo<'fs, 'tx, 'core> {
+    fs: &'fs Ext4,
+    transaction: Option<&'tx mut super::journal_transaction::Transaction<'core>>,
+}
+
+impl<'fs, 'tx, 'core> MetadataIo<'fs, 'tx, 'core> {
+    pub(super) fn direct(fs: &'fs Ext4) -> Self {
+        Self {
+            fs,
+            transaction: None,
+        }
+    }
+
+    pub(super) fn transaction(
+        fs: &'fs Ext4,
+        transaction: &'tx mut super::journal_transaction::Transaction<'core>,
+    ) -> Self {
+        Self {
+            fs,
+            transaction: Some(transaction),
+        }
+    }
+
+    pub(super) fn transaction_ref(
+        &self,
+    ) -> Option<&super::journal_transaction::Transaction<'core>> {
+        self.transaction.as_deref()
+    }
+
+    /// Allocate a tree metadata block through the same operation as its
+    /// parent pointer. Direct mode retains its existing allocation protocol.
+    pub(super) fn allocate_block(&mut self, inode: &mut InodeRef) -> Result<PBlockId> {
+        match self.transaction.as_deref_mut() {
+            Some(transaction) => {
+                let home = self
+                    .fs
+                    .transaction_alloc_metadata_block(transaction, inode.id, None)?;
+                let blocks = inode
+                    .inode
+                    .fs_block_count()
+                    .checked_add(1)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+                inode.inode.set_fs_block_count(blocks);
+                Ok(home)
+            }
+            None => self.fs.alloc_block(inode),
+        }
+    }
+
+    pub(super) fn allocate_initialized_data(
+        &mut self,
+        inode: &mut InodeRef,
+        image: Box<[u8; BLOCK_SIZE]>,
+    ) -> Result<PBlockId> {
+        if self.transaction.is_none() {
+            return self.fs.alloc_initialized_data_block(inode, image);
+        }
+        let home = self.allocate_block(inode)?;
+        // Payload bypasses metadata staging; the journal's first flush orders
+        // this successful write before the mapping's commit record.
+        self.fs.block_device.write_block(&Block::new(home, image))?;
+        Ok(home)
+    }
+
+    pub(super) fn request_retirement_progress(&self) -> bool {
+        self.transaction
+            .as_deref()
+            .is_some_and(|tx| tx.request_retirement_progress())
+    }
+
+    pub(super) fn inode_reusable(&self, id: InodeId) -> bool {
+        self.transaction
+            .as_deref()
+            .is_none_or(|tx| tx.inode_reusable(id))
+    }
+
+    pub(super) fn is_transactional(&self) -> bool {
+        self.transaction.is_some()
+    }
+
+    pub(super) fn read_block(&self, id: PBlockId) -> Result<Block> {
+        match self.transaction.as_deref() {
+            Some(transaction) => {
+                let image = transaction.read(self.fs.block_device.as_ref(), id)?;
+                Ok(Block::new(id, Box::new(*image)))
+            }
+            None => self.fs.read_block(id),
+        }
+    }
+
+    pub(super) fn write_block(&mut self, block: &Block) -> Result<()> {
+        match self.transaction.as_deref_mut() {
+            Some(transaction) => transaction.stage(block.id, block.data.clone()),
+            None => self.fs.write_block(block),
+        }
+    }
+
+    pub(super) fn read_super_block(&self) -> Result<SuperBlock> {
+        match self.transaction.as_deref() {
+            Some(transaction) => self.fs.transaction_read_super_block(transaction),
+            None => Ok(self.fs.read_super_block_cached()),
+        }
+    }
+
+    pub(super) fn write_super_block(&mut self, sb: &SuperBlock) -> Result<()> {
+        match self.transaction.as_deref_mut() {
+            Some(transaction) => self.fs.transaction_stage_super_block(transaction, sb),
+            None => self.fs.write_super_block(sb),
+        }
+    }
+
+    pub(super) fn read_block_group(&self, id: BlockGroupId) -> Result<BlockGroupRef> {
+        match self.transaction.as_deref() {
+            Some(transaction) => self.fs.transaction_read_block_group(transaction, id),
+            None => self.fs.read_block_group(id),
+        }
+    }
+
+    pub(super) fn write_block_group_with_csum(&mut self, bg: &mut BlockGroupRef) -> Result<()> {
+        match self.transaction.as_deref_mut() {
+            Some(transaction) => self
+                .fs
+                .transaction_stage_block_group_with_csum(transaction, bg),
+            None => self.fs.write_block_group_with_csum(bg),
+        }
+    }
+
+    pub(super) fn read_inode(&self, id: InodeId) -> Result<InodeRef> {
+        // Geometry is immutable while mounted. The inode image, unlike its
+        // position, must come from the current operation and bypass value cache.
+        let (block, offset) = self.fs.inode_disk_pos(id)?;
+        let image = self.read_block(block)?;
+        Ok(InodeRef::new(id, Box::new(image.read_offset_as(offset))))
+    }
+
+    pub(super) fn write_inode_with_csum(&mut self, inode: &mut InodeRef) -> Result<()> {
+        match self.transaction.as_deref_mut() {
+            Some(transaction) => self
+                .fs
+                .transaction_stage_inode_with_csum(transaction, inode),
+            None => self.fs.write_inode_with_csum(inode),
+        }
+    }
+}
+
 impl Ext4 {
     /// Obtain a transaction-private metadata block image for mutation.
     /// Repeated calls for the same block merge changes in one staged image.
@@ -92,11 +242,22 @@ impl Ext4 {
 
     /// Read a block from block device
     pub(super) fn read_block(&self, block_id: PBlockId) -> Result<Block> {
-        self.block_device.read_block(block_id)
+        match &self.metadata_mode {
+            super::MetadataMutationMode::Batched(core) => {
+                core.read_metadata(self.block_device.as_ref(), block_id)
+            }
+            _ => self.block_device.read_block(block_id),
+        }
     }
 
     /// Write a block to block device
     pub(super) fn write_block(&self, block: &Block) -> Result<()> {
+        if matches!(self.metadata_mode, super::MetadataMutationMode::Batched(_)) {
+            // A runtime metadata writer bypassing a private operation is a
+            // contract violation, never an alternate write-through route.
+            self.poison(ErrCode::EIO);
+            return Err(Ext4Error::new(ErrCode::EIO));
+        }
         self.block_device.write_block(block)
     }
 
@@ -136,6 +297,11 @@ impl Ext4 {
     /// Read an inode from cache or block device, return an `InodeRef` that
     /// combines the inode and its id.
     pub(super) fn read_inode(&self, inode_id: InodeId) -> Result<InodeRef> {
+        // Callers hold a read/direct/exclusive metadata gate through lookup
+        // and cold insertion. Logical publication takes the exclusive gate
+        // and invalidates changed inode-table homes, so a cold reader cannot
+        // insert an older value after publication. Transaction-private reads
+        // use MetadataIo::read_inode and deliberately bypass this cache.
         // Try cache first
         if let Some(cached) = self.inode_cache.lock().get(inode_id) {
             return Ok(cached);

--- a/kernel/crates/another_ext4/src/ext4/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr.rs
@@ -1,0 +1,357 @@
+//! Extended attribute access and atomic journal-mode replacement.
+use super::Ext4;
+use crate::constants::*;
+use crate::ext4_defs::*;
+use crate::prelude::*;
+use crate::{format_error, return_error};
+
+impl Ext4 {
+    fn xattr_checksum_seed(&self) -> Result<Option<MetadataChecksumSeed>> {
+        let sb = self.read_super_block_cached();
+        if !sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
+            return Ok(None);
+        }
+        Ok(Some(sb.metadata_checksum_seed()))
+    }
+
+    fn verify_xattr_block_checksum(&self, block_id: PBlockId, block: &XattrBlock) -> Result<()> {
+        if let Some(seed) = self.xattr_checksum_seed()? {
+            if !block.verify_checksum(seed, block_id) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+        Ok(())
+    }
+
+    fn update_xattr_block_checksum(
+        &self,
+        block_id: PBlockId,
+        block: &mut XattrBlock,
+    ) -> Result<()> {
+        if let Some(seed) = self.xattr_checksum_seed()? {
+            if !block.update_checksum(seed, block_id) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+        }
+        Ok(())
+    }
+
+    /// Get extended attribute of a file.
+    ///
+    /// # Params
+    ///
+    /// * `inode` - the inode of the file
+    /// * `name` - the name of the attribute
+    ///
+    /// # Return
+    ///
+    /// `Ok(value)` - the value of the attribute
+    ///
+    /// # Error
+    ///
+    /// `ENODATA` - the attribute does not exist
+    pub fn getxattr(&self, inode: InodeId, name: &str) -> Result<Vec<u8>> {
+        let _view = self.lock_metadata_read_view()?;
+        let inode_ref = self.read_inode(inode)?;
+        let xattr_block_id = inode_ref.inode.xattr_block();
+        if xattr_block_id == 0 {
+            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
+        }
+        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
+        match xattr_block.get(name) {
+            Some(value) => Ok(value.to_owned()),
+            None => Err(format_error!(
+                ErrCode::ENODATA,
+                "Xattr {} does not exist",
+                name
+            )),
+        }
+    }
+
+    /// Set extended attribute of a file.
+    ///
+    /// # Params
+    ///
+    /// * `inode` - the inode of the file
+    /// * `name` - the name of the attribute
+    /// * `value` - the value of the attribute
+    ///
+    /// # Error
+    ///
+    /// `ENOSPC` - xattr block does not have enough space
+    pub fn setxattr(&self, inode: InodeId, name: &str, value: &[u8]) -> Result<()> {
+        self.ensure_mutable()?;
+        self.setxattr_with_flags(inode, name, value, false, false)
+    }
+
+    /// Set extended attribute of a file with Linux create/replace semantics.
+    ///
+    /// Existing xattr blocks are modified on a cloned candidate block first and
+    /// written back only after the whole operation succeeds. This preserves the
+    /// old value when replacing with a value that does not fit.
+    pub fn setxattr_with_flags(
+        &self,
+        inode: InodeId,
+        name: &str,
+        value: &[u8],
+        create: bool,
+        replace: bool,
+    ) -> Result<()> {
+        self.ensure_mutable()?;
+        if self.uses_journal() {
+            return self.update_xattr_transaction(inode, name, Some(value), create, replace);
+        }
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _mutation_guard =
+            self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
+        let mut inode_ref = self.read_inode(inode)?;
+        let xattr_block_id = inode_ref.inode.xattr_block();
+        if xattr_block_id == 0 {
+            if replace {
+                return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
+            }
+            // lazy allocate xattr block
+            let pblock = self.alloc_block(&mut inode_ref)?;
+            let old_xattr_block = xattr_block_id;
+            let result = (|| {
+                let mut xattr_block = XattrBlock::new(self.read_block(pblock)?);
+                xattr_block.init();
+                if !xattr_block.insert(name, value) {
+                    return_error!(
+                        ErrCode::ENOSPC,
+                        "Xattr block of Inode {} does not have enough space",
+                        inode
+                    );
+                }
+                self.update_xattr_block_checksum(pblock, &mut xattr_block)?;
+                self.write_block(&xattr_block.block())?;
+                inode_ref.inode.set_xattr_block(pblock);
+                let blocks = inode_ref
+                    .inode
+                    .fs_block_count()
+                    .checked_add(1)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+                inode_ref.inode.set_fs_block_count(blocks);
+                self.write_inode_with_csum(&mut inode_ref)?;
+                Ok(())
+            })();
+            if let Err(err) = result {
+                inode_ref.inode.set_xattr_block(old_xattr_block);
+                return match self.dealloc_block(&mut inode_ref, pblock) {
+                    Ok(()) => Err(err),
+                    Err(rollback_err) => Err(rollback_err),
+                };
+            }
+            return Ok(());
+        }
+
+        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
+        let exists = xattr_block.get(name).is_some();
+        if exists && create {
+            return_error!(ErrCode::EEXIST, "Xattr {} already exists", name);
+        }
+        if !exists && replace {
+            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
+        }
+
+        let mut new_xattr_block = xattr_block;
+        if exists {
+            let _ = new_xattr_block.remove(name);
+        }
+        if new_xattr_block.insert(name, value) {
+            self.update_xattr_block_checksum(xattr_block_id, &mut new_xattr_block)?;
+            self.write_block(&new_xattr_block.block())?;
+            Ok(())
+        } else {
+            return_error!(
+                ErrCode::ENOSPC,
+                "Xattr block of Inode {} does not have enough space",
+                inode
+            );
+        }
+    }
+
+    /// Remove extended attribute of a file.
+    ///
+    /// # Params
+    ///
+    /// * `inode` - the inode of the file
+    /// * `name` - the name of the attribute
+    ///
+    /// # Error
+    ///
+    /// `ENODATA` - the attribute does not exist
+    pub fn removexattr(&self, inode: InodeId, name: &str) -> Result<()> {
+        self.ensure_mutable()?;
+        if self.uses_journal() {
+            return self.update_xattr_transaction(inode, name, None, false, true);
+        }
+        let _metadata_guard = self.lock_direct_metadata_mutation()?;
+        let _mutation_guard =
+            self.inode_mutation_locks[self.inode_mutation_lock_index(inode)].lock();
+        let mut inode_ref = self.read_inode(inode)?;
+        let xattr_block_id = inode_ref.inode.xattr_block();
+        if xattr_block_id == 0 {
+            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
+        }
+        let image = self.read_block(xattr_block_id)?;
+        let mut header = XattrHeader::from_bytes(&image.data[..]);
+        let mut xattr_block = XattrBlock::new(image);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
+        if xattr_block.remove(name) {
+            if xattr_block.list().is_empty() {
+                let blocks = inode_ref
+                    .inode
+                    .fs_block_count()
+                    .checked_sub(1)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                inode_ref.inode.set_xattr_block(0);
+                inode_ref.inode.set_fs_block_count(blocks);
+                self.write_inode_with_csum(&mut inode_ref)?;
+                // In nojournal mode detach durably before returning this block
+                // to the allocator; otherwise the old inode could reference a
+                // newly reused block after a crash.
+                if self.write_barrier {
+                    self.block_device.flush()?;
+                }
+                let released = if header.refcount() == 1 {
+                    self.dealloc_block(&mut inode_ref, xattr_block_id)
+                } else {
+                    // Detaching one owner must preserve the shared contents.
+                    let mut original = self.read_block(xattr_block_id)?;
+                    header.set_refcount(
+                        header
+                            .refcount()
+                            .checked_sub(1)
+                            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?,
+                    );
+                    original.data[..core::mem::size_of::<XattrHeader>()]
+                        .copy_from_slice(header.to_bytes());
+                    let mut original = XattrBlock::new(original);
+                    self.update_xattr_block_checksum(xattr_block_id, &mut original)?;
+                    self.write_block(&original.block())
+                };
+                if released.is_err() {
+                    self.poison(ErrCode::EIO);
+                }
+                return released;
+            }
+            self.update_xattr_block_checksum(xattr_block_id, &mut xattr_block)?;
+            self.write_block(&xattr_block.block())?;
+            Ok(())
+        } else {
+            return_error!(ErrCode::ENODATA, "Xattr {} does not exist", name);
+        }
+    }
+
+    /// List extended attributes of a file.
+    ///
+    /// # Params
+    ///
+    /// * `inode` - the inode of the file
+    ///
+    /// # Returns
+    ///
+    /// A list of extended attributes of the file.
+    pub fn listxattr(&self, inode: InodeId) -> Result<Vec<String>> {
+        let _view = self.lock_metadata_read_view()?;
+        let inode_ref = self.read_inode(inode)?;
+        let xattr_block_id = inode_ref.inode.xattr_block();
+        if xattr_block_id == 0 {
+            return Ok(Vec::new());
+        }
+        let xattr_block = XattrBlock::new(self.read_block(xattr_block_id)?);
+        self.verify_xattr_block_checksum(xattr_block_id, &xattr_block)?;
+        Ok(xattr_block.list())
+    }
+    /// External xattr replacement is one allocation/reference/inode operation.
+    /// Shared Linux xattr blocks are copied, never changed through another
+    /// inode's reference. All fallible candidate construction precedes commit.
+    fn update_xattr_transaction(
+        &self,
+        inode_id: InodeId,
+        name: &str,
+        value: Option<&[u8]>,
+        create: bool,
+        replace: bool,
+    ) -> Result<()> {
+        let _metadata = self.lock_transactional_metadata_mutation()?;
+        let _inode = self.inode_mutation_locks[self.inode_mutation_lock_index(inode_id)].lock();
+        let mut inode = self.read_inode(inode_id)?;
+        let old_home = inode.inode.xattr_block();
+        // At most: inode table, old/new xattr, bitmap, GDT and superblock.
+        let mut transaction = self.transaction_start(6)?;
+        let (mut candidate, shared) = if old_home == 0 {
+            if replace || value.is_none() {
+                return Err(Ext4Error::new(ErrCode::ENODATA));
+            }
+            let mut block = XattrBlock::new(Block::new(0, Box::new([0; BLOCK_SIZE])));
+            block.init();
+            (block, false)
+        } else {
+            let image = transaction.read(self.block_device.as_ref(), old_home)?;
+            let (header, ea_inode) = validate_xattr_block_for_release(&*image)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            if ea_inode {
+                return Err(Ext4Error::new(ErrCode::ENOTSUP));
+            }
+            let block = XattrBlock::new(Block::new(old_home, Box::new(*image)));
+            self.verify_xattr_block_checksum(old_home, &block)?;
+            (block, header.refcount() > 1)
+        };
+        let exists = candidate.get(name).is_some();
+        if exists && create {
+            return Err(Ext4Error::new(ErrCode::EEXIST));
+        }
+        if !exists && (replace || value.is_none()) {
+            return Err(Ext4Error::new(ErrCode::ENODATA));
+        }
+        if exists {
+            candidate.remove(name);
+        }
+        if let Some(value) = value {
+            if !candidate.insert(name, value) {
+                return Err(Ext4Error::new(ErrCode::ENOSPC));
+            }
+        }
+        if value.is_none() && candidate.list().is_empty() {
+            if let Some(home) = self.transaction_release_xattr(&mut transaction, &mut inode)? {
+                self.transaction_dealloc_block_range(&mut transaction, home, 1)?;
+            }
+            return self
+                .commit_metadata_operation(transaction)
+                .map(|_| ())
+                .map_err(|error| error.error);
+        }
+        let home = if old_home == 0 || shared {
+            let home = self.transaction_alloc_metadata_block(&mut transaction, inode_id, None)?;
+            if shared {
+                self.transaction_release_xattr(&mut transaction, &mut inode)?;
+            }
+            let blocks = inode
+                .inode
+                .fs_block_count()
+                .checked_add(1)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+            inode.inode.set_fs_block_count(blocks);
+            inode.inode.set_xattr_block(home);
+            self.transaction_stage_inode_with_csum(&mut transaction, &mut inode)?;
+            home
+        } else {
+            old_home
+        };
+        let mut image = candidate.block();
+        image.id = home;
+        let mut header = XattrHeader::from_bytes(&image.data[..]);
+        header.set_refcount(1);
+        image.data[..core::mem::size_of::<XattrHeader>()].copy_from_slice(header.to_bytes());
+        let mut candidate = XattrBlock::new(image);
+        self.update_xattr_block_checksum(home, &mut candidate)?;
+        transaction.stage(home, candidate.block().data)?;
+        self.commit_metadata_operation(transaction)
+            .map(|_| ())
+            .map_err(|error| error.error)
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
@@ -81,6 +81,13 @@ impl Ext4 {
         if block_id == 0 {
             return Ok(None);
         }
+        // Detaching one external reference releases this inode's block
+        // charge even when another inode still owns the shared block.
+        let remaining_blocks = inode
+            .inode
+            .fs_block_count()
+            .checked_sub(1)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
         let sb = self.read_super_block_cached();
         self.validate_xattr_block_allocation(transaction, block_id)?;
         let image = transaction.read(self.block_device.as_ref(), block_id)?;
@@ -120,10 +127,12 @@ impl Ext4 {
             // transaction as the shared reference-count decrement, otherwise
             // a restartable reclaim would decrement the block repeatedly.
             inode.inode.set_xattr_block(0);
+            inode.inode.set_fs_block_count(remaining_blocks);
             self.transaction_stage_inode_with_csum(transaction, inode)?;
             Ok(None)
         } else {
             inode.inode.set_xattr_block(0);
+            inode.inode.set_fs_block_count(remaining_blocks);
             self.transaction_stage_inode_with_csum(transaction, inode)?;
             Ok(Some(block_id))
         }

--- a/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4_defs/xattr.rs
@@ -202,7 +202,7 @@ pub struct XattrEntry {
     value_inum: u32,
     /// Length of attribute value.
     value_size: u32,
-    /// Hash value of attribute name and attribute value (UNUSED by now)
+    /// Linux hash of the stored name suffix and padded inline value
     hash: u32,
     /// Attribute name, max 255 bytes.
     name: [u8; 255],
@@ -507,7 +507,37 @@ impl XattrBlock {
         // Insert value to `[ins_value_pos-ins_value_size, ins_value_pos)`
         self.0.write_offset(ins_value_pos - ins_value_size, value);
 
+        self.rehash();
         true
+    }
+
+    /// Linux ext4_xattr_hash_entry/ext4_xattr_rehash. The namespace prefix
+    /// is encoded separately and is not part of the entry hash. Inline values
+    /// are hashed as zero-padded little-endian words, including the final word.
+    fn rehash(&mut self) {
+        let mut offset = size_of::<XattrHeader>();
+        let mut block_hash = 0u32;
+        let mut shareable = true;
+        while self.0.data[offset] != 0 {
+            let mut entry: XattrEntry = self.0.read_offset_as(offset);
+            let mut hash = 0u32;
+            for byte in &entry.name[..entry.name_len as usize] {
+                hash = hash.rotate_left(5) ^ u32::from(*byte);
+            }
+            let start = entry.value_offset as usize;
+            let end = start + (entry.value_size as usize).div_ceil(4) * 4;
+            for word in self.0.data[start..end].chunks_exact(4) {
+                hash = hash.rotate_left(16) ^ u32::from_le_bytes(word.try_into().unwrap());
+            }
+            entry.hash = hash;
+            shareable &= hash != 0;
+            block_hash = block_hash.rotate_left(16) ^ hash;
+            self.0.write_offset_as(offset, &entry);
+            offset += entry.used_size();
+        }
+        let mut header: XattrHeader = self.0.read_offset_as(0);
+        header.hash = if shareable { block_hash } else { 0 };
+        self.0.write_offset_as(0, &header);
     }
 
     /// Remove a xattr entry from the block. Return true if success.
@@ -577,6 +607,7 @@ impl XattrBlock {
             p_entry2 += entry.used_size();
         }
 
+        self.rehash();
         true
     }
 }
@@ -584,6 +615,27 @@ impl XattrBlock {
 #[cfg(test)]
 mod release_tests {
     use super::*;
+
+    #[test]
+    fn mutation_hashes_name_suffix_and_padded_values_like_linux() {
+        let mut block = XattrBlock::new(Block::new(9, Box::new([0; BLOCK_SIZE])));
+        block.init();
+        assert!(block.insert("user.a", &[1, 2, 3]));
+        let first: XattrEntry = block.0.read_offset_as(size_of::<XattrHeader>());
+        assert_eq!(first.hash, 0x0062_0201);
+        let header: XattrHeader = block.0.read_offset_as(0);
+        assert_eq!(header.hash, first.hash);
+        assert!(block.remove("user.a"));
+        assert_eq!(block.0.read_offset_as::<XattrHeader>(0).hash, 0);
+        assert!(block.insert("user.a", &[]));
+        assert_eq!(
+            block
+                .0
+                .read_offset_as::<XattrEntry>(size_of::<XattrHeader>())
+                .hash,
+            97
+        );
+    }
 
     fn add_inline_entry(
         bytes: &mut [u8; BLOCK_SIZE],

--- a/kernel/crates/another_ext4/src/lib.rs
+++ b/kernel/crates/another_ext4/src/lib.rs
@@ -15,9 +15,9 @@ mod prelude;
 pub use constants::{BLOCK_SIZE, EXT4_ROOT_INO, INODE_BLOCK_SIZE};
 pub use error::{ErrCode, Ext4Error};
 pub use ext4::{
-    DelallocAppendBlockPublication, DelallocAppendBlockReservation,
+    BatchProgress, DelallocAppendBlockPublication, DelallocAppendBlockReservation,
     DelallocAppendBlockSubmitOutcome, DelallocAppendMapperAuthority, DelallocExtentNodePool,
-    DelallocLease, Ext4, InodeOwner, MetadataMutationWaker, SetAttr,
+    DelallocLease, Ext4, InodeOwner, MetadataMutationWaker, MetadataWriterWait, SetAttr,
 };
 // The bounded append mapper implementation is compiled in normal builds, but
 // its raw facade remains test-only until the DragonOS VFS can supply the

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -12,7 +12,7 @@ use crate::{
         vfs::{
             self,
             fcntl::AtFlags,
-            mount::MountFlags,
+            mount::{MountFlags, SuperBlockState},
             utils::{user_path_at, DName},
             vcore::try_find_gendisk,
             EvictionEpoch, FileSystem, FileSystemMakerData, FsReconfigureRequest, IndexNode,
@@ -29,7 +29,7 @@ use crate::{
         fault::{PageFaultHandler, PageFaultMessage},
         VmFaultReason,
     },
-    process::ProcessManager,
+    process::{namespace::user_namespace::UserNamespace, ProcessManager},
     register_mountable_fs,
 };
 use alloc::{
@@ -47,7 +47,10 @@ use lazy_static::lazy_static;
 use linkme::distributed_slice;
 use system_error::SystemError;
 
-use super::inode::LockedExt4Inode;
+use super::{
+    inode::LockedExt4Inode,
+    journal::{Ext4Journal, Ext4JournalSyncRequest, Ext4MetadataMutationWait},
+};
 
 #[derive(Debug)]
 struct CanonicalInodeEntry {
@@ -69,28 +72,27 @@ lazy_static! {
     /// Locates the mount-serialization domain for each block device.  The
     /// global lock covers only this in-memory lookup; recovery and writeback
     /// are serialized by the selected device domain.
-    static ref EXT4_DELALLOC_MOUNT_REGISTRY:
+    static ref EXT4_MOUNT_REGISTRY:
         Mutex<BTreeMap<usize, Weak<Ext4MountDomain>>> = Mutex::new(BTreeMap::new());
 }
 
 #[derive(Debug)]
 struct Ext4MountDomain {
-    /// Multiple mounts remain allowed; until VFS shares one canonical
-    /// superblock, publishing a second writable instance permanently disables
-    /// delayed admission on both sides after draining the first.
-    instances: Mutex<Vec<Weak<Ext4FileSystem>>>,
+    /// One complete superblock per device, including PageCache/inode identity.
+    /// This sleeping lock serializes initial recovery and publication only.
+    canonical: Mutex<Weak<Ext4FileSystem>>,
 }
 
 impl Default for Ext4MountDomain {
     fn default() -> Self {
         Self {
-            instances: Mutex::new(Vec::new()),
+            canonical: Mutex::new(Weak::new()),
         }
     }
 }
 
 fn ext4_mount_domain(device: usize) -> Arc<Ext4MountDomain> {
-    let mut registry = EXT4_DELALLOC_MOUNT_REGISTRY.lock();
+    let mut registry = EXT4_MOUNT_REGISTRY.lock();
     registry.retain(|_, domain| domain.strong_count() != 0);
     if let Some(domain) = registry.get(&device).and_then(Weak::upgrade) {
         return domain;
@@ -100,42 +102,17 @@ fn ext4_mount_domain(device: usize) -> Arc<Ext4MountDomain> {
     domain
 }
 
-#[derive(Default)]
-struct DelallocAdmissionRollback {
-    reopen: Vec<Arc<Ext4FileSystem>>,
-    committed: bool,
-}
-
-impl DelallocAdmissionRollback {
-    fn record(&mut self, fs: Arc<Ext4FileSystem>) {
-        self.reopen.push(fs);
-    }
-
-    fn commit(&mut self) {
-        self.committed = true;
-    }
-}
-
-impl Drop for DelallocAdmissionRollback {
-    fn drop(&mut self) {
-        if self.committed {
-            return;
-        }
-        for fs in &self.reopen {
-            fs.reopen_delalloc_admission_after_failed_mount();
-        }
-    }
-}
-
 pub(crate) fn prepare_stats_report() -> String {
     let mut report = String::new();
     let mut registry = EXT4_STATS_REGISTRY.lock();
     registry.retain(|entry| entry.strong_count() != 0);
     for entry in registry.iter().filter_map(Weak::upgrade) {
         let snapshot = entry.fs.prepare_stats_snapshot();
+        let batch = entry.fs.batch_progress();
+        let batch_snapshot = batch.unwrap_or_default();
         let _ = writeln!(
             report,
-            "device={} generation={} enabled={} journal={} reliable_flush={} write_barrier={} calls={} requested_blocks={} mapped_blocks={} missing_blocks={} failures={} elapsed_cycles={} bitmap_io={} gdt_io={} superblock_io={} inode_io={} extent_io={} zero_io={}",
+            "device={} generation={} enabled={} journal={} reliable_flush={} write_barrier={} calls={} requested_blocks={} mapped_blocks={} missing_blocks={} failures={} elapsed_cycles={} bitmap_io={} gdt_io={} superblock_io={} inode_io={} extent_io={} zero_io={} batch={} accepted={} durable={} running={} frozen={} failed={}",
             entry.raw_dev.data(),
             snapshot.generation,
             snapshot.enabled as usize,
@@ -154,6 +131,12 @@ pub(crate) fn prepare_stats_report() -> String {
             snapshot.inode_io,
             snapshot.extent_io,
             snapshot.zero_io,
+            batch.is_some() as usize,
+            batch_snapshot.accepted,
+            batch_snapshot.durable,
+            batch_snapshot.running_blocks,
+            batch_snapshot.frozen_blocks,
+            batch_snapshot.failed as usize,
         );
     }
     report
@@ -167,26 +150,8 @@ pub(super) struct Ext4InodeTombstone {
     resolved: bool,
 }
 
-#[derive(Debug)]
-struct Ext4MetadataMutationWait {
-    wait_queue: WaitQueue,
-}
-
-impl Ext4MetadataMutationWait {
-    fn new() -> Self {
-        Self {
-            wait_queue: WaitQueue::default(),
-        }
-    }
-}
-
-impl another_ext4::MetadataMutationWaker for Ext4MetadataMutationWait {
-    fn wake_all(&self) {
-        self.wait_queue.wake_all();
-    }
-}
-
 pub struct Ext4FileSystem {
+    pub(super) journal: Option<Arc<Ext4Journal>>,
     pub(super) writeback_domain: Arc<PageCacheWritebackDomain>,
     /// 对应 another_ext4 中的实际文件系统
     pub(super) fs: another_ext4::Ext4,
@@ -207,6 +172,8 @@ pub struct Ext4FileSystem {
     /// Keeps this device's mount-serialization domain alive for the complete
     /// filesystem lifetime.
     _mount_domain: Arc<Ext4MountDomain>,
+    mount_owner: Arc<UserNamespace>,
+    mount_state: Mutex<Option<Arc<SuperBlockState>>>,
 
     /// Unique lower authority and strong owners for the Stage-3b single-head
     /// delayed mapper.  An inode is present exactly while it owns a live
@@ -333,6 +300,30 @@ impl Ext4MountOptions {
 }
 
 impl FileSystem for Ext4FileSystem {
+    fn begin_sync_writeback(&self) -> Option<alloc::boxed::Box<dyn vfs::FileSystemSyncGuard>> {
+        self.begin_journal_sync().map(|guard| {
+            alloc::boxed::Box::new(guard) as alloc::boxed::Box<dyn vfs::FileSystemSyncGuard>
+        })
+    }
+
+    fn shared_mount_superblock_state(&self, flags: MountFlags) -> Option<Arc<SuperBlockState>> {
+        let mut state = self.mount_state.lock();
+        Some(
+            state
+                .get_or_insert_with(|| {
+                    Arc::new(SuperBlockState::new_with_owner(
+                        flags,
+                        self.mount_owner.clone(),
+                    ))
+                })
+                .clone(),
+        )
+    }
+
+    fn mount_owner_user_ns(&self) -> Option<Arc<UserNamespace>> {
+        Some(self.mount_owner.clone())
+    }
+
     fn page_cache_writeback_domain(&self) -> Option<&Arc<PageCacheWritebackDomain>> {
         Some(&self.writeback_domain)
     }
@@ -425,6 +416,7 @@ impl FileSystem for Ext4FileSystem {
     }
 
     fn sync_fs(&self, wait: bool) -> Result<(), SystemError> {
+        let _sync_request = wait.then(|| self.begin_journal_sync());
         let flush_result = self.flush_dirty_inodes();
         let eviction_epoch = wait.then(|| {
             // Capture after dirty metadata flush: releasing the last AsyncWork
@@ -441,11 +433,7 @@ impl FileSystem for Ext4FileSystem {
             flush_result
         };
         if wait {
-            if self._mount_options.write_barrier {
-                result.and_then(|_| self.fs.flush_device().map_err(SystemError::from))
-            } else {
-                result
-            }
+            result.and_then(|_| self.finish_sync_durability_boundary())
         } else {
             result
         }
@@ -455,11 +443,15 @@ impl FileSystem for Ext4FileSystem {
         if self._mount_options.read_only {
             return;
         }
-        if let Err(error) = self.flush_dirty_inodes() {
-            log::error!(
-                "ext4: failed final metadata sync after delayed-map drain: {:?}",
-                error
-            );
+        let flush = self.flush_dirty_inodes();
+        // Always drain/join, including a preceding metadata error. Published
+        // completion owners cannot be discarded by an early-return error path.
+        let drained = self
+            .journal
+            .as_ref()
+            .map_or(Ok(()), |journal| journal.shutdown(self));
+        if let Err(error) = flush.and(drained) {
+            log::error!("ext4: final journal drain failed: {:?}", error);
             self.fail_stop_lifecycle();
             self.terminalize_idle_delalloc_after_fail_stop();
             return;
@@ -507,13 +499,60 @@ impl Ext4FileSystem {
 
     pub(super) fn retry_metadata_contention<T>(
         &self,
-        mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
+        operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
     ) -> Result<T, SystemError> {
+        self.retry_metadata_operation(operation, true)
+    }
+
+    /// Sample after releasing the previous preference: its Drop itself wakes
+    /// readers. Waiting on the earlier token would otherwise self-wake a busy
+    /// retry loop while an unrelated reader is still doing I/O.
+    pub(super) fn prepare_metadata_writer_wait(
+        &self,
+        observed: u64,
+    ) -> core::result::Result<
+        (u64, Option<another_ext4::MetadataWriterWait<'_>>),
+        another_ext4::Ext4Error,
+    > {
+        let after_release = self.fs.metadata_mutation_generation();
+        let intent = self.fs.begin_metadata_writer_wait()?;
+        let observed = if intent.is_some() {
+            after_release
+        } else {
+            observed
+        };
+        Ok((observed, intent))
+    }
+
+    pub(super) fn retry_metadata_read_contention<T>(
+        &self,
+        operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
+    ) -> Result<T, SystemError> {
+        self.retry_metadata_operation(operation, false)
+    }
+
+    fn retry_metadata_operation<T>(
+        &self,
+        mut operation: impl FnMut() -> core::result::Result<T, another_ext4::Ext4Error>,
+        writer: bool,
+    ) -> Result<T, SystemError> {
+        let mut writer_wait = None;
         loop {
             let observed = self.fs.metadata_mutation_generation();
-            match operation() {
+            let result = operation();
+            // A preference spans one wait and the following attempt only.
+            // Capacity waits at an idle gate must not block public readers.
+            drop(writer_wait.take());
+            match result {
                 Ok(value) => return Ok(value),
                 Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                    let observed = if writer {
+                        let (observed, intent) = self.prepare_metadata_writer_wait(observed)?;
+                        writer_wait = intent;
+                        observed
+                    } else {
+                        observed
+                    };
                     self.wait_metadata_mutation_progress(observed)?;
                 }
                 Err(error) => return Err(error.into()),
@@ -557,18 +596,6 @@ impl Ext4FileSystem {
         self.delalloc_admission_open.store(false, Ordering::Release);
     }
 
-    /// Restore admission on a healthy mapper-owning filesystem after a
-    /// prospective sibling writable mount failed.
-    ///
-    /// The caller holds the per-device mount-domain lock, so a successful
-    /// reopen cannot race publication of another writable instance.
-    fn reopen_delalloc_admission_after_failed_mount(&self) {
-        let lifecycle_error = self.lifecycle_error.lock();
-        if self.delalloc_mapper_authority.is_some() && lifecycle_error.is_none() {
-            self.delalloc_admission_open.store(true, Ordering::Release);
-        }
-    }
-
     fn drain_registered_delalloc(&self) -> Result<(), SystemError> {
         loop {
             let owners: Vec<_> = self.delalloc_inodes.lock().values().cloned().collect();
@@ -602,10 +629,26 @@ impl Ext4FileSystem {
     /// writeback, rather than flushing every ordinary metadata transaction.
     /// Read-only and `nobarrier` mounts do not issue a device flush.
     pub(super) fn finish_sync_durability_boundary(&self) -> Result<(), SystemError> {
-        if self._mount_options.read_only || !self._mount_options.write_barrier {
+        if self._mount_options.read_only {
             return Ok(());
         }
-        self.fs.flush_device().map_err(SystemError::from)
+        if let Some(journal) = &self.journal {
+            let target = self
+                .fs
+                .batch_progress()
+                .expect("journal worker requires batch mode")
+                .accepted;
+            journal.wait_through(target)?;
+        }
+        if self._mount_options.write_barrier {
+            self.fs.flush_device().map_err(SystemError::from)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(super) fn begin_journal_sync(&self) -> Option<Ext4JournalSyncRequest> {
+        self.journal.as_ref().map(Ext4Journal::sync_request)
     }
 
     pub(super) fn schedule_inode_eviction(
@@ -1281,29 +1324,38 @@ impl Ext4FileSystem {
         lazy_static::initialize(&EXT4_EVICTION_WQ);
         let raw_dev = mount_data.device_num();
         let mount_domain = ext4_mount_domain(raw_dev.data() as usize);
-        let mut mounted_instances = mount_domain.instances.lock();
-        let existing_writable: Vec<_> = {
-            mounted_instances.retain(|entry| entry.strong_count() != 0);
-            mounted_instances
-                .iter()
-                .filter_map(Weak::upgrade)
-                .filter(|fs| !fs._mount_options.read_only)
-                .collect()
-        };
-        let mut admission_rollback = DelallocAdmissionRollback::default();
-        if !mount_options.read_only {
-            for existing in &existing_writable {
-                let was_open = existing.delalloc_admission_open();
-                if was_open {
-                    // Record before close/drain so every failure exit restores
-                    // this instance, including an error from the drain itself.
-                    admission_rollback.record(existing.clone());
+        let owner = ProcessManager::current_user_ns();
+        let mut canonical = mount_domain.canonical.lock();
+        loop {
+            let Some(existing) = canonical.upgrade() else {
+                break;
+            };
+            let existing_state = existing.mount_state.lock().clone();
+            if let Some(state) = existing_state {
+                if state.shutdown_started() {
+                    // Final shutdown may need the filesystem/device domain.
+                    // Never wait for it while holding the factory lock.
+                    drop(canonical);
+                    state.wait_for_shutdown_if_started();
+                    canonical = mount_domain.canonical.lock();
+                    if canonical
+                        .upgrade()
+                        .is_some_and(|current| Arc::ptr_eq(&current, &existing))
+                    {
+                        *canonical = Weak::new();
+                    }
+                    continue;
                 }
-                existing.close_delalloc_admission();
-                existing.drain_registered_delalloc()?;
             }
+            if existing._mount_options.read_only != mount_options.read_only
+                || !Arc::ptr_eq(&existing.mount_owner, &owner)
+            {
+                return Err(SystemError::EBUSY);
+            }
+            // Like get_tree_bdev, a compatible mount reuses the existing
+            // configuration and never replays a live filesystem's journal.
+            return Ok(existing);
         }
-        let delalloc_unique_writable = !mount_options.read_only && existing_writable.is_empty();
         // Writable mounts recover the journal and the validated legacy orphan
         // chain before this filesystem is published to the VFS.
         let prospective = (|| {
@@ -1318,14 +1370,24 @@ impl Ext4FileSystem {
             let root_attr = fs.getattr(another_ext4::EXT4_ROOT_INO)?;
             Ok::<_, SystemError>((fs, root_attr))
         })();
-        let (fs, root_attr) = prospective?;
+        let (mut fs, root_attr) = prospective?;
+        // Recovery is complete. Every runtime metadata path now uses the
+        // authoritative batch view before this mount becomes visible.
+        fs.enable_batching(256)?;
         let metadata_mutation_wait = Arc::new(Ext4MetadataMutationWait::new());
         fs.install_metadata_mutation_waker(metadata_mutation_wait.clone())?;
-        let delalloc_mapper_authority = if !delalloc_unique_writable {
+        let delalloc_mapper_authority = if mount_options.read_only {
             None
         } else {
             fs.delalloc_append_mapper_authority().ok()
         };
+        let journal = fs
+            .batch_progress()
+            .map(|_| Ext4Journal::new(metadata_mutation_wait.clone()))
+            .transpose()?;
+        if let Some(journal) = &journal {
+            fs.install_batch_progress_waker(journal.progress_waker());
+        }
         let root_inode: Arc<LockedExt4Inode> =
             Arc::new_cyclic(|self_ref: &Weak<LockedExt4Inode>| LockedExt4Inode {
                 inner: Mutex::new(Ext4Inode::new_mount_root(
@@ -1348,6 +1410,7 @@ impl Ext4FileSystem {
             });
 
         let fs = Arc::new(Ext4FileSystem {
+            journal,
             writeback_domain: PageCacheWritebackDomain::new(),
             fs,
             raw_dev,
@@ -1356,6 +1419,8 @@ impl Ext4FileSystem {
             dirty_inodes: Mutex::new(Vec::new()),
             inode_table: Mutex::new(BTreeMap::new()),
             _mount_domain: mount_domain.clone(),
+            mount_owner: owner,
+            mount_state: Mutex::new(None),
             delalloc_mapper_authority,
             delalloc_inodes: Mutex::new(BTreeMap::new()),
             delalloc_wait: WaitQueue::default(),
@@ -1369,14 +1434,6 @@ impl Ext4FileSystem {
             eviction_wait: WaitQueue::default(),
             _mount_options: mount_options,
         });
-        mounted_instances.push(Arc::downgrade(&fs));
-        admission_rollback.commit();
-        drop(mounted_instances);
-        let mut stats_registry = EXT4_STATS_REGISTRY.lock();
-        stats_registry.retain(|entry| entry.strong_count() != 0);
-        stats_registry.push(Arc::downgrade(&fs));
-        drop(stats_registry);
-
         let mut guard = fs.root_inode.inner.lock();
         guard.fs_ptr = Arc::downgrade(&fs);
         guard.cached_file_size = Some(root_attr.size);
@@ -1389,6 +1446,17 @@ impl Ext4FileSystem {
                 lifecycle: fs.root_inode.lifecycle().clone(),
             },
         );
+
+        if let Some(journal) = &fs.journal {
+            journal.start(&fs)?;
+        }
+        // Publish only after root back-pointers and canonical identity exist.
+        *canonical = Arc::downgrade(&fs);
+        drop(canonical);
+        let mut stats_registry = EXT4_STATS_REGISTRY.lock();
+        stats_registry.retain(|entry| entry.strong_count() != 0);
+        stats_registry.push(Arc::downgrade(&fs));
+        drop(stats_registry);
 
         Ok(fs)
     }
@@ -1428,6 +1496,11 @@ impl Drop for Ext4InodeTombstone {
 
 impl Drop for Ext4FileSystem {
     fn drop(&mut self) {
+        if let Some(journal) = &self.journal {
+            if let Err(error) = journal.stop_and_join() {
+                log::error!("ext4: journal worker cleanup failed: {:?}", error);
+            }
+        }
         if self.delalloc_inodes.lock().is_empty() {
             return;
         }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -7,10 +7,11 @@ use crate::{
             AsyncPageCacheBackend, PageCache, PageCacheBackend, PageCacheDirtyCertificate,
             PageCacheExpectedDirtyTransition, PageCacheWritebackAdmissionOrder,
             PageCacheWritebackBindResult, PageCacheWritebackCancellationContext,
-            PageCacheWritebackDescriptor, PageCacheWritebackDispatchOutcome,
-            PageCacheWritebackProgress, PageCacheWritebackProgressOutcome,
-            PageCacheWritebackProtocol, PageCacheWritebackSnapshotPhase,
-            PageCacheWritebackSubmission, PageCacheWritebackSubmitResult,
+            PageCacheWritebackCompletion, PageCacheWritebackDescriptor,
+            PageCacheWritebackDispatchOutcome, PageCacheWritebackProgress,
+            PageCacheWritebackProgressOutcome, PageCacheWritebackProtocol,
+            PageCacheWritebackSnapshotPhase, PageCacheWritebackSubmission,
+            PageCacheWritebackSubmitResult,
         },
         vfs::{
             self, syscall::RenameFlags, utils::DName, vcore::generate_inode_id, FilePrivateData,
@@ -47,6 +48,7 @@ use num::ToPrimitive;
 use system_error::SystemError;
 
 use super::filesystem::Ext4FileSystem;
+use super::journal::Ext4JournalCompletion;
 
 const WHITEOUT_DEV: DeviceNumber = DeviceNumber::new(Major::UNNAMED_MAJOR, 0);
 
@@ -734,6 +736,7 @@ struct Ext4DelayedSubmission {
     entries: Vec<ClaimedDelallocEntry>,
     claim_incarnation: u64,
     progress: Arc<Ext4DelallocProgress>,
+    completion: Option<Arc<PageCacheWritebackCompletion>>,
 }
 
 struct ClaimedDelallocEntry {
@@ -742,6 +745,22 @@ struct ClaimedDelallocEntry {
 }
 
 impl Ext4DelayedSubmission {
+    fn finish_durable(&mut self) -> Result<(), SystemError> {
+        {
+            let mut guard = self.inode.inner.lock();
+            for entry in self.entries.iter() {
+                guard.durable_mtime_version =
+                    guard.durable_mtime_version.max(entry.pending.mtime_version);
+                guard.durable_ctime_version =
+                    guard.durable_ctime_version.max(entry.pending.ctime_version);
+            }
+        }
+        self.finish_completed()?;
+        self.progress
+            .publish(PageCacheWritebackProgressOutcome::Progress);
+        Ok(())
+    }
+
     fn claimed_entries_match(
         state: &ProductionDelallocState,
         entries: &[ClaimedDelallocEntry],
@@ -946,6 +965,25 @@ impl Ext4DelayedSubmission {
     }
 }
 
+impl Ext4JournalCompletion for Ext4DelayedSubmission {
+    fn complete(mut self: Box<Self>, result: Result<(), SystemError>) {
+        let result = result.and_then(|()| self.finish_durable());
+        if let Err(error) = &result {
+            self.finish_terminal();
+            self.progress
+                .publish(PageCacheWritebackProgressOutcome::Failed(error.clone()));
+        }
+        let completion = self
+            .completion
+            .take()
+            .expect("accepted writeback owns completion");
+        // Completion can synchronously enter PageCache and release retention.
+        // Drop filesystem claim state before entering that independent domain.
+        drop(self);
+        completion.complete(result);
+    }
+}
+
 impl PageCacheWritebackSubmission for Ext4EagerSubmission {
     fn submit(
         self: Box<Self>,
@@ -985,6 +1023,31 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
             self.finish_terminal();
             return Err(SystemError::EIO);
         }
+        // Reserve bounded completion ownership before taking any mount,
+        // inode or pool lock. Publication must never be followed by ENOMEM.
+        let journal = self.fs.journal.clone();
+        let mut completion_reservation = if let Some(journal) = journal {
+            match journal.reserve_completion() {
+                Ok(reservation) => {
+                    self.completion = Some(PageCacheWritebackCompletion::new());
+                    Some(reservation)
+                }
+                Err(SystemError::ENOMEM) => {
+                    self.restore_ready(false)?;
+                    self.progress
+                        .publish(PageCacheWritebackProgressOutcome::Progress);
+                    return Err(SystemError::ENOMEM);
+                }
+                Err(error) => {
+                    self.finish_terminal();
+                    self.progress
+                        .publish(PageCacheWritebackProgressOutcome::Failed(error.clone()));
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
         let Some(authority) = self.fs.delalloc_mapper_authority.as_ref() else {
             self.finish_terminal();
             self.progress
@@ -1045,6 +1108,7 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
                 let mut pool_slot = self.inode.delalloc_pool.lock();
                 let pool = pool_slot.as_mut().ok_or(SystemError::EIO)?;
 
+                let mut writer_wait = None;
                 let outcome = loop {
                     let observed = self.fs.fs.metadata_mutation_generation();
                     let outcome = self
@@ -1056,6 +1120,7 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
                             &publications,
                             pool,
                         );
+                    drop(writer_wait.take());
                     if matches!(
                         outcome,
                         another_ext4::DelallocAppendBlockSubmitOutcome::RetryableNotPublished(
@@ -1065,23 +1130,13 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
                         // Preserve the exact claimed pages, reservations and
                         // pool while sleeping on the filesystem-wide owner
                         // which can actually make this transaction runnable.
+                        let (observed, intent) = self.fs.prepare_metadata_writer_wait(observed)?;
+                        writer_wait = intent;
                         self.fs.wait_metadata_mutation_progress(observed)?;
                         continue;
                     }
                     break outcome;
                 };
-                if matches!(
-                    outcome,
-                    another_ext4::DelallocAppendBlockSubmitOutcome::Completed
-                ) {
-                    let mut guard = self.inode.inner.lock();
-                    for entry in self.entries.iter() {
-                        guard.durable_mtime_version =
-                            guard.durable_mtime_version.max(entry.pending.mtime_version);
-                        guard.durable_ctime_version =
-                            guard.durable_ctime_version.max(entry.pending.ctime_version);
-                    }
-                }
                 Ok(outcome)
             })();
         let outcome = match outcome {
@@ -1101,10 +1156,23 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
         };
         match outcome {
             another_ext4::DelallocAppendBlockSubmitOutcome::Completed => {
-                self.finish_completed()?;
-                self.progress
-                    .publish(PageCacheWritebackProgressOutcome::Progress);
+                self.finish_durable()?;
                 Ok(PageCacheWritebackSubmitResult::Completed)
+            }
+            another_ext4::DelallocAppendBlockSubmitOutcome::Published(sequence) => {
+                let Some(reservation) = completion_reservation.take() else {
+                    self.finish_terminal();
+                    return Err(SystemError::EIO);
+                };
+                let completion = self
+                    .completion
+                    .as_ref()
+                    .expect("reserved completion")
+                    .clone();
+                // All submission locks were scoped inside the closure above.
+                // The reservation consumes this existing Box without allocation.
+                reservation.publish(sequence, self);
+                Ok(PageCacheWritebackSubmitResult::Submitted(completion))
             }
             another_ext4::DelallocAppendBlockSubmitOutcome::RetryableNotPublished(
                 another_ext4::ErrCode::EAGAIN,
@@ -1376,6 +1444,7 @@ impl PageCacheBackend for Ext4PageCacheBackend {
                     entries: claimed,
                     claim_incarnation: incarnation,
                     progress,
+                    completion: None,
                 },
             )));
         }
@@ -1602,12 +1671,18 @@ impl IndexNode for LockedExt4Inode {
             let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
-        let file_type = fs.fs.getattr(inode_num)?.ftype;
+        let file_type = fs
+            .retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+            .ftype;
         match file_type {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
-            FileType::RegularFile => fs.fs.read(inode_num, offset, buf).map_err(Into::into),
-            FileType::SymLink => fs.fs.readlink(inode_num, offset, buf).map_err(Into::into),
+            FileType::RegularFile => fs
+                .retry_metadata_read_contention(|| fs.fs.read(inode_num, offset, buf))
+                .map_err(Into::into),
+            FileType::SymLink => fs
+                .retry_metadata_read_contention(|| fs.fs.readlink(inode_num, offset, buf))
+                .map_err(Into::into),
             _ => Err(SystemError::EINVAL),
         }
     }
@@ -1709,7 +1784,9 @@ impl IndexNode for LockedExt4Inode {
                 match cached_size {
                     Some(size) => size,
                     None => {
-                        let size = fs.fs.getattr(inode_num)?.size;
+                        let size = fs
+                            .retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+                            .size;
                         self.inner.lock().cached_file_size = Some(size);
                         size
                     }
@@ -1806,7 +1883,9 @@ impl IndexNode for LockedExt4Inode {
             let guard = self.inner.lock();
             (guard.concret_fs(), guard.inner_inode_num)
         };
-        let file_type = fs.fs.getattr(inode_num)?.ftype;
+        let file_type = fs
+            .retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+            .ftype;
         match file_type {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
@@ -1855,7 +1934,8 @@ impl IndexNode for LockedExt4Inode {
             guard.children.remove(&dname);
         }
         let fs = guard.concret_fs();
-        let next_inode = fs.fs.lookup(guard.inner_inode_num, name)?;
+        let next_inode =
+            fs.retry_metadata_read_contention(|| fs.fs.lookup(guard.inner_inode_num, name))?;
         // 通过self_ref获取Arc<Self>，然后转换为Arc<dyn IndexNode>
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
         let inode =
@@ -1880,7 +1960,8 @@ impl IndexNode for LockedExt4Inode {
     fn list(&self) -> Result<Vec<String>, SystemError> {
         let _operation = self.begin_operation()?;
         let guard = self.inner.lock();
-        let dentry = guard.concret_fs().fs.listdir(guard.inner_inode_num)?;
+        let fs = guard.concret_fs();
+        let dentry = fs.retry_metadata_read_contention(|| fs.fs.listdir(guard.inner_inode_num))?;
         let mut list = Vec::new();
         for entry in dentry {
             list.push(entry.name());
@@ -1909,8 +1990,8 @@ impl IndexNode for LockedExt4Inode {
         let _other_operation = other_arc.begin_operation()?;
         let other_inode_num = other_arc.inner.lock().inner_inode_num;
 
-        let my_attr = ext4.getattr(inode_num)?;
-        let other_attr = ext4.getattr(other_inode_num)?;
+        let my_attr = fs.retry_metadata_read_contention(|| ext4.getattr(inode_num))?;
+        let other_attr = fs.retry_metadata_read_contention(|| ext4.getattr(other_inode_num))?;
 
         if my_attr.ftype != another_ext4::FileType::Directory {
             return Err(SystemError::ENOTDIR);
@@ -1920,7 +2001,10 @@ impl IndexNode for LockedExt4Inode {
             return Err(SystemError::EISDIR);
         }
 
-        if ext4.lookup(inode_num, name).is_ok() {
+        if fs
+            .retry_metadata_read_contention(|| ext4.lookup(inode_num, name))
+            .is_ok()
+        {
             return Err(SystemError::EEXIST);
         }
 
@@ -1945,12 +2029,16 @@ impl IndexNode for LockedExt4Inode {
         let fs = guard.concret_fs();
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
-        let attr = ext4.getattr(inode_num)?;
+        let attr = fs.retry_metadata_read_contention(|| ext4.getattr(inode_num))?;
         if attr.ftype != another_ext4::FileType::Directory {
             return Err(SystemError::ENOTDIR);
         }
-        let target_num = ext4.lookup(inode_num, name)?;
-        if ext4.getattr(target_num)?.ftype == FileType::Directory {
+        let target_num = fs.retry_metadata_read_contention(|| ext4.lookup(inode_num, name))?;
+        if fs
+            .retry_metadata_read_contention(|| ext4.getattr(target_num))?
+            .ftype
+            == FileType::Directory
+        {
             return Err(SystemError::EISDIR);
         }
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
@@ -1962,7 +2050,7 @@ impl IndexNode for LockedExt4Inode {
         let target_lifecycle = target.lifecycle().clone();
         let _link_mutation = target_lifecycle.lock_link_mutation();
         let _target_operation = target.begin_operation()?;
-        match ext4.lookup(inode_num, name) {
+        match fs.retry_metadata_read_contention(|| ext4.lookup(inode_num, name)) {
             Ok(current) if current == target_num => {}
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
             Err(error) => return Err(error.into()),
@@ -1990,7 +2078,7 @@ impl IndexNode for LockedExt4Inode {
                 guard.cached_file_size,
             )
         };
-        let attr = fs.fs.getattr(inode_num)?;
+        let attr = fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?;
         // Disk attributes provide non-cached fields. Read the authoritative
         // in-memory values afterwards so a concurrent atime update cannot be
         // hidden by a stale pre-getattr snapshot.
@@ -2037,6 +2125,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn sync(&self) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
+        let fs = self.inner.lock().concret_fs();
+        let _journal_sync = fs.begin_journal_sync();
         let snapshot = if let Some(page_cache) = self.page_cache() {
             let (snapshot, range) =
                 page_cache
@@ -2056,6 +2146,8 @@ impl IndexNode for LockedExt4Inode {
 
     fn datasync(&self) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
+        let fs = self.inner.lock().concret_fs();
+        let _journal_sync = fs.begin_journal_sync();
         let snapshot = if let Some(page_cache) = self.page_cache() {
             let (snapshot, range) =
                 page_cache
@@ -2089,6 +2181,8 @@ impl IndexNode for LockedExt4Inode {
         _data: PrivateData,
     ) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
+        let fs = self.inner.lock().concret_fs();
+        let _journal_sync = fs.begin_journal_sync();
         let snapshot = if let Some(page_cache) = self.page_cache() {
             let start_index = start >> MMArch::PAGE_SHIFT;
             let end_index = end >> MMArch::PAGE_SHIFT;
@@ -2385,7 +2479,10 @@ impl IndexNode for LockedExt4Inode {
                     let cached_size = self.inner.lock().cached_file_size;
                     let current_size = match cached_size {
                         Some(size) => size,
-                        None => fs.fs.getattr(inode_num)?.size,
+                        None => {
+                            fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+                                .size
+                        }
                     };
                     // After truncate_locked() asks for another unmap pass, the
                     // inode size already equals len.  Preserve that pending
@@ -2531,10 +2628,15 @@ impl IndexNode for LockedExt4Inode {
         let fs = guard.concret_fs();
         let concret_fs = &fs.fs;
         let inode_num = guard.inner_inode_num;
-        if concret_fs.getattr(inode_num)?.ftype != FileType::Directory {
+        if fs
+            .retry_metadata_read_contention(|| concret_fs.getattr(inode_num))?
+            .ftype
+            != FileType::Directory
+        {
             return Err(SystemError::ENOTDIR);
         }
-        let target_num = concret_fs.lookup(inode_num, name)?;
+        let target_num =
+            fs.retry_metadata_read_contention(|| concret_fs.lookup(inode_num, name))?;
         if target_num == inode_num {
             return Err(if name == "." {
                 SystemError::EINVAL
@@ -2542,10 +2644,18 @@ impl IndexNode for LockedExt4Inode {
                 SystemError::ENOTEMPTY
             });
         }
-        if concret_fs.getattr(target_num)?.ftype != FileType::Directory {
+        if fs
+            .retry_metadata_read_contention(|| concret_fs.getattr(target_num))?
+            .ftype
+            != FileType::Directory
+        {
             return Err(SystemError::ENOTDIR);
         }
-        if concret_fs.listdir(target_num)?.len() > 2 {
+        if fs
+            .retry_metadata_read_contention(|| concret_fs.listdir(target_num))?
+            .len()
+            > 2
+        {
             return Err(SystemError::ENOTEMPTY);
         }
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
@@ -2556,16 +2666,16 @@ impl IndexNode for LockedExt4Inode {
         )?;
         let target_lifecycle = target.lifecycle().clone();
         let _link_mutation = target_lifecycle.lock_link_mutation();
-        match concret_fs.lookup(inode_num, name) {
+        match fs.retry_metadata_read_contention(|| concret_fs.lookup(inode_num, name)) {
             Ok(current) if current == target_num => {}
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
             Err(error) => return Err(error.into()),
         }
-        let target_attr = concret_fs.getattr(target_num)?;
+        let target_attr = fs.retry_metadata_read_contention(|| concret_fs.getattr(target_num))?;
         if target_attr.ftype != FileType::Directory {
             return Err(SystemError::ENOTDIR);
         }
-        match concret_fs.listdir(target_num) {
+        match fs.retry_metadata_read_contention(|| concret_fs.listdir(target_num)) {
             Ok(entries) if entries.len() <= 2 => {}
             Ok(_) => return Err(SystemError::ENOTEMPTY),
             Err(error) => return Err(error.into()),
@@ -2589,12 +2699,16 @@ impl IndexNode for LockedExt4Inode {
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
-        if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
+        if fs
+            .retry_metadata_read_contention(|| ext4.getattr(inode_num))?
+            .ftype
+            == FileType::SymLink
+        {
             return Err(SystemError::EPERM);
         }
 
         // 调用another_ext4库的getxattr接口
-        let value = ext4.getxattr(inode_num, name)?;
+        let value = fs.retry_metadata_read_contention(|| ext4.getxattr(inode_num, name))?;
 
         // 如果缓冲区为空，只返回需要的长度
         if buf.is_empty() {
@@ -2620,7 +2734,11 @@ impl IndexNode for LockedExt4Inode {
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
-        if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
+        if fs
+            .retry_metadata_read_contention(|| ext4.getattr(inode_num))?
+            .ftype
+            == FileType::SymLink
+        {
             return Err(SystemError::EPERM);
         }
 
@@ -2640,10 +2758,11 @@ impl IndexNode for LockedExt4Inode {
     fn listxattr(&self, buf: &mut [u8]) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
         let guard = self.inner.lock();
-        let ext4 = &guard.concret_fs().fs;
+        let fs = guard.concret_fs();
+        let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
-        let names = ext4.listxattr(inode_num)?;
+        let names = fs.retry_metadata_read_contention(|| ext4.listxattr(inode_num))?;
         let total_len = names.iter().try_fold(0usize, |acc, name| {
             acc.checked_add(name.len())
                 .and_then(|len| len.checked_add(1))
@@ -2676,7 +2795,11 @@ impl IndexNode for LockedExt4Inode {
         let ext4 = &fs.fs;
         let inode_num = guard.inner_inode_num;
 
-        if ext4.getattr(inode_num)?.ftype == FileType::SymLink {
+        if fs
+            .retry_metadata_read_contention(|| ext4.getattr(inode_num))?
+            .ftype
+            == FileType::SymLink
+        {
             return Err(SystemError::EPERM);
         }
 
@@ -2709,7 +2832,11 @@ impl IndexNode for LockedExt4Inode {
         // no fallible parent lookup remains after the namespace transaction.
         let self_arc = guard.self_ref.upgrade().ok_or(SystemError::ENOENT)?;
 
-        if ext4.getattr(inode_num)?.ftype != FileType::Directory {
+        if fs
+            .retry_metadata_read_contention(|| ext4.getattr(inode_num))?
+            .ftype
+            != FileType::Directory
+        {
             return Err(SystemError::ENOTDIR);
         }
 
@@ -2819,7 +2946,10 @@ impl IndexNode for LockedExt4Inode {
         let new_dname = DName::from(new_name);
 
         // NOREPLACE check (VFS layer responsibility - ext4 lib doesn't know about flags)
-        if flags.contains(RenameFlags::NOREPLACE) && ext4.lookup(target_inode_num, new_name).is_ok()
+        if flags.contains(RenameFlags::NOREPLACE)
+            && ext4_fs
+                .retry_metadata_read_contention(|| ext4.lookup(target_inode_num, new_name))
+                .is_ok()
         {
             return Err(SystemError::EEXIST);
         }
@@ -2848,12 +2978,15 @@ impl IndexNode for LockedExt4Inode {
         }
 
         // Capture the replacement target while both parent namespace locks are held.
-        let dst_inode_num = match ext4.lookup(target_inode_num, new_name) {
+        let dst_inode_num = match ext4_fs
+            .retry_metadata_read_contention(|| ext4.lookup(target_inode_num, new_name))
+        {
             Ok(inode) => Some(inode),
-            Err(error) if error.code() == another_ext4::ErrCode::ENOENT => None,
+            Err(SystemError::ENOENT) => None,
             Err(error) => return Err(error.into()),
         };
-        let src_child_num = ext4.lookup(src_inode_num, old_name)?;
+        let src_child_num =
+            ext4_fs.retry_metadata_read_contention(|| ext4.lookup(src_inode_num, old_name))?;
         if dst_inode_num == Some(src_child_num) {
             return Ok(vfs::RenameOutcome::NoOp);
         }
@@ -2878,15 +3011,24 @@ impl IndexNode for LockedExt4Inode {
             .as_ref()
             .map(|lifecycle| lifecycle.lock_link_mutation());
         if let Some(dst_inode_num) = dst_inode_num {
-            let src_type = ext4.getattr(src_child_num)?.ftype;
-            let dst_type = ext4.getattr(dst_inode_num)?.ftype;
+            let src_type = ext4_fs
+                .retry_metadata_read_contention(|| ext4.getattr(src_child_num))?
+                .ftype;
+            let dst_type = ext4_fs
+                .retry_metadata_read_contention(|| ext4.getattr(dst_inode_num))?
+                .ftype;
             match (
                 src_type == FileType::Directory,
                 dst_type == FileType::Directory,
             ) {
                 (true, false) => return Err(SystemError::ENOTDIR),
                 (false, true) => return Err(SystemError::EISDIR),
-                (true, true) if ext4.listdir(dst_inode_num)?.len() > 2 => {
+                (true, true)
+                    if ext4_fs
+                        .retry_metadata_read_contention(|| ext4.listdir(dst_inode_num))?
+                        .len()
+                        > 2 =>
+                {
                     return Err(SystemError::ENOTEMPTY);
                 }
                 _ => {}
@@ -2907,7 +3049,10 @@ impl IndexNode for LockedExt4Inode {
                 .ok_or(SystemError::ENOENT)?;
             for _ in 0..32 {
                 let candidate = format!(".dragonos-whiteout-{}", generate_inode_id().data());
-                if ext4.lookup(src_inode_num, &candidate).is_ok() {
+                if ext4_fs
+                    .retry_metadata_read_contention(|| ext4.lookup(src_inode_num, &candidate))
+                    .is_ok()
+                {
                     continue;
                 }
                 let allocation = ext4_fs.begin_allocation()?;
@@ -3917,6 +4062,8 @@ impl LockedExt4Inode {
     }
 
     pub(super) fn drain_delalloc_before_eager(&self) -> Result<(), SystemError> {
+        let fs = self.inner.lock().concret_fs();
+        let mut journal_sync = None;
         loop {
             let (page_cache, first_page, last_page) = {
                 let guard = self.inner.lock();
@@ -3946,6 +4093,12 @@ impl LockedExt4Inode {
                     last_offset / MMArch::PAGE_SIZE,
                 )
             };
+            // Empty drains are ordinary metadata operations, not durability
+            // requests. Only force progress when a real delayed head can make
+            // the following PageCache wait depend on journal completion.
+            if journal_sync.is_none() {
+                journal_sync = fs.begin_journal_sync();
+            }
             page_cache
                 .manager()
                 .writeback_range(first_page, last_page)?;
@@ -3963,6 +4116,8 @@ impl LockedExt4Inode {
         offset: usize,
         len: usize,
     ) -> Result<(), SystemError> {
+        let fs = self.inner.lock().concret_fs();
+        let mut journal_sync = None;
         if len == 0 {
             return Ok(());
         }
@@ -4015,6 +4170,9 @@ impl LockedExt4Inode {
                     submit_last / MMArch::PAGE_SIZE,
                 )
             };
+            if journal_sync.is_none() {
+                journal_sync = fs.begin_journal_sync();
+            }
             page_cache.manager().writeback_range(batch.0, batch.1)?;
         }
 
@@ -4107,9 +4265,12 @@ impl LockedExt4Inode {
         fs: &Arc<Ext4FileSystem>,
         mut handle: another_ext4::InodeReclaimHandle,
     ) -> Result<(), (another_ext4::Ext4Error, another_ext4::InodeReclaimHandle)> {
+        let mut writer_wait = None;
         loop {
             let observed = fs.fs.metadata_mutation_generation();
-            match fs.fs.reclaim_inode(handle) {
+            let result = fs.fs.reclaim_inode(handle);
+            drop(writer_wait.take());
+            match result {
                 Ok(()) => return Ok(()),
                 Err(failure) => {
                     let (error, returned_handle) = failure.into_parts();
@@ -4117,6 +4278,13 @@ impl LockedExt4Inode {
                         return Err((error, returned_handle));
                     }
                     handle = returned_handle;
+                    let observed = match fs.prepare_metadata_writer_wait(observed) {
+                        Ok((observed, intent)) => {
+                            writer_wait = intent;
+                            observed
+                        }
+                        Err(error) => return Err((error, handle)),
+                    };
                     if fs.wait_metadata_mutation_progress(observed).is_err() {
                         return Err((
                             another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO),
@@ -4138,9 +4306,12 @@ impl LockedExt4Inode {
         let _link_mutation = lifecycle.lock_link_mutation();
         let tombstone = fs.begin_freeing(&inode)?;
         let _reuse = fs.begin_reclaim();
+        let mut writer_wait = None;
         let handle = loop {
             let observed = fs.fs.metadata_mutation_generation();
-            match fs.fs.unlink(parent_inode_num, name) {
+            let result = fs.fs.unlink(parent_inode_num, name);
+            drop(writer_wait.take());
+            match result {
                 Ok(Some(handle)) => break handle,
                 Ok(None) => {
                     let error = SystemError::EIO;
@@ -4148,6 +4319,17 @@ impl LockedExt4Inode {
                     return Err(error);
                 }
                 Err(error) if error.code() == another_ext4::ErrCode::EAGAIN => {
+                    let observed = match fs.prepare_metadata_writer_wait(observed) {
+                        Ok((observed, intent)) => {
+                            writer_wait = intent;
+                            observed
+                        }
+                        Err(error) => {
+                            let error = SystemError::from(error);
+                            let _ = fs.poison_freeing(tombstone, error.clone());
+                            return Err(error);
+                        }
+                    };
                     if let Err(error) = fs.wait_metadata_mutation_progress(observed) {
                         let _ = fs.poison_freeing(tombstone, error.clone());
                         return Err(error);
@@ -4297,7 +4479,7 @@ impl LockedExt4Inode {
         parent: Option<Weak<LockedExt4Inode>>,
     ) -> Result<Arc<Self>, SystemError> {
         let fs = fs_ptr.upgrade().ok_or(SystemError::EIO)?;
-        let attr = fs.fs.getattr(inode_num)?;
+        let attr = fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?;
         Self::new_with_attr(inode_num, fs_ptr, dname, parent, &attr)
     }
 
@@ -4712,7 +4894,10 @@ impl LockedExt4Inode {
         let size = if size_dirty {
             Some(match cached_size {
                 Some(size) => size,
-                None => fs.fs.getattr(inode_num)?.size,
+                None => {
+                    fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+                        .size
+                }
             })
         } else {
             None
@@ -4785,7 +4970,9 @@ impl LockedExt4Inode {
             let file_size = match guard.cached_file_size {
                 Some(size) => size,
                 None => {
-                    let size = fs.fs.getattr(guard.inner_inode_num)?.size;
+                    let size = fs
+                        .retry_metadata_read_contention(|| fs.fs.getattr(guard.inner_inode_num))?
+                        .size;
                     guard.cached_file_size = Some(size);
                     size
                 }

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -1677,12 +1677,12 @@ impl IndexNode for LockedExt4Inode {
         match file_type {
             FileType::Directory => Err(SystemError::EISDIR),
             FileType::Unknown => Err(SystemError::EROFS),
-            FileType::RegularFile => fs
-                .retry_metadata_read_contention(|| fs.fs.read(inode_num, offset, buf))
-                .map_err(Into::into),
-            FileType::SymLink => fs
-                .retry_metadata_read_contention(|| fs.fs.readlink(inode_num, offset, buf))
-                .map_err(Into::into),
+            FileType::RegularFile => {
+                fs.retry_metadata_read_contention(|| fs.fs.read(inode_num, offset, buf))
+            }
+            FileType::SymLink => {
+                fs.retry_metadata_read_contention(|| fs.fs.readlink(inode_num, offset, buf))
+            }
             _ => Err(SystemError::EINVAL),
         }
     }
@@ -2053,7 +2053,7 @@ impl IndexNode for LockedExt4Inode {
         match fs.retry_metadata_read_contention(|| ext4.lookup(inode_num, name)) {
             Ok(current) if current == target_num => {}
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(error),
         }
         let reclaim = fs.retry_metadata_contention(|| ext4.unlink(inode_num, name))?;
         let outcome = if reclaim.is_some() {
@@ -2669,7 +2669,7 @@ impl IndexNode for LockedExt4Inode {
         match fs.retry_metadata_read_contention(|| concret_fs.lookup(inode_num, name)) {
             Ok(current) if current == target_num => {}
             Ok(_) => return Err(SystemError::EAGAIN_OR_EWOULDBLOCK),
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(error),
         }
         let target_attr = fs.retry_metadata_read_contention(|| concret_fs.getattr(target_num))?;
         if target_attr.ftype != FileType::Directory {
@@ -2678,7 +2678,7 @@ impl IndexNode for LockedExt4Inode {
         match fs.retry_metadata_read_contention(|| concret_fs.listdir(target_num)) {
             Ok(entries) if entries.len() <= 2 => {}
             Ok(_) => return Err(SystemError::ENOTEMPTY),
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(error),
         }
         let reclaim = fs.retry_metadata_contention(|| concret_fs.rmdir(inode_num, name))?;
         target.handoff_namespace_reclaim(reclaim)?;
@@ -2983,7 +2983,7 @@ impl IndexNode for LockedExt4Inode {
         {
             Ok(inode) => Some(inode),
             Err(SystemError::ENOENT) => None,
-            Err(error) => return Err(error.into()),
+            Err(error) => return Err(error),
         };
         let src_child_num =
             ext4_fs.retry_metadata_read_contention(|| ext4.lookup(src_inode_num, old_name))?;

--- a/kernel/src/filesystem/ext4/journal.rs
+++ b/kernel/src/filesystem/ext4/journal.rs
@@ -1,0 +1,528 @@
+//! Mount-owned batch scheduling and bounded completion ownership.
+//!
+//! The disk worker never runs inode cleanup. Cleanup has a separate thread:
+//! it may need io/pool locks held by a caller waiting for another disk batch.
+//! Both workers use weak owners while asleep and are joined at final unmount.
+
+use super::filesystem::Ext4FileSystem;
+use crate::{
+    libs::{mutex::Mutex, wait_queue::WaitQueue},
+    process::{
+        kthread::{KernelThreadClosure, KernelThreadMechanism},
+        ProcessControlBlock, ProcessManager,
+    },
+    time::{Duration, Instant},
+};
+use alloc::{
+    boxed::Box,
+    string::ToString,
+    sync::{Arc, Weak},
+    vec::Vec,
+};
+use core::{
+    fmt,
+    sync::atomic::{AtomicU64, Ordering},
+};
+use system_error::SystemError;
+
+const COMPLETION_SLOTS: usize = 128;
+const COMMIT_DEADLINE_US: u64 = 100_000;
+
+/// Gate progress wakes only foreground metadata retries. In particular a
+/// read-view release must not schedule journal or completion work.
+pub(super) struct Ext4MetadataMutationWait {
+    pub(super) wait_queue: WaitQueue,
+}
+impl Ext4MetadataMutationWait {
+    pub(super) fn new() -> Self {
+        Self {
+            wait_queue: WaitQueue::default(),
+        }
+    }
+}
+impl kdepends::another_ext4::MetadataMutationWaker for Ext4MetadataMutationWait {
+    fn wake_all(&self) {
+        self.wait_queue.wake_all();
+    }
+}
+
+/// Batch progress additionally drives the disk worker. Capacity/checkpoint
+/// changes also unblock foreground retries whose generation includes batch state.
+struct JournalWake {
+    wait_queue: WaitQueue,
+    event: AtomicU64,
+    first_notification: AtomicU64,
+    metadata: Arc<Ext4MetadataMutationWait>,
+}
+impl JournalWake {
+    fn notify(&self) {
+        if self.first_notification.load(Ordering::Relaxed) == 0 {
+            let _ = self.first_notification.compare_exchange(
+                0,
+                now_us(),
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            );
+        }
+        self.event.fetch_add(1, Ordering::Release);
+        self.wait_queue.wake_all();
+    }
+}
+impl kdepends::another_ext4::MetadataMutationWaker for JournalWake {
+    fn wake_all(&self) {
+        self.metadata.wait_queue.wake_all();
+        self.notify();
+    }
+}
+
+fn now_us() -> u64 {
+    Instant::now().total_micros().max(1) as u64
+}
+
+/// A pre-existing boxed submission can implement this directly. In particular,
+/// registration after Published must not allocate a boxed closure or queue node.
+pub(super) trait Ext4JournalCompletion: Send {
+    fn complete(self: Box<Self>, result: Result<(), SystemError>);
+}
+
+enum CompletionSlot {
+    Free,
+    Reserved,
+    Pending {
+        sequence: u64,
+        context: Box<dyn Ext4JournalCompletion>,
+    },
+    Completing,
+}
+
+struct JournalState {
+    slots: Vec<CompletionSlot>,
+    in_flight: usize,
+    durable: u64,
+    error: Option<SystemError>,
+    error_reported: bool,
+    closed: bool,
+    stopping: bool,
+    sync_requests: usize,
+}
+
+pub(super) struct Ext4Journal {
+    filesystem: Mutex<Weak<Ext4FileSystem>>,
+    state: Mutex<JournalState>,
+    wake: Arc<JournalWake>,
+    completion_wait: Arc<WaitQueue>,
+    disk_worker: Mutex<Option<Arc<ProcessControlBlock>>>,
+    completion_worker: Mutex<Option<Arc<ProcessControlBlock>>>,
+}
+
+impl fmt::Debug for Ext4Journal {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let state = self.state.lock();
+        f.debug_struct("Ext4Journal")
+            .field("in_flight", &state.in_flight)
+            .field("durable", &state.durable)
+            .field("closed", &state.closed)
+            .finish()
+    }
+}
+
+pub(super) struct Ext4CompletionReservation {
+    journal: Arc<Ext4Journal>,
+    slot: Option<usize>,
+}
+
+impl Ext4CompletionReservation {
+    /// Infallible ownership transfer after logical publication, including
+    /// publication racing failure or an already-advanced durable frontier.
+    pub(super) fn publish(mut self, sequence: u64, context: Box<dyn Ext4JournalCompletion>) {
+        let index = self
+            .slot
+            .take()
+            .expect("completion reservation consumed once");
+        let force = {
+            let mut state = self.journal.state.lock();
+            assert!(matches!(state.slots[index], CompletionSlot::Reserved));
+            state.slots[index] = CompletionSlot::Pending { sequence, context };
+            state.sync_requests != 0
+        };
+        if force {
+            self.journal.request_commit();
+        }
+        self.journal.completion_wait.wake_all();
+    }
+}
+
+impl Drop for Ext4CompletionReservation {
+    fn drop(&mut self) {
+        if let Some(index) = self.slot.take() {
+            self.journal.release_slot(index);
+        }
+    }
+}
+
+pub(super) struct Ext4JournalSyncRequest {
+    journal: Arc<Ext4Journal>,
+}
+
+impl crate::filesystem::vfs::FileSystemSyncGuard for Ext4JournalSyncRequest {}
+
+impl Drop for Ext4JournalSyncRequest {
+    fn drop(&mut self) {
+        let mut state = self.journal.state.lock();
+        debug_assert!(state.sync_requests != 0);
+        state.sync_requests -= 1;
+    }
+}
+
+impl Ext4Journal {
+    pub(super) fn new(wake: Arc<Ext4MetadataMutationWait>) -> Result<Arc<Self>, SystemError> {
+        let mut slots = Vec::new();
+        slots
+            .try_reserve_exact(COMPLETION_SLOTS)
+            .map_err(|_| SystemError::ENOMEM)?;
+        slots.resize_with(COMPLETION_SLOTS, || CompletionSlot::Free);
+        Ok(Arc::new(Self {
+            filesystem: Mutex::new(Weak::new()),
+            state: Mutex::new(JournalState {
+                slots,
+                in_flight: 0,
+                durable: 0,
+                error: None,
+                error_reported: false,
+                closed: false,
+                stopping: false,
+                sync_requests: 0,
+            }),
+            wake: Arc::new(JournalWake {
+                wait_queue: WaitQueue::default(),
+                event: AtomicU64::new(0),
+                first_notification: AtomicU64::new(0),
+                metadata: wake,
+            }),
+            completion_wait: Arc::new(WaitQueue::default()),
+            disk_worker: Mutex::new(None),
+            completion_worker: Mutex::new(None),
+        }))
+    }
+
+    pub(super) fn progress_waker(&self) -> Arc<dyn kdepends::another_ext4::MetadataMutationWaker> {
+        self.wake.clone()
+    }
+
+    /// Called once, after the filesystem root is initialized but before the
+    /// canonical device instance is visible to a mount caller.
+    pub(super) fn start(self: &Arc<Self>, fs: &Arc<Ext4FileSystem>) -> Result<(), SystemError> {
+        *self.filesystem.lock() = Arc::downgrade(fs);
+        let weak = Arc::downgrade(self);
+        let wake = self.wake.clone();
+        let disk = KernelThreadMechanism::create_and_run(
+            KernelThreadClosure::EmptyClosure((
+                Box::new(move || disk_loop(weak.clone(), wake.clone())),
+                (),
+            )),
+            "ext4_journal".to_string(),
+        )
+        .ok_or(SystemError::ENOMEM)?;
+        *self.disk_worker.lock() = Some(disk);
+        let weak = Arc::downgrade(self);
+        let wake = self.completion_wait.clone();
+        let completion = KernelThreadMechanism::create_and_run(
+            KernelThreadClosure::EmptyClosure((
+                Box::new(move || completion_loop(weak.clone(), wake.clone())),
+                (),
+            )),
+            "ext4_complete".to_string(),
+        );
+        let Some(completion) = completion else {
+            let _ = self.stop_and_join();
+            return Err(SystemError::ENOMEM);
+        };
+        *self.completion_worker.lock() = Some(completion);
+        self.wake.notify();
+        Ok(())
+    }
+
+    fn try_reserve(self: &Arc<Self>) -> Option<Result<Ext4CompletionReservation, SystemError>> {
+        let mut state = self.state.lock();
+        if let Some(error) = state.error.clone() {
+            return Some(Err(error));
+        }
+        if state.closed || state.stopping {
+            return Some(Err(SystemError::EROFS));
+        }
+        let index = state
+            .slots
+            .iter()
+            .position(|slot| matches!(slot, CompletionSlot::Free))?;
+        state.slots[index] = CompletionSlot::Reserved;
+        state.in_flight += 1;
+        Some(Ok(Ext4CompletionReservation {
+            journal: self.clone(),
+            slot: Some(index),
+        }))
+    }
+
+    /// Must be called without inode, admission, pool or metadata locks. On
+    /// capacity pressure both progress producers remain independently runnable,
+    /// even if every bounded PageCache worker is waiting for a reservation.
+    pub(super) fn reserve_completion(
+        self: &Arc<Self>,
+    ) -> Result<Ext4CompletionReservation, SystemError> {
+        if let Some(result) = self.try_reserve() {
+            return result;
+        }
+        self.request_commit();
+        self.completion_wait.wait_until_io(|| self.try_reserve())
+    }
+
+    fn release_slot(&self, index: usize) {
+        {
+            let mut state = self.state.lock();
+            debug_assert!(matches!(
+                state.slots[index],
+                CompletionSlot::Reserved | CompletionSlot::Completing
+            ));
+            state.slots[index] = CompletionSlot::Free;
+            debug_assert!(state.in_flight != 0);
+            state.in_flight -= 1;
+        }
+        self.completion_wait.wake_all();
+    }
+
+    pub(super) fn sync_request(self: &Arc<Self>) -> Ext4JournalSyncRequest {
+        {
+            let mut state = self.state.lock();
+            state.sync_requests = state
+                .sync_requests
+                .checked_add(1)
+                .expect("sync request count overflow");
+        }
+        self.request_commit();
+        Ext4JournalSyncRequest {
+            journal: self.clone(),
+        }
+    }
+
+    fn request_commit(&self) {
+        let filesystem = self.filesystem.lock().upgrade();
+        if let Some(fs) = filesystem {
+            fs.fs.request_batch_commit();
+        }
+        self.wake.notify();
+    }
+
+    pub(super) fn wait_through(&self, sequence: u64) -> Result<(), SystemError> {
+        self.request_commit();
+        self.completion_wait.wait_until_io(|| {
+            let state = self.state.lock();
+            if let Some(error) = state.error.clone() {
+                Some(Err(error))
+            } else if state.durable >= sequence {
+                Some(Ok(()))
+            } else if state.stopping {
+                Some(Err(SystemError::EIO))
+            } else {
+                None
+            }
+        })
+    }
+
+    pub(super) fn shutdown(&self, fs: &Ext4FileSystem) -> Result<(), SystemError> {
+        self.state.lock().closed = true;
+        self.completion_wait.wake_all();
+        fs.fs.close_batch_admission();
+        let target = fs
+            .fs
+            .batch_progress()
+            .map_or(0, |progress| progress.accepted);
+        let result = self.wait_through(target);
+        self.completion_wait.wait_until_io(|| {
+            let state = self.state.lock();
+            // Even with no data-completion owners, a pure metadata failure
+            // must reach superblock errseq before the completion worker exits.
+            (state.in_flight == 0 && (state.error.is_none() || state.error_reported)).then_some(())
+        });
+        result.and(self.stop_and_join())
+    }
+
+    /// Also used for a factory/attachment failure before normal VFS teardown.
+    /// If the last temporary fs owner is dropped by a worker itself, request
+    /// its exit without joining itself; its loop returns immediately afterwards.
+    pub(super) fn stop_and_join(&self) -> Result<(), SystemError> {
+        self.state.lock().stopping = true;
+        self.wake.notify();
+        self.completion_wait.wake_all();
+        let workers = [
+            self.disk_worker.lock().take(),
+            self.completion_worker.lock().take(),
+        ];
+        let mut error = None;
+        for worker in workers.into_iter().flatten() {
+            let result = if worker.raw_pid() == ProcessManager::current_pid() {
+                KernelThreadMechanism::request_stop(&worker).map(|_| 0)
+            } else {
+                KernelThreadMechanism::stop(&worker)
+            };
+            if let Err(failure) = result {
+                error.get_or_insert(failure);
+            }
+        }
+        error.map_or(Ok(()), Err)
+    }
+
+    fn observe(&self, durable: u64, failed: bool) {
+        let changed = {
+            let mut state = self.state.lock();
+            let changed = state.durable != durable || (failed && state.error.is_none());
+            state.durable = durable;
+            if failed {
+                state.error.get_or_insert(SystemError::EIO);
+            }
+            changed
+        };
+        if changed {
+            self.completion_wait.wake_all();
+        }
+    }
+}
+
+fn disk_loop(owner: Weak<Ext4Journal>, wake: Arc<JournalWake>) -> i32 {
+    let mut oldest = None::<u64>;
+    loop {
+        let observed = wake.event.load(Ordering::Acquire);
+        let notified = wake.first_notification.swap(0, Ordering::AcqRel);
+        let timeout = {
+            let Some(journal) = owner.upgrade() else {
+                return 0;
+            };
+            let state = journal.state.lock();
+            if state.stopping {
+                return 0;
+            }
+            let force = state.sync_requests != 0;
+            drop(state);
+            let Some(fs) = journal.filesystem.lock().upgrade() else {
+                return 0;
+            };
+            let Some(progress) = fs.fs.batch_progress() else {
+                return 0;
+            };
+            journal.observe(progress.durable, progress.failed);
+            if progress.failed || progress.running_operations == 0 {
+                oldest = None;
+            } else {
+                let began = oldest.get_or_insert(if notified == 0 { now_us() } else { notified });
+                if !progress.seal_requested
+                    && (force || now_us().saturating_sub(*began) >= COMMIT_DEADLINE_US)
+                {
+                    fs.fs.request_batch_commit();
+                }
+            }
+            let progress = fs
+                .fs
+                .batch_progress()
+                .expect("batch mode cannot change after mount");
+            if progress.seal_requested
+                && !progress.active_operation
+                && !progress.publishing
+                && !progress.failed
+            {
+                // The next Running set may be populated during this I/O.
+                // Freeze notifications seed its deadline conservatively early.
+                oldest = None;
+                let result = fs.fs.commit_pending_batch();
+                let after = fs.fs.batch_progress().expect("mounted batch mode");
+                journal.observe(after.durable, result.is_err() || after.failed);
+            }
+            if progress.seal_requested {
+                // An active operation must release its token to make this
+                // seal runnable. Its generation wake is the producer edge;
+                // an expired deadline must not become a one-microsecond poll.
+                None
+            } else {
+                oldest.map(|start| {
+                    Duration::from_micros(
+                        COMMIT_DEADLINE_US
+                            .saturating_sub(now_us().saturating_sub(start))
+                            .max(1),
+                    )
+                })
+            }
+        };
+        // No filesystem/journal strong owner is retained while sleeping.
+        let ready = || {
+            if wake.event.load(Ordering::Acquire) != observed || owner.strong_count() == 0 {
+                Some(())
+            } else {
+                None
+            }
+        };
+        if let Some(timeout) = timeout {
+            let _ = wake.wait_queue.wait_until_timeout(ready, timeout);
+        } else {
+            wake.wait_queue.wait_until(ready);
+        }
+    }
+}
+
+fn completion_loop(owner: Weak<Ext4Journal>, wake: Arc<WaitQueue>) -> i32 {
+    loop {
+        // Predicate and waiter registration share the normal WaitQueue protocol;
+        // no event generation or polling is needed for completion ownership.
+        let action = wake.wait_until(|| {
+            let Some(journal) = owner.upgrade() else {
+                return Some(None);
+            };
+            let mut state = journal.state.lock();
+            if state.stopping {
+                return Some(None);
+            }
+            let report = state.error.is_some() && !state.error_reported;
+            let index = state.slots.iter().position(|slot| match slot {
+                CompletionSlot::Pending { sequence, .. } => {
+                    state.error.is_some() || *sequence <= state.durable
+                }
+                _ => false,
+            });
+            if !report && index.is_none() {
+                return None;
+            }
+            let ready = index.map(|index| {
+                let CompletionSlot::Pending { sequence, context } =
+                    core::mem::replace(&mut state.slots[index], CompletionSlot::Completing)
+                else {
+                    unreachable!()
+                };
+                let result = if sequence <= state.durable {
+                    Ok(())
+                } else {
+                    Err(state
+                        .error
+                        .clone()
+                        .expect("non-durable completion requires failure"))
+                };
+                (index, context, result)
+            });
+            drop(state);
+            Some(Some((journal, report, ready)))
+        });
+        let Some((journal, report_error, ready)) = action else {
+            return 0;
+        };
+        if report_error {
+            let filesystem = journal.filesystem.lock().upgrade();
+            if let Some(fs) = filesystem {
+                fs.writeback_domain.record_writeback_error(SystemError::EIO);
+                fs.fail_stop_lifecycle();
+            }
+            // Publish reporting completion only after errseq/lifecycle update.
+            journal.state.lock().error_reported = true;
+            journal.completion_wait.wake_all();
+        }
+        if let Some((index, context, result)) = ready {
+            // No journal/metadata lock remains held across inode cleanup.
+            context.complete(result);
+            journal.release_slot(index);
+        }
+    }
+}

--- a/kernel/src/filesystem/ext4/mod.rs
+++ b/kernel/src/filesystem/ext4/mod.rs
@@ -2,3 +2,5 @@
 pub mod filesystem;
 pub mod gendisk;
 pub mod inode;
+
+pub(super) mod journal;

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -60,15 +60,17 @@ pub(crate) use writeback::{
     PageCacheWritebackDispatchOutcome,
 };
 use writeback::{
-    run_async_writeback_budget_retry_selftest, ClaimedWritebackBatch, TaggedWritebackBudgetRetry,
-    TaggedWritebackIncarnationRetry, TaggedWritebackSubmission, WritebackBatchRange,
-    WritebackClaimOutcome, WritebackSubmitOutcome, PAGECACHE_WRITEBACK_WQS,
+    run_async_writeback_budget_retry_selftest, run_submitted_writeback_selftest,
+    ClaimedWritebackBatch, TaggedWritebackBudgetRetry, TaggedWritebackIncarnationRetry,
+    TaggedWritebackSubmission, WritebackBatchRange, WritebackClaimOutcome, WritebackSubmitOutcome,
+    PAGECACHE_WRITEBACK_WQS,
 };
 pub use writeback::{
     AsyncPageCacheBackend, PageCacheBackend, PageCacheWritebackAdmissionOrder,
     PageCacheWritebackBindResult, PageCacheWritebackCancellationContext,
-    PageCacheWritebackDescriptor, PageCacheWritebackProgress, PageCacheWritebackProgressOutcome,
-    PageCacheWritebackSnapshotPhase, PageCacheWritebackSubmission, PageCacheWritebackSubmitResult,
+    PageCacheWritebackCompletion, PageCacheWritebackDescriptor, PageCacheWritebackProgress,
+    PageCacheWritebackProgressOutcome, PageCacheWritebackSnapshotPhase,
+    PageCacheWritebackSubmission, PageCacheWritebackSubmitResult,
 };
 
 static PAGE_CACHE_ID: AtomicUsize = AtomicUsize::new(0);

--- a/kernel/src/filesystem/page_cache/selftest.rs
+++ b/kernel/src/filesystem/page_cache/selftest.rs
@@ -1981,6 +1981,10 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
         ));
     }
 
+    if !run_submitted_writeback_selftest()? {
+        return Ok("status=fail stage=submitted_writeback\n".into());
+    }
+
     let writeback_budget_retry = run_async_writeback_budget_retry_selftest();
     if !writeback_budget_retry {
         return Ok("status=fail stage=writeback_budget_retry\n".into());
@@ -2528,7 +2532,7 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     let submit_defer_progress = match submit_defer_batch {
         Some(batch) => match PageCacheManager::submit_writeback_batch(batch) {
             Ok(WritebackSubmitOutcome::Deferred(progress)) => Some(progress),
-            Ok(WritebackSubmitOutcome::Completed)
+            Ok(WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted)
             | Ok(WritebackSubmitOutcome::Failed(_))
             | Err(_) => None,
         },
@@ -3764,6 +3768,6 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     }
 
     Ok(alloc::format!(
-        "status=ok\nramfs_fallocate_range=ok\nwrite_prepare_rollback=ok\npreallocate_rollback=ok\nwriteback_domain_lifecycle=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nremote_dirty_publish=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
+        "status=ok\nramfs_fallocate_range=ok\nwrite_prepare_rollback=ok\npreallocate_rollback=ok\nwriteback_domain_lifecycle=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nremote_dirty_publish=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nsubmitted_writeback=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
     ))
 }

--- a/kernel/src/filesystem/page_cache/writeback.rs
+++ b/kernel/src/filesystem/page_cache/writeback.rs
@@ -508,6 +508,171 @@ pub enum PageCacheWritebackBindResult {
     Deferred(Arc<dyn PageCacheWritebackProgress>),
 }
 
+struct WritebackCompletionState {
+    result: Option<Result<(), SystemError>>,
+    batch: Option<ClaimedWritebackBatch>,
+    registered: bool,
+}
+
+/// One accepted writeback's terminal notification. The producer must retain
+/// this handle and complete it on success, failure, cancellation and shutdown.
+/// Publication and registration share a lock, so either ordering invokes the
+/// consumer exactly once. Duplicate producer notifications are ignored.
+///
+/// `complete` may synchronously finish PageCache entries, release inode
+/// retention and dispatch retries. Call it outside filesystem transaction,
+/// inode, admission and PageCache locks; those paths may acquire these locks.
+pub struct PageCacheWritebackCompletion {
+    state: Mutex<WritebackCompletionState>,
+}
+
+impl PageCacheWritebackCompletion {
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(WritebackCompletionState {
+                result: None,
+                batch: None,
+                registered: false,
+            }),
+        })
+    }
+
+    /// Returns true only for the first terminal notification.
+    pub fn complete(&self, result: Result<(), SystemError>) -> bool {
+        let batch = {
+            let mut state = self.state.lock();
+            if state.result.is_some() {
+                return false;
+            }
+            state.result = Some(result.clone());
+            state.batch.take()
+        };
+        if let Some(batch) = batch {
+            PageCacheManager::finish_submitted_writeback(batch, result);
+        }
+        true
+    }
+
+    fn register(&self, batch: ClaimedWritebackBatch) {
+        let result = {
+            let mut state = self.state.lock();
+            assert!(!state.registered, "writeback completion registered twice");
+            state.registered = true;
+            match state.result.clone() {
+                Some(result) => result,
+                None => {
+                    state.batch = Some(batch);
+                    return;
+                }
+            }
+        };
+        PageCacheManager::finish_submitted_writeback(batch, result);
+    }
+}
+
+/// Exercise accepted completion using real claim/snapshot/page completion,
+/// including the separate tagged start and completion predicates. No producer
+/// thread is needed: both linearization orders are deliberately controlled.
+pub(super) fn run_submitted_writeback_selftest() -> Result<bool, SystemError> {
+    struct Submission(Arc<PageCacheWritebackCompletion>);
+    impl PageCacheWritebackSubmission for Submission {
+        fn submit(
+            self: Box<Self>,
+            _descriptor: &PageCacheWritebackDescriptor,
+            _data: &[u8],
+        ) -> Result<PageCacheWritebackSubmitResult, SystemError> {
+            Ok(PageCacheWritebackSubmitResult::Submitted(self.0))
+        }
+        fn cancel(self: Box<Self>, _context: PageCacheWritebackCancellationContext) {}
+    }
+
+    for (early, redirty, failed) in [
+        (true, false, false),
+        (false, false, false),
+        (false, true, false),
+        (false, false, true),
+    ] {
+        let cache = PageCache::new_unowned(None, None);
+        let page = cache.get_or_create_page_zero(0)?;
+        let epoch = 0x6b00;
+        let entry = {
+            let _transition = cache.tagged_writeback_lock.lock();
+            let mut inner = cache.inner.lock();
+            let entry = inner.get_entry(0).ok_or(SystemError::EIO)?;
+            page.write().add_flags(PageFlags::PG_DIRTY);
+            entry.account_state_transition(entry.state(), PageState::Dirty);
+            entry.set_state(PageState::Dirty);
+            entry.set_writeback_tag(epoch);
+            inner.dirty_pages.insert(0);
+            entry
+        };
+        let claim = {
+            let _invalidate = cache.invalidate_read();
+            PageCacheManager::claim_and_snapshot_tagged_locked(
+                &cache,
+                WritebackBatchRange::new(0, 0),
+                MMArch::PAGE_SIZE,
+                &entry,
+                epoch,
+                false,
+                None,
+            )?
+        };
+        let WritebackClaimOutcome::Claimed(mut batch) = claim else {
+            return Ok(false);
+        };
+        let completion = PageCacheWritebackCompletion::new();
+        batch.submission = Some(Box::new(Submission(completion.clone())));
+        if early && !completion.complete(Ok(())) {
+            return Ok(false);
+        }
+        if !matches!(
+            PageCacheManager::submit_writeback_batch(batch)?,
+            WritebackSubmitOutcome::Submitted
+        ) {
+            return Ok(false);
+        }
+        if !early {
+            if entry.state() != PageState::Writeback
+                || PageCacheManager::has_pending_tagged_writeback_submission(
+                    &cache, 0, 0, epoch, false,
+                )
+                || !PageCacheManager::has_pending_tagged_writeback_submission(
+                    &cache, 0, 0, epoch, true,
+                )
+            {
+                completion.complete(Err(SystemError::EIO));
+                return Ok(false);
+            }
+            // The start boundary must return while completion is outstanding.
+            PageCacheManager::wait_tagged_writeback_submission(&cache, 0, 0, epoch)?;
+            if redirty {
+                page.write().add_flags(PageFlags::PG_DIRTY);
+            }
+            if !completion.complete(if failed {
+                Err(SystemError::EIO)
+            } else {
+                Ok(())
+            }) {
+                return Ok(false);
+            }
+        }
+        let expected = if redirty || failed {
+            PageState::Dirty
+        } else {
+            PageState::UpToDate
+        };
+        if completion.complete(Ok(()))
+            || entry.state() != expected
+            || !cache.tagged_writeback_submissions.lock().is_empty()
+            || page.read().flags().contains(PageFlags::PG_ERROR) != failed
+        {
+            return Ok(false);
+        }
+    }
+    Ok(true)
+}
+
 /// Submission-time outcome of a previously bound writeback token.
 ///
 /// Unlike `Err`, `Deferred` is not a writeback failure: PageCache returns the
@@ -515,6 +680,8 @@ pub enum PageCacheWritebackBindResult {
 /// synchronous caller wait for the supplied progress ticket before retrying.
 pub enum PageCacheWritebackSubmitResult {
     Completed,
+    /// Accepted; pages and exact-generation ownership remain in Writeback.
+    Submitted(Arc<PageCacheWritebackCompletion>),
     Deferred(Arc<dyn PageCacheWritebackProgress>),
 }
 
@@ -547,13 +714,12 @@ pub enum PageCacheWritebackCancellationContext {
 /// claim until it explicitly resolves that claim on every success or error
 /// path.
 ///
-/// This first-generation token contract is completion-oriented: returning
-/// `Completed` lets PageCache clean the pages immediately.  It therefore
-/// cannot represent a lower layer which has merely accepted asynchronous I/O
-/// while completion remains outstanding.  Such a backend must keep using a
-/// completion-preserving path until PageCache grows an explicit
-/// `Submitted(completion_handle)` result; it must never return `Completed`
-/// early and let `WAIT_AFTER` observe clean pages before the actual I/O.
+/// `Completed` permits immediate PageCache completion. `Submitted` transfers
+/// completion to the supplied one-shot handle: the backend must own its data
+/// and private claim until terminal notification, without borrowing `data` or
+/// `descriptor`. `Deferred` means no accepted I/O and remains a retry.
+/// Backends must bound their accepted in-flight resources before returning
+/// Submitted; the PageCache worker slot is released after registration.
 ///
 /// `cancel()` receives the exact lock context. In particular, only
 /// `AfterAdmissionWithInvalidateRead` may use the split ext4 finalizer which
@@ -869,6 +1035,7 @@ impl PageCacheBackend for AsyncPageCacheBackend {
 
 #[derive(Debug)]
 pub(super) struct TaggedWritebackSubmission {
+    accepted: bool,
     epoch: u64,
     first_index: usize,
     last_index: usize,
@@ -1057,13 +1224,15 @@ pub(super) enum WritebackClaimOutcome {
 
 pub(super) enum WritebackSubmitOutcome {
     Completed,
+    Submitted,
     Failed(SystemError),
     Deferred(Arc<dyn PageCacheWritebackProgress>),
 }
 
 enum WritebackNextBatchOutcome {
     NoBatch,
-    Completed,
+    /// A batch was completed or accepted; range waits own completion.
+    Progress,
     Deferred(Arc<dyn PageCacheWritebackProgress>),
 }
 
@@ -1548,6 +1717,17 @@ impl PageCacheManager {
         first_error.map_or(Ok(()), Err)
     }
 
+    fn finish_submitted_writeback(batch: ClaimedWritebackBatch, result: Result<(), SystemError>) {
+        let cache = batch.cache.clone();
+        let epoch = batch.retry_writeback_tag;
+        let first = batch.first_index;
+        let last = batch.descriptor.last_index();
+        // Publish page state and errseq before retiring the exact tagged
+        // completion obligation. No filesystem or completion-state lock is held.
+        let _ = Self::complete_writeback_batch(batch, result);
+        Self::finish_tagged_writeback_submission(&cache, epoch, first, last);
+    }
+
     /// Return an intentionally deferred batch to the Dirty set without
     /// reporting a writeback error.  The submission token has already
     /// finalized its filesystem-private claim and supplied the progress ticket
@@ -1731,6 +1911,18 @@ impl PageCacheManager {
                 );
                 completion?;
                 Ok(WritebackSubmitOutcome::Completed)
+            }
+            Ok(PageCacheWritebackSubmitResult::Submitted(completion)) => {
+                // Publish acceptance before registration: an already-complete
+                // handle may immediately retire the same tagged record.
+                Self::accept_tagged_writeback_submission(
+                    &submission_cache,
+                    submission_epoch,
+                    submission_first,
+                    submission_last,
+                );
+                completion.register(batch);
+                Ok(WritebackSubmitOutcome::Submitted)
             }
             Ok(PageCacheWritebackSubmitResult::Deferred(progress)) => {
                 Self::defer_writeback_batch(batch);
@@ -1944,7 +2136,7 @@ impl PageCacheManager {
             WritebackClaimOutcome::FailedRecorded(error) => return Err(error),
         };
         match Self::submit_writeback_batch(batch)? {
-            WritebackSubmitOutcome::Completed => Ok(true),
+            WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted => Ok(true),
             WritebackSubmitOutcome::Failed(error) => Err(error),
             WritebackSubmitOutcome::Deferred(_) => {
                 panic!("stable-size writeback must not submit a deferred token")
@@ -2345,7 +2537,9 @@ impl PageCacheManager {
             }
             WritebackClaimOutcome::FailedRecorded(error) => Err(error),
             WritebackClaimOutcome::Claimed(batch) => match Self::submit_writeback_batch(batch)? {
-                WritebackSubmitOutcome::Completed => Ok(WritebackNextBatchOutcome::Completed),
+                WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted => {
+                    Ok(WritebackNextBatchOutcome::Progress)
+                }
                 WritebackSubmitOutcome::Failed(error) => Err(error),
                 WritebackSubmitOutcome::Deferred(progress) => {
                     Ok(WritebackNextBatchOutcome::Deferred(progress))
@@ -2490,7 +2684,7 @@ impl PageCacheManager {
             loop {
                 match self.writeback_next_batch(&cache, &inode, start_index, end_index, None)? {
                     WritebackNextBatchOutcome::NoBatch => break,
-                    WritebackNextBatchOutcome::Completed => continue,
+                    WritebackNextBatchOutcome::Progress => continue,
                     WritebackNextBatchOutcome::Deferred(progress) => {
                         // `writeback_next_batch()` has completed the token
                         // transition and released all PageCache/admission
@@ -2614,7 +2808,7 @@ impl PageCacheManager {
             .ok_or(SystemError::EIO)?;
         match self.writeback_next_batch(&cache, &inode, start_index, end_index, Some(admitted))? {
             WritebackNextBatchOutcome::NoBatch => Ok(PageCacheWritebackDispatchOutcome::Idle),
-            WritebackNextBatchOutcome::Completed => Ok(PageCacheWritebackDispatchOutcome::Progress),
+            WritebackNextBatchOutcome::Progress => Ok(PageCacheWritebackDispatchOutcome::Progress),
             WritebackNextBatchOutcome::Deferred(_) => {
                 Ok(PageCacheWritebackDispatchOutcome::Deferred)
             }
@@ -2748,10 +2942,36 @@ impl PageCacheManager {
             .tagged_writeback_submissions
             .lock()
             .push(TaggedWritebackSubmission {
+                accepted: false,
                 epoch,
                 first_index,
                 last_index,
             });
+    }
+
+    fn accept_tagged_writeback_submission(
+        cache: &PageCache,
+        epoch: Option<u64>,
+        first_index: usize,
+        last_index: usize,
+    ) {
+        let Some(epoch) = epoch else {
+            return;
+        };
+        {
+            let _transition = cache.tagged_writeback_lock.lock();
+            let mut pending = cache.tagged_writeback_submissions.lock();
+            let submission = pending
+                .iter_mut()
+                .find(|submission| {
+                    submission.epoch == epoch
+                        && submission.first_index == first_index
+                        && submission.last_index == last_index
+                })
+                .expect("accepted writeback lost its tagged registration");
+            submission.accepted = true;
+        }
+        Self::notify_tagged_writeback_progress(cache);
     }
 
     fn finish_tagged_writeback_submission(
@@ -2786,13 +3006,15 @@ impl PageCacheManager {
         start_index: usize,
         end_index: usize,
         epoch: u64,
+        include_accepted: bool,
     ) -> bool {
         cache
             .tagged_writeback_submissions
             .lock()
             .iter()
             .any(|submission| {
-                submission.epoch != 0
+                (include_accepted || !submission.accepted)
+                    && submission.epoch != 0
                     && submission.epoch <= epoch
                     && submission.first_index <= end_index
                     && start_index <= submission.last_index
@@ -2937,7 +3159,7 @@ impl PageCacheManager {
             return Ok(());
         };
         loop {
-            Self::wait_tagged_writeback_submission(cache, start_index, end_index, epoch)?;
+            Self::wait_tagged_writeback_pending(cache, start_index, end_index, epoch, true)?;
 
             // Claim clears the tag immediately before publishing Writeback.
             // A submission-time defer can restore it after this wait, so the
@@ -2956,6 +3178,7 @@ impl PageCacheManager {
                     start_index,
                     end_index,
                     epoch,
+                    true,
                 )
             {
                 return Ok(());
@@ -2969,6 +3192,16 @@ impl PageCacheManager {
         end_index: usize,
         epoch: u64,
     ) -> Result<(), SystemError> {
+        Self::wait_tagged_writeback_pending(cache, start_index, end_index, epoch, false)
+    }
+
+    fn wait_tagged_writeback_pending(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        end_index: usize,
+        epoch: u64,
+        include_accepted: bool,
+    ) -> Result<(), SystemError> {
         loop {
             let observed = {
                 let _tagged_writeback_transition = cache.tagged_writeback_lock.lock();
@@ -2979,6 +3212,7 @@ impl PageCacheManager {
                             start_index,
                             end_index,
                             epoch,
+                            include_accepted,
                         );
                 if !pending {
                     return Ok(());
@@ -2998,6 +3232,7 @@ impl PageCacheManager {
                         start_index,
                         end_index,
                         epoch,
+                        include_accepted,
                     ))
                     || cache.tagged_writeback_progress.load(Ordering::Acquire) != observed
                 {
@@ -3353,7 +3588,7 @@ impl PageCacheManager {
             let outcome = Self::submit_writeback_batch(batch);
             drop(permit);
             match outcome {
-                Ok(WritebackSubmitOutcome::Completed) => {
+                Ok(WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted) => {
                     if last_index == usize::MAX {
                         if let Some(cache) = cache.upgrade() {
                             Self::notify_tagged_writeback_progress(&cache);
@@ -3706,14 +3941,17 @@ impl PageCacheManager {
                         continue;
                     }
                     match Self::submit_writeback_batch(batch) {
-                        Ok(WritebackSubmitOutcome::Completed) => {
+                        Ok(
+                            WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted,
+                        ) => {
                             drop(permit);
                             if last_index == usize::MAX {
                                 Self::notify_tagged_writeback_progress(cache);
                                 return;
                             }
-                            // The submit result is now known.  Only a
-                            // completed head permits claiming its successor.
+                            // Acceptance permits claiming a successor. An
+                            // outstanding completion retains its own
+                            // Writeback ownership.
                             cursor = last_index + 1;
                         }
                         Ok(WritebackSubmitOutcome::Deferred(progress)) => {
@@ -4223,10 +4461,14 @@ impl PageCacheManager {
                     break;
                 };
                 match Self::submit_writeback_batch(batch) {
-                    Ok(WritebackSubmitOutcome::Completed) if last_index != usize::MAX => {
+                    Ok(WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted)
+                        if last_index != usize::MAX =>
+                    {
                         cursor = last_index + 1;
                     }
-                    Ok(WritebackSubmitOutcome::Completed) => break,
+                    Ok(WritebackSubmitOutcome::Completed | WritebackSubmitOutcome::Submitted) => {
+                        break
+                    }
                     Ok(WritebackSubmitOutcome::Failed(_)) => break,
                     Ok(WritebackSubmitOutcome::Deferred(progress)) => {
                         Self::schedule_reclaimer_deferred_retry(

--- a/kernel/src/filesystem/vfs/mod.rs
+++ b/kernel/src/filesystem/vfs/mod.rs
@@ -16,7 +16,7 @@ pub mod vcore;
 pub mod write_access;
 pub mod writeback;
 
-use alloc::{string::String, sync::Arc, vec::Vec};
+use alloc::{boxed::Box, string::String, sync::Arc, vec::Vec};
 use core::{
     any::Any,
     fmt::{Debug, Display, Write},
@@ -2303,8 +2303,19 @@ impl WritebackControl {
     }
 }
 
+/// Lifetime-only request that lets a filesystem promptly submit metadata
+/// required by a bounded data-writeback wait. Dropping it ends the request.
+pub trait FileSystemSyncGuard: Send {}
+
 /// @brief 所有文件系统都应该实现的trait
 pub trait FileSystem: Any + Sync + Send + Debug {
+    /// Called before a synchronous PageCache wait, not after it. Backends
+    /// with accepted asynchronous metadata use this to push the relevant
+    /// batches; the PageCache range still defines the finite completion target.
+    fn begin_sync_writeback(&self) -> Option<Box<dyn FileSystemSyncGuard>> {
+        None
+    }
+
     /// Return the stable writeback/shutdown domain for file-backed mappings.
     /// In-memory and pseudo filesystems must explicitly return `None`.
     fn page_cache_writeback_domain(
@@ -2317,6 +2328,17 @@ pub trait FileSystem: Any + Sync + Send + Debug {
     }
     /// @brief 获取当前文件系统的root inode的指针
     fn root_inode(&self) -> Arc<dyn IndexNode>;
+
+    /// Optional canonical state for repeated mounts of this filesystem.
+    /// A backend opting in must return the same state for its whole lifetime,
+    /// with no I/O, and recreate the backend only after final shutdown. VFS
+    /// retains ownership of mount counts, construction pins and teardown.
+    fn shared_mount_superblock_state(
+        &self,
+        _flags: MountFlags,
+    ) -> Option<Arc<mount::SuperBlockState>> {
+        None
+    }
 
     /// Optional owner for a newly created VFS superblock. Bind mounts and
     /// mount-namespace copies reuse the existing superblock state.

--- a/kernel/src/filesystem/vfs/mount/mod.rs
+++ b/kernel/src/filesystem/vfs/mount/mod.rs
@@ -1259,9 +1259,15 @@ impl SuperBlockState {
         self.shutdown_wait.wake_all();
     }
 
+    /// A fresh mount must not revive a superblock whose final teardown won
+    /// the construction-pin race. Dead instances may be replaced by a factory.
+    pub(crate) fn shutdown_started(&self) -> bool {
+        self.lifecycle.lock().state != SuperBlockLifecycleState::Active
+    }
+
     /// Wait only when this unmount started the final superblock shutdown.
     /// A still-active shared superblock needs no shutdown completion wait.
-    fn wait_for_shutdown_if_started(&self) {
+    pub(crate) fn wait_for_shutdown_if_started(&self) {
         self.shutdown_wait.wait_until(|| {
             let state = self.lifecycle.lock().state;
             (state != SuperBlockLifecycleState::Dying).then_some(())
@@ -1586,6 +1592,30 @@ pub struct MountFSInode {
 }
 
 impl MountFS {
+    /// Resolve one mount's superblock identity without performing backend I/O.
+    /// Bind/copy callers supply their state explicitly; ordinary mounts may
+    /// opt into a canonical state through the filesystem's narrow hook.
+    fn new_mount_superblock_state(
+        inner: &Arc<dyn FileSystem>,
+        flags: MountFlags,
+    ) -> Result<Arc<SuperBlockState>, SystemError> {
+        if let Some(state) = inner.shared_mount_superblock_state(flags) {
+            if state.shutdown_started() {
+                return Err(SystemError::ESTALE);
+            }
+            if state.flags().contains(MountFlags::RDONLY) != flags.contains(MountFlags::RDONLY)
+                || !Arc::ptr_eq(state.owner_user_ns(), &ProcessManager::current_user_ns())
+            {
+                return Err(SystemError::EBUSY);
+            }
+            return Ok(state);
+        }
+        let owner = inner
+            .mount_owner_user_ns()
+            .unwrap_or_else(ProcessManager::current_user_ns);
+        Ok(Arc::new(SuperBlockState::new_with_owner(flags, owner)))
+    }
+
     pub fn new(
         inner_filesystem: Arc<dyn FileSystem>,
         root_inner_inode: Option<Arc<dyn IndexNode>>,
@@ -1595,18 +1625,13 @@ impl MountFS {
         mount_flags: MountFlags,
         mount_source: Option<String>,
     ) -> Result<Arc<Self>, SystemError> {
-        let owner_user_ns = inner_filesystem
-            .mount_owner_user_ns()
-            .unwrap_or_else(ProcessManager::current_user_ns);
-        let super_block_state =
-            Arc::new(SuperBlockState::new_with_owner(mount_flags, owner_user_ns));
+        let super_block_state = Self::new_mount_superblock_state(&inner_filesystem, mount_flags)?;
         if let Some(domain) = inner_filesystem.page_cache_writeback_domain() {
             domain.bind(&inner_filesystem, &super_block_state)?;
         }
-        assert!(
-            super_block_state.try_add_external_pin(),
-            "a fresh superblock accepts its construction reservation"
-        );
+        if !super_block_state.try_add_external_pin() {
+            return Err(SystemError::ESTALE);
+        }
         Ok(Self::new_with_super_block_state(
             inner_filesystem,
             root_inner_inode,
@@ -3178,6 +3203,7 @@ impl MountFS {
             return Ok(());
         }
 
+        let _sync_request = self.inner_filesystem.begin_sync_writeback();
         self.sync_inodes_of_mount()
     }
 
@@ -3240,6 +3266,11 @@ impl MountFS {
         if self.is_sb_readonly() {
             return Ok(());
         }
+
+        // Accepted filesystem metadata may complete the PageCache I/O below.
+        // Keep one request across this whole bounded sync, including later
+        // inode submissions, rather than allocating one guard per mapping.
+        let _sync_request = self.inner_filesystem.begin_sync_writeback();
 
         // writeback_inodes_sb(sb) — void
         let mut last_err = self.sync_inodes_of_mount();
@@ -4375,6 +4406,17 @@ impl MountFSInode {
             return Err(SystemError::EINVAL);
         }
 
+        let state = match super_block_state {
+            Some(state) => state,
+            None => MountFS::new_mount_superblock_state(&inner_fs, mount_flags)?,
+        };
+        // Root metadata is a backend operation. Keep final teardown from
+        // closing its admission before the construction pin has been acquired.
+        let _umount = state.umount_read();
+        if state.shutdown_started() {
+            return Err(SystemError::ESTALE);
+        }
+
         let metadata = self.dentry.inode.metadata()?;
         let root_metadata = root_inner_inode.metadata()?;
         let is_dir = metadata.file_type == FileType::Dir;
@@ -4388,7 +4430,7 @@ impl MountFSInode {
             root_inner_inode,
             root_dentry,
             mount_flags,
-            super_block_state,
+            Some(state.clone()),
             bind_source,
         )
     }
@@ -4422,12 +4464,7 @@ impl MountFSInode {
 
         let super_block_state = match super_block_state {
             Some(super_block_state) => super_block_state,
-            None => {
-                let owner_user_ns = inner_fs
-                    .mount_owner_user_ns()
-                    .unwrap_or_else(ProcessManager::current_user_ns);
-                Arc::new(SuperBlockState::new_with_owner(mount_flags, owner_user_ns))
-            }
+            None => MountFS::new_mount_superblock_state(&inner_fs, mount_flags)?,
         };
         if let Some(domain) = inner_fs.page_cache_writeback_domain() {
             domain.bind(&inner_fs, &super_block_state)?;
@@ -5733,6 +5770,10 @@ impl IndexNode for MountFSInode {
 }
 
 impl FileSystem for MountFS {
+    fn begin_sync_writeback(&self) -> Option<alloc::boxed::Box<dyn super::FileSystemSyncGuard>> {
+        self.inner_filesystem.begin_sync_writeback()
+    }
+
     fn page_cache_writeback_domain(
         &self,
     ) -> Option<&Arc<crate::filesystem::page_cache::PageCacheWritebackDomain>> {

--- a/kernel/src/filesystem/vfs/syscall/sys_mount.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_mount.rs
@@ -485,60 +485,59 @@ fn do_new_mount(
     mount_flags: MountFlags,
 ) -> Result<Arc<MountFS>, SystemError> {
     let fs_type_str = filesystemtype.ok_or(SystemError::EINVAL)?;
-    // Linux accepts a NULL source for nodev filesystems and reports it as
-    // "none" in mountinfo. Keep an explicitly supplied empty string distinct.
-    let fs = produce_fs(
-        &fs_type_str,
-        data.as_deref(),
-        source.as_deref().unwrap_or(""),
-        mount_flags,
-    )
-    .inspect_err(|e| {
-        log::warn!("Failed to produce filesystem: {:?}", e);
-    })?;
-    let source = source.unwrap_or_else(|| String::from("none"));
+    loop {
+        // Linux accepts a NULL source for nodev filesystems. Keep an
+        // explicitly supplied empty string distinct from the display name.
+        let fs = produce_fs(
+            &fs_type_str,
+            data.as_deref(),
+            source.as_deref().unwrap_or(""),
+            mount_flags,
+        )
+        .inspect_err(|e| {
+            log::warn!("Failed to produce filesystem: {:?}", e);
+        })?;
+        let mnt_inode = target_inode
+            .clone()
+            .downcast_arc::<MountFSInode>()
+            .ok_or(SystemError::EINVAL)?;
+        let (to_mount_fs, root_inner_inode) = fs
+            .clone()
+            .downcast_arc::<MountFS>()
+            .map(|it| (it.inner_filesystem(), it.root_inner_inode()))
+            .unwrap_or_else(|| {
+                let root_inner_inode = fs.root_inode();
+                (fs, root_inner_inode)
+            });
 
-    let new_mount_res: Result<Arc<MountFS>, SystemError> =
-        if let Some(mnt_inode) = target_inode.clone().downcast_arc::<MountFSInode>() {
-            let (to_mount_fs, root_inner_inode) = fs
-                .clone()
-                .downcast_arc::<MountFS>()
-                .map(|it| (it.inner_filesystem(), it.root_inner_inode()))
-                .unwrap_or_else(|| {
-                    let root_inner_inode = fs.root_inode();
-                    (fs, root_inner_inode)
-                });
-
-            let prepared = mnt_inode.prepare_subtree_with_root_dentry(
-                to_mount_fs,
-                root_inner_inode,
-                None,
-                mount_flags,
-                None,
-                None,
-            )?;
-            prepared.set_mount_source(Some(source.clone()));
-            if let Err(error) = mnt_inode.publish_prepared_subtree(&prepared) {
-                MountFS::deactivate_disconnected_subtree(&prepared);
-                return Err(error);
+        let prepared = match mnt_inode.prepare_subtree_with_root_dentry(
+            to_mount_fs.clone(),
+            root_inner_inode,
+            None,
+            mount_flags,
+            None,
+            None,
+        ) {
+            Ok(prepared) => prepared,
+            Err(SystemError::ESTALE)
+                if to_mount_fs
+                    .shared_mount_superblock_state(mount_flags)
+                    .is_some_and(|state| state.shutdown_started()) =>
+            {
+                // The last unmount beat this construction reservation. No
+                // topology has been published. Re-enter the factory, which
+                // waits for final shutdown before recovering a new instance.
+                continue;
             }
-            Ok(prepared)
-        } else {
-            // A pathname usable as a mountpoint in this namespace resolves to
-            // a MountFSInode. A bare inode can be reached through an internal
-            // pseudo-filesystem magic link (for example /proc/self/fd/N), but
-            // it is not attached to the caller's mount namespace.
-            Err(SystemError::EINVAL)
+            Err(error) => return Err(error),
         };
-
-    let new_mount = new_mount_res?;
-    // Legacy non-MountFS targets cannot propagate before this point. Normal
-    // namespace mounts set the source on their detached MountFS above.
-    if new_mount.mount_source().is_none() {
-        new_mount.set_mount_source(Some(source));
+        prepared.set_mount_source(Some(source.clone().unwrap_or_else(|| String::from("none"))));
+        if let Err(error) = mnt_inode.publish_prepared_subtree(&prepared) {
+            MountFS::deactivate_disconnected_subtree(&prepared);
+            return Err(error);
+        }
+        return Ok(prepared);
     }
-
-    Ok(new_mount)
 }
 #[inline(never)]
 fn copy_mount_string(raw: Option<*const u8>) -> Result<Option<String>, SystemError> {

--- a/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
+++ b/kernel/src/filesystem/vfs/syscall/sys_sync_file_range.rs
@@ -108,6 +108,12 @@ fn sync_file_range(
     };
     let manager = page_cache.manager();
 
+    // WRITE-only remains asynchronous. Waiting ranges must push accepted
+    // filesystem metadata before their first PageCache completion wait.
+    let _sync_request = flags
+        .intersects(SyncFileRangeFlags::WAIT_BEFORE | SyncFileRangeFlags::WAIT_AFTER)
+        .then(|| inode.fs().begin_sync_writeback());
+
     if flags.contains(SyncFileRangeFlags::WAIT_BEFORE) {
         manager.wait_writeback_range(start_index, end_index)?;
         file.check_and_advance_wb_error(&page_cache)?;

--- a/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_inode_identity.cc
@@ -166,8 +166,8 @@ class LoopExt4 {
         ASSERT_EQ(0, ioctl(loop_fd_, kLoopSetFd, backing_fd_)) << strerror(errno);
     }
 
-    void Mount() {
-        ASSERT_EQ(0, mount(loop_path_.c_str(), mount_point_.c_str(), "ext4", 0, nullptr))
+    void Mount(unsigned long flags = 0) {
+        ASSERT_EQ(0, mount(loop_path_.c_str(), mount_point_.c_str(), "ext4", flags, nullptr))
             << strerror(errno);
         mounted_ = true;
     }
@@ -195,13 +195,13 @@ class LoopExt4 {
         EXPECT_EQ(0, close(probe));
     }
 
-    void MountSecond() {
-        ASSERT_TRUE(mounted_);
+    void MountSecond(const char* options = nullptr) {
+        ASSERT_TRUE(mounted_ || detached_);
         ASSERT_FALSE(second_mounted_);
         second_mount_point_ = "/tmp/ext4_inode_identity_" + std::to_string(getpid())
             + "_second_mnt";
         ASSERT_EQ(0, mkdir(second_mount_point_.c_str(), 0700)) << strerror(errno);
-        ASSERT_EQ(0, mount(loop_path_.c_str(), second_mount_point_.c_str(), "ext4", 0, nullptr))
+        ASSERT_EQ(0, mount(loop_path_.c_str(), second_mount_point_.c_str(), "ext4", 0, options))
             << strerror(errno);
         second_mounted_ = true;
     }
@@ -246,6 +246,10 @@ class LoopExt4 {
         mount_point_.clear();
         ASSERT_EQ(0, unlink(image_.c_str())) << strerror(errno);
         image_.clear();
+    }
+
+    const std::string& loop_path() const {
+        return loop_path_;
     }
 
     const std::string& mount_point() const {
@@ -912,9 +916,9 @@ TEST(Ext4InodeIdentity, DelayedAndEagerWritesPersistCtimeAcrossRemount) {
 
     // This is an overwrite of an already mapped block, so it exercises the
     // eager buffered fallback rather than the append-only delayed mapper.
-    // Keep a second mount alive as an independent on-disk observer: checking
-    // it immediately after fsync proves that fsync itself committed the
-    // timestamp, without relying on the first mount's later clean unmount.
+    // A second mount shares Linux's canonical inode and must observe the
+    // same timestamp. Persistence is checked after both mounts are removed;
+    // a live second mount is not an independent on-disk observer.
     ASSERT_NO_FATAL_FAILURE(fs.MountSecond());
     sleep(1);
     ASSERT_EQ(1, pwrite(fd, "B", 1, 0)) << strerror(errno);
@@ -1010,18 +1014,141 @@ TEST(Ext4InodeIdentity, ConcurrentAppendRecordsRemainAtomicAndDurable) {
 }
 
 TEST(Ext4InodeIdentity, SameBlockDeviceCanBeMountedTwice) {
-    // Linux reuses a block device's superblock for a compatible second mount.
-    // DragonOS does not have that shared-superblock layer yet, but a dormant
-    // delayed-allocation experiment must not turn the established mount(2)
-    // behavior into unconditional EBUSY. This test intentionally asserts
-    // only mount namespace admission; page-cache sharing is a separate VFS
-    // design task and must not be emulated by this ext4 regression test.
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    const std::string first = fs.mount_point() + "/shared";
+    int first_fd = open(first.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(first_fd, 0) << strerror(errno);
+    ASSERT_EQ(4, write(first_fd, "live", 4)) << strerror(errno);
+
+    // Repeated mount options do not reconfigure an existing superblock.
+    // In particular, this must not start a second lower journal/cache.
+    ASSERT_NO_FATAL_FAILURE(fs.MountSecond("nobarrier"));
+    const std::string second = fs.second_mount_point() + "/shared";
+    int second_fd = open(second.c_str(), O_RDWR);
+    ASSERT_GE(second_fd, 0) << strerror(errno);
+    char bytes[4] = {};
+    ASSERT_EQ(4, pread(second_fd, bytes, sizeof(bytes), 0)) << strerror(errno);
+    EXPECT_EQ(0, memcmp(bytes, "live", sizeof(bytes)));
+    struct stat one = {}, two = {};
+    ASSERT_EQ(0, fstat(first_fd, &one)) << strerror(errno);
+    ASSERT_EQ(0, fstat(second_fd, &two)) << strerror(errno);
+    EXPECT_EQ(one.st_dev, two.st_dev);
+    EXPECT_EQ(one.st_ino, two.st_ino);
+
+    ASSERT_EQ(4, pwrite(second_fd, "both", 4, 0)) << strerror(errno);
+    ASSERT_EQ(4, pread(first_fd, bytes, sizeof(bytes), 0)) << strerror(errno);
+    EXPECT_EQ(0, memcmp(bytes, "both", sizeof(bytes)));
+    const std::string linked = fs.second_mount_point() + "/alias";
+    ASSERT_EQ(0, link(second.c_str(), linked.c_str())) << strerror(errno);
+    ASSERT_EQ(0, fstat(first_fd, &one)) << strerror(errno);
+    EXPECT_EQ(static_cast<nlink_t>(2), one.st_nlink);
+    ASSERT_EQ(0, close(first_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(second_fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.UnmountSecond());
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, UnmountOneSharedMountKeepsOtherWritable) {
     LoopExt4 fs;
     ASSERT_NO_FATAL_FAILURE(fs.SetUp());
     ASSERT_NO_FATAL_FAILURE(fs.Mount());
     ASSERT_NO_FATAL_FAILURE(fs.MountSecond());
-    ASSERT_NO_FATAL_FAILURE(fs.UnmountSecond());
+    const std::string second = fs.second_mount_point() + "/survivor";
+    int fd = open(second.c_str(), O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    ASSERT_EQ(4, write(fd, "part", 4)) << strerror(errno);
     ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    ASSERT_EQ(4, write(fd, "done", 4)) << strerror(errno);
+    ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.UnmountSecond());
+
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    fd = open((fs.mount_point() + "/survivor").c_str(), O_RDONLY);
+    ASSERT_GE(fd, 0) << strerror(errno);
+    char bytes[8] = {};
+    ASSERT_EQ(8, read(fd, bytes, sizeof(bytes))) << strerror(errno);
+    EXPECT_EQ(0, memcmp(bytes, "partdone", sizeof(bytes)));
+    ASSERT_EQ(0, close(fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+}
+
+TEST(Ext4InodeIdentity, LazyDetachedOpenFileSharesSubsequentMount) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    ASSERT_NO_FATAL_FAILURE(fs.Mount());
+    int old_fd = open((fs.mount_point() + "/detached_shared").c_str(),
+                      O_CREAT | O_EXCL | O_RDWR, 0600);
+    ASSERT_GE(old_fd, 0) << strerror(errno);
+    ASSERT_EQ(4, write(old_fd, "held", 4)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.Detach());
+    ASSERT_NO_FATAL_FAILURE(fs.MountSecond());
+    int new_fd = open((fs.second_mount_point() + "/detached_shared").c_str(), O_RDWR);
+    ASSERT_GE(new_fd, 0) << strerror(errno);
+    char bytes[4] = {};
+    ASSERT_EQ(4, pread(new_fd, bytes, sizeof(bytes), 0)) << strerror(errno);
+    EXPECT_EQ(0, memcmp(bytes, "held", sizeof(bytes)));
+    ASSERT_EQ(0, close(old_fd)) << strerror(errno);
+    ASSERT_EQ(4, pwrite(new_fd, "kept", 4, 0)) << strerror(errno);
+    ASSERT_EQ(0, fsync(new_fd)) << strerror(errno);
+    ASSERT_EQ(0, close(new_fd)) << strerror(errno);
+    ASSERT_NO_FATAL_FAILURE(fs.UnmountSecond());
+    ASSERT_NO_FATAL_FAILURE(fs.FinishDetached());
+}
+
+TEST(Ext4InodeIdentity, RepeatedMountRejectsReadonlyModeConflict) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    const std::string other = fs.mount_point() + "_conflict";
+    ASSERT_EQ(0, mkdir(other.c_str(), 0700)) << strerror(errno);
+    for (unsigned long first_flags : {0UL, static_cast<unsigned long>(MS_RDONLY)}) {
+        ASSERT_NO_FATAL_FAILURE(fs.Mount(first_flags));
+        errno = 0;
+        int result = mount(fs.loop_path().c_str(), other.c_str(), "ext4",
+                           first_flags ^ MS_RDONLY, nullptr);
+        int saved_errno = errno;
+        if (result == 0) {
+            EXPECT_EQ(0, umount(other.c_str())) << strerror(errno);
+        }
+        EXPECT_EQ(-1, result);
+        EXPECT_EQ(EBUSY, saved_errno);
+        ASSERT_NO_FATAL_FAILURE(fs.Unmount());
+    }
+    ASSERT_EQ(0, rmdir(other.c_str())) << strerror(errno);
+}
+
+TEST(Ext4InodeIdentity, RepeatedMountRacesLastUnmount) {
+    LoopExt4 fs;
+    ASSERT_NO_FATAL_FAILURE(fs.SetUp());
+    const std::string other = fs.mount_point() + "_racer";
+    ASSERT_EQ(0, mkdir(other.c_str(), 0700)) << strerror(errno);
+    for (int iteration = 0; iteration < 8; ++iteration) {
+        ASSERT_NO_FATAL_FAILURE(fs.Mount());
+        std::atomic<bool> start{false};
+        int result = -1;
+        int mount_error = 0;
+        std::thread mounter([&] {
+            while (!start.load(std::memory_order_acquire)) {
+                std::this_thread::yield();
+            }
+            result = mount(fs.loop_path().c_str(), other.c_str(), "ext4", 0, nullptr);
+            mount_error = errno;
+        });
+        start.store(true, std::memory_order_release);
+        fs.Unmount();
+        mounter.join();
+        ASSERT_EQ(0, result) << strerror(mount_error);
+        const std::string path = other + "/raced";
+        int fd = open(path.c_str(), O_CREAT | O_RDWR, 0600);
+        ASSERT_GE(fd, 0) << strerror(errno);
+        ASSERT_EQ(1, pwrite(fd, "R", 1, iteration)) << strerror(errno);
+        ASSERT_EQ(0, fsync(fd)) << strerror(errno);
+        ASSERT_EQ(0, close(fd)) << strerror(errno);
+        ASSERT_EQ(0, umount(other.c_str())) << strerror(errno);
+    }
+    ASSERT_EQ(0, rmdir(other.c_str())) << strerror(errno);
 }
 
 TEST(Ext4InodeIdentity, OpenFileSurvivesFinalUnlink) {

--- a/user/apps/tests/dunitest/suites/normal/ext4_xattr.cc
+++ b/user/apps/tests/dunitest/suites/normal/ext4_xattr.cc
@@ -47,6 +47,10 @@ class TempFile {
         return path_.c_str();
     }
 
+    int fd() const {
+        return fd_;
+    }
+
   private:
     std::string path_;
     int fd_ = -1;
@@ -175,6 +179,34 @@ TEST(Ext4Xattr, CreateReplaceFlagsAndFailurePreserveValue) {
     errno = 0;
     EXPECT_EQ(-1, removexattr(file.path(), kName));
     EXPECT_EQ(ENODATA, errno);
+}
+
+TEST(Ext4Xattr, UnlinkWithAttributeKeepsFilesystemWritableAfterSync) {
+    struct statfs st = {};
+    ASSERT_EQ(0, statfs("/root", &st)) << strerror(errno);
+    if (st.f_type != kExt4SuperMagic) {
+        GTEST_SKIP() << "/root is not ext4";
+    }
+    {
+        TempFile file;
+        ASSERT_TRUE(file.valid()) << strerror(errno);
+        ASSERT_EQ(0, setxattr(file.path(), "user.reclaim", "retained", 8, 0))
+            << strerror(errno);
+        // Leave the attribute attached when close/unlink triggers eviction.
+    }
+    int directory = open("/root", O_RDONLY | O_DIRECTORY | O_CLOEXEC);
+    ASSERT_GE(directory, 0) << strerror(errno);
+    int synced = syncfs(directory);
+    int sync_error = errno;
+    close(directory);
+    ASSERT_EQ(0, synced) << "reclaim syncfs: " << strerror(sync_error);
+
+    TempFile next;
+    ASSERT_TRUE(next.valid()) << "creation after reclaim: " << strerror(errno);
+    const char payload[] = "filesystem remains writable";
+    ASSERT_EQ(static_cast<ssize_t>(sizeof(payload)), write(next.fd(), payload, sizeof(payload)))
+        << strerror(errno);
+    ASSERT_EQ(0, fsync(next.fd())) << "fsync after reclaim: " << strerror(errno);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
## Problem and behavior

Small ext4 metadata operations synchronously pay the complete journal flush protocol, delaying filesystem-heavy application work. This change publishes coherent metadata updates into bounded batches and commits them in the background, while explicit synchronization still waits for the required durability boundary.

## Implementation

- Centralize metadata access and publication across namespace, allocator, extent, xattr and delayed-allocation operations. Use one running batch, at most one frozen batch, a 256-block budget and a 100 ms deadline.
- Preserve the existing five-flush journal protocol. Retired blocks and inodes become reusable only after checkpoint and clean-tail persistence.
- Separate journal I/O and completion workers; reserve completion slots before publication and preserve accepted ownership on failures.
- Add generation-specific PageCache `Submitted` completion, finite synchronization targets, asynchronous error reporting and final-unmount draining.
- Share filesystem/cache/superblock state across same-device mounts. Centralize metadata reader/writer coordination while retaining inode caching and separating wakeup domains.
- Fix external-xattr hashes and block accounting, directory-growth accounting and fragmented-reclaim budgeting exposed by the new regression coverage.

## Validation

- Kernel build passed. The final build required `RUST_MIN_STACK=16777216` after a rustc/LLVM stack-related crash.
- 183 lower-level unit tests and 76 guest tests passed, covering inode identity/shared mounts, xattrs, fsync/fdatasync, syncfs, sync_file_range, mmap/truncate and writeback error reporting.
- Submitted/accounting self-tests passed with zero accounting drift; final guest batches drained without failure.
- 124 namespace write/flush crash points recovered and passed e2fsck. Real-image batch, delayed-allocation failure, fragmented-reclaim and inode-cache concurrency tests passed.
- Independent adversarial review covered architecture, responsibilities, redundancy, performance, safety, design, maintainability, workarounds and overdesign; identified defects were corrected and retested.

For five sequential rounds of 100 × 4 KiB files, including data syncfs, read verification, unlink and final syncfs, median total time decreased from **3.662096 s to 2.717986 s (25.8%)**. Creation time decreased from **0.125948 s to 0.011058 s**. Both kernels used release builds and the same initial QEMU disk snapshot/configuration; the baseline additionally contained DWARF debug information. These are sequential rounds, not independent cold boots.

## Remaining limits

Existing orphan-list scanning still produces long tails under sustained unlink workloads; this change does not introduce an additional orphan topology index. Global allocator OOM injection and all device-failure combinations were not exhaustively tested.

One CodeBuddy background-install exit comparison improved from 40.704 s to 9.988 s, but download and application cancellation timing were uncontrolled. Residual waiting remains, and this observation does not establish a stable application-level speedup or elimination of all interactive delays.
