### PR TITLE
fix(ext4): batch page reads and cache metadata blocks

### DIFF
--- a/kernel/crates/another_ext4/src/ext4/alloc.rs
+++ b/kernel/crates/another_ext4/src/ext4/alloc.rs
@@ -1122,11 +1122,8 @@ impl Ext4 {
                 continue;
             }
             let bitmap_home = bg.desc.block_bitmap_block();
-            let bitmap_block = self.prepare_allocation_bitmap(
-                &sb,
-                &bg,
-                transaction.read(self.block_device.as_ref(), bitmap_home)?,
-            )?;
+            let bitmap_block =
+                self.prepare_allocation_bitmap(&sb, &bg, transaction.read(self, bitmap_home)?)?;
             self.prepare_stats.record_bitmap_io();
             let checksum_bytes = (sb.clusters_per_group() as usize) / 8;
 
@@ -1613,7 +1610,7 @@ impl Ext4 {
             if !bg.verify_checksum(sb.metadata_checksum_seed()) {
                 return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
             }
-            let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
+            let bitmap_image = transaction.read(self, bitmap_block_id)?;
             if !bg.desc.verify_block_bitmap_csum(
                 sb.metadata_checksum_seed(),
                 &*bitmap_image,
@@ -1696,7 +1693,7 @@ impl Ext4 {
             if !bg.verify_checksum(sb.metadata_checksum_seed()) {
                 return_error!(ErrCode::EIO, "Corrupt block-group descriptor checksum");
             }
-            let bitmap_image = transaction.read(self.block_device.as_ref(), bitmap_block_id)?;
+            let bitmap_image = transaction.read(self, bitmap_block_id)?;
             if !bg.desc.verify_inode_bitmap_csum(
                 sb.metadata_checksum_seed(),
                 &*bitmap_image,

--- a/kernel/crates/another_ext4/src/ext4/dir.rs
+++ b/kernel/crates/another_ext4/src/ext4/dir.rs
@@ -93,7 +93,7 @@ impl Ext4 {
         Self::validate_dir_name(name)?;
         for iblock in 0..Self::dir_data_block_count(dir)? {
             let fblock = self.transaction_extent_query(transaction, dir, iblock)?;
-            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let view = transaction.read(self, fblock)?;
             let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
             let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
             if layout == DirBlockLayout::Htree {
@@ -326,7 +326,7 @@ impl Ext4 {
             // Scanning must not consume a credit for every non-matching block
             // in a large directory. `read` still observes an already-staged
             // image if this helper is composed with another directory update.
-            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let view = transaction.read(self, fblock)?;
             let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
             let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
             if layout == DirBlockLayout::Htree {
@@ -390,7 +390,7 @@ impl Ext4 {
         let total_blocks = Self::dir_data_block_count(dir)?;
         for iblock in 0..total_blocks {
             let fblock = self.transaction_extent_query(transaction, dir, iblock)?;
-            let view = transaction.read(self.block_device.as_ref(), fblock)?;
+            let view = transaction.read(self, fblock)?;
             let mut dir_block = DirBlock::new(Block::new(fblock, Box::new(*view)));
             let layout = self.validate_dir_block(dir, iblock, &dir_block)?;
             if dir_block.replace(name, new_inode, new_type, self.metadata_csum_enabled()) {

--- a/kernel/crates/another_ext4/src/ext4/extent.rs
+++ b/kernel/crates/another_ext4/src/ext4/extent.rs
@@ -5,6 +5,126 @@ use crate::format_error;
 use crate::prelude::*;
 use core::cmp::min;
 
+/// One bounded, logically contiguous part of a block-aligned file read.
+///
+/// `Mapped` segments are also physically contiguous and may therefore be
+/// submitted as one multi-block request. `Zero` covers sparse holes and
+/// unwritten extents and must not issue data I/O.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ReadSegment {
+    Mapped {
+        logical_start: u32,
+        physical_start: u64,
+        blocks: u32,
+    },
+    Zero {
+        logical_start: u32,
+        blocks: u32,
+    },
+}
+
+impl ReadSegment {
+    pub fn logical_start(&self) -> u32 {
+        match self {
+            Self::Mapped { logical_start, .. } | Self::Zero { logical_start, .. } => *logical_start,
+        }
+    }
+
+    pub fn block_count(&self) -> u32 {
+        match self {
+            Self::Mapped { blocks, .. } | Self::Zero { blocks, .. } => *blocks,
+        }
+    }
+}
+
+/// Stable lower-filesystem plan for one block-aligned read window.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ReadPlan {
+    /// Bytes before the inode-size snapshot's EOF. The final planned block may
+    /// contain fewer valid bytes; its caller must zero the unread tail.
+    pub valid_bytes: usize,
+    pub segments: Vec<ReadSegment>,
+}
+
+struct ReadPlanState {
+    request_start: u64,
+    request_end: u64,
+    cursor: u64,
+    max_segment_blocks: u32,
+    segments: Vec<ReadSegment>,
+}
+
+impl ReadPlanState {
+    fn push(&mut self, segment: ReadSegment) -> Result<()> {
+        let mut logical = segment.logical_start();
+        let mut physical = match segment {
+            ReadSegment::Mapped { physical_start, .. } => Some(physical_start),
+            ReadSegment::Zero { .. } => None,
+        };
+        let mut remaining = segment.block_count();
+        while remaining > 0 {
+            let merged = match (self.segments.last_mut(), physical) {
+                (
+                    Some(ReadSegment::Mapped {
+                        logical_start,
+                        physical_start,
+                        blocks,
+                    }),
+                    Some(next_physical),
+                ) if logical_start.checked_add(*blocks) == Some(logical)
+                    && physical_start.checked_add(u64::from(*blocks)) == Some(next_physical)
+                    && *blocks < self.max_segment_blocks =>
+                {
+                    let add = remaining.min(self.max_segment_blocks - *blocks);
+                    *blocks += add;
+                    add
+                }
+                (
+                    Some(ReadSegment::Zero {
+                        logical_start,
+                        blocks,
+                    }),
+                    None,
+                ) if logical_start.checked_add(*blocks) == Some(logical)
+                    && *blocks < self.max_segment_blocks =>
+                {
+                    let add = remaining.min(self.max_segment_blocks - *blocks);
+                    *blocks += add;
+                    add
+                }
+                _ => 0,
+            };
+            let consumed = if merged > 0 {
+                merged
+            } else {
+                let blocks = remaining.min(self.max_segment_blocks);
+                self.segments.push(match physical {
+                    Some(physical_start) => ReadSegment::Mapped {
+                        logical_start: logical,
+                        physical_start,
+                        blocks,
+                    },
+                    None => ReadSegment::Zero {
+                        logical_start: logical,
+                        blocks,
+                    },
+                });
+                blocks
+            };
+            logical = logical
+                .checked_add(consumed)
+                .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            if let Some(value) = physical.as_mut() {
+                *value = value
+                    .checked_add(u64::from(consumed))
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+            }
+            remaining -= consumed;
+        }
+        Ok(())
+    }
+}
+
 /// One contiguous tail of the right-most data extent removed from a tree.
 ///
 /// The caller owns allocation accounting: `metadata_blocks` have already been
@@ -215,7 +335,7 @@ impl Ext4 {
                 let block = if let Some(transaction) = transaction {
                     self.ensure_valid_pblock(inode.id, home, "extent tree node")?;
                     self.validate_data_blocks(home, 1)?;
-                    let block = transaction.read(self.block_device.as_ref(), home)?;
+                    let block = transaction.read(self, home)?;
                     self.verify_transaction_extent_block(inode, &*block)?;
                     block
                 } else {
@@ -321,7 +441,7 @@ impl Ext4 {
                 .path
                 .last()
                 .ok_or_else(|| Ext4Error::new(ErrCode::EINVAL))?;
-            let leaf_view = transaction.read(self.block_device.as_ref(), leaf_home)?;
+            let leaf_view = transaction.read(self, leaf_home)?;
             self.verify_transaction_extent_block(inode, &*leaf_view)?;
             let leaf = ExtentNode::from_bytes(&*leaf_view);
             self.validate_extent_node(inode.id, &leaf)?;
@@ -353,7 +473,7 @@ impl Ext4 {
 
                 for parent_home in plan.path[..plan.path.len() - 1].iter().rev() {
                     let carry_index = carry.ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
-                    let view = transaction.read(self.block_device.as_ref(), *parent_home)?;
+                    let view = transaction.read(self, *parent_home)?;
                     self.verify_transaction_extent_block(inode, &*view)?;
                     let parent = ExtentNode::from_bytes(&*view);
                     self.validate_extent_node(inode.id, &parent)?;
@@ -493,7 +613,7 @@ impl Ext4 {
             let block = if let Some(transaction) = transaction {
                 self.ensure_valid_pblock(inode.id, home, "extent tree node")?;
                 self.validate_data_blocks(home, 1)?;
-                let block = transaction.read(self.block_device.as_ref(), home)?;
+                let block = transaction.read(self, home)?;
                 self.verify_transaction_extent_block(inode, &*block)?;
                 block
             } else {
@@ -871,7 +991,7 @@ impl Ext4 {
                     return Err(Ext4Error::new(ErrCode::EINVAL));
                 }
 
-                let image = transaction.read(self.block_device.as_ref(), home)?;
+                let image = transaction.read(self, home)?;
                 self.verify_transaction_extent_block(inode, &*image)?;
                 let leaf = ExtentNode::from_bytes(&*image);
                 self.validate_extent_node(inode.id, &leaf)?;
@@ -909,7 +1029,7 @@ impl Ext4 {
         }
         if let Some(home) = leaf_home {
             {
-                let image = transaction.read(self.block_device.as_ref(), home)?;
+                let image = transaction.read(self, home)?;
                 self.verify_transaction_extent_block(inode, &*image)?;
                 let node = ExtentNode::from_bytes(&*image);
                 self.validate_extent_node(inode.id, &node)?;
@@ -1008,10 +1128,7 @@ impl Ext4 {
         self.ensure_valid_pblock(inode_ref.id, pblock, "extent tree node")?;
         self.validate_data_blocks(pblock, 1)?;
         let block = match transaction {
-            Some(tx) => Block::new(
-                pblock,
-                Box::new(*tx.read(self.block_device.as_ref(), pblock)?),
-            ),
+            Some(tx) => Block::new(pblock, Box::new(*tx.read(self, pblock)?)),
             None => self.read_block(pblock)?,
         };
         self.prepare_stats.record_extent_io();
@@ -1044,7 +1161,7 @@ impl Ext4 {
         };
         while let Some(pblock) = next {
             self.ensure_valid_pblock(inode_ref.id, pblock, "extent tail node")?;
-            let image = transaction.read(self.block_device.as_ref(), pblock)?;
+            let image = transaction.read(self, pblock)?;
             self.verify_transaction_extent_block(inode_ref, &*image)?;
             let node = ExtentNode::from_bytes(&*image);
             self.validate_extent_node(inode_ref.id, &node)?;
@@ -1118,7 +1235,7 @@ impl Ext4 {
             let mut pblock = root.extent_index_at(last).leaf();
             loop {
                 self.ensure_valid_pblock(inode_ref.id, pblock, "extent tail node")?;
-                let image = transaction.read(self.block_device.as_ref(), pblock)?;
+                let image = transaction.read(self, pblock)?;
                 self.verify_transaction_extent_block(inode_ref, &*image)?;
                 let node = ExtentNode::from_bytes(&*image);
                 self.validate_extent_node(inode_ref.id, &node)?;
@@ -1178,7 +1295,7 @@ impl Ext4 {
         // A full last extent leaves its leaf empty only when it was that leaf's
         // sole entry.  Otherwise stage the shortened leaf and stop cascading.
         let leaf_entries = {
-            let image = transaction.read(self.block_device.as_ref(), leaf_pblock)?;
+            let image = transaction.read(self, leaf_pblock)?;
             ExtentNode::from_bytes(&*image).header().entries_count()
         };
         if leaf_entries > 1 {
@@ -1202,7 +1319,7 @@ impl Ext4 {
             }
             let pblock = path[level];
             let entries = {
-                let image = transaction.read(self.block_device.as_ref(), pblock)?;
+                let image = transaction.read(self, pblock)?;
                 ExtentNode::from_bytes(&*image).header().entries_count()
             };
             if entries == 0 {
@@ -1313,6 +1430,221 @@ impl ExtentSearchStep {
 }
 
 impl Ext4 {
+    /// Resolve one block-aligned file window into bounded data and zero ranges.
+    ///
+    /// The inode and every extent node are observed under one metadata read
+    /// view. `valid_bytes` records that inode-size snapshot; bytes beyond it in
+    /// the final block are EOF and must be zeroed by the caller.
+    ///
+    /// A plan does not pin allocated blocks. The caller must hold its inode
+    /// mapping exclusion across this call and I/O submission, so truncate or
+    /// extent replacement cannot recycle a mapped block in between.
+    pub fn plan_read(
+        &self,
+        file: u32,
+        offset: usize,
+        len: usize,
+        max_segment_blocks: u32,
+    ) -> Result<ReadPlan> {
+        let _view = self.lock_metadata_read_view()?;
+        let inode_ref = self.read_inode(file)?;
+        self.build_read_plan_from_inode(&inode_ref, offset, len, max_segment_blocks)
+    }
+
+    fn build_read_plan_from_inode(
+        &self,
+        inode_ref: &InodeRef,
+        offset: usize,
+        len: usize,
+        max_segment_blocks: u32,
+    ) -> Result<ReadPlan> {
+        if !inode_ref.inode.is_file() {
+            return Err(format_error!(
+                ErrCode::EISDIR,
+                "Inode {} is not a file",
+                inode_ref.id
+            ));
+        }
+        if !offset.is_multiple_of(BLOCK_SIZE)
+            || !len.is_multiple_of(BLOCK_SIZE)
+            || max_segment_blocks == 0
+        {
+            return Err(Ext4Error::new(ErrCode::EINVAL));
+        }
+        offset
+            .checked_add(len)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?;
+        if len == 0 {
+            return Ok(ReadPlan {
+                valid_bytes: 0,
+                segments: Vec::new(),
+            });
+        }
+
+        let file_size =
+            usize::try_from(inode_ref.inode.size()).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
+        if offset >= file_size {
+            return Ok(ReadPlan {
+                valid_bytes: 0,
+                segments: Vec::new(),
+            });
+        }
+        let valid_bytes = min(len, file_size - offset);
+        let start_lblock =
+            u32::try_from(offset / BLOCK_SIZE).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
+        let block_count = valid_bytes
+            .checked_add(BLOCK_SIZE - 1)
+            .ok_or_else(|| Ext4Error::new(ErrCode::EFBIG))?
+            / BLOCK_SIZE;
+        let block_count = u32::try_from(block_count).map_err(|_| Ext4Error::new(ErrCode::EFBIG))?;
+        let end_lblock = u64::from(start_lblock) + u64::from(block_count);
+        if end_lblock > (1u64 << 32) {
+            return Err(Ext4Error::new(ErrCode::EFBIG));
+        }
+
+        let root = inode_ref.inode.extent_root();
+        let mut state = ReadPlanState {
+            request_start: u64::from(start_lblock),
+            request_end: end_lblock,
+            cursor: u64::from(start_lblock),
+            max_segment_blocks,
+            segments: Vec::new(),
+        };
+        self.collect_read_segments(
+            inode_ref,
+            &root,
+            root.header().depth(),
+            0,
+            1u64 << 32,
+            &mut state,
+        )?;
+        if state.cursor < state.request_end {
+            state.push(ReadSegment::Zero {
+                logical_start: u32::try_from(state.cursor)
+                    .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+                blocks: u32::try_from(state.request_end - state.cursor)
+                    .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+            })?;
+        }
+        Ok(ReadPlan {
+            valid_bytes,
+            segments: state.segments,
+        })
+    }
+
+    fn collect_read_segments(
+        &self,
+        inode_ref: &InodeRef,
+        node: &ExtentNode<'_>,
+        expected_depth: u16,
+        subtree_start: u64,
+        subtree_end: u64,
+        state: &mut ReadPlanState,
+    ) -> Result<()> {
+        self.validate_extent_node(inode_ref.id, node)?;
+        if node.header().depth() != expected_depth || subtree_start >= subtree_end {
+            return Err(format_error!(
+                ErrCode::EIO,
+                "extent tree depth or bounds invalid on inode {}",
+                inode_ref.id
+            ));
+        }
+        let entries = node.header().entries_count() as usize;
+        if expected_depth == 0 {
+            for pos in 0..entries {
+                let extent = node.extent_at(pos);
+                let extent_start = u64::from(extent.start_lblock());
+                let extent_end = extent_start
+                    .checked_add(u64::from(extent.block_count()))
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                if extent_start < subtree_start || extent_end > subtree_end {
+                    return Err(format_error!(
+                        ErrCode::EIO,
+                        "extent outside parent bounds on inode {}",
+                        inode_ref.id
+                    ));
+                }
+                self.ensure_valid_pblock(inode_ref.id, extent.start_pblock(), "extent data range")?;
+                self.validate_data_blocks(extent.start_pblock(), u64::from(extent.block_count()))?;
+                if extent_end <= state.request_start {
+                    continue;
+                }
+                if extent_start >= state.request_end {
+                    break;
+                }
+                let overlap_start = state.cursor.max(extent_start).max(state.request_start);
+                let overlap_end = state.request_end.min(extent_end);
+                if overlap_start >= overlap_end {
+                    continue;
+                }
+                if state.cursor < overlap_start {
+                    state.push(ReadSegment::Zero {
+                        logical_start: u32::try_from(state.cursor)
+                            .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+                        blocks: u32::try_from(overlap_start - state.cursor)
+                            .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+                    })?;
+                }
+                let blocks = u32::try_from(overlap_end - overlap_start)
+                    .map_err(|_| Ext4Error::new(ErrCode::EIO))?;
+                let physical_start = extent
+                    .start_pblock()
+                    .checked_add(overlap_start - extent_start)
+                    .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
+                let segment = if extent.is_unwritten() {
+                    ReadSegment::Zero {
+                        logical_start: u32::try_from(overlap_start)
+                            .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+                        blocks,
+                    }
+                } else {
+                    ReadSegment::Mapped {
+                        logical_start: u32::try_from(overlap_start)
+                            .map_err(|_| Ext4Error::new(ErrCode::EIO))?,
+                        physical_start,
+                        blocks,
+                    }
+                };
+                state.push(segment)?;
+                state.cursor = overlap_end;
+            }
+            return Ok(());
+        }
+
+        for pos in 0..entries {
+            let index = node.extent_index_at(pos);
+            let child_start = u64::from(index.start_lblock());
+            let child_end = if pos + 1 < entries {
+                u64::from(node.extent_index_at(pos + 1).start_lblock())
+            } else {
+                subtree_end
+            };
+            if child_start < subtree_start || child_start >= child_end || child_end > subtree_end {
+                return Err(format_error!(
+                    ErrCode::EIO,
+                    "extent index outside parent bounds on inode {}",
+                    inode_ref.id
+                ));
+            }
+            if child_end <= state.request_start || child_start >= state.request_end {
+                continue;
+            }
+            let child_pblock = index.leaf();
+            self.ensure_valid_pblock(inode_ref.id, child_pblock, "extent child node")?;
+            let child_block = self.read_extent_block_from_view(inode_ref, child_pblock, None)?;
+            let child = ExtentNode::from_bytes(&*child_block.data);
+            self.collect_read_segments(
+                inode_ref,
+                &child,
+                expected_depth - 1,
+                child_start,
+                child_end,
+                state,
+            )?;
+        }
+        Ok(())
+    }
+
     /// Given a logic block id, find the corresponding fs block id.
     pub(super) fn extent_query(&self, inode_ref: &InodeRef, iblock: LBlockId) -> Result<PBlockId> {
         self.extent_query_from_view(inode_ref, iblock, None)
@@ -1983,11 +2315,16 @@ mod tests {
         sb_block: Block,
     }
 
+    struct PlanBlockDevice {
+        base: StubBlockDevice,
+        blocks: BTreeMap<PBlockId, Block>,
+    }
+
     impl StubBlockDevice {
         fn with_block_count(block_count: u32) -> Self {
             let mut data = [0u8; BLOCK_SIZE];
             let off = BASE_OFFSET;
-            data[off..off + 4].copy_from_slice(&block_count.to_le_bytes());
+            data[off + 4..off + 8].copy_from_slice(&block_count.to_le_bytes());
             Self {
                 sb_block: Block::new(0, Box::new(data)),
             }
@@ -2015,12 +2352,39 @@ mod tests {
         }
     }
 
+    impl BlockDevice for PlanBlockDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            self.blocks
+                .get(&block_id)
+                .cloned()
+                .map(Ok)
+                .unwrap_or_else(|| self.base.read_block(block_id))
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
     fn make_test_fs(block_count: u32) -> Ext4 {
         let block_device = Arc::new(StubBlockDevice::with_block_count(block_count));
+        make_test_fs_with_device(block_device)
+    }
+
+    fn make_test_fs_with_device(block_device: Arc<dyn BlockDevice>) -> Ext4 {
         let block = block_device.read_block(0).unwrap();
         let sb = block.read_offset_as::<SuperBlock>(BASE_OFFSET);
         Ext4 {
             block_device,
+            metadata_cache: crate::ext4::MetadataBlockCache::new(16),
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups: Vec::new(),
             system_metadata_ranges: Vec::new(),
@@ -2040,6 +2404,21 @@ mod tests {
         }
     }
 
+    fn make_read_inode(size: u64, extents: &[Extent]) -> InodeRef {
+        let mut inode_ref = InodeRef::new(7, Box::default());
+        inode_ref.inode.set_mode(InodeMode::from_type_and_perm(
+            FileType::RegularFile,
+            InodeMode::ALL_RW,
+        ));
+        inode_ref.inode.set_size(size);
+        inode_ref.inode.extent_init();
+        let mut root = inode_ref.inode.extent_root_mut();
+        for (pos, extent) in extents.iter().enumerate() {
+            root.insert_extent(extent, pos).unwrap();
+        }
+        inode_ref
+    }
+
     fn make_metadata_csum_test_fs(block_count: u32) -> Ext4 {
         let mut device = StubBlockDevice::with_block_count(block_count);
         // ext4_super_block: s_feature_ro_compat at byte 100, UUID at 104.
@@ -2054,6 +2433,7 @@ mod tests {
             .read_offset_as::<SuperBlock>(BASE_OFFSET);
         Ext4 {
             block_device,
+            metadata_cache: crate::ext4::MetadataBlockCache::new(16),
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups: Vec::new(),
             system_metadata_ranges: Vec::new(),
@@ -2078,6 +2458,135 @@ mod tests {
         let fs = make_test_fs(16);
         let err = fs.ensure_valid_pblock(2, 16, "test").unwrap_err();
         assert_eq!(err.code(), ErrCode::EIO);
+    }
+
+    #[test]
+    fn read_plan_coalesces_holes_and_unwritten_extents_and_caps_segments() {
+        let fs = make_test_fs(1024);
+        let mut unwritten = Extent::new(7, 200, 2);
+        unwritten.mark_unwritten();
+        let inode_ref = make_read_inode(
+            (10 * BLOCK_SIZE) as u64,
+            &[Extent::new(0, 100, 2), Extent::new(4, 104, 2), unwritten],
+        );
+
+        let plan = fs
+            .build_read_plan_from_inode(&inode_ref, 0, 10 * BLOCK_SIZE, 3)
+            .unwrap();
+
+        assert_eq!(plan.valid_bytes, 10 * BLOCK_SIZE);
+        assert_eq!(
+            plan.segments,
+            vec![
+                ReadSegment::Mapped {
+                    logical_start: 0,
+                    physical_start: 100,
+                    blocks: 2,
+                },
+                ReadSegment::Zero {
+                    logical_start: 2,
+                    blocks: 2,
+                },
+                ReadSegment::Mapped {
+                    logical_start: 4,
+                    physical_start: 104,
+                    blocks: 2,
+                },
+                ReadSegment::Zero {
+                    logical_start: 6,
+                    blocks: 3,
+                },
+                ReadSegment::Zero {
+                    logical_start: 9,
+                    blocks: 1,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn read_plan_reports_partial_eof_without_mapping_past_its_last_block() {
+        let fs = make_test_fs(1024);
+        let inode_ref = make_read_inode((5 * BLOCK_SIZE + 123) as u64, &[Extent::new(0, 100, 12)]);
+
+        let plan = fs
+            .build_read_plan_from_inode(&inode_ref, 4 * BLOCK_SIZE, 4 * BLOCK_SIZE, 8)
+            .unwrap();
+
+        assert_eq!(plan.valid_bytes, BLOCK_SIZE + 123);
+        assert_eq!(
+            plan.segments,
+            vec![ReadSegment::Mapped {
+                logical_start: 4,
+                physical_start: 104,
+                blocks: 2,
+            }]
+        );
+    }
+
+    #[test]
+    fn read_plan_rejects_invalid_contract_and_corrupt_physical_range() {
+        let fs = make_test_fs(128);
+        let inode_ref = make_read_inode(BLOCK_SIZE as u64, &[Extent::new(0, 127, 2)]);
+
+        assert_eq!(
+            fs.build_read_plan_from_inode(&inode_ref, 1, BLOCK_SIZE, 1)
+                .unwrap_err()
+                .code(),
+            ErrCode::EINVAL
+        );
+        assert_eq!(
+            fs.build_read_plan_from_inode(&inode_ref, 0, BLOCK_SIZE, 0)
+                .unwrap_err()
+                .code(),
+            ErrCode::EINVAL
+        );
+        assert_eq!(
+            fs.build_read_plan_from_inode(&inode_ref, 0, BLOCK_SIZE, 1)
+                .unwrap_err()
+                .code(),
+            ErrCode::EIO
+        );
+    }
+
+    #[test]
+    fn read_plan_only_loads_extent_subtrees_intersecting_the_window() {
+        let mut device = StubBlockDevice::with_block_count(1024);
+        let mut leaf_data = [0u8; BLOCK_SIZE];
+        let mut leaf = ExtentNodeMut::from_bytes(&mut leaf_data);
+        leaf.init(0, 0);
+        leaf.insert_extent(&Extent::new(100, 500, 4), 0).unwrap();
+        device.sb_block.data[BASE_OFFSET + 4..BASE_OFFSET + 8]
+            .copy_from_slice(&1024u32.to_le_bytes());
+        // Block 10 is intentionally absent. Reading it would produce an
+        // invalid extent header and fail this request.
+        let mut blocks = BTreeMap::new();
+        blocks.insert(20, Block::new(20, Box::new(leaf_data)));
+        let block_device = Arc::new(PlanBlockDevice {
+            base: device,
+            blocks,
+        });
+        let fs = make_test_fs_with_device(block_device);
+
+        let mut inode_ref = make_read_inode((104 * BLOCK_SIZE) as u64, &[]);
+        let mut root = inode_ref.inode.extent_root_mut();
+        root.init(1, 0);
+        root.insert_extent_index(&ExtentIndex::new(0, 10), 0)
+            .unwrap();
+        root.insert_extent_index(&ExtentIndex::new(100, 20), 1)
+            .unwrap();
+
+        let plan = fs
+            .build_read_plan_from_inode(&inode_ref, 100 * BLOCK_SIZE, 4 * BLOCK_SIZE, 16)
+            .unwrap();
+        assert_eq!(
+            plan.segments,
+            vec![ReadSegment::Mapped {
+                logical_start: 100,
+                physical_start: 500,
+                blocks: 4,
+            }]
+        );
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/journal.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal.rs
@@ -1,4 +1,4 @@
-use super::{journal_recovery, journal_transaction, Ext4, MetadataMutationMode};
+use super::{journal_recovery, journal_transaction, Ext4, MetadataMutationMode, PublicationPoint};
 use crate::constants::BLOCK_SIZE;
 use crate::ext4_defs::{AsBytes, Block, BlockDevice, InodeRef, SuperBlock};
 use crate::jbd2::Superblock as JournalSuperblock;
@@ -226,6 +226,7 @@ impl Ext4 {
                 unreachable!()
             };
             self.metadata_mode = MetadataMutationMode::Batched(journal.into_batch(block_budget)?);
+            self.metadata_cache = super::MetadataBlockCache::new(super::METADATA_CACHE_BLOCKS);
         }
         Ok(())
     }
@@ -246,7 +247,7 @@ impl Ext4 {
     pub fn commit_pending_batch(&self) -> Result<Option<u64>> {
         match &self.metadata_mode {
             MetadataMutationMode::Batched(core) => core
-                .commit_pending(self.block_device.as_ref())
+                .commit_pending_with_publisher(self.block_device.as_ref(), self)
                 .map_err(|failure| {
                     self.poison(ErrCode::EIO);
                     failure.error
@@ -484,8 +485,11 @@ impl Ext4 {
     }
 }
 
-impl journal_transaction::CachePublisher for Ext4 {
-    fn publish(&self, blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>) {
+impl Ext4 {
+    fn publish_typed_metadata_caches(
+        &self,
+        blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>,
+    ) {
         // Normal transactions change descriptor counters/checksums, never the
         // validated bitmap/table addresses. Therefore system_metadata_ranges
         // remains immutable here; journal replay is the only path which can
@@ -518,6 +522,75 @@ impl journal_transaction::CachePublisher for Ext4 {
                 .map(|(block, _)| !blocks.contains_key(&block))
                 .unwrap_or(false)
         });
+    }
+}
+
+impl journal_transaction::CachePublisher for Ext4 {
+    fn publish(&self, blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>) {
+        let mut notify = false;
+        for block in blocks.values() {
+            notify |= self.metadata_cache.publish_existing(
+                block.home(),
+                block.bytes(),
+                PublicationPoint::HomeCurrent,
+            );
+        }
+        self.publish_typed_metadata_caches(blocks);
+        if notify {
+            self.metadata_mutation_barrier.notify_progress();
+        }
+    }
+
+    fn publish_home_current(
+        &self,
+        blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>,
+        retired: &[super::journal_batch::RetiredRange],
+    ) {
+        let mut notify = false;
+        for block in blocks.values() {
+            notify |= self.metadata_cache.publish_existing(
+                block.home(),
+                block.bytes(),
+                PublicationPoint::HomeCurrent,
+            );
+        }
+        notify |= self
+            .metadata_cache
+            .invalidate_block_ranges(retired.iter().filter_map(|range| range.block_bounds()));
+        self.publish_typed_metadata_caches(blocks);
+        if notify {
+            self.metadata_mutation_barrier.notify_progress();
+        }
+    }
+
+    fn publish_accepted(
+        &self,
+        blocks: &BTreeMap<PBlockId, journal_transaction::StagedBlock>,
+        sequence: u64,
+        retired: &[super::journal_batch::RetiredRange],
+    ) {
+        let mut notify = false;
+        for block in blocks.values() {
+            notify |= self.metadata_cache.publish_existing(
+                block.home(),
+                block.bytes(),
+                PublicationPoint::Accepted { sequence },
+            );
+        }
+        // Retirement wins if an operation both staged and freed a home.
+        notify |= self
+            .metadata_cache
+            .invalidate_block_ranges(retired.iter().filter_map(|range| range.block_bounds()));
+        self.publish_typed_metadata_caches(blocks);
+        if notify {
+            self.metadata_mutation_barrier.notify_progress();
+        }
+    }
+
+    fn checkpoint(&self, sequence: u64, blocks: &[journal_transaction::StagedBlock]) {
+        for block in blocks {
+            self.metadata_cache.checkpoint(sequence, &[block.home()]);
+        }
     }
 }
 

--- a/kernel/crates/another_ext4/src/ext4/journal_batch.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_batch.rs
@@ -6,8 +6,8 @@
 //! It must only be selected after *all* runtime metadata access uses this view.
 
 use super::journal_transaction::{
-    CachePublisher, CommitError, JournalContext, JournalTransactionCore, StagedBlock, Transaction,
-    TransactionCoreRef,
+    CachePublisher, CommitError, JournalContext, JournalTransactionCore, MetadataBlockSource,
+    StagedBlock, Transaction, TransactionCoreRef,
 };
 use super::MetadataMutationWaker;
 use crate::constants::BLOCK_SIZE;
@@ -66,6 +66,10 @@ impl RetiredRange {
 
     fn overlaps(self, other: Self) -> bool {
         self.inode == other.inode && self.start < other.end && other.start < self.end
+    }
+
+    pub(super) fn block_bounds(self) -> Option<(PBlockId, PBlockId)> {
+        (!self.inode).then_some((self.start, self.end))
     }
 }
 
@@ -371,7 +375,7 @@ impl JournalBatchCore {
             state.generation = state.generation.wrapping_add(1);
             next
         };
-        publisher.publish(staged);
+        publisher.publish_accepted(staged, sequence, retired);
         incoming.extend(core::mem::take(staged).into_values());
         // Capacity and all validation were settled before the first visible
         // cache change. Sorted Vec insertion moves only small block owners,
@@ -407,7 +411,11 @@ impl JournalBatchCore {
     /// Read from the latest accepted view. Allocate the destination before
     /// locking; a cold read is revalidated after I/O even when an intervening
     /// checkpoint removed the last overlay version of this home.
-    pub fn read_metadata(&self, device: &dyn BlockDevice, home: PBlockId) -> Result<Block> {
+    pub(super) fn read_metadata<S: MetadataBlockSource + ?Sized>(
+        &self,
+        source: &S,
+        home: PBlockId,
+    ) -> Result<Block> {
         self.validate_home(home)?;
         let mut image = Box::new([0; BLOCK_SIZE]);
         loop {
@@ -422,7 +430,7 @@ impl JournalBatchCore {
                 }
                 state.generation
             };
-            let disk = device.read_block(home)?;
+            let disk = source.read_committed_metadata(home)?;
             let state = self.state.lock();
             if state.publishing {
                 return Err(Ext4Error::new(ErrCode::EAGAIN));
@@ -521,6 +529,22 @@ impl JournalBatchCore {
         &self,
         device: &dyn BlockDevice,
     ) -> core::result::Result<Option<u64>, CommitError> {
+        self.commit_pending_inner(device, None)
+    }
+
+    pub(super) fn commit_pending_with_publisher(
+        &self,
+        device: &dyn BlockDevice,
+        publisher: &dyn CachePublisher,
+    ) -> core::result::Result<Option<u64>, CommitError> {
+        self.commit_pending_inner(device, Some(publisher))
+    }
+
+    fn commit_pending_inner(
+        &self,
+        device: &dyn BlockDevice,
+        publisher: Option<&dyn CachePublisher>,
+    ) -> core::result::Result<Option<u64>, CommitError> {
         let (mut frozen, sequence) = {
             let mut state = self.state.lock();
             if state.failed || state.committing || state.active || !state.seal_requested {
@@ -575,6 +599,9 @@ impl JournalBatchCore {
             state.generation = state.generation.wrapping_add(1);
             state.frozen.take()
         };
+        if let Some(publisher) = publisher {
+            publisher.checkpoint(sequence, &frozen.blocks);
+        }
         drop(old_owner);
         let recycled = Arc::get_mut(&mut frozen).expect("only worker owns retired frozen images");
         recycled.blocks.clear();

--- a/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
+++ b/kernel/crates/another_ext4/src/ext4/journal_transaction.rs
@@ -81,7 +81,7 @@ impl StagedBlock {
 /// Synchronous journal commits publish after a durable checkpoint; batch
 /// operations publish at acceptance. Old batch checkpoints never republish.
 /// Direct commits publish after every synchronous home write has succeeded.
-pub trait CachePublisher: Send + Sync {
+pub(super) trait CachePublisher: Send + Sync {
     /// Publish the operation's final images to in-memory caches.
     ///
     /// This is an irrevocable logical publication, so it must not allocate,
@@ -89,6 +89,39 @@ pub trait CachePublisher: Send + Sync {
     /// lets publishers inspect the final image for a particular home block
     /// without building a temporary collection.
     fn publish(&self, blocks: &BTreeMap<PBlockId, StagedBlock>);
+
+    fn publish_home_current(
+        &self,
+        blocks: &BTreeMap<PBlockId, StagedBlock>,
+        _retired: &[RetiredRange],
+    ) {
+        self.publish(blocks);
+    }
+
+    /// Publish one batched transaction at its logical acceptance point. The
+    /// default preserves publishers which only maintain decoded value caches.
+    fn publish_accepted(
+        &self,
+        blocks: &BTreeMap<PBlockId, StagedBlock>,
+        _sequence: u64,
+        _retired: &[RetiredRange],
+    ) {
+        self.publish(blocks);
+    }
+
+    /// Notify discardable caches that the exact Frozen images reached their
+    /// home blocks. Old checkpoints must never republish their payload.
+    fn checkpoint(&self, _sequence: u64, _blocks: &[StagedBlock]) {}
+}
+
+pub(super) trait MetadataBlockSource {
+    fn read_committed_metadata(&self, home: PBlockId) -> Result<Block>;
+}
+
+impl<T: BlockDevice + ?Sized> MetadataBlockSource for T {
+    fn read_committed_metadata(&self, home: PBlockId) -> Result<Block> {
+        self.read_block(home)
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -362,16 +395,16 @@ impl Transaction<'_> {
     /// The first access snapshots the device block and consumes one credit;
     /// later accesses return the same image, providing read-your-writes and
     /// naturally merging updates to shared metadata blocks.
-    pub fn read_for_update<'a>(
+    pub(super) fn read_for_update<'a, S: MetadataBlockSource + ?Sized>(
         &'a mut self,
-        device: &dyn BlockDevice,
+        source: &S,
         home: PBlockId,
     ) -> Result<&'a mut [u8; BLOCK_SIZE]> {
         if !self.staged.contains_key(&home) {
             if self.staged.len() == self.credits {
                 return Err(Ext4Error::new(ErrCode::E2BIG));
             }
-            let block = self.read_base(device, home)?;
+            let block = self.read_base(source, home)?;
             let original = self.preserve_originals.then(|| block.data.clone());
             self.staged.insert(
                 home,
@@ -390,18 +423,26 @@ impl Transaction<'_> {
             .as_mut())
     }
 
-    pub fn read<'a>(&'a self, device: &dyn BlockDevice, home: PBlockId) -> Result<BlockView<'a>> {
+    pub(super) fn read<'a, S: MetadataBlockSource + ?Sized>(
+        &'a self,
+        source: &S,
+        home: PBlockId,
+    ) -> Result<BlockView<'a>> {
         if let Some(block) = self.staged.get(&home) {
             Ok(BlockView::Staged(block.bytes()))
         } else {
-            Ok(BlockView::Device(self.read_base(device, home)?))
+            Ok(BlockView::Device(self.read_base(source, home)?))
         }
     }
 
-    fn read_base(&self, device: &dyn BlockDevice, home: PBlockId) -> Result<Block> {
+    fn read_base<S: MetadataBlockSource + ?Sized>(
+        &self,
+        source: &S,
+        home: PBlockId,
+    ) -> Result<Block> {
         match self.core {
-            TransactionCoreRef::Batch(core) => core.read_metadata(device, home),
-            _ => device.read_block(home),
+            TransactionCoreRef::Batch(core) => core.read_metadata(source, home),
+            _ => source.read_committed_metadata(home),
         }
     }
 
@@ -468,7 +509,7 @@ impl Transaction<'_> {
     /// Accept an operation into the live metadata view. This is deliberately
     /// distinct from `commit`: successful publication is not durability, and
     /// subsequent disk failures must never trigger reservation rollback.
-    pub fn publish(mut self, publisher: &dyn CachePublisher) -> Result<u64> {
+    pub(super) fn publish(mut self, publisher: &dyn CachePublisher) -> Result<u64> {
         let TransactionCoreRef::Batch(core) = self.core else {
             return Err(Ext4Error::new(ErrCode::EINVAL));
         };
@@ -481,7 +522,7 @@ impl Transaction<'_> {
         self.release_writer();
     }
 
-    pub fn commit(
+    pub(super) fn commit(
         mut self,
         device: &dyn BlockDevice,
         publisher: &dyn CachePublisher,
@@ -578,7 +619,7 @@ impl Transaction<'_> {
         if let Err(error) = write_bytes(device, inode_home, inode.bytes()) {
             return self.fail(error, CommitFailure::CommitUncertain, true);
         }
-        publisher.publish(&self.staged);
+        publisher.publish_home_current(&self.staged, &self.retired);
         self.release_writer();
         Ok(())
     }
@@ -627,7 +668,7 @@ impl Transaction<'_> {
                 return self.fail(error, CommitFailure::CheckpointFailed, true);
             }
         }
-        publisher.publish(&self.staged);
+        publisher.publish_home_current(&self.staged, &self.retired);
         self.release_writer();
         Ok(())
     }
@@ -641,7 +682,9 @@ impl Transaction<'_> {
             unreachable!()
         };
         let images = self.staged.values().collect::<Vec<_>>();
-        let result = core.commit_images(device, &images, || publisher.publish(&self.staged));
+        let result = core.commit_images(device, &images, || {
+            publisher.publish_home_current(&self.staged, &self.retired)
+        });
         self.release_writer();
         result
     }

--- a/kernel/crates/another_ext4/src/ext4/low_level.rs
+++ b/kernel/crates/another_ext4/src/ext4/low_level.rs
@@ -4479,6 +4479,7 @@ mod tests {
         let sb = block.read_offset_as::<SuperBlock>(BASE_OFFSET);
         Ext4 {
             block_device,
+            metadata_cache: crate::ext4::MetadataBlockCache::new(16),
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups: Vec::new(),
             system_metadata_ranges: Vec::new(),

--- a/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
+++ b/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
@@ -223,10 +223,21 @@ impl MetadataBlockCache {
         let MetadataCacheStorage::Enabled(sets) = &self.storage else {
             return None;
         };
-        // Fibonacci hashing prevents aligned ext4 metadata homes from mapping
-        // directly by their low bits. Modulo supports non-power-of-two sizes.
-        let mixed = home.wrapping_mul(0x9e37_79b9_7f4a_7c15);
-        sets.get((mixed % sets.len() as u64) as usize)
+        sets.get(Self::set_index(home, sets.len()))
+    }
+
+    fn set_index(home: PBlockId, set_count: usize) -> usize {
+        // The SplitMix64 finalizer avalanches high block-number bits before the
+        // modulo. Multiplication alone would only permute low bits for the
+        // common power-of-two set count, making equal offsets in ext4 block
+        // groups contend for the same four ways.
+        let mut mixed = home;
+        mixed ^= mixed >> 30;
+        mixed = mixed.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+        mixed ^= mixed >> 27;
+        mixed = mixed.wrapping_mul(0x94d0_49bb_1331_11eb);
+        mixed ^= mixed >> 31;
+        (mixed % set_count as u64) as usize
     }
 
     fn allocate_ticket(&self) -> Option<u64> {
@@ -749,6 +760,25 @@ mod tests {
         assert!(retired.notify_progress);
         assert!(cache.read(device.as_ref(), 13).result.is_ok());
         assert_eq!(device.reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn aligned_block_group_metadata_remains_resident() {
+        let cache = MetadataBlockCache::new(1024);
+        let device = TestDevice::plain();
+        let mut homes = [0u64; 8];
+        for (group, home) in homes.iter_mut().enumerate() {
+            // 32,768 blocks is a common 4 KiB ext4 blocks-per-group value and
+            // is divisible by all 256 sets in the production cache.
+            *home = 17 + group as u64 * 32_768;
+            cache.read(&device, *home).result.unwrap();
+        }
+        let populated_reads = device.reads.load(Ordering::SeqCst);
+        for home in homes {
+            cache.read(&device, home).result.unwrap();
+        }
+        assert_eq!(populated_reads, homes.len());
+        assert_eq!(device.reads.load(Ordering::SeqCst), populated_reads);
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
+++ b/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
@@ -457,6 +457,13 @@ impl MetadataBlockCache {
     where
         I: Iterator<Item = (PBlockId, PBlockId)> + Clone,
     {
+        // The common metadata transaction retires no physical block. Avoid
+        // taking every set lock and inspecting the complete cache in that
+        // path. Clone keeps the caller's iterator available for the bounded
+        // scan below without allocating in the infallible publication path.
+        if ranges.clone().next().is_none() {
+            return false;
+        }
         let MetadataCacheStorage::Enabled(sets) = &self.storage else {
             return false;
         };
@@ -541,8 +548,9 @@ impl MetadataBlockCache {
 mod tests {
     use super::*;
     use core::sync::atomic::{AtomicBool, Ordering};
-    use std::sync::{Arc as StdArc, Barrier, Condvar, Mutex as StdMutex};
+    use std::sync::{mpsc, Arc as StdArc, Barrier, Condvar, Mutex as StdMutex};
     use std::thread;
+    use std::time::Duration;
 
     struct TestDevice {
         reads: AtomicUsize,
@@ -756,6 +764,26 @@ mod tests {
         cache.read(&device, 5).result.unwrap();
         cache.read(&device, 20).result.unwrap();
         assert_eq!(device.reads.load(Ordering::SeqCst) - before, 2);
+    }
+
+    #[test]
+    fn empty_retirement_does_not_take_any_set_lock() {
+        let cache = StdArc::new(MetadataBlockCache::new(WAYS));
+        let MetadataCacheStorage::Enabled(sets) = &cache.storage else {
+            panic!("test cache must be enabled");
+        };
+        let first_set = sets[0].lock();
+        let worker_cache = StdArc::clone(&cache);
+        let (sender, receiver) = mpsc::channel();
+        let worker = thread::spawn(move || {
+            let notify = worker_cache.invalidate_block_ranges(core::iter::empty());
+            sender.send(notify).unwrap();
+        });
+
+        let returned_without_lock = receiver.recv_timeout(Duration::from_millis(250));
+        drop(first_set);
+        worker.join().unwrap();
+        assert_eq!(returned_without_lock.unwrap(), false);
     }
 
     #[test]

--- a/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
+++ b/kernel/crates/another_ext4/src/ext4/metadata_cache.rs
@@ -1,0 +1,788 @@
+//! Bounded cache for committed ext4 metadata block images.
+//!
+//! This module deliberately has no journal or [`super::Ext4`] dependency.  A
+//! caller supplies publication and checkpoint events. The mounted filesystem
+//! enables it only for a metadata mode whose read, publication, retirement and
+//! checkpoint paths are wired as one unit.
+#![allow(dead_code)] // Introspection is currently consumed by host-side tests.
+
+use crate::constants::BLOCK_SIZE;
+use crate::ext4_defs::{Block, BlockDevice};
+use crate::prelude::*;
+use core::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+const WAYS: usize = 4;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum PublicationPoint {
+    /// The supplied image is the current home-block view.  This says nothing
+    /// about power-loss durability.
+    HomeCurrent,
+    /// The supplied image is logically visible but has not necessarily been
+    /// checkpointed to its home block.
+    Accepted { sequence: u64 },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SlotState {
+    Empty,
+    Loading { ticket: u64, invalidated: bool },
+    Clean,
+    Dirty { sequence: u64 },
+    Error { code: ErrCode },
+}
+
+struct CacheSlot {
+    home: Option<PBlockId>,
+    image: Vec<u8>,
+    state: SlotState,
+    referenced: bool,
+}
+
+impl CacheSlot {
+    fn try_new() -> core::result::Result<Self, ()> {
+        // Construct the 4 KiB owner through Vec's fallible reservation.  A
+        // plain Box::new([0; BLOCK_SIZE]) would make cache enablement capable
+        // of aborting the kernel on allocation failure.
+        let mut image = Vec::new();
+        image.try_reserve_exact(BLOCK_SIZE).map_err(|_| ())?;
+        image.resize(BLOCK_SIZE, 0);
+        Ok(Self {
+            home: None,
+            image,
+            state: SlotState::Empty,
+            referenced: false,
+        })
+    }
+
+    fn clear(&mut self) {
+        self.home = None;
+        self.state = SlotState::Empty;
+        self.referenced = false;
+    }
+
+    fn reclaimable(&self) -> bool {
+        matches!(self.state, SlotState::Clean | SlotState::Error { .. })
+    }
+}
+
+struct CacheSet {
+    ways: [CacheSlot; WAYS],
+    hand: usize,
+}
+
+impl CacheSet {
+    fn try_new() -> core::result::Result<Self, ()> {
+        let mut ways = Vec::new();
+        ways.try_reserve_exact(WAYS).map_err(|_| ())?;
+        for _ in 0..WAYS {
+            ways.push(CacheSlot::try_new()?);
+        }
+        let ways = ways.try_into().map_err(|_| ())?;
+        Ok(Self { ways, hand: 0 })
+    }
+
+    fn find(&self, home: PBlockId) -> Option<usize> {
+        self.ways.iter().position(|slot| slot.home == Some(home))
+    }
+
+    /// Select an empty way or perform at most two clock passes. Loading and
+    /// dirty ways remain pinned. The bounded scan is important because this is
+    /// also called by a transaction which may prevent journal retirement.
+    fn admit_way(&mut self) -> Option<(usize, bool)> {
+        if let Some(index) = self
+            .ways
+            .iter()
+            .position(|slot| slot.state == SlotState::Empty)
+        {
+            return Some((index, false));
+        }
+
+        for _ in 0..WAYS * 2 {
+            let index = self.hand;
+            self.hand = (self.hand + 1) % WAYS;
+            let slot = &mut self.ways[index];
+            if !slot.reclaimable() {
+                continue;
+            }
+            if slot.referenced {
+                slot.referenced = false;
+                continue;
+            }
+            return Some((index, true));
+        }
+        None
+    }
+}
+
+enum MetadataCacheStorage {
+    Disabled,
+    Enabled(Vec<spin::Mutex<CacheSet>>),
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(super) struct MetadataCacheStatsSnapshot {
+    pub hits: usize,
+    pub misses: usize,
+    pub loaders: usize,
+    pub loading_contention: usize,
+    pub io_errors: usize,
+    pub evictions: usize,
+    pub bypasses: usize,
+    pub published_dirty: usize,
+    pub checkpoint_cleaned: usize,
+    pub invalidations: usize,
+    pub stale_loads: usize,
+}
+
+#[derive(Default)]
+struct MetadataCacheStats {
+    hits: AtomicUsize,
+    misses: AtomicUsize,
+    loaders: AtomicUsize,
+    loading_contention: AtomicUsize,
+    io_errors: AtomicUsize,
+    evictions: AtomicUsize,
+    bypasses: AtomicUsize,
+    published_dirty: AtomicUsize,
+    checkpoint_cleaned: AtomicUsize,
+    invalidations: AtomicUsize,
+    stale_loads: AtomicUsize,
+}
+
+/// Result of one cache read. `notify_progress` is set when this call retired a
+/// Loading owner; the future Ext4 integration must advance its wait generation
+/// and wake waiters after receiving the outcome.
+pub(super) struct MetadataCacheReadOutcome {
+    pub result: Result<Block>,
+    pub notify_progress: bool,
+}
+
+impl MetadataCacheReadOutcome {
+    fn ready(block: Block, notify_progress: bool) -> Self {
+        Self {
+            result: Ok(block),
+            notify_progress,
+        }
+    }
+
+    fn error(code: ErrCode, notify_progress: bool) -> Self {
+        Self {
+            result: Err(Ext4Error::new(code)),
+            notify_progress,
+        }
+    }
+}
+
+/// Fixed-capacity four-way set-associative metadata block cache.
+pub(super) struct MetadataBlockCache {
+    storage: MetadataCacheStorage,
+    next_ticket: AtomicU64,
+    stats: MetadataCacheStats,
+}
+
+impl MetadataBlockCache {
+    /// Build a cache whose usable capacity is rounded down to a multiple of
+    /// four. Too-small, overflowing, or failed allocations select Disabled;
+    /// cache availability must never decide whether an ext4 mount succeeds.
+    pub(super) fn new(requested_blocks: usize) -> Self {
+        let set_count = requested_blocks / WAYS;
+        let storage = Self::try_storage(set_count).unwrap_or(MetadataCacheStorage::Disabled);
+        Self {
+            storage,
+            // Zero is reserved so a zero-filled/corrupted token cannot match.
+            next_ticket: AtomicU64::new(1),
+            stats: MetadataCacheStats::default(),
+        }
+    }
+
+    fn try_storage(set_count: usize) -> core::result::Result<MetadataCacheStorage, ()> {
+        if set_count == 0 || set_count.checked_mul(WAYS).is_none() {
+            return Err(());
+        }
+        let mut sets = Vec::new();
+        sets.try_reserve_exact(set_count).map_err(|_| ())?;
+        for _ in 0..set_count {
+            sets.push(spin::Mutex::new(CacheSet::try_new()?));
+        }
+        Ok(MetadataCacheStorage::Enabled(sets))
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        matches!(&self.storage, MetadataCacheStorage::Enabled(_))
+    }
+
+    pub(super) fn capacity(&self) -> usize {
+        match &self.storage {
+            MetadataCacheStorage::Disabled => 0,
+            MetadataCacheStorage::Enabled(sets) => sets.len() * WAYS,
+        }
+    }
+
+    fn set_for(&self, home: PBlockId) -> Option<&spin::Mutex<CacheSet>> {
+        let MetadataCacheStorage::Enabled(sets) = &self.storage else {
+            return None;
+        };
+        // Fibonacci hashing prevents aligned ext4 metadata homes from mapping
+        // directly by their low bits. Modulo supports non-power-of-two sizes.
+        let mixed = home.wrapping_mul(0x9e37_79b9_7f4a_7c15);
+        sets.get((mixed % sets.len() as u64) as usize)
+    }
+
+    fn allocate_ticket(&self) -> Option<u64> {
+        self.next_ticket
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |ticket| {
+                ticket.checked_add(1)
+            })
+            .ok()
+            .filter(|ticket| *ticket != 0)
+    }
+
+    /// Read one home block. A resident Loading entry returns EAGAIN; admission
+    /// failure performs an uncached read so an active transaction never waits
+    /// for the checkpoint which it is itself preventing.
+    pub(super) fn read(
+        &self,
+        device: &dyn BlockDevice,
+        home: PBlockId,
+    ) -> MetadataCacheReadOutcome {
+        let Some(set_lock) = self.set_for(home) else {
+            self.stats.bypasses.fetch_add(1, Ordering::Relaxed);
+            return Self::read_uncached(device, home);
+        };
+
+        // Block's owned return image is not part of cache capacity. Allocate it
+        // before taking the set lock so allocator work never occurs in a cache
+        // critical section.
+        let mut hit_image = Box::new([0; BLOCK_SIZE]);
+        let ticket = {
+            let mut set = set_lock.lock();
+            if let Some(index) = set.find(home) {
+                let slot = &mut set.ways[index];
+                match slot.state {
+                    SlotState::Clean | SlotState::Dirty { .. } => {
+                        slot.referenced = true;
+                        hit_image.copy_from_slice(slot.image.as_ref());
+                        self.stats.hits.fetch_add(1, Ordering::Relaxed);
+                        return MetadataCacheReadOutcome::ready(Block::new(home, hit_image), false);
+                    }
+                    SlotState::Loading { .. } => {
+                        self.stats
+                            .loading_contention
+                            .fetch_add(1, Ordering::Relaxed);
+                        return MetadataCacheReadOutcome::error(ErrCode::EAGAIN, false);
+                    }
+                    SlotState::Error { .. } => {
+                        let Some(ticket) = self.allocate_ticket() else {
+                            self.stats.bypasses.fetch_add(1, Ordering::Relaxed);
+                            drop(set);
+                            return Self::read_uncached(device, home);
+                        };
+                        slot.state = SlotState::Loading {
+                            ticket,
+                            invalidated: false,
+                        };
+                        slot.referenced = true;
+                        ticket
+                    }
+                    SlotState::Empty => unreachable!("an indexed cache slot cannot be empty"),
+                }
+            } else {
+                self.stats.misses.fetch_add(1, Ordering::Relaxed);
+                let Some(ticket) = self.allocate_ticket() else {
+                    self.stats.bypasses.fetch_add(1, Ordering::Relaxed);
+                    drop(set);
+                    return Self::read_uncached(device, home);
+                };
+                let Some((index, evicted)) = set.admit_way() else {
+                    self.stats.bypasses.fetch_add(1, Ordering::Relaxed);
+                    drop(set);
+                    return Self::read_uncached(device, home);
+                };
+                if evicted {
+                    self.stats.evictions.fetch_add(1, Ordering::Relaxed);
+                }
+                let slot = &mut set.ways[index];
+                slot.home = Some(home);
+                slot.state = SlotState::Loading {
+                    ticket,
+                    invalidated: false,
+                };
+                slot.referenced = true;
+                ticket
+            }
+        };
+
+        self.stats.loaders.fetch_add(1, Ordering::Relaxed);
+        let disk = device.read_block(home);
+        let mut set = set_lock.lock();
+        let Some(index) = set.find(home) else {
+            self.stats.stale_loads.fetch_add(1, Ordering::Relaxed);
+            return MetadataCacheReadOutcome::error(ErrCode::EAGAIN, false);
+        };
+        let slot = &mut set.ways[index];
+        match slot.state {
+            SlotState::Loading {
+                ticket: current,
+                invalidated: true,
+            } if current == ticket => {
+                slot.clear();
+                self.stats.stale_loads.fetch_add(1, Ordering::Relaxed);
+                MetadataCacheReadOutcome::error(ErrCode::EAGAIN, true)
+            }
+            SlotState::Loading {
+                ticket: current,
+                invalidated: false,
+            } if current == ticket => match disk {
+                Ok(block) => {
+                    slot.image.copy_from_slice(block.data.as_ref());
+                    slot.state = SlotState::Clean;
+                    slot.referenced = true;
+                    MetadataCacheReadOutcome::ready(block, true)
+                }
+                Err(error) => {
+                    slot.state = SlotState::Error { code: error.code() };
+                    slot.referenced = false;
+                    self.stats.io_errors.fetch_add(1, Ordering::Relaxed);
+                    MetadataCacheReadOutcome {
+                        result: Err(error),
+                        notify_progress: true,
+                    }
+                }
+            },
+            _ => {
+                // Publication won the race and now owns the cache image.
+                self.stats.stale_loads.fetch_add(1, Ordering::Relaxed);
+                MetadataCacheReadOutcome::error(ErrCode::EAGAIN, false)
+            }
+        }
+    }
+
+    fn read_uncached(device: &dyn BlockDevice, home: PBlockId) -> MetadataCacheReadOutcome {
+        MetadataCacheReadOutcome {
+            result: device.read_block(home),
+            notify_progress: false,
+        }
+    }
+
+    /// Publish one image if the home is already resident. The return value asks
+    /// the caller to notify waiters because a Loading owner was superseded.
+    pub(super) fn publish_existing(
+        &self,
+        home: PBlockId,
+        image: &[u8; BLOCK_SIZE],
+        point: PublicationPoint,
+    ) -> bool {
+        let Some(set_lock) = self.set_for(home) else {
+            return false;
+        };
+        let mut set = set_lock.lock();
+        let Some(index) = set.find(home) else {
+            return false;
+        };
+        let slot = &mut set.ways[index];
+        let ended_loading = matches!(slot.state, SlotState::Loading { .. });
+        if let (
+            SlotState::Dirty { sequence: current },
+            PublicationPoint::Accepted { sequence: incoming },
+        ) = (slot.state, point)
+        {
+            if incoming < current {
+                return false;
+            }
+        }
+        slot.image.copy_from_slice(image);
+        slot.state = match point {
+            PublicationPoint::HomeCurrent => SlotState::Clean,
+            PublicationPoint::Accepted { sequence } => {
+                self.stats.published_dirty.fetch_add(1, Ordering::Relaxed);
+                SlotState::Dirty { sequence }
+            }
+        };
+        slot.referenced = true;
+        ended_loading
+    }
+
+    /// Mark a resident accepted image clean only when this checkpoint cannot
+    /// be older than the cached image.
+    pub(super) fn checkpoint(&self, sequence: u64, homes: &[PBlockId]) -> usize {
+        let mut cleaned = 0;
+        for home in homes.iter().copied() {
+            let Some(set_lock) = self.set_for(home) else {
+                continue;
+            };
+            let mut set = set_lock.lock();
+            let Some(index) = set.find(home) else {
+                continue;
+            };
+            let slot = &mut set.ways[index];
+            if matches!(slot.state, SlotState::Dirty { sequence: dirty } if dirty <= sequence) {
+                slot.state = SlotState::Clean;
+                slot.referenced = true;
+                cleaned += 1;
+            }
+        }
+        self.stats
+            .checkpoint_cleaned
+            .fetch_add(cleaned, Ordering::Relaxed);
+        cleaned
+    }
+
+    /// Invalidate one physical home. A Loading slot remains reserved until its
+    /// exact loader retires, preventing a train of duplicate loaders.
+    pub(super) fn invalidate(&self, home: PBlockId) -> bool {
+        let Some(set_lock) = self.set_for(home) else {
+            return false;
+        };
+        let mut set = set_lock.lock();
+        let Some(index) = set.find(home) else {
+            return false;
+        };
+        let slot = &mut set.ways[index];
+        let notify = match &mut slot.state {
+            SlotState::Loading { invalidated, .. } => {
+                *invalidated = true;
+                true
+            }
+            _ => {
+                slot.clear();
+                false
+            }
+        };
+        self.stats.invalidations.fetch_add(1, Ordering::Relaxed);
+        notify
+    }
+
+    pub(super) fn invalidate_block_ranges<I>(&self, ranges: I) -> bool
+    where
+        I: Iterator<Item = (PBlockId, PBlockId)> + Clone,
+    {
+        let MetadataCacheStorage::Enabled(sets) = &self.storage else {
+            return false;
+        };
+        let mut notify = false;
+        for set_lock in sets {
+            let mut set = set_lock.lock();
+            for slot in &mut set.ways {
+                let Some(home) = slot.home else {
+                    continue;
+                };
+                if !ranges
+                    .clone()
+                    .any(|(start, end)| start < end && start <= home && home < end)
+                {
+                    continue;
+                }
+                match &mut slot.state {
+                    SlotState::Loading { invalidated, .. } => {
+                        *invalidated = true;
+                        notify = true;
+                    }
+                    _ => slot.clear(),
+                }
+                self.stats.invalidations.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+        notify
+    }
+
+    /// Reclaim at most `target` clean/error entries without touching Loading or
+    /// dirty journal images.
+    pub(super) fn reclaim_clean(&self, target: usize) -> usize {
+        let MetadataCacheStorage::Enabled(sets) = &self.storage else {
+            return 0;
+        };
+        let mut reclaimed = 0;
+        for set_lock in sets {
+            if reclaimed == target {
+                break;
+            }
+            let mut set = set_lock.lock();
+            for _ in 0..WAYS * 2 {
+                if reclaimed == target {
+                    break;
+                }
+                let index = set.hand;
+                set.hand = (set.hand + 1) % WAYS;
+                let slot = &mut set.ways[index];
+                if !slot.reclaimable() {
+                    continue;
+                }
+                if slot.referenced {
+                    slot.referenced = false;
+                    continue;
+                }
+                slot.clear();
+                reclaimed += 1;
+            }
+        }
+        self.stats.evictions.fetch_add(reclaimed, Ordering::Relaxed);
+        reclaimed
+    }
+
+    pub(super) fn stats(&self) -> MetadataCacheStatsSnapshot {
+        MetadataCacheStatsSnapshot {
+            hits: self.stats.hits.load(Ordering::Relaxed),
+            misses: self.stats.misses.load(Ordering::Relaxed),
+            loaders: self.stats.loaders.load(Ordering::Relaxed),
+            loading_contention: self.stats.loading_contention.load(Ordering::Relaxed),
+            io_errors: self.stats.io_errors.load(Ordering::Relaxed),
+            evictions: self.stats.evictions.load(Ordering::Relaxed),
+            bypasses: self.stats.bypasses.load(Ordering::Relaxed),
+            published_dirty: self.stats.published_dirty.load(Ordering::Relaxed),
+            checkpoint_cleaned: self.stats.checkpoint_cleaned.load(Ordering::Relaxed),
+            invalidations: self.stats.invalidations.load(Ordering::Relaxed),
+            stale_loads: self.stats.stale_loads.load(Ordering::Relaxed),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use core::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc as StdArc, Barrier, Condvar, Mutex as StdMutex};
+    use std::thread;
+
+    struct TestDevice {
+        reads: AtomicUsize,
+        fail: AtomicBool,
+        gate: Option<StdArc<(StdMutex<bool>, Condvar)>>,
+    }
+
+    impl TestDevice {
+        fn plain() -> Self {
+            Self {
+                reads: AtomicUsize::new(0),
+                fail: AtomicBool::new(false),
+                gate: None,
+            }
+        }
+
+        fn blocking(gate: StdArc<(StdMutex<bool>, Condvar)>) -> Self {
+            Self {
+                reads: AtomicUsize::new(0),
+                fail: AtomicBool::new(false),
+                gate: Some(gate),
+            }
+        }
+    }
+
+    impl BlockDevice for TestDevice {
+        fn read_block(&self, block_id: PBlockId) -> Result<Block> {
+            self.reads.fetch_add(1, Ordering::SeqCst);
+            if let Some(gate) = &self.gate {
+                let (lock, wake) = &**gate;
+                let mut open = lock.lock().unwrap();
+                while !*open {
+                    open = wake.wait(open).unwrap();
+                }
+            }
+            if self.fail.load(Ordering::SeqCst) {
+                return Err(Ext4Error::new(ErrCode::EIO));
+            }
+            Ok(Block::new(block_id, Box::new([block_id as u8; BLOCK_SIZE])))
+        }
+
+        fn write_block(&self, _block: &Block) -> Result<()> {
+            Ok(())
+        }
+
+        fn flush(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn supports_reliable_flush(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn too_small_capacity_disables_without_affecting_reads() {
+        let cache = MetadataBlockCache::new(WAYS - 1);
+        let device = TestDevice::plain();
+        assert!(!cache.enabled());
+        assert_eq!(cache.capacity(), 0);
+        assert_eq!(cache.read(&device, 7).result.unwrap().data[0], 7);
+        assert_eq!(cache.stats().bypasses, 1);
+    }
+
+    #[test]
+    fn impossible_preallocation_falls_back_to_disabled() {
+        // This reaches Vec's fallible capacity check without asking the host
+        // allocator to commit an enormous mapping.
+        let cache = MetadataBlockCache::new(usize::MAX);
+        assert!(!cache.enabled());
+        assert_eq!(cache.capacity(), 0);
+    }
+
+    #[test]
+    fn concurrent_cold_read_is_single_flight() {
+        let cache = StdArc::new(MetadataBlockCache::new(WAYS));
+        let gate = StdArc::new((StdMutex::new(false), Condvar::new()));
+        let device = StdArc::new(TestDevice::blocking(StdArc::clone(&gate)));
+        let started = StdArc::new(Barrier::new(2));
+        let loader_cache = StdArc::clone(&cache);
+        let loader_device = StdArc::clone(&device);
+        let loader_started = StdArc::clone(&started);
+        let loader = thread::spawn(move || {
+            loader_started.wait();
+            loader_cache.read(loader_device.as_ref(), 11)
+        });
+        started.wait();
+        while device.reads.load(Ordering::SeqCst) == 0 {
+            thread::yield_now();
+        }
+        let contender = cache.read(device.as_ref(), 11);
+        assert_eq!(contender.result.unwrap_err().code(), ErrCode::EAGAIN);
+        assert!(!contender.notify_progress);
+        {
+            let (lock, wake) = &*gate;
+            *lock.lock().unwrap() = true;
+            wake.notify_all();
+        }
+        let loaded = loader.join().unwrap();
+        assert!(loaded.result.is_ok());
+        assert!(loaded.notify_progress);
+        assert_eq!(device.reads.load(Ordering::SeqCst), 1);
+        assert_eq!(cache.read(device.as_ref(), 11).result.unwrap().data[0], 11);
+    }
+
+    #[test]
+    fn io_error_is_observable_and_next_access_retries() {
+        let cache = MetadataBlockCache::new(WAYS);
+        let device = TestDevice::plain();
+        device.fail.store(true, Ordering::SeqCst);
+        let failed = cache.read(&device, 5);
+        assert_eq!(failed.result.unwrap_err().code(), ErrCode::EIO);
+        assert!(failed.notify_progress);
+        device.fail.store(false, Ordering::SeqCst);
+        assert!(cache.read(&device, 5).result.is_ok());
+        assert_eq!(device.reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn publication_wins_over_late_loader() {
+        let cache = StdArc::new(MetadataBlockCache::new(WAYS));
+        let gate = StdArc::new((StdMutex::new(false), Condvar::new()));
+        let device = StdArc::new(TestDevice::blocking(StdArc::clone(&gate)));
+        let loader_cache = StdArc::clone(&cache);
+        let loader_device = StdArc::clone(&device);
+        let loader = thread::spawn(move || loader_cache.read(loader_device.as_ref(), 9));
+        while device.reads.load(Ordering::SeqCst) == 0 {
+            thread::yield_now();
+        }
+        let image = [0x5a; BLOCK_SIZE];
+        assert!(cache.publish_existing(9, &image, PublicationPoint::Accepted { sequence: 4 }));
+        {
+            let (lock, wake) = &*gate;
+            *lock.lock().unwrap() = true;
+            wake.notify_all();
+        }
+        let stale = loader.join().unwrap();
+        assert_eq!(stale.result.unwrap_err().code(), ErrCode::EAGAIN);
+        assert_eq!(cache.read(device.as_ref(), 9).result.unwrap().data[0], 0x5a);
+    }
+
+    #[test]
+    fn old_checkpoint_does_not_clean_newer_publication() {
+        let cache = MetadataBlockCache::new(WAYS);
+        let device = TestDevice::plain();
+        cache.read(&device, 3).result.unwrap();
+        assert!(
+            cache.publish_existing(
+                3,
+                &[10; BLOCK_SIZE],
+                PublicationPoint::Accepted { sequence: 10 }
+            ) == false
+        );
+        cache.publish_existing(
+            3,
+            &[11; BLOCK_SIZE],
+            PublicationPoint::Accepted { sequence: 11 },
+        );
+        assert!(!cache.publish_existing(
+            3,
+            &[10; BLOCK_SIZE],
+            PublicationPoint::Accepted { sequence: 10 },
+        ));
+        assert_eq!(cache.checkpoint(10, &[3]), 0);
+        // Dirty entries are pinned, so neither reclaim nor the old checkpoint
+        // may discard the current accepted image.
+        assert_eq!(cache.reclaim_clean(1), 0);
+        assert_eq!(cache.read(&device, 3).result.unwrap().data[0], 11);
+        assert_eq!(cache.checkpoint(11, &[3]), 1);
+        assert_eq!(cache.reclaim_clean(1), 1);
+    }
+
+    #[test]
+    fn invalidated_loader_holds_way_until_io_retires() {
+        let cache = StdArc::new(MetadataBlockCache::new(WAYS));
+        let gate = StdArc::new((StdMutex::new(false), Condvar::new()));
+        let device = StdArc::new(TestDevice::blocking(StdArc::clone(&gate)));
+        let loader_cache = StdArc::clone(&cache);
+        let loader_device = StdArc::clone(&device);
+        let loader = thread::spawn(move || loader_cache.read(loader_device.as_ref(), 13));
+        while device.reads.load(Ordering::SeqCst) == 0 {
+            thread::yield_now();
+        }
+        assert!(cache.invalidate(13));
+        assert_eq!(
+            cache.read(device.as_ref(), 13).result.unwrap_err().code(),
+            ErrCode::EAGAIN
+        );
+        {
+            let (lock, wake) = &*gate;
+            *lock.lock().unwrap() = true;
+            wake.notify_all();
+        }
+        let retired = loader.join().unwrap();
+        assert_eq!(retired.result.unwrap_err().code(), ErrCode::EAGAIN);
+        assert!(retired.notify_progress);
+        assert!(cache.read(device.as_ref(), 13).result.is_ok());
+        assert_eq!(device.reads.load(Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn retirement_ranges_invalidate_only_matching_homes() {
+        let cache = MetadataBlockCache::new(WAYS * 4);
+        let device = TestDevice::plain();
+        for home in [4, 5, 20] {
+            cache.read(&device, home).result.unwrap();
+        }
+        assert!(!cache.invalidate_block_ranges([(4, 6)].into_iter()));
+        let before = device.reads.load(Ordering::SeqCst);
+        cache.read(&device, 4).result.unwrap();
+        cache.read(&device, 5).result.unwrap();
+        cache.read(&device, 20).result.unwrap();
+        assert_eq!(device.reads.load(Ordering::SeqCst) - before, 2);
+    }
+
+    #[test]
+    fn pinned_set_bypasses_without_eviction_or_wait() {
+        let cache = MetadataBlockCache::new(WAYS);
+        let device = TestDevice::plain();
+        for home in 0..WAYS as u64 {
+            cache.read(&device, home).result.unwrap();
+            cache.publish_existing(
+                home,
+                &[home as u8; BLOCK_SIZE],
+                PublicationPoint::Accepted { sequence: home + 1 },
+            );
+        }
+        let reads = device.reads.load(Ordering::SeqCst);
+        assert!(cache.read(&device, 99).result.is_ok());
+        assert_eq!(device.reads.load(Ordering::SeqCst), reads + 1);
+        assert_eq!(cache.stats().bypasses, 1);
+    }
+
+    #[test]
+    fn home_current_publication_is_clean_and_reclaimable() {
+        let cache = MetadataBlockCache::new(WAYS);
+        let device = TestDevice::plain();
+        cache.read(&device, 1).result.unwrap();
+        cache.publish_existing(1, &[8; BLOCK_SIZE], PublicationPoint::HomeCurrent);
+        assert_eq!(cache.read(&device, 1).result.unwrap().data[0], 8);
+        assert_eq!(cache.reclaim_clean(1), 1);
+    }
+}

--- a/kernel/crates/another_ext4/src/ext4/mod.rs
+++ b/kernel/crates/another_ext4/src/ext4/mod.rs
@@ -11,7 +11,10 @@ use core::{
 mod alloc;
 mod dir;
 mod extent;
+pub use extent::{ReadPlan, ReadSegment};
 mod high_level;
+mod metadata_cache;
+use metadata_cache::{MetadataBlockCache, PublicationPoint};
 mod metadata_gate;
 #[cfg(test)]
 use metadata_gate::METADATA_GATE_DIRECT_MAX;
@@ -36,6 +39,8 @@ pub use low_level::{
     DelallocAppendBlockSubmitOutcome, DelallocAppendMapperAuthority, DelallocExtentNodePool,
 };
 pub use low_level::{InodeOwner, SetAttr};
+
+const METADATA_CACHE_BLOCKS: usize = 1024;
 
 /// Simple fixed-size inode cache.
 /// When full, the entire cache is cleared (simple but effective for common workloads).
@@ -341,6 +346,9 @@ impl AllocationState {
 /// The Ext4 filesystem implementation.
 pub struct Ext4 {
     block_device: Arc<dyn BlockDevice>,
+    /// Bounded raw metadata acceleration. Journal overlays remain the
+    /// authoritative accepted view; this cache is always discardable.
+    metadata_cache: MetadataBlockCache,
     /// Cached superblock to avoid repeated disk reads.
     /// The superblock is loaded once at mount time and updated
     /// in memory whenever it is written to disk.
@@ -809,6 +817,7 @@ impl Ext4 {
         }
         Ok(Self {
             block_device,
+            metadata_cache: MetadataBlockCache::new(0),
             cached_super_block: spin::Mutex::new(sb),
             cached_block_groups,
             system_metadata_ranges,

--- a/kernel/crates/another_ext4/src/ext4/rw.rs
+++ b/kernel/crates/another_ext4/src/ext4/rw.rs
@@ -13,6 +13,19 @@ pub(super) struct MetadataIo<'fs, 'tx, 'core> {
     transaction: Option<&'tx mut super::journal_transaction::Transaction<'core>>,
 }
 
+impl super::journal_transaction::MetadataBlockSource for Ext4 {
+    fn read_committed_metadata(&self, home: PBlockId) -> Result<Block> {
+        if !matches!(self.metadata_mode, super::MetadataMutationMode::Batched(_)) {
+            return self.block_device.read_block(home);
+        }
+        let outcome = self.metadata_cache.read(self.block_device.as_ref(), home);
+        if outcome.notify_progress {
+            self.metadata_mutation_barrier.notify_progress();
+        }
+        outcome.result
+    }
+}
+
 impl<'fs, 'tx, 'core> MetadataIo<'fs, 'tx, 'core> {
     pub(super) fn direct(fs: &'fs Ext4) -> Self {
         Self {
@@ -91,7 +104,7 @@ impl<'fs, 'tx, 'core> MetadataIo<'fs, 'tx, 'core> {
     pub(super) fn read_block(&self, id: PBlockId) -> Result<Block> {
         match self.transaction.as_deref() {
             Some(transaction) => {
-                let image = transaction.read(self.fs.block_device.as_ref(), id)?;
+                let image = transaction.read(self.fs, id)?;
                 Ok(Block::new(id, Box::new(*image)))
             }
             None => self.fs.read_block(id),
@@ -161,7 +174,7 @@ impl Ext4 {
         transaction: &'tx mut super::journal_transaction::Transaction<'_>,
         block_id: PBlockId,
     ) -> Result<&'tx mut [u8; BLOCK_SIZE]> {
-        transaction.read_for_update(self.block_device.as_ref(), block_id)
+        transaction.read_for_update(self, block_id)
     }
 
     /// Stage block 0 with a checksum-correct ext4 superblock while preserving
@@ -187,7 +200,7 @@ impl Ext4 {
         &self,
         transaction: &super::journal_transaction::Transaction<'_>,
     ) -> Result<SuperBlock> {
-        let image = transaction.read(self.block_device.as_ref(), 0)?;
+        let image = transaction.read(self, 0)?;
         Ok(SuperBlock::from_bytes(&image[BASE_OFFSET..]))
     }
 
@@ -198,7 +211,7 @@ impl Ext4 {
         block_group_id: BlockGroupId,
     ) -> Result<BlockGroupRef> {
         let (block_id, offset) = self.block_group_disk_pos(block_group_id)?;
-        let image = transaction.read(self.block_device.as_ref(), block_id)?;
+        let image = transaction.read(self, block_id)?;
         Ok(BlockGroupRef::new(
             block_group_id,
             BlockGroupDesc::from_bytes(&image[offset..]),
@@ -243,10 +256,10 @@ impl Ext4 {
     /// Read a block from block device
     pub(super) fn read_block(&self, block_id: PBlockId) -> Result<Block> {
         match &self.metadata_mode {
-            super::MetadataMutationMode::Batched(core) => {
-                core.read_metadata(self.block_device.as_ref(), block_id)
-            }
-            _ => self.block_device.read_block(block_id),
+            super::MetadataMutationMode::Batched(core) => core.read_metadata(self, block_id),
+            _ => super::journal_transaction::MetadataBlockSource::read_committed_metadata(
+                self, block_id,
+            ),
         }
     }
 

--- a/kernel/crates/another_ext4/src/ext4/xattr.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr.rs
@@ -291,7 +291,7 @@ impl Ext4 {
             block.init();
             (block, false)
         } else {
-            let image = transaction.read(self.block_device.as_ref(), old_home)?;
+            let image = transaction.read(self, old_home)?;
             let (header, ea_inode) = validate_xattr_block_for_release(&*image)
                 .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
             if ea_inode {

--- a/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
+++ b/kernel/crates/another_ext4/src/ext4/xattr_reclaim.rs
@@ -46,7 +46,7 @@ impl Ext4 {
         if bitmap_block == 0 || bitmap_block >= sb.block_count() {
             return Err(Ext4Error::new(ErrCode::EIO));
         }
-        let bitmap = transaction.read(self.block_device.as_ref(), bitmap_block)?;
+        let bitmap = transaction.read(self, bitmap_block)?;
         if sb.has_read_only_compatible_feature(SuperBlock::FEATURE_RO_COMPAT_METADATA_CSUM) {
             let checksum_bytes = sb.clusters_per_group() as usize / 8;
             if !bg.verify_checksum(sb.metadata_checksum_seed())
@@ -90,7 +90,7 @@ impl Ext4 {
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
         let sb = self.read_super_block_cached();
         self.validate_xattr_block_allocation(transaction, block_id)?;
-        let image = transaction.read(self.block_device.as_ref(), block_id)?;
+        let image = transaction.read(self, block_id)?;
         let (mut header, has_ea_inode) = validate_xattr_block_for_release(&*image)
             .ok_or_else(|| Ext4Error::new(ErrCode::EIO))?;
         if has_ea_inode {

--- a/kernel/crates/another_ext4/src/lib.rs
+++ b/kernel/crates/another_ext4/src/lib.rs
@@ -17,7 +17,8 @@ pub use error::{ErrCode, Ext4Error};
 pub use ext4::{
     BatchProgress, DelallocAppendBlockPublication, DelallocAppendBlockReservation,
     DelallocAppendBlockSubmitOutcome, DelallocAppendMapperAuthority, DelallocExtentNodePool,
-    DelallocLease, Ext4, InodeOwner, MetadataMutationWaker, MetadataWriterWait, SetAttr,
+    DelallocLease, Ext4, InodeOwner, MetadataMutationWaker, MetadataWriterWait, ReadPlan,
+    ReadSegment, SetAttr,
 };
 // The bounded append mapper implementation is compiled in normal builds, but
 // its raw facade remains test-only until the DragonOS VFS can supply the

--- a/kernel/src/driver/base/block/bio.rs
+++ b/kernel/src/driver/base/block/bio.rs
@@ -134,8 +134,13 @@ impl BioRequest {
         Ok(())
     }
 
-    /// 获取缓冲区的可变引用（仅用于提交时）
-    pub fn buffer_mut(&self) -> *mut [u8] {
+    /// 获取缓冲区的可变指针，供块设备在 BIO 完成前提交 DMA 或回收结果。
+    ///
+    /// # Safety
+    ///
+    /// 调用者必须独占设备侧对缓冲区的访问，并保证所有访问在调用
+    /// [`Self::complete`] 前结束。BIO 进入终态后，等待者可以无锁读取该缓冲区。
+    pub unsafe fn buffer_mut(&self) -> *mut [u8] {
         let mut inner = self.inner.lock_irqsave();
         inner.buffer.as_mut_slice() as *mut [u8]
     }
@@ -146,11 +151,18 @@ impl BioRequest {
         inner.buffer.as_slice() as *const [u8]
     }
 
-    /// 将数据写入BIO缓冲区（用于同步回退路径）
-    pub fn write_buffer(&self, data: &[u8]) {
+    /// 将数据写入 BIO 缓冲区（用于同步回退路径）。
+    ///
+    /// 提交状态把缓冲区所有权移交给设备，因此安全写入只允许发生在 `Init`；
+    /// 等待者随后可以在终态发布后于锁外复制较大的 DMA 数据。
+    pub fn write_buffer(&self, data: &[u8]) -> Result<(), SystemError> {
         let mut inner = self.inner.lock_irqsave();
+        if inner.state != BioState::Init {
+            return Err(SystemError::EINVAL);
+        }
         let copy_len = data.len().min(inner.buffer.len());
         inner.buffer.as_mut_slice()[..copy_len].copy_from_slice(&data[..copy_len]);
+        Ok(())
     }
 
     /// 获取BIO类型
@@ -198,22 +210,40 @@ impl BioRequest {
             let callbacks = core::mem::take(&mut inner.complete_callbacks);
             (inner.completion.clone(), callbacks)
         };
+        // Publish the completion predicate before invoking callbacks. A
+        // callback may re-enter `wait*()` on this BIO; signaling afterwards
+        // would deadlock that callback and every callback behind it.
+        completion.complete();
         for cb in callbacks {
             cb(result.clone());
         }
-        completion.complete();
     }
 
     pub fn on_complete<F>(&self, callback: F)
     where
         F: Fn(Result<usize, SystemError>) + Send + Sync + 'static,
     {
-        let mut inner = self.inner.lock_irqsave();
-        if let Some(result) = inner.result.clone() {
-            callback(result);
-            return;
+        let mut callback = Some(Box::new(callback) as BioCompleteCallback);
+        let completed = {
+            let mut inner = self.inner.lock_irqsave();
+            if let Some(result) = inner.result.clone() {
+                Some(result)
+            } else {
+                inner.complete_callbacks.push(
+                    callback
+                        .take()
+                        .expect("callback is owned until registration"),
+                );
+                None
+            }
+        };
+        // A callback is allowed to inspect the BIO. Never invoke it while
+        // holding the BIO spin lock, including the already-completed race.
+        if let Some(result) = completed {
+            callback
+                .take()
+                .expect("completed callback was not registered")(result);
         }
-        inner.complete_callbacks.push(Box::new(callback));
     }
 
     /// 等待BIO完成并返回结果
@@ -233,6 +263,36 @@ impl BioRequest {
             Some(Err(e)) => Err(e.clone()),
             None => Err(SystemError::EIO),
         }
+    }
+
+    /// Wait for an exact read completion and copy the DMA payload directly
+    /// into the caller's buffer. This avoids the intermediate `Vec` allocated
+    /// by [`Self::wait`] and never exposes the DMA buffer pointer after submit.
+    pub fn wait_read_into(&self, dst: &mut [u8]) -> Result<usize, SystemError> {
+        let completion = self.inner.lock_irqsave().completion.clone();
+        completion.wait_for_completion()?;
+
+        let (source, expected) = {
+            let inner = self.inner.lock_irqsave();
+            let expected = Self::expected_len(&inner);
+            if inner.bio_type != BioType::Read || dst.len() != expected {
+                return Err(SystemError::EINVAL);
+            }
+            match inner.result.as_ref() {
+                Some(Ok(completed)) if *completed == expected => {
+                    (inner.buffer.as_slice().as_ptr(), expected)
+                }
+                Some(Ok(_)) => return Err(SystemError::EIO),
+                Some(Err(error)) => return Err(error.clone()),
+                None => return Err(SystemError::EIO),
+            }
+        };
+        // Completion retires device ownership before it wakes us. BioRequest
+        // owns a fixed-size DMA buffer for its whole lifetime, so the pointer
+        // remains stable and read-only while `&self` is alive. Keep the 64 KiB
+        // worst-case copy outside the IRQ-disabled spin-lock section.
+        dst.copy_from_slice(unsafe { core::slice::from_raw_parts(source, expected) });
+        Ok(expected)
     }
 
     /// Wait for completion without copying the DMA payload. This is the

--- a/kernel/src/driver/base/block/block_device.rs
+++ b/kernel/src/driver/base/block/block_device.rs
@@ -355,11 +355,7 @@ pub trait BlockDevice: Device {
             return Err(SystemError::EINVAL);
         }
         let bio = self.submit_bio_read(lba_id_start, count)?;
-        let data = bio.wait()?;
-        if data.len() != expected {
-            return Err(SystemError::EIO);
-        }
-        buf[..expected].copy_from_slice(&data);
+        bio.wait_read_into(&mut buf[..expected])?;
         Ok(expected)
     }
 
@@ -481,7 +477,7 @@ pub trait BlockDevice: Device {
             Ok(()) => Ok(bio),
             Err(SystemError::ENOSYS) => {
                 log::trace!("BlockDevice submit_bio_read ENOSYS, falling back to sync read");
-                let buf_ptr = bio.buffer_mut();
+                let buf_ptr = unsafe { bio.buffer_mut() };
                 let buf = unsafe { &mut *buf_ptr };
                 let expected = count.checked_mul(LBA_SIZE).ok_or(SystemError::EOVERFLOW)?;
                 let completed = self.read_at_sync(lba_start, count, &mut buf[..expected])?;

--- a/kernel/src/driver/block/virtio_blk.rs
+++ b/kernel/src/driver/block/virtio_blk.rs
@@ -373,7 +373,7 @@ fn complete_used_requests(device: &Arc<VirtIOBlkDevice>, token_map: &Arc<BioToke
         let count = bio.count();
         let result = match bio.bio_type() {
             BioType::Read => {
-                let buf_ptr = bio.buffer_mut();
+                let buf_ptr = unsafe { bio.buffer_mut() };
                 let buf = unsafe { &mut *buf_ptr };
                 match unsafe {
                     device_inner.complete_read_blocks(
@@ -1613,7 +1613,7 @@ fn submit_bio_to_virtio(
         let device_inner = inner.device_inner.as_mut().ok_or(SystemError::ENODEV)?;
         match bio_type {
             BioType::Read => {
-                let buf_ptr = bio.buffer_mut();
+                let buf_ptr = unsafe { bio.buffer_mut() };
                 let buf = unsafe { &mut *buf_ptr };
                 Some(
                     unsafe {

--- a/kernel/src/filesystem/ext4/filesystem.rs
+++ b/kernel/src/filesystem/ext4/filesystem.rs
@@ -157,6 +157,9 @@ pub struct Ext4FileSystem {
     pub(super) fs: another_ext4::Ext4,
     /// 当前文件系统对应的设备号
     pub(super) raw_dev: DeviceNumber,
+    /// Strong device owner used by ext4 PageCache batch reads. Keeping this
+    /// exact partition object avoids a late device-number lookup after submit.
+    pub(super) gendisk: Arc<GenDisk>,
     /// Prevents loop clear/remove for the complete filesystem lifetime.
     _device_mount_holder: GenDiskMountGuard,
 
@@ -1395,8 +1398,10 @@ impl Ext4FileSystem {
                     Ext4InodeTimes::from(&root_attr),
                 )),
                 io_lock: Mutex::new(()),
+                mapping_io: super::inode::Ext4MappingIoDomain::new(),
                 metadata_commit_lock: Mutex::new(()),
                 size_lock: RwSem::new(()),
+                size_change_lock: RwSem::new(()),
                 namespace_lock: Mutex::new(()),
                 link_mutation_coordinator: vfs::LinkMutationCoordinator::new(),
                 lifecycle: Ext4InodeLifecycle::new(),
@@ -1414,6 +1419,7 @@ impl Ext4FileSystem {
             writeback_domain: PageCacheWritebackDomain::new(),
             fs,
             raw_dev,
+            gendisk: mount_data,
             _device_mount_holder: device_mount_holder,
             root_inode,
             dirty_inodes: Mutex::new(Vec::new()),

--- a/kernel/src/filesystem/ext4/gendisk.rs
+++ b/kernel/src/filesystem/ext4/gendisk.rs
@@ -1,13 +1,50 @@
 use alloc::boxed::Box;
+use alloc::sync::Arc;
 use kdepends::another_ext4;
 use system_error::SystemError;
 
-use crate::driver::base::block::block_device::LBA_SIZE;
 use crate::driver::base::block::gendisk::GenDisk;
+use crate::driver::base::block::{bio::BioRequest, block_device::LBA_SIZE};
 
-const EXT4_BLOCKS_PER_BULK_WRITE: usize = 16;
+pub(super) const EXT4_BLOCKS_PER_BULK_IO: usize = 16;
+
+/// One accepted contiguous ext4 read. The BIO and its DMA storage stay owned
+/// until `wait_read_into` observes device retirement.
+pub(super) struct SubmittedExt4Read {
+    bio: Arc<BioRequest>,
+    expected_bytes: usize,
+}
+
+impl SubmittedExt4Read {
+    pub(super) fn wait_read_into(self, dst: &mut [u8]) -> Result<(), SystemError> {
+        if dst.len() != self.expected_bytes {
+            return Err(SystemError::EINVAL);
+        }
+        self.bio.wait_read_into(dst)?;
+        Ok(())
+    }
+}
 
 impl GenDisk {
+    pub(super) fn submit_ext4_read(
+        &self,
+        start: u64,
+        ext4_block_count: usize,
+    ) -> Result<SubmittedExt4Read, SystemError> {
+        if ext4_block_count == 0 || ext4_block_count > EXT4_BLOCKS_PER_BULK_IO {
+            return Err(SystemError::EINVAL);
+        }
+        let expected_bytes = ext4_block_count
+            .checked_mul(another_ext4::BLOCK_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let (lba_start, lba_count) = self.checked_ext4_range(start, ext4_block_count)?;
+        let bio = self.block_device()?.submit_bio_read(lba_start, lba_count)?;
+        Ok(SubmittedExt4Read {
+            bio,
+            expected_bytes,
+        })
+    }
+
     fn convert_from_ext4_blkid(&self, ext4_blkid: u64) -> (usize, usize, usize) {
         // another_ext4 的逻辑块固定为 4096 字节（another_ext4::BLOCK_SIZE）。
         //
@@ -94,6 +131,44 @@ impl another_ext4::BlockDevice for GenDisk {
         Ok(another_ext4::Block::new(block_id, buf))
     }
 
+    fn read_blocks(
+        &self,
+        start: u64,
+        data: &mut [u8],
+    ) -> core::result::Result<(), another_ext4::Ext4Error> {
+        if data.is_empty() || !data.len().is_multiple_of(another_ext4::BLOCK_SIZE) {
+            return Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EINVAL));
+        }
+
+        for (chunk_index, chunk) in data
+            .chunks_mut(EXT4_BLOCKS_PER_BULK_IO * another_ext4::BLOCK_SIZE)
+            .enumerate()
+        {
+            let block_offset = chunk_index
+                .checked_mul(EXT4_BLOCKS_PER_BULK_IO)
+                .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EFBIG))?;
+            let chunk_start = start
+                .checked_add(block_offset as u64)
+                .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EFBIG))?;
+            let ext4_blocks = chunk.len() / another_ext4::BLOCK_SIZE;
+            let (lba_start, lba_count) = self
+                .checked_ext4_range(chunk_start, ext4_blocks)
+                .map_err(|error| {
+                    another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&error))
+                })?;
+            let completed = self
+                .block_device()
+                .and_then(|bdev| bdev.read_at(lba_start, lba_count, chunk))
+                .map_err(|error| {
+                    another_ext4::Ext4Error::new(Self::map_system_error_to_ext4(&error))
+                })?;
+            if completed != chunk.len() {
+                return Err(another_ext4::Ext4Error::new(another_ext4::ErrCode::EIO));
+            }
+        }
+        Ok(())
+    }
+
     fn write_block(
         &self,
         block: &another_ext4::Block,
@@ -127,11 +202,11 @@ impl another_ext4::BlockDevice for GenDisk {
         }
 
         for (chunk_index, chunk) in data
-            .chunks(EXT4_BLOCKS_PER_BULK_WRITE * another_ext4::BLOCK_SIZE)
+            .chunks(EXT4_BLOCKS_PER_BULK_IO * another_ext4::BLOCK_SIZE)
             .enumerate()
         {
             let block_offset = chunk_index
-                .checked_mul(EXT4_BLOCKS_PER_BULK_WRITE)
+                .checked_mul(EXT4_BLOCKS_PER_BULK_IO)
                 .ok_or_else(|| another_ext4::Ext4Error::new(another_ext4::ErrCode::EFBIG))?;
             let chunk_start = start
                 .checked_add(block_offset as u64)

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -5,7 +5,8 @@ use crate::{
     filesystem::{
         page_cache::{
             AsyncPageCacheBackend, PageCache, PageCacheBackend, PageCacheDirtyCertificate,
-            PageCacheExpectedDirtyTransition, PageCacheWritebackAdmissionOrder,
+            PageCacheExpectedDirtyTransition, PageCacheReadBatchCompletion,
+            PageCacheReadBatchRequest, PageCacheWritebackAdmissionOrder,
             PageCacheWritebackBindResult, PageCacheWritebackCancellationContext,
             PageCacheWritebackCompletion, PageCacheWritebackDescriptor,
             PageCacheWritebackDispatchOutcome, PageCacheWritebackProgress,
@@ -23,7 +24,7 @@ use crate::{
     libs::{
         casting::DowncastArc,
         mutex::{Mutex, MutexGuard},
-        rwsem::{RwSem, RwSemReadGuard},
+        rwsem::{RwSem, RwSemReadGuard, RwSemWriteGuard},
         spinlock::SpinLock,
         wait_queue::WaitQueue,
     },
@@ -48,6 +49,7 @@ use num::ToPrimitive;
 use system_error::SystemError;
 
 use super::filesystem::Ext4FileSystem;
+use super::gendisk::SubmittedExt4Read;
 use super::journal::Ext4JournalCompletion;
 
 const WHITEOUT_DEV: DeviceNumber = DeviceNumber::new(Major::UNNAMED_MAJOR, 0);
@@ -187,6 +189,86 @@ impl Ext4InodeLifecycle {
 pub(super) struct Ext4InodeOperation {
     lifecycle: Arc<Ext4InodeLifecycle>,
     owner: RawPid,
+}
+
+#[derive(Debug, Default)]
+struct Ext4MappingIoState {
+    active_reads: usize,
+    mutation_closed: bool,
+}
+
+/// Pins extent mappings from planning until every submitted read BIO retires.
+///
+/// Mapping mutators close the domain while holding `io_lock`, then wait here
+/// before changing or freeing extents. Read completion never needs `io_lock`,
+/// so this ordering cannot form a lock cycle.
+#[derive(Debug)]
+pub(super) struct Ext4MappingIoDomain {
+    state: Mutex<Ext4MappingIoState>,
+    wait_queue: WaitQueue,
+}
+
+impl Ext4MappingIoDomain {
+    pub(super) fn new() -> Arc<Self> {
+        Arc::new(Self {
+            state: Mutex::new(Ext4MappingIoState::default()),
+            wait_queue: WaitQueue::default(),
+        })
+    }
+
+    fn begin_read(self: &Arc<Self>) -> Result<Ext4MappingReadPermit, SystemError> {
+        let mut state = self.state.lock();
+        if state.mutation_closed {
+            return Err(SystemError::EBUSY);
+        }
+        state.active_reads = state
+            .active_reads
+            .checked_add(1)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(Ext4MappingReadPermit {
+            domain: self.clone(),
+        })
+    }
+
+    fn close_for_mutation(&self) -> Ext4MappingMutationGuard<'_> {
+        {
+            let mut state = self.state.lock();
+            debug_assert!(!state.mutation_closed);
+            state.mutation_closed = true;
+        }
+        self.wait_queue
+            .wait_until(|| (self.state.lock().active_reads == 0).then_some(()));
+        Ext4MappingMutationGuard { domain: self }
+    }
+}
+
+struct Ext4MappingReadPermit {
+    domain: Arc<Ext4MappingIoDomain>,
+}
+
+impl Drop for Ext4MappingReadPermit {
+    fn drop(&mut self) {
+        let wake = {
+            let mut state = self.domain.state.lock();
+            debug_assert!(state.active_reads > 0);
+            state.active_reads = state.active_reads.saturating_sub(1);
+            state.active_reads == 0
+        };
+        if wake {
+            self.domain.wait_queue.wake_all();
+        }
+    }
+}
+
+struct Ext4MappingMutationGuard<'a> {
+    domain: &'a Ext4MappingIoDomain,
+}
+
+impl Drop for Ext4MappingMutationGuard<'_> {
+    fn drop(&mut self) {
+        self.domain.state.lock().mutation_closed = false;
+        self.domain.wait_queue.wake_all();
+    }
 }
 
 /// Keeps the ext4 mmap write-preparation critical section alive until the
@@ -694,10 +776,14 @@ pub struct Ext4Inode {
 pub struct LockedExt4Inode {
     pub(super) inner: Mutex<Ext4Inode>,
     pub(super) io_lock: Mutex<()>,
+    pub(super) mapping_io: Arc<Ext4MappingIoDomain>,
     /// Orders timestamp publication by VFS version across delayed mapper
     /// transactions and frozen fsync metadata commits.
     pub(super) metadata_commit_lock: Mutex<()>,
     pub(super) size_lock: RwSem<()>,
+    /// Serializes a truncate's complete lower-size/PageCache cleanup window
+    /// against writers which may extend cached EOF.
+    pub(super) size_change_lock: RwSem<()>,
     pub(super) namespace_lock: Mutex<()>,
     pub(super) link_mutation_coordinator: LinkMutationCoordinator,
     pub(super) lifecycle: Arc<Ext4InodeLifecycle>,
@@ -713,6 +799,38 @@ pub struct LockedExt4Inode {
 #[derive(Debug)]
 struct Ext4PageCacheBackend {
     inode: Weak<LockedExt4Inode>,
+}
+
+struct Ext4SubmittedReadSegment {
+    first_slot: usize,
+    page_count: usize,
+    last_page_valid_bytes: usize,
+    request: SubmittedExt4Read,
+    payload: Vec<u8>,
+}
+
+enum Ext4PreparedReadSegment {
+    Zero {
+        first_slot: usize,
+        page_count: usize,
+        last_page_valid_bytes: usize,
+    },
+    Mapped {
+        first_slot: usize,
+        page_count: usize,
+        last_page_valid_bytes: usize,
+        physical_start: u64,
+        payload: Vec<u8>,
+    },
+}
+
+struct Ext4ReadWorkerState {
+    submitted: Vec<Ext4SubmittedReadSegment>,
+    inode: Arc<LockedExt4Inode>,
+    operation: Ext4InodeOperation,
+    fs: Arc<Ext4FileSystem>,
+    completion: PageCacheReadBatchCompletion,
+    mapping_read: Ext4MappingReadPermit,
 }
 
 impl Ext4PageCacheBackend {
@@ -1223,6 +1341,236 @@ impl PageCacheWritebackSubmission for Ext4DelayedSubmission {
 }
 
 impl PageCacheBackend for Ext4PageCacheBackend {
+    fn read_batch_pages(&self) -> usize {
+        super::gendisk::EXT4_BLOCKS_PER_BULK_IO
+    }
+
+    fn read_window_limit(
+        &self,
+        start_index: usize,
+        requested_pages: usize,
+    ) -> Result<usize, SystemError> {
+        let inode = self.inode()?;
+        let _size = inode.size_lock.read();
+        let file_size = inode
+            .inner
+            .lock()
+            .cached_file_size
+            .ok_or(SystemError::EIO)? as usize;
+        let start = start_index
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let requested = requested_pages
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(file_size.saturating_sub(start).min(requested))
+    }
+
+    fn submit_read_batch(
+        self: Arc<Self>,
+        request: PageCacheReadBatchRequest,
+        completion: PageCacheReadBatchCompletion,
+    ) {
+        // Build the queued owner before submitting any BIO. After the device
+        // accepts a request, completion and mapping-exclusion lifetime must no
+        // longer depend on another allocation succeeding.
+        let work_state = Arc::new(Mutex::new(None));
+        let worker_state = work_state.clone();
+        let work = Work::new(move || {
+            let Some(state) = worker_state.lock().take() else {
+                return;
+            };
+            let Ext4ReadWorkerState {
+                submitted,
+                inode: _inode,
+                operation: _operation,
+                fs: _fs,
+                completion,
+                mapping_read,
+            } = state;
+            for mut segment in submitted {
+                let result = segment.request.wait_read_into(&mut segment.payload);
+                match result {
+                    Ok(()) => {
+                        let _ = completion.complete_data(
+                            segment.first_slot,
+                            segment.page_count,
+                            &segment.payload,
+                            segment.last_page_valid_bytes,
+                        );
+                    }
+                    Err(error) => {
+                        let _ = completion.complete_error(
+                            segment.first_slot,
+                            segment.page_count,
+                            error,
+                        );
+                    }
+                }
+            }
+            drop(mapping_read);
+        });
+        let mut completion = Some(completion);
+        let result = (|| -> Result<Ext4ReadWorkerState, SystemError> {
+            let inode = self.inode()?;
+            let operation = inode.begin_operation()?;
+            let _size = inode.size_lock.read();
+            let _io = inode.io_lock.lock();
+            let mapping_read = inode.mapping_io.begin_read()?;
+            let (fs, inode_num, file_size) = {
+                let guard = inode.inner.lock();
+                (
+                    guard.concret_fs(),
+                    guard.inner_inode_num,
+                    guard.cached_file_size.ok_or(SystemError::EIO)? as usize,
+                )
+            };
+            let offset = request
+                .start_index
+                .checked_mul(MMArch::PAGE_SIZE)
+                .ok_or(SystemError::EOVERFLOW)?;
+            let capacity = request
+                .page_count
+                .checked_mul(MMArch::PAGE_SIZE)
+                .ok_or(SystemError::EOVERFLOW)?;
+            let stable_valid = file_size.saturating_sub(offset).min(capacity);
+            if stable_valid != request.valid_bytes {
+                return Err(SystemError::EIO);
+            }
+            let plan = fs.retry_metadata_read_contention(|| {
+                fs.fs.plan_read(
+                    inode_num,
+                    offset,
+                    capacity,
+                    request.page_count.min(16) as u32,
+                )
+            })?;
+            if plan.valid_bytes != request.valid_bytes {
+                return Err(SystemError::EIO);
+            }
+
+            // Finish every fallible allocation before the first BIO is
+            // submitted. Once a device owns a request, no later ENOMEM may
+            // drop its lifetime permit before retirement.
+            let mut prepared = Vec::new();
+            prepared
+                .try_reserve_exact(plan.segments.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+            for segment in plan.segments {
+                let logical_start = segment.logical_start() as usize;
+                let first_byte = logical_start
+                    .checked_mul(another_ext4::BLOCK_SIZE)
+                    .ok_or(SystemError::EOVERFLOW)?;
+                let first_slot =
+                    first_byte.checked_sub(offset).ok_or(SystemError::EIO)? / MMArch::PAGE_SIZE;
+                let page_count = segment.block_count() as usize;
+                let segment_end = first_slot
+                    .checked_add(page_count)
+                    .ok_or(SystemError::EOVERFLOW)?;
+                let last_valid = if segment_end == request.page_count {
+                    let tail = request.valid_bytes % MMArch::PAGE_SIZE;
+                    if tail == 0 {
+                        MMArch::PAGE_SIZE
+                    } else {
+                        tail
+                    }
+                } else {
+                    MMArch::PAGE_SIZE
+                };
+                match segment {
+                    another_ext4::ReadSegment::Zero { .. } => {
+                        prepared.push(Ext4PreparedReadSegment::Zero {
+                            first_slot,
+                            page_count,
+                            last_page_valid_bytes: last_valid,
+                        });
+                    }
+                    another_ext4::ReadSegment::Mapped { physical_start, .. } => {
+                        let payload_len = page_count
+                            .checked_mul(MMArch::PAGE_SIZE)
+                            .ok_or(SystemError::EOVERFLOW)?;
+                        let mut payload = Vec::new();
+                        payload
+                            .try_reserve_exact(payload_len)
+                            .map_err(|_| SystemError::ENOMEM)?;
+                        payload.resize(payload_len, 0);
+                        prepared.push(Ext4PreparedReadSegment::Mapped {
+                            first_slot,
+                            page_count,
+                            last_page_valid_bytes: last_valid,
+                            physical_start,
+                            payload,
+                        });
+                    }
+                }
+            }
+
+            let mut submitted = Vec::new();
+            submitted
+                .try_reserve_exact(prepared.len())
+                .map_err(|_| SystemError::ENOMEM)?;
+            for segment in prepared {
+                match segment {
+                    Ext4PreparedReadSegment::Zero {
+                        first_slot,
+                        page_count,
+                        last_page_valid_bytes,
+                    } => {
+                        let _ = completion
+                            .as_ref()
+                            .expect("completion owner")
+                            .complete_zero(first_slot, page_count, last_page_valid_bytes);
+                    }
+                    Ext4PreparedReadSegment::Mapped {
+                        first_slot,
+                        page_count,
+                        last_page_valid_bytes,
+                        physical_start,
+                        payload,
+                    } => match fs.gendisk.submit_ext4_read(physical_start, page_count) {
+                        Ok(submission) => submitted.push(Ext4SubmittedReadSegment {
+                            first_slot,
+                            page_count,
+                            last_page_valid_bytes,
+                            request: submission,
+                            payload,
+                        }),
+                        Err(error) => {
+                            let _ = completion
+                                .as_ref()
+                                .expect("completion owner")
+                                .complete_error(first_slot, page_count, error);
+                        }
+                    },
+                }
+            }
+            drop(_io);
+            drop(_size);
+            Ok(Ext4ReadWorkerState {
+                submitted,
+                inode,
+                operation,
+                fs,
+                completion: completion.take().expect("completion transfers to worker"),
+                mapping_read,
+            })
+        })();
+
+        let state = match result {
+            Ok(state) => state,
+            Err(error) => {
+                let completion = completion.take().expect("failed preparation retains owner");
+                let unfinished = completion.unfinished();
+                if unfinished > 0 {
+                    let _ = completion.complete_error(0, request.page_count, error);
+                }
+                return;
+            }
+        };
+        *work_state.lock() = Some(state);
+        schedule_work(work);
+    }
+
     fn read_page(&self, index: usize, buf: &mut [u8]) -> Result<usize, SystemError> {
         let offset = index
             .checked_mul(MMArch::PAGE_SIZE)
@@ -1708,6 +2056,7 @@ impl IndexNode for LockedExt4Inode {
         data: PrivateData,
     ) -> Result<usize, SystemError> {
         let _operation = self.begin_operation()?;
+        let _size_change = self.size_change_lock.read();
         let len = core::cmp::min(len, buf.len());
         if len == 0 {
             return Ok(0);
@@ -2210,11 +2559,11 @@ impl IndexNode for LockedExt4Inode {
     }
 
     fn set_metadata(&self, metadata: &vfs::Metadata) -> Result<(), SystemError> {
+        let requested_size = metadata.size.max(0) as usize;
         let _operation = self.begin_operation()?;
+        let size_change = self.size_change_lock.write();
         let _delalloc_admission = self.close_production_delalloc_admission()?;
         self.drain_delalloc_before_eager()?;
-        let _io_guard = self.io_lock.lock();
-        let _metadata_commit = self.metadata_commit_lock.lock();
         let mode = metadata.mode.union(InodeMode::from(metadata.file_type));
 
         let to_ext4_time =
@@ -2239,47 +2588,51 @@ impl IndexNode for LockedExt4Inode {
         let next_ctime_version = before_ctime_version
             .checked_add(1)
             .ok_or(SystemError::EOVERFLOW)?;
-        let ext4 = &fs.fs;
-        fs.retry_metadata_contention(|| {
-            ext4.setattr(
-                inode_num,
-                another_ext4::SetAttr {
-                    mode: Some(another_ext4::InodeMode::from_bits_truncate(
-                        mode.bits() as u16
-                    )),
-                    uid: Some(metadata.uid as u32),
-                    gid: Some(metadata.gid as u32),
-                    size: Some(metadata.size as u64),
-                    atime: Some(to_ext4_time(&metadata.atime)),
-                    mtime: Some(to_ext4_time(&metadata.mtime)),
-                    ctime: Some(to_ext4_time(&metadata.ctime)),
-                    crtime: Some(to_ext4_time(&metadata.btime)),
-                },
-            )
+        self.commit_size_mutation(&size_change, &fs, inode_num, requested_size, || {
+            let _metadata_commit = self.metadata_commit_lock.lock();
+            let ext4 = &fs.fs;
+            fs.retry_metadata_contention(|| {
+                ext4.setattr(
+                    inode_num,
+                    another_ext4::SetAttr {
+                        mode: Some(another_ext4::InodeMode::from_bits_truncate(
+                            mode.bits() as u16
+                        )),
+                        uid: Some(metadata.uid as u32),
+                        gid: Some(metadata.gid as u32),
+                        size: Some(requested_size as u64),
+                        atime: Some(to_ext4_time(&metadata.atime)),
+                        mtime: Some(to_ext4_time(&metadata.mtime)),
+                        ctime: Some(to_ext4_time(&metadata.ctime)),
+                        crtime: Some(to_ext4_time(&metadata.btime)),
+                    },
+                )
+            })?;
+            {
+                let mut guard = self.inner.lock();
+                guard.cached_file_size = Some(requested_size as u64);
+                guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
+                if guard.cached_atime_version == before_atime_version {
+                    guard.cached_times.atime = to_ext4_time(&metadata.atime);
+                    guard.cached_atime_version = next_atime_version;
+                    guard.durable_atime_version = guard.cached_atime_version;
+                    guard.dirty_state.remove(InodeDirtyState::ATIME_DIRTY);
+                }
+                if guard.cached_mtime_version == before_mtime_version {
+                    guard.cached_times.mtime = to_ext4_time(&metadata.mtime);
+                    guard.cached_mtime_version = next_mtime_version;
+                    guard.durable_mtime_version = guard.cached_mtime_version;
+                    guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
+                }
+                if guard.cached_ctime_version == before_ctime_version {
+                    guard.cached_times.ctime = to_ext4_time(&metadata.ctime);
+                    guard.cached_ctime_version = next_ctime_version;
+                    guard.durable_ctime_version = guard.cached_ctime_version;
+                    guard.dirty_state.remove(InodeDirtyState::CTIME_DIRTY);
+                }
+            }
+            Ok(())
         })?;
-        {
-            let mut guard = self.inner.lock();
-            guard.cached_file_size = Some(metadata.size as u64);
-            if guard.cached_atime_version == before_atime_version {
-                guard.cached_times.atime = to_ext4_time(&metadata.atime);
-                guard.cached_atime_version = next_atime_version;
-                guard.durable_atime_version = guard.cached_atime_version;
-                guard.dirty_state.remove(InodeDirtyState::ATIME_DIRTY);
-            }
-            if guard.cached_mtime_version == before_mtime_version {
-                guard.cached_times.mtime = to_ext4_time(&metadata.mtime);
-                guard.cached_mtime_version = next_mtime_version;
-                guard.durable_mtime_version = guard.cached_mtime_version;
-                guard.dirty_state.remove(InodeDirtyState::MTIME_DIRTY);
-            }
-            if guard.cached_ctime_version == before_ctime_version {
-                guard.cached_times.ctime = to_ext4_time(&metadata.ctime);
-                guard.cached_ctime_version = next_ctime_version;
-                guard.durable_ctime_version = guard.cached_ctime_version;
-                guard.dirty_state.remove(InodeDirtyState::CTIME_DIRTY);
-            }
-            guard.dirty_state.remove(InodeDirtyState::SIZE_DIRTY);
-        }
         self.release_clean_metadata_queue_owner(&fs);
 
         Ok(())
@@ -2420,20 +2773,15 @@ impl IndexNode for LockedExt4Inode {
 
     fn resize(&self, len: usize) -> Result<(), SystemError> {
         let _operation = self.begin_operation()?;
+        let size_change = self.size_change_lock.write();
         let _delalloc_admission = self.close_production_delalloc_admission()?;
         self.drain_delalloc_before_eager()?;
-        let (fs, inode_num, page_cache) = {
+        let (fs, inode_num) = {
             let guard = self.inner.lock();
-            (
-                guard.concret_fs(),
-                guard.inner_inode_num,
-                guard.page_cache.clone(),
-            )
+            (guard.concret_fs(), guard.inner_inode_num)
         };
-        let apply_resize = || -> Result<(), SystemError> {
-            let _io_guard = self.io_lock.lock();
+        self.commit_size_mutation(&size_change, &fs, inode_num, len, || {
             let ext4 = &fs.fs;
-            // 仅调整文件大小，其他属性保持不变
             fs.retry_metadata_contention(|| {
                 ext4.setattr(
                     inode_num,
@@ -2457,54 +2805,7 @@ impl IndexNode for LockedExt4Inode {
             }
             self.release_clean_metadata_queue_owner(&fs);
             Ok(())
-        };
-
-        if let Some(page_cache) = page_cache {
-            let hole_start_page = len
-                .checked_add(MMArch::PAGE_SIZE - 1)
-                .ok_or(SystemError::EFBIG)?
-                >> MMArch::PAGE_SHIFT;
-            let mut truncate_pending = false;
-            loop {
-                // Match PageCache::truncate(), but acquire ext4's size lock
-                // after invalidate_write so mmap faults and regular writes
-                // use one global order: invalidate -> size -> inode I/O.
-                page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
-                let (shrinking, committed) = {
-                    let _invalidate = page_cache.invalidate_write();
-                    let _size_guard = self.size_lock.write();
-                    // Classify against the authoritative size while holding the
-                    // same lock that serializes the update.  A function-entry
-                    // snapshot can become stale after a concurrent extension.
-                    let cached_size = self.inner.lock().cached_file_size;
-                    let current_size = match cached_size {
-                        Some(size) => size,
-                        None => {
-                            fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
-                                .size
-                        }
-                    };
-                    // After truncate_locked() asks for another unmap pass, the
-                    // inode size already equals len.  Preserve that pending
-                    // cache truncation unless a concurrent resize moved the
-                    // authoritative size below this request.
-                    let shrinking = len < current_size as usize
-                        || (truncate_pending && len == current_size as usize);
-                    apply_resize()?;
-                    let committed = !shrinking || page_cache.truncate_locked(len)?;
-                    (shrinking, committed)
-                };
-                if committed {
-                    if shrinking {
-                        page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
-                    }
-                    return Ok(());
-                }
-                truncate_pending = shrinking;
-            }
-        }
-        let _size_guard = self.size_lock.write();
-        apply_resize()
+        })
     }
 
     fn fallocate_resize_atomic(
@@ -2514,8 +2815,11 @@ impl IndexNode for LockedExt4Inode {
         _lock_owner: u64,
     ) -> Result<SetMetadataMask, SystemError> {
         let _operation = self.begin_operation()?;
+        let _size_change = self.size_change_lock.write();
         let _delalloc_admission = self.close_production_delalloc_admission()?;
         self.drain_delalloc_before_eager()?;
+        let page_cache = self.page_cache();
+        let _invalidate = page_cache.as_ref().map(|cache| cache.invalidate_write());
         let _size_guard = self.size_lock.write();
         let _io_guard = self.io_lock.lock();
         let _metadata_commit = self.metadata_commit_lock.lock();
@@ -3194,6 +3498,63 @@ impl IndexNode for LockedExt4Inode {
 }
 
 impl LockedExt4Inode {
+    /// Run one lower-filesystem size mutation under the single lock order used
+    /// by truncate, full setattr and readahead mapping pins.
+    fn commit_size_mutation<F>(
+        &self,
+        _size_change: &RwSemWriteGuard<'_, ()>,
+        fs: &Arc<Ext4FileSystem>,
+        inode_num: u32,
+        len: usize,
+        mut commit: F,
+    ) -> Result<(), SystemError>
+    where
+        F: FnMut() -> Result<(), SystemError>,
+    {
+        let Some(page_cache) = self.page_cache() else {
+            let _size = self.size_lock.write();
+            let _io = self.io_lock.lock();
+            let _mapping = self.mapping_io.close_for_mutation();
+            return commit();
+        };
+        let hole_start_page = len
+            .checked_add(MMArch::PAGE_SIZE - 1)
+            .ok_or(SystemError::EFBIG)?
+            >> MMArch::PAGE_SHIFT;
+        let mut shrinking = None;
+        let mut lower_committed = false;
+        loop {
+            page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
+            let (shrinking, committed) = {
+                let _invalidate = page_cache.invalidate_write();
+                let _size = self.size_lock.write();
+                let cached_size = self.inner.lock().cached_file_size;
+                let current_size = match cached_size {
+                    Some(size) => size,
+                    None => {
+                        fs.retry_metadata_read_contention(|| fs.fs.getattr(inode_num))?
+                            .size
+                    }
+                };
+                let shrinking = *shrinking.get_or_insert(len < current_size as usize);
+                if !lower_committed {
+                    let _io = self.io_lock.lock();
+                    let _mapping = self.mapping_io.close_for_mutation();
+                    commit()?;
+                    lower_committed = true;
+                }
+                let committed = !shrinking || page_cache.truncate_locked(len)?;
+                (shrinking, committed)
+            };
+            if committed {
+                if shrinking {
+                    page_cache.unmap_mapping_pages_even_cow(hole_start_page, None)?;
+                }
+                return Ok(());
+            }
+        }
+    }
+
     fn close_production_delalloc_admission_locked<'a>(
         &'a self,
         production: &mut ProductionDelallocState,
@@ -4502,8 +4863,10 @@ impl LockedExt4Inode {
                 Ext4InodeTimes::from(attr),
             )),
             io_lock: Mutex::new(()),
+            mapping_io: Ext4MappingIoDomain::new(),
             metadata_commit_lock: Mutex::new(()),
             size_lock: RwSem::new(()),
+            size_change_lock: RwSem::new(()),
             namespace_lock: Mutex::new(()),
             link_mutation_coordinator: LinkMutationCoordinator::new(),
             lifecycle,

--- a/kernel/src/filesystem/ext4/inode.rs
+++ b/kernel/src/filesystem/ext4/inode.rs
@@ -824,6 +824,65 @@ enum Ext4PreparedReadSegment {
     },
 }
 
+/// Reconciles the PageCache-visible EOF with ext4's durable inode EOF for one
+/// stable read window. Delayed allocation may place the visible EOF ahead of
+/// the durable EOF; the lower plan cannot expose that suffix, so absent cache
+/// pages and the durable EOF page tail are read as zero.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct Ext4ReadWindowCoverage {
+    durable_pages: usize,
+    durable_last_page_valid_bytes: usize,
+    visible_last_page_valid_bytes: usize,
+}
+
+impl Ext4ReadWindowCoverage {
+    fn new(
+        page_count: usize,
+        visible_valid_bytes: usize,
+        durable_valid_bytes: usize,
+    ) -> Result<Self, SystemError> {
+        let capacity = page_count
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if page_count == 0
+            || visible_valid_bytes == 0
+            || visible_valid_bytes > capacity
+            || durable_valid_bytes > visible_valid_bytes
+        {
+            return Err(SystemError::EIO);
+        }
+        Ok(Self {
+            durable_pages: durable_valid_bytes.div_ceil(MMArch::PAGE_SIZE),
+            durable_last_page_valid_bytes: Self::last_page_valid_bytes(durable_valid_bytes),
+            visible_last_page_valid_bytes: Self::last_page_valid_bytes(visible_valid_bytes),
+        })
+    }
+
+    fn last_page_valid_bytes(valid_bytes: usize) -> usize {
+        match valid_bytes % MMArch::PAGE_SIZE {
+            0 => MMArch::PAGE_SIZE,
+            tail => tail,
+        }
+    }
+
+    fn lower_segment_last_valid_bytes(&self, segment_end: usize) -> usize {
+        if segment_end == self.durable_pages {
+            self.durable_last_page_valid_bytes
+        } else {
+            MMArch::PAGE_SIZE
+        }
+    }
+
+    fn zero_extension(&self, page_count: usize) -> Option<(usize, usize, usize)> {
+        let count = page_count.checked_sub(self.durable_pages)?;
+        (count > 0).then_some((
+            self.durable_pages,
+            count,
+            self.visible_last_page_valid_bytes,
+        ))
+    }
+}
+
 struct Ext4ReadWorkerState {
     submitted: Vec<Ext4SubmittedReadSegment>,
     inode: Arc<LockedExt4Inode>,
@@ -1445,17 +1504,26 @@ impl PageCacheBackend for Ext4PageCacheBackend {
                     request.page_count.min(16) as u32,
                 )
             })?;
-            if plan.valid_bytes != request.valid_bytes {
-                return Err(SystemError::EIO);
-            }
+            let coverage = Ext4ReadWindowCoverage::new(
+                request.page_count,
+                request.valid_bytes,
+                plan.valid_bytes,
+            )?;
+            let zero_extension = coverage.zero_extension(request.page_count);
 
             // Finish every fallible allocation before the first BIO is
             // submitted. Once a device owns a request, no later ENOMEM may
             // drop its lifetime permit before retirement.
             let mut prepared = Vec::new();
+            let prepared_capacity = plan
+                .segments
+                .len()
+                .checked_add(usize::from(zero_extension.is_some()))
+                .ok_or(SystemError::EOVERFLOW)?;
             prepared
-                .try_reserve_exact(plan.segments.len())
+                .try_reserve_exact(prepared_capacity)
                 .map_err(|_| SystemError::ENOMEM)?;
+            let mut next_lower_slot = 0usize;
             for segment in plan.segments {
                 let logical_start = segment.logical_start() as usize;
                 let first_byte = logical_start
@@ -1464,19 +1532,17 @@ impl PageCacheBackend for Ext4PageCacheBackend {
                 let first_slot =
                     first_byte.checked_sub(offset).ok_or(SystemError::EIO)? / MMArch::PAGE_SIZE;
                 let page_count = segment.block_count() as usize;
+                if first_slot != next_lower_slot || page_count == 0 {
+                    return Err(SystemError::EIO);
+                }
                 let segment_end = first_slot
                     .checked_add(page_count)
                     .ok_or(SystemError::EOVERFLOW)?;
-                let last_valid = if segment_end == request.page_count {
-                    let tail = request.valid_bytes % MMArch::PAGE_SIZE;
-                    if tail == 0 {
-                        MMArch::PAGE_SIZE
-                    } else {
-                        tail
-                    }
-                } else {
-                    MMArch::PAGE_SIZE
-                };
+                if segment_end > coverage.durable_pages {
+                    return Err(SystemError::EIO);
+                }
+                next_lower_slot = segment_end;
+                let last_valid = coverage.lower_segment_last_valid_bytes(segment_end);
                 match segment {
                     another_ext4::ReadSegment::Zero { .. } => {
                         prepared.push(Ext4PreparedReadSegment::Zero {
@@ -1503,6 +1569,16 @@ impl PageCacheBackend for Ext4PageCacheBackend {
                         });
                     }
                 }
+            }
+            if next_lower_slot != coverage.durable_pages {
+                return Err(SystemError::EIO);
+            }
+            if let Some((first_slot, page_count, last_page_valid_bytes)) = zero_extension {
+                prepared.push(Ext4PreparedReadSegment::Zero {
+                    first_slot,
+                    page_count,
+                    last_page_valid_bytes,
+                });
             }
 
             let mut submitted = Vec::new();
@@ -5401,6 +5477,31 @@ impl Debug for Ext4Inode {
     }
 }
 
+fn run_read_window_coverage_selftest() -> bool {
+    let partial_same_page = Ext4ReadWindowCoverage::new(1, 513, 257);
+    let aligned_durable_eof =
+        Ext4ReadWindowCoverage::new(2, MMArch::PAGE_SIZE + 99, MMArch::PAGE_SIZE);
+    let delayed_extension =
+        Ext4ReadWindowCoverage::new(3, MMArch::PAGE_SIZE * 2 + 123, MMArch::PAGE_SIZE + 17);
+    let wholly_beyond_durable_eof = Ext4ReadWindowCoverage::new(1, 99, 0);
+
+    partial_same_page.is_ok_and(|coverage| {
+        coverage.durable_pages == 1
+            && coverage.lower_segment_last_valid_bytes(1) == 257
+            && coverage.zero_extension(1).is_none()
+    }) && aligned_durable_eof.is_ok_and(|coverage| {
+        coverage.durable_pages == 1
+            && coverage.lower_segment_last_valid_bytes(1) == MMArch::PAGE_SIZE
+            && coverage.zero_extension(2) == Some((1, 1, 99))
+    }) && delayed_extension.is_ok_and(|coverage| {
+        coverage.durable_pages == 2
+            && coverage.lower_segment_last_valid_bytes(2) == 17
+            && coverage.zero_extension(3) == Some((2, 1, 123))
+    }) && wholly_beyond_durable_eof
+        .is_ok_and(|coverage| coverage.zero_extension(1) == Some((0, 1, 99)))
+        && Ext4ReadWindowCoverage::new(1, 99, 100).is_err()
+}
+
 pub(crate) fn run_lifecycle_selftests() -> String {
     let mut failures = 0usize;
     let mut report = String::new();
@@ -5448,6 +5549,10 @@ pub(crate) fn run_lifecycle_selftests() -> String {
     append(
         "poison_is_observable",
         lifecycle.begin_operation().err() == Some(SystemError::EIO),
+    );
+    append(
+        "read_window_eof_coverage",
+        run_read_window_coverage_selftest(),
     );
 
     if failures == 0 {

--- a/kernel/src/filesystem/page_cache.rs
+++ b/kernel/src/filesystem/page_cache.rs
@@ -47,12 +47,14 @@ use crate::{libs::align::page_align_up, mm::page::PageType};
 use lazy_static::lazy_static;
 
 mod mapping;
+mod read_batch;
 mod read_dma;
 mod selftest;
 mod writeback;
 use mapping::FileVmaIndex;
 pub(crate) use mapping::PageCacheFaultInvalidateRead;
 pub use mapping::UnmapMappingMode;
+pub use read_batch::{PageCacheReadBatchCompletion, PageCacheReadBatchRequest};
 pub use read_dma::PageCacheReadDmaReservation;
 pub(crate) use selftest::{run_accounting_debug_selftest, run_completion_domain_debug_selftest};
 pub(crate) use writeback::{
@@ -3474,8 +3476,75 @@ impl PageCache {
     }
 
     pub fn read_pages(&self, start_page_index: usize, page_num: usize) -> Result<(), SystemError> {
-        for i in 0..page_num {
-            self.start_async_read(start_page_index + i)?;
+        if page_num == 0 {
+            return Ok(());
+        }
+        start_page_index
+            .checked_add(page_num)
+            .ok_or(SystemError::EOVERFLOW)?;
+
+        let cache = self.manager.upgrade()?;
+        let Some(backend) = cache.backend() else {
+            for offset in 0..page_num {
+                cache.start_async_read(start_page_index + offset)?;
+            }
+            return Ok(());
+        };
+
+        // Size writers for a batch-capable backend must take
+        // invalidate_write. This keeps the preflight EOF stable through every
+        // Loading reservation and synchronous submit below.
+        let _invalidate = cache.invalidate_read();
+        let valid_bytes = backend.read_window_limit(start_page_index, page_num)?;
+        if valid_bytes == 0 {
+            return Ok(());
+        }
+        let clipped_pages = valid_bytes.div_ceil(MMArch::PAGE_SIZE).min(page_num);
+        let max_batch_pages = backend.read_batch_pages().max(1);
+        let end = start_page_index + clipped_pages;
+        let mut cursor = start_page_index;
+        while cursor < end {
+            let run = {
+                let inner = cache.inner.lock();
+                while cursor < end && inner.get_entry(cursor).is_some() {
+                    cursor += 1;
+                }
+                let run_start = cursor;
+                while cursor < end
+                    && cursor - run_start < max_batch_pages
+                    && inner.get_entry(cursor).is_none()
+                {
+                    cursor += 1;
+                }
+                (run_start, cursor - run_start)
+            };
+            if run.1 == 0 {
+                continue;
+            }
+
+            let domain_io = cache.try_acquire_domain_io()?;
+            let completion =
+                match PageCacheReadBatchCompletion::reserve(&cache, run.0, run.1, domain_io) {
+                    Ok(completion) => completion,
+                    // A racing reader installed one of these pages after the
+                    // scan. It owns the fill; a later cache read will wait on it.
+                    Err(SystemError::EEXIST) => {
+                        cursor = run.0;
+                        continue;
+                    }
+                    Err(error) => return Err(error),
+                };
+            let relative_start = (run.0 - start_page_index) * MMArch::PAGE_SIZE;
+            let run_capacity = run.1 * MMArch::PAGE_SIZE;
+            let run_valid = valid_bytes.saturating_sub(relative_start).min(run_capacity);
+            backend.clone().submit_read_batch(
+                PageCacheReadBatchRequest {
+                    start_index: run.0,
+                    page_count: run.1,
+                    valid_bytes: run_valid,
+                },
+                completion,
+            );
         }
         Ok(())
     }

--- a/kernel/src/filesystem/page_cache/read_batch.rs
+++ b/kernel/src/filesystem/page_cache/read_batch.rs
@@ -1,0 +1,358 @@
+use super::{
+    schedule_work, Arc, AtomicUsize, MMArch, MemoryManagementArch, Ordering, Page, PageCache,
+    PageCacheBackend, PageCacheDomainIoPermit, PageEntry, PageFlags, PageState, SystemError, Vec,
+    Work,
+};
+
+/// Stable bounds passed to one backend submission. `valid_bytes` is relative
+/// to `start_index` and may end in the middle of the final page.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct PageCacheReadBatchRequest {
+    pub start_index: usize,
+    pub page_count: usize,
+    pub valid_bytes: usize,
+}
+
+struct LoadingSlot {
+    page_index: usize,
+    entry: Arc<PageEntry>,
+    page: Arc<Page>,
+    terminal: core::sync::atomic::AtomicBool,
+}
+
+struct LoadingBatch {
+    cache: Arc<PageCache>,
+    slots: Vec<LoadingSlot>,
+    unfinished: AtomicUsize,
+    _domain_io: Option<PageCacheDomainIoPermit>,
+}
+
+/// The sole page-state publication authority for one backend read batch.
+/// Device owners may only report results through this object; they never see
+/// PageCache's map or mutate PageState directly.
+pub struct PageCacheReadBatchCompletion {
+    inner: Arc<LoadingBatch>,
+}
+
+impl PageCacheReadBatchCompletion {
+    pub(super) fn reserve(
+        cache: &Arc<PageCache>,
+        start_index: usize,
+        page_count: usize,
+        domain_io: Option<PageCacheDomainIoPermit>,
+    ) -> Result<Self, SystemError> {
+        if page_count == 0 || start_index.checked_add(page_count - 1).is_none() {
+            return Err(SystemError::EINVAL);
+        }
+        let page_cache_ref = {
+            let inner = cache.inner.lock();
+            if (0..page_count).any(|offset| inner.get_entry(start_index + offset).is_some()) {
+                return Err(SystemError::EEXIST);
+            }
+            inner.page_cache_ref.clone()
+        };
+
+        let mut slots = Vec::new();
+        slots
+            .try_reserve_exact(page_count)
+            .map_err(|_| SystemError::ENOMEM)?;
+        for offset in 0..page_count {
+            let page_index = start_index + offset;
+            let page = match cache.allocate_page(page_cache_ref.clone(), page_index) {
+                Ok(page) => page,
+                Err(error) => {
+                    Self::discard_unsubmitted(cache, &slots);
+                    return Err(error);
+                }
+            };
+            let entry = Arc::new(PageEntry::new(page.clone(), PageState::Loading));
+            slots.push(LoadingSlot {
+                page_index,
+                entry,
+                page,
+                terminal: core::sync::atomic::AtomicBool::new(false),
+            });
+        }
+
+        // Publish the whole empty subrange atomically. A concurrent reader
+        // must never attach to a prefix which is later rolled back because a
+        // later page conflicted.
+        let mut inner = cache.inner.lock();
+        if slots
+            .iter()
+            .any(|slot| inner.get_entry(slot.page_index).is_some())
+        {
+            drop(inner);
+            Self::discard_unsubmitted(cache, &slots);
+            return Err(SystemError::EEXIST);
+        }
+        for slot in &slots {
+            if let Err(error) = inner.insert_entry(slot.page_index, slot.entry.clone()) {
+                drop(inner);
+                Self::discard_unsubmitted(cache, &slots);
+                return Err(error);
+            }
+        }
+        drop(inner);
+        for slot in &slots {
+            cache.reconcile_entry_unevictable_for_insert(&slot.entry);
+        }
+
+        Ok(Self {
+            inner: Arc::new(LoadingBatch {
+                cache: cache.clone(),
+                unfinished: AtomicUsize::new(page_count),
+                slots,
+                _domain_io: domain_io,
+            }),
+        })
+    }
+
+    pub fn page_count(&self) -> usize {
+        self.inner.slots.len()
+    }
+
+    /// Publish one full-block payload range. `last_page_valid_bytes` is only
+    /// used for the final EOF page; all bytes after it are zeroed before the
+    /// page becomes visible.
+    pub fn complete_data(
+        &self,
+        first_slot: usize,
+        page_count: usize,
+        payload: &[u8],
+        last_page_valid_bytes: usize,
+    ) -> Result<(), SystemError> {
+        self.validate_range(first_slot, page_count)?;
+        let expected = page_count
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        if payload.len() != expected
+            || last_page_valid_bytes == 0
+            || last_page_valid_bytes > MMArch::PAGE_SIZE
+        {
+            return Err(SystemError::EINVAL);
+        }
+        for offset in 0..page_count {
+            let slot_index = first_slot + offset;
+            let valid = if offset + 1 == page_count {
+                last_page_valid_bytes
+            } else {
+                MMArch::PAGE_SIZE
+            };
+            let start = offset * MMArch::PAGE_SIZE;
+            self.complete_one_data(
+                slot_index,
+                &payload[start..start + MMArch::PAGE_SIZE],
+                valid,
+            )?;
+        }
+        Ok(())
+    }
+
+    pub fn complete_zero(
+        &self,
+        first_slot: usize,
+        page_count: usize,
+        last_page_valid_bytes: usize,
+    ) -> Result<(), SystemError> {
+        self.validate_range(first_slot, page_count)?;
+        if last_page_valid_bytes == 0 || last_page_valid_bytes > MMArch::PAGE_SIZE {
+            return Err(SystemError::EINVAL);
+        }
+        for offset in 0..page_count {
+            let slot = &self.inner.slots[first_slot + offset];
+            if !Self::claim(slot)? {
+                continue;
+            }
+            {
+                let mut page = slot.page.write();
+                unsafe { page.as_slice_mut().fill(0) };
+                page.add_flags(PageFlags::PG_UPTODATE);
+            }
+            self.publish_ready(slot);
+        }
+        Ok(())
+    }
+
+    pub fn complete_error(
+        &self,
+        first_slot: usize,
+        page_count: usize,
+        _error: SystemError,
+    ) -> Result<(), SystemError> {
+        self.validate_range(first_slot, page_count)?;
+        for offset in 0..page_count {
+            let slot = &self.inner.slots[first_slot + offset];
+            if !Self::claim(slot)? {
+                continue;
+            }
+            slot.page.write().add_flags(PageFlags::PG_ERROR);
+            slot.entry.set_state(PageState::Error);
+            slot.entry.wait_queue.wake_all();
+            self.remove_failed(slot);
+        }
+        Ok(())
+    }
+
+    pub fn unfinished(&self) -> usize {
+        self.inner.unfinished.load(Ordering::Acquire)
+    }
+
+    fn complete_one_data(
+        &self,
+        slot_index: usize,
+        payload: &[u8],
+        valid: usize,
+    ) -> Result<(), SystemError> {
+        let slot = &self.inner.slots[slot_index];
+        if !Self::claim(slot)? {
+            return Ok(());
+        }
+        {
+            let mut page = slot.page.write();
+            let dst = unsafe { page.as_slice_mut() };
+            dst[..valid].copy_from_slice(&payload[..valid]);
+            dst[valid..].fill(0);
+            page.add_flags(PageFlags::PG_UPTODATE);
+        }
+        self.publish_ready(slot);
+        Ok(())
+    }
+
+    fn claim(slot: &LoadingSlot) -> Result<bool, SystemError> {
+        slot.terminal
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .map(|_| true)
+            .map_err(|_| SystemError::EIO)
+    }
+
+    fn publish_ready(&self, slot: &LoadingSlot) {
+        let inner = self.inner.cache.inner.lock();
+        let matches = inner.get_entry(slot.page_index).is_some_and(|current| {
+            Arc::ptr_eq(&current, &slot.entry)
+                && Arc::ptr_eq(&current.page, &slot.page)
+                && current.state() == PageState::Loading
+        });
+        if matches {
+            slot.entry
+                .account_state_transition(PageState::Loading, PageState::UpToDate);
+            slot.entry.set_state(PageState::UpToDate);
+            slot.entry.wait_queue.wake_all();
+        }
+        drop(inner);
+        self.finish_one();
+    }
+
+    fn remove_failed(&self, slot: &LoadingSlot) {
+        let removed = {
+            let mut inner = self.inner.cache.inner.lock();
+            if inner
+                .get_entry(slot.page_index)
+                .is_some_and(|current| Arc::ptr_eq(&current, &slot.entry))
+            {
+                inner.remove_page(slot.page_index);
+                true
+            } else {
+                false
+            }
+        };
+        if removed {
+            self.inner.cache.discard_unlinked_page(&slot.page);
+        }
+        self.finish_one();
+    }
+
+    fn finish_one(&self) {
+        let previous = self.inner.unfinished.fetch_sub(1, Ordering::AcqRel);
+        debug_assert!(previous > 0);
+    }
+
+    fn validate_range(&self, first_slot: usize, page_count: usize) -> Result<(), SystemError> {
+        if page_count == 0
+            || first_slot
+                .checked_add(page_count)
+                .is_none_or(|end| end > self.inner.slots.len())
+        {
+            return Err(SystemError::EINVAL);
+        }
+        Ok(())
+    }
+
+    fn discard_unsubmitted(cache: &Arc<PageCache>, slots: &[LoadingSlot]) {
+        for slot in slots {
+            let removed = {
+                let mut inner = cache.inner.lock();
+                if inner
+                    .get_entry(slot.page_index)
+                    .is_some_and(|current| Arc::ptr_eq(&current, &slot.entry))
+                {
+                    inner.remove_page(slot.page_index);
+                    true
+                } else {
+                    false
+                }
+            };
+            if removed {
+                slot.entry.set_state(PageState::Error);
+                slot.entry.wait_queue.wake_all();
+            }
+            cache.discard_unlinked_page(&slot.page);
+        }
+    }
+}
+
+impl Drop for LoadingBatch {
+    fn drop(&mut self) {
+        for slot in &self.slots {
+            if slot.terminal.load(Ordering::Acquire) {
+                continue;
+            }
+            slot.page.write().add_flags(PageFlags::PG_ERROR);
+            slot.entry.set_state(PageState::Error);
+            slot.entry.wait_queue.wake_all();
+            let removed = {
+                let mut inner = self.cache.inner.lock();
+                if inner
+                    .get_entry(slot.page_index)
+                    .is_some_and(|current| Arc::ptr_eq(&current, &slot.entry))
+                {
+                    inner.remove_page(slot.page_index);
+                    true
+                } else {
+                    false
+                }
+            };
+            if removed {
+                self.cache.discard_unlinked_page(&slot.page);
+            }
+        }
+    }
+}
+
+/// Default compatibility path used by filesystems without a native batch
+/// implementation. The Arc receiver makes the queued owner explicit.
+pub(super) fn submit_default_read_batch<B: PageCacheBackend + ?Sized + 'static>(
+    backend: Arc<B>,
+    request: PageCacheReadBatchRequest,
+    completion: PageCacheReadBatchCompletion,
+) {
+    let work = Work::new(move || {
+        for offset in 0..request.page_count {
+            let mut payload = [0u8; MMArch::PAGE_SIZE];
+            let page_index = request.start_index + offset;
+            match backend.read_page(page_index, &mut payload) {
+                Ok(len) if len <= MMArch::PAGE_SIZE => {
+                    let valid = if len == 0 { MMArch::PAGE_SIZE } else { len };
+                    let _ = completion.complete_data(offset, 1, &payload, valid);
+                }
+                Ok(_) => {
+                    let _ = completion.complete_error(offset, 1, SystemError::EIO);
+                }
+                Err(error) => {
+                    let _ = completion.complete_error(offset, 1, error);
+                }
+            }
+        }
+    });
+    schedule_work(work);
+}

--- a/kernel/src/filesystem/page_cache/read_batch.rs
+++ b/kernel/src/filesystem/page_cache/read_batch.rs
@@ -238,6 +238,13 @@ impl PageCacheReadBatchCompletion {
                 .account_state_transition(PageState::Loading, PageState::UpToDate);
             slot.entry.set_state(PageState::UpToDate);
             slot.entry.wait_queue.wake_all();
+        } else {
+            // The mapping may have been torn down after a reader captured this
+            // Loading entry. Identity validation must prevent stale data from
+            // being republished, but the detached entry still owns its wait
+            // protocol and therefore needs an observable terminal state.
+            slot.entry.set_state(PageState::Error);
+            slot.entry.wait_queue.wake_all();
         }
         drop(inner);
         self.finish_one();

--- a/kernel/src/filesystem/page_cache/selftest.rs
+++ b/kernel/src/filesystem/page_cache/selftest.rs
@@ -72,6 +72,26 @@ fn run_writeback_domain_lifecycle_selftest() -> bool {
         && active.wait_drained().is_ok()
 }
 
+fn run_detached_read_batch_completion_selftest() -> Result<bool, SystemError> {
+    let cache = PageCache::new_unowned(None, None);
+    let completion = PageCacheReadBatchCompletion::reserve(&cache, 0, 1, None)?;
+    let entry = cache.inner.lock().get_entry(0).ok_or(SystemError::EIO)?;
+    let page = cache.manager.remove_page(0)?.ok_or(SystemError::EIO)?;
+
+    let payload = [0u8; MMArch::PAGE_SIZE];
+    completion.complete_data(0, 1, &payload, MMArch::PAGE_SIZE)?;
+    let completed = entry.state() == PageState::Error && completion.unfinished() == 0;
+
+    drop(completion);
+    drop(entry);
+    let paddr = page.phys_address();
+    page_manager_lock().remove_page(&paddr);
+    let _ = page_reclaimer_lock().remove_page(&paddr);
+    drop(page);
+    drop(cache);
+    Ok(completed)
+}
+
 #[inline(never)]
 fn run_preallocated_batch_lifecycle_selftest() -> Result<bool, SystemError> {
     use crate::{
@@ -1907,6 +1927,10 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
 
     if !run_writeback_domain_lifecycle_selftest() {
         return Ok("status=fail stage=writeback_domain_lifecycle\n".into());
+    }
+
+    if !run_detached_read_batch_completion_selftest()? {
+        return Ok("status=fail stage=detached_read_batch_completion\n".into());
     }
 
     if !run_preallocated_batch_lifecycle_selftest()? {
@@ -3768,6 +3792,6 @@ pub(crate) fn run_accounting_debug_selftest() -> Result<alloc::string::String, S
     }
 
     Ok(alloc::format!(
-        "status=ok\nramfs_fallocate_range=ok\nwrite_prepare_rollback=ok\npreallocate_rollback=ok\nwriteback_domain_lifecycle=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nremote_dirty_publish=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nsubmitted_writeback=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
+        "status=ok\nramfs_fallocate_range=ok\nwrite_prepare_rollback=ok\npreallocate_rollback=ok\nwriteback_domain_lifecycle=ok\ndetached_read_batch_completion=ok\npreallocated_batch_lifecycle=ok\nfile_membership=ok\nshmem_membership=ok\ndirty_membership=ok\ndirty_incarnation=ok\nremote_dirty_publish=ok\nwriteback_membership=ok\nwriteback_admission_order=ok\nwriteback_submission_token=ok\nwriteback_defer_progress=ok\nwriteback_budget_retry=ok\nsubmitted_writeback=ok\nfault_invalidate_retry_order=ok\ntag_scan_chunk_release=ok\nunevictable_membership=ok\ninflight_teardown=ok\nlate_completion=ok\nglobal_wiring=ok\nlayout=ok\nfile_drop_drift={file_drop_drift}\nshmem_drop_drift={shmem_drop_drift}\ndirty_drop_drift={dirty_drop_drift}\nwriteback_drop_drift={writeback_drop_drift}\nunevictable_drop_drift={unevictable_drop_drift}\nentry_size={entry_size}\nbaseline_size={baseline_size}\n"
     ))
 }

--- a/kernel/src/filesystem/page_cache/writeback.rs
+++ b/kernel/src/filesystem/page_cache/writeback.rs
@@ -744,10 +744,49 @@ pub trait PageCacheWritebackSubmission: Send {
     fn cancel(self: Box<Self>, context: PageCacheWritebackCancellationContext);
 }
 
-pub trait PageCacheBackend: Send + Sync + core::fmt::Debug {
+pub trait PageCacheBackend: Send + Sync + core::fmt::Debug + 'static {
     fn read_page(&self, index: usize, buf: &mut [u8]) -> Result<usize, SystemError>;
     fn write_page(&self, index: usize, buf: &[u8]) -> Result<usize, SystemError>;
     fn npages(&self) -> usize;
+
+    /// Clip a speculative read window against a stable backend EOF. PageCache
+    /// calls this while holding invalidate_read, before it inserts Loading
+    /// pages, so a backend whose size writers take invalidate_write can return
+    /// one authoritative bound for reservation and submission.
+    fn read_window_limit(
+        &self,
+        start_index: usize,
+        requested_pages: usize,
+    ) -> Result<usize, SystemError> {
+        let start = start_index
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let requested = requested_pages
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        let size = self
+            .npages()
+            .checked_mul(MMArch::PAGE_SIZE)
+            .ok_or(SystemError::EOVERFLOW)?;
+        Ok(size.saturating_sub(start).min(requested))
+    }
+
+    /// Maximum number of pages this backend can usefully submit together.
+    /// The default preserves the existing per-page workqueue behavior.
+    fn read_batch_pages(&self) -> usize {
+        1
+    }
+
+    /// Accept ownership of every Loading slot in `completion`. Planning or
+    /// submission failures are reported through per-page completion; there is
+    /// deliberately no second caller-side rollback result.
+    fn submit_read_batch(
+        self: Arc<Self>,
+        request: super::PageCacheReadBatchRequest,
+        completion: super::PageCacheReadBatchCompletion,
+    ) {
+        super::read_batch::submit_default_read_batch(self, request, completion);
+    }
 
     /// Reserve one filesystem block before publishing a new cache page.
     fn reserve_page(&self) -> Result<(), SystemError> {


### PR DESCRIPTION
## Problem

ext4 readahead handled a PageCache window as independent page reads, causing contiguous file data to degrade into repeated 4 KiB I/O. Metadata reads also lacked a unified bounded cache tied to journal visibility, so small-file workloads repeatedly fetched committed inode, bitmap, extent, and directory blocks.

## Changes

- Plan a readahead window against one ext4 metadata view and represent it as bounded mapped or zero segments.
- Submit physically contiguous ext4 blocks through real multi-page BIOs, with per-page PageCache completion and error publication.
- Keep extent mappings pinned until accepted BIOs retire, and serialize complete size mutations with writers and PageCache invalidation.
- Add a fixed-capacity, four-way set-associative metadata block cache with loading, clean, dirty, and error states.
- Integrate single-flight reads with batched journal publication, sequence-aware checkpoint cleanup, and block-retirement invalidation.
- Route transaction read-for-update operations through the same committed metadata source.
- Harden BIO callback ordering and DMA buffer ownership while moving large completion copies outside IRQ-disabled spin-lock regions.
- Keep the compatibility batch size at one page for filesystems without a native batch implementation.

## Correctness properties

- EOF tails are zeroed and holes or unwritten extents complete without device I/O.
- Every reserved page reaches exactly one terminal state; failed pages are removed by identity and can be retried.
- Truncate and extent replacement cannot reuse a physical mapping while a submitted read still owns it.
- Late metadata loaders and old checkpoints cannot overwrite newer journal publication.
- Loading and dirty cache entries are not reclaimed; a fully pinned set uses a bounded bypass path.
- Non-batched journal, direct, read-only, and recovery modes retain their existing uncached path until the full publication protocol is available for those modes.

## Validation

- `make fmt`
- `cargo test --manifest-path kernel/crates/another_ext4/Cargo.toml --lib` — 197 passed
- `make kernel`
- QEMU boot to the DragonOS shell with ext4 rootfs
- Cold-cache SHA-256 verification of a 512 KiB file
- Sparse-file hole and mapped-page verification after cache drop
- Truncate from 512 KiB to 100 bytes and extend to 8192 bytes, verifying the grown range is zero-filled
- Create and remove 500 small files on ext4
- Independent adversarial reviews for logic/lifetime, concurrency/safety, and performance/architecture
