### PR TITLE
fix(qemu): propagate host TERM to the x86_64 nographic console

### DIFF
--- a/tools/qemu/console-term.sh
+++ b/tools/qemu/console-term.sh
@@ -1,0 +1,63 @@
+#!/bin/bash
+
+# Resolve the terminal description for the x86_64 BusyBox/hvc0 console.
+# Callers remain responsible for adding the validated result to their kernel
+# command line.
+
+_dragonos_console_term_is_valid() {
+    local LC_ALL=C
+    local value="$1"
+
+    [ "${#value}" -le 32 ] && [[ "${value}" =~ ^[A-Za-z0-9][A-Za-z0-9._+-]*$ ]]
+}
+
+dragonos_resolve_console_term() {
+    local transport="${1:-}"
+    local candidate=""
+    local source=""
+    local explicit=0
+
+    DRAGONOS_RESOLVED_CONSOLE_TERM=""
+    DRAGONOS_RESOLVED_CONSOLE_TERM_SOURCE=""
+
+    case "${transport}" in
+        stdio|socket) ;;
+        *)
+            echo "[ERROR] console TERM resolver received an unsupported transport"
+            return 1
+            ;;
+    esac
+
+    if [ -n "${DRAGONOS_QEMU_CONSOLE_TERM:-}" ]; then
+        candidate="${DRAGONOS_QEMU_CONSOLE_TERM}"
+        source="explicit"
+        explicit=1
+    elif [ "${transport}" = "stdio" ] && [ -t 0 ] && [ -t 1 ]; then
+        case "${TERM:-}" in
+            ""|dumb|linux) return 0 ;;
+            *)
+                candidate="${TERM}"
+                source="host"
+                ;;
+        esac
+    else
+        return 0
+    fi
+
+    if [ "${explicit}" -eq 1 ] && [ "${candidate}" = "linux" ]; then
+        echo "[ERROR] DRAGONOS_QEMU_CONSOLE_TERM=linux cannot be preserved by BusyBox on hvc0; use an accurate non-linux terminfo name"
+        return 1
+    fi
+
+    if ! _dragonos_console_term_is_valid "${candidate}"; then
+        if [ "${explicit}" -eq 1 ]; then
+            echo "[ERROR] DRAGONOS_QEMU_CONSOLE_TERM must be a 1-32 byte ASCII terminfo name matching [A-Za-z0-9][A-Za-z0-9._+-]*"
+            return 1
+        fi
+        echo "[WARN] Host TERM is not a safe terminfo name; keeping the guest console fallback"
+        return 0
+    fi
+
+    DRAGONOS_RESOLVED_CONSOLE_TERM="${candidate}"
+    DRAGONOS_RESOLVED_CONSOLE_TERM_SOURCE="${source}"
+}

--- a/tools/qemu/default.nix
+++ b/tools/qemu/default.nix
@@ -14,6 +14,7 @@
 
 let
   qemuFirmware = if preferSystemQemu then null else pkgs.callPackage ./qemu-firmware.nix { };
+  consoleTermHelper = ./console-term.sh;
 
   baseConfig = {
     nographic = true;
@@ -348,9 +349,26 @@ let
       # 原脚本是 rm -rf ... -> qemu -> rm -rf ...
 
       EXTRA_CMDLINE="${qemuConfig.cmdlineExtra}"
+      CONSOLE_TERM_CMDLINE=""
+
+      ${lib.optionalString (arch == "x86_64") ''
+        if ! . ${consoleTermHelper}; then
+          echo "[ERROR] failed to load the console TERM resolver"
+          exit 1
+        fi
+        if ! dragonos_resolve_console_term stdio; then
+          exit 1
+        fi
+        if [ -n "$DRAGONOS_RESOLVED_CONSOLE_TERM" ]; then
+          CONSOLE_TERM_CMDLINE="TERM=$DRAGONOS_RESOLVED_CONSOLE_TERM"
+          echo "[INFO] Guest console TERM=$DRAGONOS_RESOLVED_CONSOLE_TERM (source=$DRAGONOS_RESOLVED_CONSOLE_TERM_SOURCE)"
+        else
+          echo "[INFO] Guest console TERM uses the current init fallback"
+        fi
+      ''}
 
       # FIXED: 补全缺失的默认内核参数 AUTO_TEST 和 SYSCALL_TEST_DIR
-      FINAL_CMDLINE="rw init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} DUNITEST_DIR=${testOpt.dunitest.testDir} ${lib.optionalString (testOpt.autotest == "dunit") "dragonos.net_test_fixtures"} $EXTRA_CMDLINE"
+      FINAL_CMDLINE="rw init=${initProgram} AUTO_TEST=${testOpt.autotest} SYSCALL_TEST_DIR=${testOpt.syscall.testDir} DUNITEST_DIR=${testOpt.dunitest.testDir} ${lib.optionalString (testOpt.autotest == "dunit") "dragonos.net_test_fixtures"} $EXTRA_CMDLINE $CONSOLE_TERM_CMDLINE"
 
       ARCH_FLAGS=( ${lib.escapeShellArgs commonArchArgs} )
       ${archSpecificBash}

--- a/tools/run-qemu.sh
+++ b/tools/run-qemu.sh
@@ -15,6 +15,7 @@
 # - DUNITEST_PATTERN: dunitest runner pattern filter
 # - DRAGONOS_QEMU_SMP: 覆盖 vCPU 拓扑，例如 1,cores=1,threads=1,sockets=1
 # - DRAGONOS_QEMU_SERIAL_SOCKET: nographic 模式下使用独立 Unix socket 承载 guest virtconsole
+# - DRAGONOS_QEMU_CONSOLE_TERM: x86_64 nographic 控制台使用的 guest terminfo 名称
 # - DRAGONOS_QEMU_ARGV_FILE: 以 JSON 数组记录实际执行的 QEMU argv（目标必须不存在）
 # - DRAGONOS_QEMU_DISK_IMAGE: 覆盖主磁盘镜像路径
 # - DRAGONOS_QEMU_SNAPSHOT: 设为1时以 QEMU snapshot 模式运行，避免修改基线镜像
@@ -757,7 +758,9 @@ fi
 
 
 if [ ${QEMU_NOGRAPHIC} == true ]; then
+    qemu_console_transport="stdio"
     if [ -n "${DRAGONOS_QEMU_SERIAL_SOCKET:-}" ]; then
+      qemu_console_transport="socket"
       qemu_serial_socket_dir="$(dirname "${DRAGONOS_QEMU_SERIAL_SOCKET}")"
       qemu_serial_socket_real_dir="$(realpath -e -- "${qemu_serial_socket_dir}" 2>/dev/null || true)"
       if [[ "${DRAGONOS_QEMU_SERIAL_SOCKET}" != /* ]] || \
@@ -778,6 +781,23 @@ if [ ${QEMU_NOGRAPHIC} == true ]; then
       QEMU_SERIAL_ARGS=(-serial none -monitor none -chardev "socket,id=${QEMU_CONSOLE_CHARDEV_ID},path=${DRAGONOS_QEMU_SERIAL_SOCKET},server=on,wait=off,logfile=${QEMU_SERIAL_LOG_FILE}")
     else
       QEMU_SERIAL_ARGS=(-serial chardev:mux -monitor chardev:mux -chardev "stdio,id=mux,mux=on,signal=off,logfile=${QEMU_SERIAL_LOG_FILE}")
+    fi
+
+    if [ "${ARCH}" = "x86_64" ]; then
+      # shellcheck source=qemu/console-term.sh
+      if ! . "${ROOT_PATH}/tools/qemu/console-term.sh"; then
+        echo "[ERROR] failed to load the console TERM resolver"
+        exit 1
+      fi
+      if ! dragonos_resolve_console_term "${qemu_console_transport}"; then
+        exit 1
+      fi
+      if [ -n "${DRAGONOS_RESOLVED_CONSOLE_TERM}" ]; then
+        KERNEL_CMDLINE+=" TERM=${DRAGONOS_RESOLVED_CONSOLE_TERM} "
+        echo "[INFO] Guest console TERM=${DRAGONOS_RESOLVED_CONSOLE_TERM} (source=${DRAGONOS_RESOLVED_CONSOLE_TERM_SOURCE})"
+      else
+        echo "[INFO] Guest console TERM uses the current init fallback"
+      fi
     fi
 
     # 添加 virtio console 设备


### PR DESCRIPTION
## Problem

The QEMU nographic console connects the host terminal to the guest `/dev/hvc0` but forwards only the byte stream, never the terminal capability name. The kernel initializes PID 1 with `TERM=linux` (matching Linux 6.6.139 semantics), and BusyBox 1.35.0 init rewrites that to `vt102` once `VT_OPENQRY` on `hvc0` reports that the console is not a Linux virtual terminal — correct behavior for a non-VT console. The result is that terminfo-aware programs such as CodeBuddy and `tput` observe a "no color" capability even though the host terminal renders 256 colors.

Neither entry point passed `TERM` on the kernel command line:

| Entry point | Location |
|---|---|
| Make / Bash | `tools/run-qemu.sh` |
| Nix `start-*` / `yolo-*` | `tools/qemu/default.nix` |

Fixing only one of them would produce entry-point dependent behavior, so the decision logic lives in a single sourced helper instead of being duplicated.

## Changes

Add `tools/qemu/console-term.sh`, which resolves the console `TERM` for the x86_64 BusyBox/hvc0 session:

- **Automatic mode** applies only to QEMU nographic stdio with both stdin and stdout attached to a TTY. Here QEMU transparently forwards bytes, so the host `TERM` describes the actual rendering endpoint and is propagated verbatim. An unset `TERM`, `dumb` or `linux` injects nothing, preserving the guest fallback.
- **`DRAGONOS_QEMU_CONSOLE_TERM` takes priority**, covering Unix socket clients, automation and manually selected terminfo entries. Because BusyBox cannot preserve that value on `hvc0`, an explicit `linux` is rejected with an error rather than silently degraded.
- **Value validation**: regardless of source, the candidate must be a 1-32 byte ASCII string matching `[A-Za-z0-9][A-Za-z0-9._+-]*` under `LC_ALL=C`. The value ends up in a space separated kernel command line, so whitespace, `=` and control characters cannot inject extra kernel parameters.
- **Conservative fallback**: when nothing resolves, no `TERM` keyword is emitted and the existing x86_64 BusyBox `vt102` fallback is preserved.

Both entry points wire in the helper and log the resolved value and its source.

## Scope and invariants

- x86_64 nographic only. RISC-V and LoongArch use different init paths and are left unchanged, since there is no behavioral evidence to justify touching them.
- No kernel, TTY or application behavior is modified. `VT_OPENQRY` is not faked into succeeding, and 256 colors are not hardcoded in `/etc/profile`, `/opt/env.sh` or any application.
- No capability is overstated: there is no terminal name mapping and no inference from `COLORTERM`. The host `TERM` is propagated exactly, so a missing guest terminfo entry remains a rootfs data concern rather than being masked by an incorrect mapping.

## Verification

In an interactive x86_64 nographic session with host `TERM=xterm-256color`, the boot log reports `Guest console TERM=xterm-256color (source=host)`, `tput colors` returns `256` after login, and CodeBuddy emits 256-color SGR sequences. With a non-TTY stdio or an unset `TERM`, no `TERM` keyword is emitted and behavior matches the pre-change baseline.

## Testing

- [x] Interactive stdio automatic propagation
- [x] `DRAGONOS_QEMU_CONSOLE_TERM` explicit override and rejection of invalid values
- [x] Non-TTY stdio / unset `TERM` keeps the fallback
- [x] Unix socket transport without explicit configuration injects nothing
